### PR TITLE
feat(caching): Add IHybridCache abstraction with FusionCache provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,6 +54,8 @@
     <PackageVersion Include="Flurl" Version="4.0.0" />
     <PackageVersion Include="Foundatio" Version="12.0.0" />
     <PackageVersion Include="Foundatio.Redis" Version="12.0.0" />
+    <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.3.0" />
+    <PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageVersion Include="Humanizer" Version="3.0.1" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.1" />
     <PackageVersion Include="IdGen" Version="3.0.7" />

--- a/src/Framework.Caching.Abstractions/Framework.Caching.Abstractions.csproj
+++ b/src/Framework.Caching.Abstractions/Framework.Caching.Abstractions.csproj
@@ -3,4 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Framework.Caching</RootNamespace>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+  </ItemGroup>
 </Project>

--- a/src/Framework.Caching.Abstractions/HybridCacheEntryOptions.cs
+++ b/src/Framework.Caching.Abstractions/HybridCacheEntryOptions.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Framework.Caching;
+
+/// <summary>
+/// Options for a single cache entry in <see cref="IHybridCache"/>.
+/// These options override the global <see cref="HybridCacheOptions"/> for a specific operation.
+/// </summary>
+[PublicAPI]
+public sealed record HybridCacheEntryOptions
+{
+    /// <summary>
+    /// The logical duration of the cache entry. After this time, the entry is considered stale
+    /// and will be refreshed on next access (or eagerly if <see cref="EagerRefreshThreshold"/> is set).
+    /// </summary>
+    public TimeSpan? Duration { get; init; }
+
+    /// <summary>
+    /// When fail-safe is enabled, this is the maximum duration to keep stale values
+    /// for fallback scenarios when the factory fails.
+    /// </summary>
+    public TimeSpan? FailSafeMaxDuration { get; init; }
+
+    /// <summary>
+    /// Maximum time to wait for the factory to complete. If exceeded, a stale value
+    /// may be returned (if fail-safe is enabled) or the operation may fail.
+    /// </summary>
+    public TimeSpan? FactoryTimeout { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, returns stale cached values when the factory fails.
+    /// This provides resilience against temporary failures.
+    /// </summary>
+    public bool? EnableFailSafe { get; init; }
+
+    /// <summary>
+    /// A value between 0.0 and 1.0 indicating when to trigger eager background refresh.
+    /// For example, 0.9 means refresh when 90% of the duration has passed.
+    /// This helps keep the cache warm and reduces latency spikes.
+    /// </summary>
+    public float? EagerRefreshThreshold { get; init; }
+
+    /// <summary>
+    /// The priority of the cache entry for eviction purposes.
+    /// Higher priority entries are less likely to be evicted under memory pressure.
+    /// </summary>
+    public CacheItemPriority Priority { get; init; } = CacheItemPriority.Normal;
+}

--- a/src/Framework.Caching.Abstractions/HybridCacheOptions.cs
+++ b/src/Framework.Caching.Abstractions/HybridCacheOptions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Framework.Caching;
+
+/// <summary>
+/// Base options for <see cref="IHybridCache"/> implementations.
+/// Provider-specific options should extend this class.
+/// </summary>
+[PublicAPI]
+public class HybridCacheOptions
+{
+    /// <summary>
+    /// A prefix to prepend to all cache keys.
+    /// Useful for isolating cache entries in shared cache instances.
+    /// </summary>
+    public string? KeyPrefix { get; set; }
+
+    /// <summary>
+    /// The default duration for cache entries when not specified per-operation.
+    /// </summary>
+    public TimeSpan DefaultDuration { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// When <see langword="true"/>, enables fail-safe behavior by default.
+    /// Individual operations can override this via <see cref="HybridCacheEntryOptions.EnableFailSafe"/>.
+    /// </summary>
+    public bool EnableFailSafe { get; set; } = true;
+
+    /// <summary>
+    /// The default maximum duration to keep stale values for fail-safe fallback.
+    /// Only applies when <see cref="EnableFailSafe"/> is <see langword="true"/>.
+    /// </summary>
+    public TimeSpan FailSafeMaxDuration { get; set; } = TimeSpan.FromHours(2);
+
+    /// <summary>
+    /// The default timeout for factory execution.
+    /// Operations can override this via <see cref="HybridCacheEntryOptions.FactoryTimeout"/>.
+    /// </summary>
+    public TimeSpan FactoryTimeout { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/src/Framework.Caching.Abstractions/IHybridCache.cs
+++ b/src/Framework.Caching.Abstractions/IHybridCache.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Framework.Caching;
+
+/// <summary>
+/// A high-level cache interface supporting cache-aside pattern with fail-safe and stampede protection.
+/// Unlike <see cref="ICache"/> which provides low-level operations, this interface focuses on
+/// the GetOrSet pattern with advanced features like fail-safe fallback and eager refresh.
+/// </summary>
+[PublicAPI]
+public interface IHybridCache : IDisposable
+{
+    /// <summary>Gets a value from the cache.</summary>
+    /// <typeparam name="T">The type of the cached value.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="CacheValue{T}"/> indicating whether the value exists and its value if present.</returns>
+    Task<CacheValue<T>> GetAsync<T>(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a value from the cache or creates it using the provided factory if not present.
+    /// This method provides stampede protection - only one factory execution per key.
+    /// </summary>
+    /// <typeparam name="T">The type of the cached value.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="factory">The factory function to create the value if not cached.</param>
+    /// <param name="options">Optional entry-specific options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cached or newly created value.</returns>
+    Task<CacheValue<T>> GetOrSetAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        HybridCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>Sets a value in the cache.</summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The value to cache.</param>
+    /// <param name="options">Optional entry-specific options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SetAsync<T>(
+        string key,
+        T? value,
+        HybridCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>Removes a value from the cache.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>Checks if a key exists in the cache.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> if the key exists; otherwise, <see langword="false"/>.</returns>
+    Task<bool> ExistsAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Expires a cache entry, marking it as stale but keeping it for fail-safe scenarios.
+    /// Different from <see cref="RemoveAsync"/> which completely removes the entry.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ExpireAsync(string key, CancellationToken cancellationToken = default);
+}

--- a/src/Framework.Caching.Abstractions/IHybridCache`T.cs
+++ b/src/Framework.Caching.Abstractions/IHybridCache`T.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Framework.Caching;
+
+/// <summary>
+/// A typed wrapper around <see cref="IHybridCache"/> for a specific type.
+/// Useful for dependency injection when you want to inject a cache for a specific type.
+/// </summary>
+/// <typeparam name="T">The type of values stored in this cache.</typeparam>
+[PublicAPI]
+public interface IHybridCache<T>
+{
+    /// <summary>Gets a value from the cache.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="CacheValue{T}"/> indicating whether the value exists.</returns>
+    Task<CacheValue<T>> GetAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a value from the cache or creates it using the provided factory.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="factory">The factory function to create the value.</param>
+    /// <param name="options">Optional entry-specific options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cached or newly created value.</returns>
+    Task<CacheValue<T>> GetOrSetAsync(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        HybridCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>Sets a value in the cache.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The value to cache.</param>
+    /// <param name="options">Optional entry-specific options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SetAsync(
+        string key,
+        T? value,
+        HybridCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>Removes a value from the cache.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>Checks if a key exists in the cache.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> if the key exists.</returns>
+    Task<bool> ExistsAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>Expires a cache entry, keeping it for fail-safe scenarios.</summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ExpireAsync(string key, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IHybridCache{T}"/> that delegates to <see cref="IHybridCache"/>.
+/// </summary>
+/// <typeparam name="T">The type of values stored in this cache.</typeparam>
+[PublicAPI]
+public sealed class HybridCache<T>(IHybridCache cache) : IHybridCache<T>
+{
+    public Task<CacheValue<T>> GetAsync(string key, CancellationToken cancellationToken = default)
+    {
+        return cache.GetAsync<T>(key, cancellationToken);
+    }
+
+    public Task<CacheValue<T>> GetOrSetAsync(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        HybridCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return cache.GetOrSetAsync(key, factory, options, cancellationToken);
+    }
+
+    public Task SetAsync(
+        string key,
+        T? value,
+        HybridCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return cache.SetAsync(key, value, options, cancellationToken);
+    }
+
+    public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        return cache.RemoveAsync(key, cancellationToken);
+    }
+
+    public Task<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        return cache.ExistsAsync(key, cancellationToken);
+    }
+
+    public Task ExpireAsync(string key, CancellationToken cancellationToken = default)
+    {
+        return cache.ExpireAsync(key, cancellationToken);
+    }
+}

--- a/src/Framework.Caching.FusionCache/Framework.Caching.FusionCache.csproj
+++ b/src/Framework.Caching.FusionCache/Framework.Caching.FusionCache.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Framework.Caching</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ZiggyCreatures.FusionCache" />
+    <PackageReference Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Framework.Caching.Abstractions\Framework.Caching.Abstractions.csproj" />
+    <ProjectReference Include="..\Framework.Hosting\Framework.Hosting.csproj" />
+    <ProjectReference Include="..\Framework.Serializer.Json\Framework.Serializer.Json.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Framework.Caching.FusionCache/FusionCacheAdapter.cs
+++ b/src/Framework.Caching.FusionCache/FusionCacheAdapter.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Checks;
+using Framework.Threading;
+using Microsoft.Extensions.Caching.Memory;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Framework.Caching;
+
+/// <summary>
+/// Implements <see cref="IHybridCache"/> using FusionCache as the underlying cache provider.
+/// Provides L1 (memory) + L2 (distributed) hybrid caching with fail-safe and stampede protection.
+/// </summary>
+public sealed class FusionCacheAdapter(IFusionCache fusionCache, FusionCacheProviderOptions options) : IHybridCache
+{
+    public async Task<CacheValue<T>> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var prefixedKey = _PrefixKey(key);
+        var maybe = await fusionCache.TryGetAsync<T>(prefixedKey, token: cancellationToken).AnyContext();
+
+        return maybe.HasValue
+            ? new CacheValue<T>(maybe.Value, hasValue: true)
+            : new CacheValue<T>(default, hasValue: false);
+    }
+
+    public async Task<CacheValue<T>> GetOrSetAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        HybridCacheEntryOptions? entryOptions = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNullOrEmpty(key);
+        Argument.IsNotNull(factory);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var prefixedKey = _PrefixKey(key);
+        var fcOptions = _MapEntryOptions(entryOptions);
+
+        var result = await fusionCache
+            .GetOrSetAsync<T?>(
+                prefixedKey,
+                async (_, ct) => await factory(ct).AnyContext(),
+                fcOptions,
+                cancellationToken
+            )
+            .AnyContext();
+
+        return new CacheValue<T>(result, hasValue: true);
+    }
+
+    public async Task SetAsync<T>(
+        string key,
+        T? value,
+        HybridCacheEntryOptions? entryOptions = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var prefixedKey = _PrefixKey(key);
+        var fcOptions = _MapEntryOptions(entryOptions);
+
+        await fusionCache.SetAsync(prefixedKey, value, fcOptions, cancellationToken).AnyContext();
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var prefixedKey = _PrefixKey(key);
+        await fusionCache.RemoveAsync(prefixedKey, token: cancellationToken).AnyContext();
+    }
+
+    public async Task<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var prefixedKey = _PrefixKey(key);
+        var maybe = await fusionCache.TryGetAsync<object>(prefixedKey, token: cancellationToken).AnyContext();
+
+        return maybe.HasValue;
+    }
+
+    public async Task ExpireAsync(string key, CancellationToken cancellationToken = default)
+    {
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var prefixedKey = _PrefixKey(key);
+        await fusionCache.ExpireAsync(prefixedKey, token: cancellationToken).AnyContext();
+    }
+
+    public void Dispose()
+    {
+        // FusionCache is typically managed by DI container, no need to dispose here
+    }
+
+    #region Private Helpers
+
+    private string _PrefixKey(string key)
+    {
+        return string.IsNullOrEmpty(options.KeyPrefix) ? key : options.KeyPrefix + key;
+    }
+
+    private FusionCacheEntryOptions _MapEntryOptions(HybridCacheEntryOptions? entryOptions)
+    {
+        var fcOptions = new FusionCacheEntryOptions
+        {
+            Duration = entryOptions?.Duration ?? options.DefaultDuration,
+            IsFailSafeEnabled = entryOptions?.EnableFailSafe ?? options.EnableFailSafe,
+            FailSafeMaxDuration = entryOptions?.FailSafeMaxDuration ?? options.FailSafeMaxDuration,
+            FactorySoftTimeout = entryOptions?.FactoryTimeout ?? options.FactoryTimeout,
+            DistributedCacheSoftTimeout = options.DistributedCacheSoftTimeout,
+            DistributedCacheHardTimeout = options.DistributedCacheHardTimeout,
+            AllowBackgroundDistributedCacheOperations = options.AllowBackgroundDistributedCacheOperations,
+            JitterMaxDuration = options.JitterMaxDuration,
+            Priority = _MapPriority(entryOptions?.Priority ?? CacheItemPriority.Normal),
+        };
+
+        if (entryOptions?.EagerRefreshThreshold.HasValue is true)
+        {
+            fcOptions.EagerRefreshThreshold = entryOptions.EagerRefreshThreshold.Value;
+        }
+
+        return fcOptions;
+    }
+
+    private static CacheItemPriority _MapPriority(CacheItemPriority priority)
+    {
+        return priority switch
+        {
+            CacheItemPriority.Low => CacheItemPriority.Low,
+            CacheItemPriority.Normal => CacheItemPriority.Normal,
+            CacheItemPriority.High => CacheItemPriority.High,
+            CacheItemPriority.NeverRemove => CacheItemPriority.NeverRemove,
+            _ => CacheItemPriority.Normal,
+        };
+    }
+
+    #endregion
+}

--- a/src/Framework.Caching.FusionCache/FusionCacheProviderOptions.cs
+++ b/src/Framework.Caching.FusionCache/FusionCacheProviderOptions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using FluentValidation;
+
+namespace Framework.Caching;
+
+/// <summary>
+/// Options for the FusionCache provider implementing <see cref="IHybridCache"/>.
+/// </summary>
+[PublicAPI]
+public sealed class FusionCacheProviderOptions : HybridCacheOptions
+{
+    /// <summary>
+    /// A unique name for this cache instance. Used for identification in logs and metrics.
+    /// </summary>
+    public string CacheName { get; set; } = "default";
+
+    /// <summary>
+    /// The default duration for L2 (distributed) cache soft timeout.
+    /// After this timeout, a stale value may be returned while background refresh continues.
+    /// </summary>
+    public TimeSpan DistributedCacheSoftTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// The default duration for L2 (distributed) cache hard timeout.
+    /// After this timeout, the operation will fail if no value is available.
+    /// </summary>
+    public TimeSpan DistributedCacheHardTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// When <see langword="true"/>, allows L2 cache operations to complete in the background
+    /// rather than blocking the caller.
+    /// </summary>
+    public bool AllowBackgroundDistributedCacheOperations { get; set; } = true;
+
+    /// <summary>
+    /// Maximum jitter to add to cache durations to prevent thundering herd on expiration.
+    /// A random value between 0 and this duration will be added to each entry's TTL.
+    /// </summary>
+    public TimeSpan JitterMaxDuration { get; set; } = TimeSpan.FromSeconds(10);
+}
+
+/// <summary>
+/// Validator for <see cref="FusionCacheProviderOptions"/>.
+/// </summary>
+public sealed class FusionCacheProviderOptionsValidator : AbstractValidator<FusionCacheProviderOptions>
+{
+    public FusionCacheProviderOptionsValidator()
+    {
+        RuleFor(x => x.CacheName).NotEmpty();
+        RuleFor(x => x.DefaultDuration).GreaterThan(TimeSpan.Zero);
+        RuleFor(x => x.FailSafeMaxDuration).GreaterThan(TimeSpan.Zero);
+        RuleFor(x => x.FactoryTimeout).GreaterThan(TimeSpan.Zero);
+        RuleFor(x => x.DistributedCacheSoftTimeout).GreaterThanOrEqualTo(TimeSpan.Zero);
+        RuleFor(x => x.DistributedCacheHardTimeout).GreaterThan(TimeSpan.Zero);
+        RuleFor(x => x.JitterMaxDuration).GreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+}

--- a/src/Framework.Caching.FusionCache/FusionCacheSerializerAdapter.cs
+++ b/src/Framework.Caching.FusionCache/FusionCacheSerializerAdapter.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Serializer;
+using ZiggyCreatures.Caching.Fusion.Serialization;
+
+namespace Framework.Caching;
+
+/// <summary>
+/// Adapts the framework's <see cref="ISerializer"/> to FusionCache's <see cref="IFusionCacheSerializer"/>.
+/// </summary>
+public sealed class FusionCacheSerializerAdapter(ISerializer serializer) : IFusionCacheSerializer
+{
+    public byte[] Serialize<T>(T? obj)
+    {
+        using var stream = new MemoryStream();
+        serializer.Serialize(obj, stream);
+        return stream.ToArray();
+    }
+
+    public T? Deserialize<T>(byte[] data)
+    {
+        using var stream = new MemoryStream(data);
+        return serializer.Deserialize<T>(stream);
+    }
+
+    public ValueTask<byte[]> SerializeAsync<T>(T? obj, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<byte[]>(Serialize(obj));
+    }
+
+    public ValueTask<T?> DeserializeAsync<T>(byte[] data, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<T?>(Deserialize<T>(data));
+    }
+}

--- a/src/Framework.Caching.FusionCache/Setup.cs
+++ b/src/Framework.Caching.FusionCache/Setup.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Framework.Caching;
+
+/// <summary>
+/// Extension methods for setting up FusionCache-based <see cref="IHybridCache"/> in an <see cref="IServiceCollection"/>.
+/// </summary>
+[PublicAPI]
+public static class FusionCacheSetup
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Adds FusionCache-based <see cref="IHybridCache"/> to the service collection.
+        /// </summary>
+        /// <param name="setupAction">Action to configure the cache options.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public IServiceCollection AddFusionHybridCache(Action<FusionCacheProviderOptions> setupAction)
+        {
+            services.Configure<FusionCacheProviderOptions, FusionCacheProviderOptionsValidator>(setupAction);
+
+            return services._AddCore();
+        }
+
+        /// <summary>
+        /// Adds FusionCache-based <see cref="IHybridCache"/> to the service collection with service provider access.
+        /// </summary>
+        /// <param name="setupAction">Action to configure the cache options with access to the service provider.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public IServiceCollection AddFusionHybridCache(Action<FusionCacheProviderOptions, IServiceProvider> setupAction)
+        {
+            services.Configure<FusionCacheProviderOptions, FusionCacheProviderOptionsValidator>(setupAction);
+
+            return services._AddCore();
+        }
+
+        private IServiceCollection _AddCore()
+        {
+            // Register the JSON serializer if not already registered
+            services.TryAddSingleton<IJsonOptionsProvider>(new DefaultJsonOptionsProvider());
+            services.TryAddSingleton<IJsonSerializer>(sp => new SystemJsonSerializer(
+                sp.GetRequiredService<IJsonOptionsProvider>()
+            ));
+            services.TryAddSingleton<ISerializer>(sp => sp.GetRequiredService<IJsonSerializer>());
+
+            // Register the options value
+            services.AddSingletonOptionValue<FusionCacheProviderOptions>();
+
+            // Register FusionCache's serializer adapter
+            services.TryAddSingleton<ZiggyCreatures.Caching.Fusion.Serialization.IFusionCacheSerializer>(sp =>
+                new FusionCacheSerializerAdapter(sp.GetRequiredService<ISerializer>())
+            );
+
+            // Register FusionCache itself - options are applied via post-configure
+            services.AddFusionCache()
+                .WithSerializer(sp => sp.GetRequiredService<ZiggyCreatures.Caching.Fusion.Serialization.IFusionCacheSerializer>());
+
+            // Configure FusionCache options from our provider options
+            services.AddOptions<ZiggyCreatures.Caching.Fusion.FusionCacheOptions>()
+                .Configure<FusionCacheProviderOptions>((fcOpt, providerOpt) =>
+                {
+                    fcOpt.CacheName = providerOpt.CacheName;
+                    fcOpt.CacheKeyPrefix = providerOpt.KeyPrefix;
+                });
+
+            services.AddOptions<ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions>()
+                .Configure<FusionCacheProviderOptions>((fcOpt, providerOpt) =>
+                {
+                    fcOpt.Duration = providerOpt.DefaultDuration;
+                    fcOpt.IsFailSafeEnabled = providerOpt.EnableFailSafe;
+                    fcOpt.FailSafeMaxDuration = providerOpt.FailSafeMaxDuration;
+                    fcOpt.FactorySoftTimeout = providerOpt.FactoryTimeout;
+                    fcOpt.DistributedCacheSoftTimeout = providerOpt.DistributedCacheSoftTimeout;
+                    fcOpt.DistributedCacheHardTimeout = providerOpt.DistributedCacheHardTimeout;
+                    fcOpt.AllowBackgroundDistributedCacheOperations = providerOpt.AllowBackgroundDistributedCacheOperations;
+                    fcOpt.JitterMaxDuration = providerOpt.JitterMaxDuration;
+                });
+
+            // Register our IHybridCache adapter
+            services.TryAddSingleton<IHybridCache, FusionCacheAdapter>();
+            services.TryAddSingleton(typeof(IHybridCache<>), typeof(HybridCache<>));
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `IHybridCache` interface for high-level cache-aside pattern with fail-safe support
- Add `Framework.Caching.FusionCache` provider with L1 (memory) + L2 (distributed) hybrid caching
- Maintain existing `ICache` interface for Foundatio low-level operations

## Test plan

- [ ] Build passes
- [ ] Manual testing with FusionCache integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)