### PR TITLE
test(blobs): add comprehensive unit tests for blob storage packages

### DIFF
--- a/tests/Framework.Blobs.Abstractions.Tests.Unit/BlobDownloadResultTests.cs
+++ b/tests/Framework.Blobs.Abstractions.Tests.Unit/BlobDownloadResultTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs;
+using Framework.Testing.Tests;
+
+namespace Tests;
+
+public sealed class BlobDownloadResultTests : TestBase
+{
+    #region Property Access Tests
+
+    [Fact]
+    public void should_expose_stream_property_when_created_with_stream()
+    {
+        // Arrange
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        // Act
+        using var result = new BlobDownloadResult(stream, "test.txt");
+
+        // Assert
+        result.Stream.Should().BeSameAs(stream);
+    }
+
+    [Fact]
+    public void should_expose_filename_property_when_created_with_filename()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var fileName = "document.pdf";
+
+        // Act
+        using var result = new BlobDownloadResult(stream, fileName);
+
+        // Assert
+        result.FileName.Should().Be(fileName);
+    }
+
+    [Fact]
+    public void should_expose_metadata_property_when_created_with_metadata()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var metadata = new Dictionary<string, string?> { ["key"] = "value", ["author"] = "test" };
+
+        // Act
+        using var result = new BlobDownloadResult(stream, "file.txt", metadata);
+
+        // Assert
+        result.Metadata.Should().NotBeNull();
+        result.Metadata!["key"].Should().Be("value");
+        result.Metadata["author"].Should().Be("test");
+    }
+
+    [Fact]
+    public void should_have_null_metadata_when_not_provided()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+
+        // Act
+        using var result = new BlobDownloadResult(stream, "file.txt");
+
+        // Assert
+        result.Metadata.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Dispose Tests
+
+    [Fact]
+    public void should_dispose_stream_when_dispose_is_called()
+    {
+        // Arrange
+        var stream = new MemoryStream([1, 2, 3]);
+        var result = new BlobDownloadResult(stream, "test.txt");
+
+        // Act
+        result.Dispose();
+
+        // Assert - verify stream is disposed by trying to read
+        var act = () => stream.ReadByte();
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task should_dispose_stream_async_when_dispose_async_is_called()
+    {
+        // Arrange
+        var stream = new MemoryStream([1, 2, 3]);
+        var result = new BlobDownloadResult(stream, "test.txt");
+
+        // Act
+        await result.DisposeAsync();
+
+        // Assert - verify stream is disposed by trying to read
+        var act = () => stream.ReadByte();
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    #endregion
+
+    #region Using Statement Tests
+
+    [Fact]
+    public void should_support_using_statement_when_used_with_using_block()
+    {
+        // Arrange
+        var stream = new MemoryStream([1, 2, 3]);
+        Stream? capturedStream = null;
+
+        // Act
+        using (var result = new BlobDownloadResult(stream, "test.txt"))
+        {
+            capturedStream = result.Stream;
+            capturedStream.ReadByte().Should().Be(1); // Stream should be readable
+        }
+
+        // Assert - stream should be disposed after using block
+        var act = () => capturedStream.ReadByte();
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task should_support_await_using_statement_when_used_with_await_using()
+    {
+        // Arrange
+        var stream = new MemoryStream([1, 2, 3]);
+        Stream? capturedStream = null;
+
+        // Act
+        await using (var result = new BlobDownloadResult(stream, "test.txt"))
+        {
+            capturedStream = result.Stream;
+            capturedStream.ReadByte().Should().Be(1); // Stream should be readable
+        }
+
+        // Assert - stream should be disposed after await using block
+        var act = () => capturedStream.ReadByte();
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    #endregion
+}

--- a/tests/Framework.Blobs.Abstractions.Tests.Unit/BlobStorageExtensionsTests.cs
+++ b/tests/Framework.Blobs.Abstractions.Tests.Unit/BlobStorageExtensionsTests.cs
@@ -1,0 +1,439 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Framework.Blobs;
+using Framework.Testing.Tests;
+
+namespace Tests;
+
+public sealed class BlobStorageExtensionsTests : TestBase
+{
+    private readonly IBlobStorage _storage = Substitute.For<IBlobStorage>();
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        await _storage.DisposeAsync();
+        await base.DisposeAsyncCore();
+    }
+
+    #region UploadAsync (with BlobUploadRequest) Tests
+
+    [Fact]
+    public async Task should_delegate_to_core_upload_when_using_request_object()
+    {
+        // Arrange
+        string[] container = ["bucket", "uploads"];
+        var stream = new MemoryStream([1, 2, 3]);
+        var metadata = new Dictionary<string, string?> { ["key"] = "value" };
+        var request = new BlobUploadRequest(stream, "test.txt", metadata);
+
+        // Act
+        await _storage.UploadAsync(container, request, AbortToken);
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, "test.txt", stream, metadata, AbortToken);
+    }
+
+    [Fact]
+    public async Task should_pass_metadata_from_request_when_metadata_is_provided()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var metadata = new Dictionary<string, string?> { ["contentType"] = "text/plain", ["author"] = "test" };
+        var request = new BlobUploadRequest(new MemoryStream(), "file.txt", metadata);
+
+        // Act
+        await _storage.UploadAsync(container, request, AbortToken);
+
+        // Assert
+        await _storage
+            .Received(1)
+            .UploadAsync(
+                container,
+                "file.txt",
+                Arg.Any<Stream>(),
+                Arg.Is<Dictionary<string, string?>>(m => m["contentType"] == "text/plain" && m["author"] == "test"),
+                AbortToken
+            );
+    }
+
+    #endregion
+
+    #region GetBlobsListAsync Tests
+
+    [Fact]
+    public async Task should_collect_all_pages_when_iterating_through_results()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+
+        var page1Blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file1.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+            new()
+            {
+                BlobKey = "file2.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        var page2Blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file3.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        var page1Result = new PagedFileListResult(
+            page1Blobs,
+            hasMore: true,
+            (_, _) =>
+                ValueTask.FromResult<INextPageResult>(
+                    new NextPageResult
+                    {
+                        Success = true,
+                        HasMore = false,
+                        Blobs = page2Blobs,
+                        NextPageFunc = null,
+                    }
+                )
+        );
+
+        _storage.GetPagedListAsync(container, null, Arg.Any<int>(), AbortToken).Returns(page1Result);
+
+        // Act
+        var result = await _storage.GetBlobsListAsync(container, cancellationToken: AbortToken);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result.Select(b => b.BlobKey).Should().BeEquivalentTo(["file1.txt", "file2.txt", "file3.txt"]);
+    }
+
+    [Fact]
+    public async Task should_respect_limit_parameter_when_limit_is_set()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+
+        var blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file1.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+            new()
+            {
+                BlobKey = "file2.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+            new()
+            {
+                BlobKey = "file3.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        var pageResult = new PagedFileListResult(
+            blobs,
+            hasMore: true,
+            (_, _) =>
+                ValueTask.FromResult<INextPageResult>(
+                    new NextPageResult
+                    {
+                        Success = true,
+                        HasMore = true,
+                        Blobs = blobs,
+                    }
+                )
+        );
+
+        _storage.GetPagedListAsync(container, null, 2, AbortToken).Returns(pageResult);
+
+        // Act
+        var result = await _storage.GetBlobsListAsync(container, limit: 2, cancellationToken: AbortToken);
+
+        // Assert - first page returns 3 but limit stops further pages
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task should_use_default_limit_of_1m_when_limit_not_specified()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobs = new List<BlobInfo>();
+        var pageResult = new PagedFileListResult(blobs);
+
+        _storage.GetPagedListAsync(container, null, 1_000_000, AbortToken).Returns(pageResult);
+
+        // Act
+        await _storage.GetBlobsListAsync(container, cancellationToken: AbortToken);
+
+        // Assert
+        await _storage.Received(1).GetPagedListAsync(container, null, 1_000_000, AbortToken);
+    }
+
+    #endregion
+
+    #region UploadContentAsync (string) Tests
+
+    [Fact]
+    public async Task should_upload_string_content_when_content_is_provided()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "test.txt";
+        var contents = "Hello, World!";
+
+        // Act
+        await _storage.UploadContentAsync(container, blobName, contents, AbortToken);
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, blobName, Arg.Any<Stream>(), null, AbortToken);
+    }
+
+    [Fact]
+    public async Task should_handle_null_content_when_string_is_null()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "test.txt";
+        string? contents = null;
+
+        // Act
+        await _storage.UploadContentAsync(container, blobName, contents, AbortToken);
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, blobName, Arg.Any<Stream>(), null, AbortToken);
+    }
+
+    [Fact]
+    public async Task should_pass_metadata_when_uploading_string_with_metadata()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "test.txt";
+        var contents = "content";
+        var metadata = new Dictionary<string, string?> { ["type"] = "text" };
+
+        // Act
+        await _storage.UploadContentAsync(container, blobName, contents, metadata, AbortToken);
+
+        // Assert
+        await _storage
+            .Received(1)
+            .UploadAsync(
+                container,
+                blobName,
+                Arg.Any<Stream>(),
+                Arg.Is<Dictionary<string, string?>>(m => m["type"] == "text"),
+                AbortToken
+            );
+    }
+
+    #endregion
+
+    #region UploadContentAsync<T> (JSON) Tests
+
+    [Fact]
+    public async Task should_serialize_object_to_json_when_uploading_typed_content()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "data.json";
+        var contents = new TestData { Name = "Test", Value = 42 };
+
+        // Act
+        await _storage.UploadContentAsync(container, blobName, contents, AbortToken);
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, blobName, Arg.Any<Stream>(), null, AbortToken);
+    }
+
+    [Fact]
+    public async Task should_handle_null_object_when_uploading_null_typed_content()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "data.json";
+        TestData? contents = null;
+
+        // Act
+        await _storage.UploadContentAsync(container, blobName, contents, AbortToken);
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, blobName, Arg.Any<Stream>(), null, AbortToken);
+    }
+
+    [Fact]
+    public async Task should_use_provided_options_when_custom_json_options_provided()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "data.json";
+        var contents = new TestData { Name = "Test", Value = 42 };
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        // Act
+        await _storage.UploadContentAsync(container, blobName, contents, options, AbortToken);
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, blobName, Arg.Any<Stream>(), null, AbortToken);
+    }
+
+    [Fact]
+    public async Task should_use_json_type_info_for_aot_when_type_info_provided()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "data.json";
+        var contents = new TestData { Name = "AOT Test", Value = 100 };
+
+        // Act
+        await _storage.UploadContentAsync(
+            container,
+            blobName,
+            contents,
+            TestDataJsonContext.Default.TestData,
+            AbortToken
+        );
+
+        // Assert
+        await _storage.Received(1).UploadAsync(container, blobName, Arg.Any<Stream>(), null, AbortToken);
+    }
+
+    #endregion
+
+    #region GetBlobContentAsync Tests
+
+    [Fact]
+    public async Task should_return_null_when_blob_not_found()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "nonexistent.txt";
+
+        _storage.OpenReadStreamAsync(container, blobName, AbortToken).Returns((BlobDownloadResult?)null);
+
+        // Act
+        var result = await _storage.GetBlobContentAsync(container, blobName, AbortToken);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_read_string_content_when_blob_exists()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "test.txt";
+        var expectedContent = "Hello, World!";
+
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(expectedContent));
+        await using var downloadResult = new BlobDownloadResult(stream, blobName);
+
+        _storage.OpenReadStreamAsync(container, blobName, AbortToken).Returns(downloadResult);
+
+        // Act
+        var result = await _storage.GetBlobContentAsync(container, blobName, AbortToken);
+
+        // Assert
+        result.Should().Be(expectedContent);
+    }
+
+    #endregion
+
+    #region GetBlobContentAsync<T> (JSON) Tests
+
+    [Fact]
+    public async Task should_deserialize_json_content_when_blob_contains_json()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "data.json";
+        var json = """{"Name":"Deserialized","Value":99}""";
+
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var downloadResult = new BlobDownloadResult(stream, blobName);
+
+        _storage.OpenReadStreamAsync(container, blobName, AbortToken).Returns(downloadResult);
+
+        // Act
+        var result = await _storage.GetBlobContentAsync<TestData>(container, blobName, cancellationToken: AbortToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Deserialized");
+        result.Value.Should().Be(99);
+    }
+
+    [Fact]
+    public async Task should_return_default_when_blob_not_found_for_typed_content()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "nonexistent.json";
+
+        _storage.OpenReadStreamAsync(container, blobName, AbortToken).Returns((BlobDownloadResult?)null);
+
+        // Act
+        var result = await _storage.GetBlobContentAsync<TestData>(container, blobName, cancellationToken: AbortToken);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_use_json_type_info_for_aot_deserialization_when_type_info_provided()
+    {
+        // Arrange
+        string[] container = ["bucket"];
+        var blobName = "data.json";
+        var json = """{"Name":"AOT","Value":123}""";
+
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var downloadResult = new BlobDownloadResult(stream, blobName);
+
+        _storage.OpenReadStreamAsync(container, blobName, AbortToken).Returns(downloadResult);
+
+        // Act
+        var result = await _storage.GetBlobContentAsync(
+            container,
+            blobName,
+            TestDataJsonContext.Default.TestData,
+            AbortToken
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("AOT");
+        result.Value.Should().Be(123);
+    }
+
+    #endregion
+}
+
+public sealed class TestData
+{
+    public string Name { get; set; } = "";
+    public int Value { get; set; }
+}
+
+[JsonSerializable(typeof(TestData))]
+internal sealed partial class TestDataJsonContext : JsonSerializerContext;

--- a/tests/Framework.Blobs.Abstractions.Tests.Unit/BlobStorageHelpersTests.cs
+++ b/tests/Framework.Blobs.Abstractions.Tests.Unit/BlobStorageHelpersTests.cs
@@ -1,0 +1,335 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs.Internals;
+using Framework.Testing.Tests;
+
+namespace Tests;
+
+public sealed class BlobStorageHelpersTests : TestBase
+{
+    #region NormalizePath Tests
+
+    [Fact]
+    public void should_return_null_for_null_when_normalizing_path()
+    {
+        // Arrange
+        string? path = null;
+
+        // Act
+        var result = BlobStorageHelpers.NormalizePath(path);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_preserve_unix_slashes_when_path_uses_forward_slashes()
+    {
+        // Arrange
+        var path = "a/b/c";
+
+        // Act
+        var result = BlobStorageHelpers.NormalizePath(path);
+
+        // Assert
+        result.Should().Be("a/b/c");
+    }
+
+    [Fact]
+    public void should_convert_backslashes_to_forward_when_path_uses_backslashes()
+    {
+        // Arrange
+        var path = "a\\b\\c";
+
+        // Act
+        var result = BlobStorageHelpers.NormalizePath(path);
+
+        // Assert
+        result.Should().Be("a/b/c");
+    }
+
+    [Fact]
+    public void should_handle_mixed_slashes_when_path_has_both_slash_types()
+    {
+        // Arrange
+        var path = "a/b\\c/d";
+
+        // Act
+        var result = BlobStorageHelpers.NormalizePath(path);
+
+        // Assert
+        result.Should().Be("a/b/c/d");
+    }
+
+    [Fact]
+    public void should_preserve_empty_string_when_path_is_empty()
+    {
+        // Arrange
+        var path = "";
+
+        // Act
+        var result = BlobStorageHelpers.NormalizePath(path);
+
+        // Assert
+        result.Should().Be("");
+    }
+
+    [Fact]
+    public void should_handle_single_backslash_when_path_is_single_separator()
+    {
+        // Arrange
+        var path = "\\";
+
+        // Act
+        var result = BlobStorageHelpers.NormalizePath(path);
+
+        // Assert
+        result.Should().Be("/");
+    }
+
+    #endregion
+
+    #region GetRequestCriteria Tests
+
+    [Fact]
+    public void should_return_empty_prefix_for_no_pattern_when_search_pattern_is_null()
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        string? pattern = null;
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().Be("dir");
+        result.Pattern.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_combine_directories_and_pattern_when_both_provided()
+    {
+        // Arrange
+        string[] directories = ["a", "b"];
+        var pattern = "*.txt";
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().Be("a/b/");
+        result.Pattern.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_use_pattern_as_prefix_without_wildcard_when_pattern_has_no_star()
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        var pattern = "file.txt";
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().Be("dir/file.txt");
+        result.Pattern.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_extract_prefix_before_wildcard_when_pattern_has_star_in_subpath()
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        var pattern = "sub/*.txt";
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().Be("dir/sub/");
+        result.Pattern.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_handle_wildcard_in_filename_when_star_in_file_part()
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        var pattern = "file*.txt";
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().Be("dir/");
+        result.Pattern.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_return_empty_for_empty_directories_and_null_pattern()
+    {
+        // Arrange
+        string[] directories = [];
+        string? pattern = null;
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().BeEmpty();
+        result.Pattern.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_handle_backslashes_in_pattern_when_pattern_uses_windows_paths()
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        var pattern = "sub\\*.txt";
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().Be("dir/sub/");
+        result.Pattern.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_set_prefix_to_empty_when_wildcard_at_start_without_directory()
+    {
+        // Arrange
+        string[] directories = [];
+        var pattern = "*.txt";
+
+        // Act
+        var result = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Assert
+        result.Prefix.Should().BeEmpty();
+        result.Pattern.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region SearchCriteria Regex Tests
+
+    [Theory]
+    [InlineData("file.txt", true)]
+    [InlineData("document.txt", true)]
+    [InlineData("file.json", false)]
+    [InlineData("file.txt.bak", false)]
+    public void should_match_single_star_pattern_when_checking_txt_files(string testPath, bool shouldMatch)
+    {
+        // Arrange
+        string[] directories = [];
+        var pattern = "*.txt";
+        var criteria = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Act
+        var isMatch = criteria.Pattern!.IsMatch(testPath);
+
+        // Assert
+        isMatch.Should().Be(shouldMatch);
+    }
+
+    [Theory]
+    [InlineData("dir/sub/file.txt", true)]
+    [InlineData("dir/sub/document.txt", true)]
+    [InlineData("dir/other/file.txt", false)]
+    public void should_match_full_path_pattern_when_checking_directory_prefix(string testPath, bool shouldMatch)
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        var pattern = "sub/*.txt";
+        var criteria = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Act
+        var isMatch = criteria.Pattern!.IsMatch(testPath);
+
+        // Assert
+        isMatch.Should().Be(shouldMatch);
+    }
+
+    [Fact]
+    public void should_escape_regex_special_chars_when_pattern_contains_brackets()
+    {
+        // Arrange
+        string[] directories = ["dir"];
+        var pattern = "file[1].txt";
+        var criteria = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Act & Assert - no wildcard means exact match via prefix, no regex pattern
+        criteria.Pattern.Should().BeNull();
+        criteria.Prefix.Should().Be("dir/file[1].txt");
+    }
+
+    [Fact]
+    public void should_match_multiple_stars_when_pattern_has_multiple_wildcards()
+    {
+        // Arrange
+        string[] directories = [];
+        var pattern = "*.test.*.txt";
+        var criteria = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Act
+        var isMatch = criteria.Pattern!.IsMatch("file.test.backup.txt");
+
+        // Assert
+        isMatch.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("file-a.txt", true)]
+    [InlineData("file-.txt", true)]
+    [InlineData("file-abc.txt", true)]
+    [InlineData("file.txt", false)]
+    public void should_match_star_wildcard_pattern_when_checking_various_filenames(string testPath, bool shouldMatch)
+    {
+        // Arrange
+        string[] directories = [];
+        var pattern = "file-*.txt";
+        var criteria = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Act
+        var isMatch = criteria.Pattern!.IsMatch(testPath);
+
+        // Assert
+        isMatch.Should().Be(shouldMatch);
+    }
+
+    [Fact]
+    public void should_match_star_only_pattern_when_pattern_is_just_star()
+    {
+        // Arrange
+        string[] directories = [];
+        var pattern = "*";
+        var criteria = BlobStorageHelpers.GetRequestCriteria(directories, pattern);
+
+        // Act & Assert
+        criteria.Pattern!.IsMatch("anything.txt").Should().BeTrue();
+        criteria.Pattern.IsMatch("folder/file.txt").Should().BeTrue();
+        criteria.Pattern.IsMatch("").Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Metadata Key Constants Tests
+
+    [Fact]
+    public void should_have_correct_upload_date_metadata_key()
+    {
+        // Assert
+        BlobStorageHelpers.UploadDateMetadataKey.Should().Be("uploadDate");
+    }
+
+    [Fact]
+    public void should_have_correct_extension_metadata_key()
+    {
+        // Assert
+        BlobStorageHelpers.ExtensionMetadataKey.Should().Be("extension");
+    }
+
+    #endregion
+}

--- a/tests/Framework.Blobs.Abstractions.Tests.Unit/ContractTypesTests.cs
+++ b/tests/Framework.Blobs.Abstractions.Tests.Unit/ContractTypesTests.cs
@@ -1,0 +1,375 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Diagnostics;
+using Framework.Blobs;
+using Framework.Testing.Tests;
+
+namespace Tests;
+
+public sealed class ContractTypesTests : TestBase
+{
+    #region BlobInfo Tests
+
+    [Fact]
+    public void should_require_blob_key_when_creating_blob_info()
+    {
+        // Arrange & Act
+        var blobInfo = new BlobInfo
+        {
+            BlobKey = "folder/file.txt",
+            Created = DateTimeOffset.UtcNow,
+            Modified = DateTimeOffset.UtcNow,
+        };
+
+        // Assert
+        blobInfo.BlobKey.Should().Be("folder/file.txt");
+    }
+
+    [Fact]
+    public void should_require_created_when_creating_blob_info()
+    {
+        // Arrange
+        var created = DateTimeOffset.UtcNow.AddDays(-1);
+
+        // Act
+        var blobInfo = new BlobInfo
+        {
+            BlobKey = "file.txt",
+            Created = created,
+            Modified = DateTimeOffset.UtcNow,
+        };
+
+        // Assert
+        blobInfo.Created.Should().Be(created);
+    }
+
+    [Fact]
+    public void should_require_modified_when_creating_blob_info()
+    {
+        // Arrange
+        var modified = DateTimeOffset.UtcNow;
+
+        // Act
+        var blobInfo = new BlobInfo
+        {
+            BlobKey = "file.txt",
+            Created = DateTimeOffset.UtcNow.AddDays(-1),
+            Modified = modified,
+        };
+
+        // Assert
+        blobInfo.Modified.Should().Be(modified);
+    }
+
+    [Fact]
+    public void should_store_size_when_size_is_set()
+    {
+        // Arrange & Act
+        var blobInfo = new BlobInfo
+        {
+            BlobKey = "file.txt",
+            Created = DateTimeOffset.UtcNow,
+            Modified = DateTimeOffset.UtcNow,
+            Size = 1024,
+        };
+
+        // Assert
+        blobInfo.Size.Should().Be(1024);
+    }
+
+    [Fact]
+    public void should_store_metadata_when_metadata_is_provided()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, string?> { ["contentType"] = "text/plain" };
+
+        // Act
+        var blobInfo = new BlobInfo
+        {
+            BlobKey = "file.txt",
+            Created = DateTimeOffset.UtcNow,
+            Modified = DateTimeOffset.UtcNow,
+            Metadata = metadata,
+        };
+
+        // Assert
+        blobInfo.Metadata.Should().NotBeNull();
+        blobInfo.Metadata!["contentType"].Should().Be("text/plain");
+    }
+
+    [Fact]
+    public void should_have_debugger_display_when_inspecting_blob_info()
+    {
+        // Arrange & Act
+        var type = typeof(BlobInfo);
+
+        // Assert
+        var attribute = type.GetCustomAttributes(typeof(DebuggerDisplayAttribute), false);
+        attribute.Should().HaveCount(1);
+    }
+
+    #endregion
+
+    #region BlobUploadRequest Tests
+
+    [Fact]
+    public void should_store_filename_when_creating_upload_request()
+    {
+        // Arrange
+        var stream = new MemoryStream();
+
+        // Act
+        var request = new BlobUploadRequest(stream, "document.pdf");
+
+        // Assert
+        request.FileName.Should().Be("document.pdf");
+    }
+
+    [Fact]
+    public void should_store_stream_when_creating_upload_request()
+    {
+        // Arrange
+        var stream = new MemoryStream([1, 2, 3]);
+
+        // Act
+        var request = new BlobUploadRequest(stream, "file.bin");
+
+        // Assert
+        request.Stream.Should().BeSameAs(stream);
+    }
+
+    [Fact]
+    public void should_store_metadata_when_creating_upload_request_with_metadata()
+    {
+        // Arrange
+        var stream = new MemoryStream();
+        var metadata = new Dictionary<string, string?> { ["author"] = "test" };
+
+        // Act
+        var request = new BlobUploadRequest(stream, "file.txt", metadata);
+
+        // Assert
+        request.Metadata.Should().NotBeNull();
+        request.Metadata!["author"].Should().Be("test");
+    }
+
+    [Fact]
+    public void should_have_null_metadata_when_not_provided_in_upload_request()
+    {
+        // Arrange
+        var stream = new MemoryStream();
+
+        // Act
+        var request = new BlobUploadRequest(stream, "file.txt");
+
+        // Assert
+        request.Metadata.Should().BeNull();
+    }
+
+    #endregion
+
+    #region NextPageResult Tests
+
+    [Fact]
+    public void should_return_has_more_true_when_next_page_exists()
+    {
+        // Arrange & Act
+        var result = new NextPageResult
+        {
+            Success = true,
+            HasMore = true,
+            Blobs = [],
+            NextPageFunc = (_, _) => ValueTask.FromResult<INextPageResult>(null!),
+        };
+
+        // Assert
+        result.HasMore.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_return_has_more_false_when_no_next_page()
+    {
+        // Arrange & Act
+        var result = new NextPageResult
+        {
+            Success = true,
+            HasMore = false,
+            Blobs = [],
+            NextPageFunc = null,
+        };
+
+        // Assert
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_store_blobs_collection_when_blobs_are_provided()
+    {
+        // Arrange
+        var blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file1.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+            new()
+            {
+                BlobKey = "file2.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        // Act
+        var result = new NextPageResult
+        {
+            Success = true,
+            HasMore = false,
+            Blobs = blobs,
+        };
+
+        // Assert
+        result.Blobs.Should().HaveCount(2);
+        result.Blobs.Select(b => b.BlobKey).Should().BeEquivalentTo(["file1.txt", "file2.txt"]);
+    }
+
+    #endregion
+
+    #region PagedFileListResult Tests
+
+    [Fact]
+    public void should_create_empty_result_when_using_empty_static()
+    {
+        // Act
+        var result = PagedFileListResult.Empty;
+
+        // Assert
+        result.Blobs.Should().BeEmpty();
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_create_result_with_blobs_when_using_constructor()
+    {
+        // Arrange
+        var blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "test.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        // Act
+        var result = new PagedFileListResult(blobs);
+
+        // Assert
+        result.Blobs.Should().HaveCount(1);
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_navigate_to_next_page_when_next_page_func_provided()
+    {
+        // Arrange
+        var page1Blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file1.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        var page2Blobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file2.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        var result = new PagedFileListResult(
+            page1Blobs,
+            hasMore: true,
+            (_, _) =>
+                ValueTask.FromResult<INextPageResult>(
+                    new NextPageResult
+                    {
+                        Success = true,
+                        HasMore = false,
+                        Blobs = page2Blobs,
+                    }
+                )
+        );
+
+        // Act
+        var hasNext = await result.NextPageAsync(AbortToken);
+
+        // Assert
+        hasNext.Should().BeTrue();
+        result.Blobs.Should().HaveCount(1);
+        result.Blobs.First().BlobKey.Should().Be("file2.txt");
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_return_false_when_no_next_page_func()
+    {
+        // Arrange
+        var blobs = new List<BlobInfo>();
+        var result = new PagedFileListResult(blobs);
+
+        // Act
+        var hasNext = await result.NextPageAsync(AbortToken);
+
+        // Assert
+        hasNext.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_handle_failed_next_page_when_success_is_false()
+    {
+        // Arrange
+        var initialBlobs = new List<BlobInfo>
+        {
+            new()
+            {
+                BlobKey = "file1.txt",
+                Created = DateTimeOffset.Now,
+                Modified = DateTimeOffset.Now,
+            },
+        };
+
+        var result = new PagedFileListResult(
+            initialBlobs,
+            hasMore: true,
+            (_, _) =>
+                ValueTask.FromResult<INextPageResult>(
+                    new NextPageResult
+                    {
+                        Success = false,
+                        HasMore = false,
+                        Blobs = [],
+                    }
+                )
+        );
+
+        // Act
+        var hasNext = await result.NextPageAsync(AbortToken);
+
+        // Assert
+        hasNext.Should().BeFalse();
+        result.Blobs.Should().BeEmpty();
+        result.HasMore.Should().BeFalse();
+    }
+
+    #endregion
+}

--- a/tests/Framework.Blobs.Abstractions.Tests.Unit/Framework.Blobs.Abstractions.Tests.Unit.csproj
+++ b/tests/Framework.Blobs.Abstractions.Tests.Unit/Framework.Blobs.Abstractions.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Blobs.Abstractions\Framework.Blobs.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Blobs.Abstractions.Tests.Unit/PathValidationTests.cs
+++ b/tests/Framework.Blobs.Abstractions.Tests.Unit/PathValidationTests.cs
@@ -1,0 +1,568 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs.Internals;
+using Framework.Testing.Tests;
+
+namespace Tests;
+
+public sealed class PathValidationTests : TestBase
+{
+    #region ThrowIfPathTraversal Tests
+
+    [Fact]
+    public void should_allow_null_path_when_checking_path_traversal()
+    {
+        // Arrange
+        string? path = null;
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_empty_path_when_checking_path_traversal()
+    {
+        // Arrange
+        var path = "";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_simple_path_when_checking_path_traversal()
+    {
+        // Arrange
+        var path = "folder/file.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_throw_for_unix_traversal_when_path_contains_parent_directory()
+    {
+        // Arrange
+        var path = "../secret.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_throw_for_windows_traversal_when_path_contains_backslash_parent()
+    {
+        // Arrange
+        var path = "..\\secret.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_throw_for_mid_path_unix_traversal_when_path_contains_embedded_parent()
+    {
+        // Arrange
+        var path = "folder/../secret.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_throw_for_mid_path_windows_traversal_when_path_contains_embedded_backslash_parent()
+    {
+        // Arrange
+        var path = "folder\\..\\secret.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_throw_for_trailing_traversal_unix_when_path_ends_with_parent()
+    {
+        // Arrange
+        var path = "folder/..";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_throw_for_trailing_traversal_windows_when_path_ends_with_backslash_parent()
+    {
+        // Arrange
+        var path = "folder\\..";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_throw_for_starts_with_double_dot_when_path_begins_with_parent()
+    {
+        // Arrange
+        var path = "..";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_allow_single_dot_when_path_contains_current_directory()
+    {
+        // Arrange
+        var path = "./file.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_dotted_filename_when_file_has_double_dots_in_name()
+    {
+        // Arrange
+        var path = "file..name.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_include_param_name_in_exception_when_path_is_invalid()
+    {
+        // Arrange
+        var badPath = "../secret";
+
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(badPath);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().Which.ParamName.Should().Be("badPath");
+    }
+
+    [Theory]
+    [InlineData("a/../b")]
+    [InlineData("a/..\\b")]
+    [InlineData("a\\../b")]
+    [InlineData("..\\a")]
+    [InlineData("a/b/..")]
+    [InlineData("a\\b\\..")]
+    public void should_throw_for_various_traversal_patterns_when_path_contains_parent_directory(string path)
+    {
+        // Act
+        var act = () => PathValidation.ThrowIfPathTraversal(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region ThrowIfAbsolutePath Tests
+
+    [Fact]
+    public void should_allow_null_path_when_checking_absolute_path()
+    {
+        // Arrange
+        string? path = null;
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_empty_path_when_checking_absolute_path()
+    {
+        // Arrange
+        var path = "";
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_relative_path_when_checking_absolute_path()
+    {
+        // Arrange
+        var path = "folder/file.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_throw_for_unix_absolute_when_path_starts_with_forward_slash()
+    {
+        // Arrange
+        var path = "/etc/passwd";
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Absolute*");
+    }
+
+    [Fact]
+    public void should_throw_for_windows_absolute_when_path_starts_with_backslash()
+    {
+        // Arrange
+        var path = "\\Windows\\system32";
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Absolute*");
+    }
+
+    [Fact]
+    public void should_allow_path_with_mid_slash_when_slash_is_not_at_start()
+    {
+        // Arrange
+        var path = "folder/subfolder";
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_include_param_name_in_absolute_path_exception_when_path_is_absolute()
+    {
+        // Arrange
+        var absolutePath = "/root/secret";
+
+        // Act
+        var act = () => PathValidation.ThrowIfAbsolutePath(absolutePath);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().Which.ParamName.Should().Be("absolutePath");
+    }
+
+    #endregion
+
+    #region ThrowIfControlCharacters Tests
+
+    [Fact]
+    public void should_allow_null_path_when_checking_control_characters()
+    {
+        // Arrange
+        string? path = null;
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_empty_path_when_checking_control_characters()
+    {
+        // Arrange
+        var path = "";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_allow_normal_characters_when_path_has_standard_chars()
+    {
+        // Arrange
+        var path = "folder/file.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_throw_for_null_char_when_path_contains_null_byte()
+    {
+        // Arrange
+        var path = "file\0.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_throw_for_newline_when_path_contains_line_feed()
+    {
+        // Arrange
+        var path = "file\n.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_throw_for_carriage_return_when_path_contains_cr()
+    {
+        // Arrange
+        var path = "file\r.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_throw_for_tab_when_path_contains_horizontal_tab()
+    {
+        // Arrange
+        var path = "file\t.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_throw_for_bell_when_path_contains_bell_character()
+    {
+        // Arrange
+        var path = "file\x07.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_allow_space_when_path_contains_space_character()
+    {
+        // Arrange
+        var path = "file name.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("\x00")] // Null
+    [InlineData("\x01")] // Start of Heading
+    [InlineData("\x1F")] // Unit Separator (char 31, just below space)
+    public void should_throw_for_various_control_chars_when_path_contains_low_ascii(string controlChar)
+    {
+        // Arrange
+        var path = $"file{controlChar}.txt";
+
+        // Act
+        var act = () => PathValidation.ThrowIfControlCharacters(path);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region ValidatePathSegment Tests
+
+    [Fact]
+    public void should_combine_all_validations_when_validating_path_segment()
+    {
+        // Arrange - path with traversal
+        var pathWithTraversal = "../secret";
+
+        // Act
+        var act = () => PathValidation.ValidatePathSegment(pathWithTraversal);
+
+        // Assert - should throw for traversal
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_validate_absolute_path_in_segment_when_path_is_absolute()
+    {
+        // Arrange
+        var absolutePath = "/root";
+
+        // Act
+        var act = () => PathValidation.ValidatePathSegment(absolutePath);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Absolute*");
+    }
+
+    [Fact]
+    public void should_validate_control_chars_in_segment_when_path_has_control_chars()
+    {
+        // Arrange
+        var pathWithControl = "file\t.txt";
+
+        // Act
+        var act = () => PathValidation.ValidatePathSegment(pathWithControl);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_allow_valid_segment_when_path_is_clean()
+    {
+        // Arrange
+        var validPath = "folder/subfolder/file.txt";
+
+        // Act
+        var act = () => PathValidation.ValidatePathSegment(validPath);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region ValidateContainer Tests
+
+    [Fact]
+    public void should_validate_all_segments_when_validating_container()
+    {
+        // Arrange
+        string[] container = ["folder", "subfolder"];
+
+        // Act
+        var act = () => PathValidation.ValidateContainer(container);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_throw_on_first_invalid_segment_when_container_has_bad_segment()
+    {
+        // Arrange
+        string[] container = ["folder", "../secret", "another"];
+
+        // Act
+        var act = () => PathValidation.ValidateContainer(container);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*traversal*");
+    }
+
+    [Fact]
+    public void should_allow_valid_container_when_all_segments_are_valid()
+    {
+        // Arrange
+        string[] container = ["bucket", "users", "uploads"];
+
+        // Act
+        var act = () => PathValidation.ValidateContainer(container);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_throw_for_absolute_segment_in_container_when_segment_starts_with_slash()
+    {
+        // Arrange
+        string[] container = ["folder", "/absolute"];
+
+        // Act
+        var act = () => PathValidation.ValidateContainer(container);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Absolute*");
+    }
+
+    [Fact]
+    public void should_throw_for_control_char_in_container_when_segment_has_control_char()
+    {
+        // Arrange
+        string[] container = ["folder", "bad\0name"];
+
+        // Act
+        var act = () => PathValidation.ValidateContainer(container);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*Control*");
+    }
+
+    [Fact]
+    public void should_allow_empty_container_when_array_is_empty()
+    {
+        // Arrange
+        string[] container = [];
+
+        // Act
+        var act = () => PathValidation.ValidateContainer(container);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+}

--- a/tests/Framework.Blobs.Aws.Tests.Unit/AwsBlobNamingNormalizerTests.cs
+++ b/tests/Framework.Blobs.Aws.Tests.Unit/AwsBlobNamingNormalizerTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs.Aws;
+using Framework.Testing.Tests;
+
+namespace Tests;
+
+public sealed class AwsBlobNamingNormalizerTests : TestBase
+{
+    private readonly AwsBlobNamingNormalizer _sut = new();
+
+    #region NormalizeContainerName Tests
+
+    [Fact]
+    public void should_lowercase_container_name()
+    {
+        var result = _sut.NormalizeContainerName("MyBucket");
+
+        result.Should().Be("mybucket");
+    }
+
+    [Fact]
+    public void should_truncate_to_63_characters()
+    {
+        var longName = new string('a', 70);
+
+        var result = _sut.NormalizeContainerName(longName);
+
+        result.Should().HaveLength(63);
+    }
+
+    [Theory]
+    [InlineData("my_bucket!", "mybucket")]
+    [InlineData("my@bucket#test", "mybuckettest")]
+    [InlineData("BUCKET_NAME_123", "bucketname123")]
+    public void should_remove_invalid_characters(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my..bucket", "my.bucket")]
+    [InlineData("my...bucket", "my.bucket")]
+    [InlineData("a....b", "a.b")]
+    public void should_remove_multiple_consecutive_periods(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my-.bucket", "mybucket")]
+    [InlineData("test-.name", "testname")]
+    public void should_remove_hyphen_before_period(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my.-bucket", "mybucket")]
+    [InlineData("test.-name", "testname")]
+    public void should_remove_period_before_hyphen(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_remove_leading_hyphen()
+    {
+        // Regex only removes single leading hyphen per application
+        var result = _sut.NormalizeContainerName("-mybucket");
+
+        result.Should().Be("mybucket");
+    }
+
+    [Fact]
+    public void should_remove_trailing_hyphen()
+    {
+        // Regex only removes single trailing hyphen per application
+        var result = _sut.NormalizeContainerName("mybucket-");
+
+        result.Should().Be("mybucket");
+    }
+
+    [Theory]
+    [InlineData(".mybucket", "mybucket")]
+    [InlineData("..mybucket", "mybucket")]
+    public void should_remove_leading_period(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("mybucket.", "mybucket")]
+    [InlineData("mybucket..", "mybucket")]
+    public void should_remove_trailing_period(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_preserve_ip_like_strings()
+    {
+        // Note: The IP address regex is intentionally permissive;
+        // normal IP addresses pass through as-is since they are valid bucket names
+        var result = _sut.NormalizeContainerName("192.168.1.1");
+
+        result.Should().Be("192.168.1.1");
+    }
+
+    [Theory]
+    [InlineData("ab", "ab0")]
+    [InlineData("a", "a00")]
+    [InlineData("x", "x00")]
+    public void should_pad_short_names_to_minimum_3(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("abc", "abc")]
+    [InlineData("abcd", "abcd")]
+    [InlineData("my-bucket", "my-bucket")]
+    public void should_not_pad_names_with_3_or_more_chars(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("!!!", "000")]
+    [InlineData("@@@", "000")]
+    [InlineData("___", "000")]
+    public void should_handle_empty_after_normalization(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my-bucket.name", "my-bucket.name")]
+    [InlineData("valid-bucket-123", "valid-bucket-123")]
+    [InlineData("test.bucket.name", "test.bucket.name")]
+    public void should_preserve_valid_characters(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region NormalizeBlobName Tests
+
+    [Theory]
+    [InlineData("file.txt")]
+    [InlineData("folder/file.txt")]
+    [InlineData("folder/subfolder/file.txt")]
+    public void should_return_valid_blob_name(string blobName)
+    {
+        var result = _sut.NormalizeBlobName(blobName);
+
+        result.Should().Be(blobName);
+    }
+
+    [Theory]
+    [InlineData("../file.txt")]
+    [InlineData("folder/../file.txt")]
+    [InlineData("..\\file.txt")]
+    [InlineData("folder\\..\\file.txt")]
+    public void should_throw_for_path_traversal(string blobName)
+    {
+        var act = () => _sut.NormalizeBlobName(blobName);
+
+        act.Should().Throw<ArgumentException>().WithParameterName(nameof(blobName)).WithMessage("*path traversal*");
+    }
+
+    [Theory]
+    [InlineData("/file.txt")]
+    [InlineData("\\file.txt")]
+    [InlineData("/folder/file.txt")]
+    public void should_throw_for_absolute_path(string blobName)
+    {
+        var act = () => _sut.NormalizeBlobName(blobName);
+
+        act.Should().Throw<ArgumentException>().WithParameterName(nameof(blobName)).WithMessage("*Absolute paths*");
+    }
+
+    [Theory]
+    [InlineData("file\0.txt")]
+    [InlineData("file\n.txt")]
+    [InlineData("file\t.txt")]
+    public void should_throw_for_control_characters(string blobName)
+    {
+        var act = () => _sut.NormalizeBlobName(blobName);
+
+        act.Should().Throw<ArgumentException>().WithParameterName(nameof(blobName)).WithMessage("*Control characters*");
+    }
+
+    [Fact]
+    public void should_allow_blob_name_with_double_dots_not_followed_by_slash()
+    {
+        var result = _sut.NormalizeBlobName("file..name.txt");
+
+        result.Should().Be("file..name.txt");
+    }
+
+    #endregion
+}

--- a/tests/Framework.Blobs.Aws.Tests.Unit/Framework.Blobs.Aws.Tests.Unit.csproj
+++ b/tests/Framework.Blobs.Aws.Tests.Unit/Framework.Blobs.Aws.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Blobs.Aws\Framework.Blobs.Aws.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Blobs.Azure.Tests.Unit/AzureBlobNamingNormalizerTests.cs
+++ b/tests/Framework.Blobs.Azure.Tests.Unit/AzureBlobNamingNormalizerTests.cs
@@ -47,4 +47,124 @@ public sealed class AzureBlobNamingNormalizerTests
 
         result.Should().Be("file..name.txt");
     }
+
+    #region NormalizeContainerName
+
+    [Theory]
+    [InlineData("MyContainer", "mycontainer")]
+    [InlineData("UPPERCASE", "uppercase")]
+    [InlineData("MixedCase", "mixedcase")]
+    public void should_lowercase_container_name(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_truncate_to_63_characters()
+    {
+        var input = new string('a', 70);
+
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().HaveLength(63);
+        result.Should().Be(new string('a', 63));
+    }
+
+    [Theory]
+    [InlineData("my_container!", "mycontainer")]
+    [InlineData("my@container#test", "mycontainertest")]
+    [InlineData("container.name", "containername")]
+    public void should_remove_invalid_characters(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my--container", "my-container")]
+    [InlineData("my---container", "my-container")]
+    [InlineData("a--b--c", "a-b-c")]
+    public void should_remove_consecutive_dashes(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("-mycontainer", "mycontainer")]
+    [InlineData("--mycontainer", "mycontainer")]
+    public void should_remove_leading_dash(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("mycontainer-", "mycontainer")]
+    [InlineData("mycontainer--", "mycontainer")]
+    public void should_remove_trailing_dash(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_pad_short_names_to_minimum_3()
+    {
+        var result = _sut.NormalizeContainerName("ab");
+
+        result.Should().Be("ab0");
+    }
+
+    [Fact]
+    public void should_pad_very_short_names()
+    {
+        var result = _sut.NormalizeContainerName("a");
+
+        result.Should().Be("a00");
+    }
+
+    [Fact]
+    public void should_not_pad_names_with_3_or_more_chars()
+    {
+        var result = _sut.NormalizeContainerName("abc");
+
+        result.Should().Be("abc");
+    }
+
+    [Fact]
+    public void should_handle_empty_after_normalization()
+    {
+        var result = _sut.NormalizeContainerName("---");
+
+        result.Should().Be("000");
+    }
+
+    [Theory]
+    [InlineData("my-container1", "my-container1")]
+    [InlineData("abc-def-123", "abc-def-123")]
+    public void should_preserve_valid_characters(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_use_invariant_culture()
+    {
+        // Turkish I issue: 'I'.ToLower() in Turkish culture is 'ı' (dotless i)
+        // With invariant culture it should be 'i'
+        var result = _sut.NormalizeContainerName("ITEM");
+
+        result.Should().Be("item");
+    }
+
+    #endregion
 }

--- a/tests/Framework.Blobs.FileSystem.Tests.Unit/CrossOsNamingNormalizerTests.cs
+++ b/tests/Framework.Blobs.FileSystem.Tests.Unit/CrossOsNamingNormalizerTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs;
+
+namespace Tests;
+
+public sealed class CrossOsNamingNormalizerTests
+{
+    private readonly CrossOsNamingNormalizer _sut = new();
+
+    [Theory]
+    [InlineData("my container", "my container")]
+    [InlineData("container name with spaces", "container name with spaces")]
+    public void should_preserve_spaces_in_container_name(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my.container", "my.container")]
+    [InlineData("file.name.txt", "file.name.txt")]
+    public void should_preserve_dots_in_container_name(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("my_container", "my_container")]
+    [InlineData("container_with_underscores", "container_with_underscores")]
+    public void should_preserve_underscores_in_container_name(string input, string expected)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("/*?<>:|\"\\")]
+    [InlineData("/:*?\"<>|\\")]
+    public void should_handle_empty_result_after_normalization(string input)
+    {
+        var result = _sut.NormalizeContainerName(input);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void should_handle_unicode_characters()
+    {
+        // Chinese characters
+        _sut.NormalizeContainerName("\u6587\u4EF6\u5939").Should().Be("\u6587\u4EF6\u5939");
+
+        // Arabic characters
+        _sut.NormalizeContainerName("\u0645\u0644\u0641").Should().Be("\u0645\u0644\u0641");
+
+        // Emoji characters
+        _sut.NormalizeContainerName("\U0001F4C1folder").Should().Be("\U0001F4C1folder");
+    }
+}

--- a/tests/Framework.Blobs.FileSystem.Tests.Unit/FileSystemBlobStorageOptionsValidatorTests.cs
+++ b/tests/Framework.Blobs.FileSystem.Tests.Unit/FileSystemBlobStorageOptionsValidatorTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs.FileSystem;
+
+namespace Tests;
+
+public sealed class FileSystemBlobStorageOptionsValidatorTests
+{
+    private readonly FileSystemBlobStorageOptionsValidator _sut = new();
+
+    [Fact]
+    public void should_fail_when_base_directory_path_is_null()
+    {
+        // Given
+        var options = new FileSystemBlobStorageOptions { BaseDirectoryPath = null! };
+
+        // When
+        var result = _sut.Validate(options);
+
+        // Then
+        result.IsValid.Should().BeFalse();
+        result
+            .Errors.Should()
+            .ContainSingle()
+            .Which.PropertyName.Should()
+            .Be(nameof(FileSystemBlobStorageOptions.BaseDirectoryPath));
+    }
+
+    [Fact]
+    public void should_fail_when_base_directory_path_is_empty()
+    {
+        // Given
+        var options = new FileSystemBlobStorageOptions { BaseDirectoryPath = string.Empty };
+
+        // When
+        var result = _sut.Validate(options);
+
+        // Then
+        result.IsValid.Should().BeFalse();
+        result
+            .Errors.Should()
+            .ContainSingle()
+            .Which.PropertyName.Should()
+            .Be(nameof(FileSystemBlobStorageOptions.BaseDirectoryPath));
+    }
+
+    [Fact]
+    public void should_fail_when_base_directory_path_is_whitespace()
+    {
+        // Given
+        var options = new FileSystemBlobStorageOptions { BaseDirectoryPath = "   " };
+
+        // When
+        var result = _sut.Validate(options);
+
+        // Then
+        result.IsValid.Should().BeFalse();
+        result
+            .Errors.Should()
+            .ContainSingle()
+            .Which.PropertyName.Should()
+            .Be(nameof(FileSystemBlobStorageOptions.BaseDirectoryPath));
+    }
+
+    [Fact]
+    public void should_pass_for_valid_path()
+    {
+        // Given
+        var options = new FileSystemBlobStorageOptions { BaseDirectoryPath = "/var/blobs" };
+
+        // When
+        var result = _sut.Validate(options);
+
+        // Then
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Framework.Blobs.FileSystem.Tests.Unit/Framework.Blobs.FileSystem.Tests.Unit.csproj
+++ b/tests/Framework.Blobs.FileSystem.Tests.Unit/Framework.Blobs.FileSystem.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Blobs.FileSystem\Framework.Blobs.FileSystem.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Blobs.Redis.Tests.Unit/Framework.Blobs.Redis.Tests.Unit.csproj
+++ b/tests/Framework.Blobs.Redis.Tests.Unit/Framework.Blobs.Redis.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Blobs.Redis\Framework.Blobs.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Blobs.Redis.Tests.Unit/RedisBlobStorageOptionsValidatorTests.cs
+++ b/tests/Framework.Blobs.Redis.Tests.Unit/RedisBlobStorageOptionsValidatorTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs.Redis;
+using NSubstitute;
+using StackExchange.Redis;
+
+namespace Tests;
+
+public sealed class RedisBlobStorageOptionsValidatorTests
+{
+    private readonly RedisBlobStorageOptionsValidator _sut = new();
+
+    private static RedisBlobStorageOptions _CreateValidOptions() =>
+        new()
+        {
+            ConnectionMultiplexer = Substitute.For<IConnectionMultiplexer>(),
+            MaxBulkParallelism = 10,
+            MaxBlobSizeBytes = 10 * 1024 * 1024,
+        };
+
+    [Fact]
+    public void should_pass_for_valid_options()
+    {
+        // given
+        var options = _CreateValidOptions();
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_fail_when_connection_multiplexer_is_null()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.ConnectionMultiplexer = null!;
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == "ConnectionMultiplexer");
+    }
+
+    [Fact]
+    public void should_fail_when_max_bulk_parallelism_is_zero()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxBulkParallelism = 0;
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == "MaxBulkParallelism");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-10)]
+    [InlineData(int.MinValue)]
+    public void should_fail_when_max_bulk_parallelism_is_negative(int parallelism)
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxBulkParallelism = parallelism;
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == "MaxBulkParallelism");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    [InlineData(long.MinValue)]
+    public void should_fail_when_max_blob_size_bytes_is_negative(long maxSize)
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxBlobSizeBytes = maxSize;
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == "MaxBlobSizeBytes");
+    }
+
+    [Fact]
+    public void should_pass_when_max_blob_size_bytes_is_zero()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxBlobSizeBytes = 0;
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Framework.Blobs.SshNet.Tests.Unit/Framework.Blobs.SshNet.Tests.Unit.csproj
+++ b/tests/Framework.Blobs.SshNet.Tests.Unit/Framework.Blobs.SshNet.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Blobs.SshNet\Framework.Blobs.SshNet.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Blobs.SshNet.Tests.Unit/SftpClientPoolTests.cs
+++ b/tests/Framework.Blobs.SshNet.Tests.Unit/SftpClientPoolTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Blobs.SshNet;
+using Framework.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Renci.SshNet;
+
+namespace Tests;
+
+/// <summary>
+/// Tests for SftpClientPool connection string parsing and pool behavior.
+/// Note: Full pool behavior requires real SFTP connections (covered in integration tests).
+/// These tests focus on:
+/// - Options validation and configuration
+/// - Disposal behavior
+/// - Connection string format validation
+/// </summary>
+public sealed class SftpClientPoolTests : TestBase
+{
+    [Fact]
+    public async Task should_throw_when_disposed_on_acquire()
+    {
+        // given
+        var options = Options.Create(_CreateValidOptions());
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+        pool.Dispose();
+
+        // when
+        var act = async () => await pool.AcquireAsync(AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void should_be_idempotent_on_multiple_dispose()
+    {
+        // given
+        var options = Options.Create(_CreateValidOptions());
+        using var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // when
+        var act = () =>
+        {
+            pool.Dispose();
+            pool.Dispose();
+            pool.Dispose();
+        };
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_use_default_port_22_when_not_specified()
+    {
+        // given - connection string without port
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user:pass@example.com",
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when - creating pool succeeds (port parsing happens at connect time)
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then - pool is created without error
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_accept_connection_string_with_explicit_port()
+    {
+        // given
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user:pass@example.com:2222",
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_accept_url_encoded_credentials()
+    {
+        // given - username with @ symbol and password with special chars
+        // user@domain -> user%40domain, pass!word -> pass%21word
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user%40domain:pass%21word@example.com:22",
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_accept_connection_string_without_password()
+    {
+        // given - username only (uses NoneAuthenticationMethod or PrivateKey)
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user@example.com:22",
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_accept_proxy_configuration()
+    {
+        // given
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user:pass@example.com:22",
+                Proxy = "http://proxyuser:proxypass@proxy.example.com:8080",
+                ProxyType = ProxyTypes.Http,
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_infer_http_proxy_type_from_scheme()
+    {
+        // given - ProxyType is None but proxy URI has http scheme
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user:pass@example.com:22",
+                Proxy = "http://proxyuser:proxypass@proxy.example.com:8080",
+                ProxyType = ProxyTypes.None, // Should be inferred as Http
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_accept_socks5_proxy_type()
+    {
+        // given
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user:pass@example.com:22",
+                Proxy = "socks5://proxyuser:proxypass@proxy.example.com:1080",
+                ProxyType = ProxyTypes.Socks5,
+                MaxPoolSize = 1,
+                MaxConcurrentOperations = 1,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    [Fact]
+    public void should_respect_max_pool_size_configuration()
+    {
+        // given
+        const int maxPoolSize = 10;
+        var options = Options.Create(
+            new SshBlobStorageOptions
+            {
+                ConnectionString = "sftp://user:pass@example.com:22",
+                MaxPoolSize = maxPoolSize,
+                MaxConcurrentOperations = maxPoolSize,
+            }
+        );
+
+        // when
+        var pool = new SftpClientPool(options, NullLogger<SftpClientPool>.Instance);
+
+        // then - pool created with specified size (behavior verified in integration tests)
+        pool.Should().NotBeNull();
+        pool.Dispose();
+    }
+
+    private static SshBlobStorageOptions _CreateValidOptions()
+    {
+        return new SshBlobStorageOptions
+        {
+            ConnectionString = "sftp://user:pass@localhost:22",
+            MaxPoolSize = 4,
+            MaxConcurrentOperations = 4,
+        };
+    }
+}

--- a/tests/Framework.Blobs.SshNet.Tests.Unit/SshBlobStorageOptionsValidatorTests.cs
+++ b/tests/Framework.Blobs.SshNet.Tests.Unit/SshBlobStorageOptionsValidatorTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using FluentValidation.TestHelper;
+using Framework.Blobs.SshNet;
+using Renci.SshNet;
+
+namespace Tests;
+
+public sealed class SshBlobStorageOptionsValidatorTests
+{
+    private readonly SshBlobStorageOptionsValidator _sut = new();
+
+    [Fact]
+    public void should_fail_when_connection_string_is_empty()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.ConnectionString = string.Empty;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldHaveValidationErrorFor(x => x.ConnectionString);
+    }
+
+    [Fact]
+    public void should_fail_when_connection_string_is_null()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.ConnectionString = null!;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldHaveValidationErrorFor(x => x.ConnectionString);
+    }
+
+    [Fact]
+    public void should_fail_when_proxy_type_is_invalid()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.ProxyType = (ProxyTypes)999;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldHaveValidationErrorFor(x => x.ProxyType);
+    }
+
+    [Fact]
+    public void should_fail_when_max_concurrent_ops_is_zero()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxConcurrentOperations = 0;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldHaveValidationErrorFor(x => x.MaxConcurrentOperations);
+    }
+
+    [Fact]
+    public void should_fail_when_max_concurrent_ops_exceeds_100()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxConcurrentOperations = 101;
+        options.MaxPoolSize = 101;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldHaveValidationErrorFor(x => x.MaxConcurrentOperations);
+    }
+
+    [Fact]
+    public void should_fail_when_max_pool_size_less_than_concurrent_ops()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxConcurrentOperations = 10;
+        options.MaxPoolSize = 5;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result
+            .ShouldHaveValidationErrorFor(x => x.MaxPoolSize)
+            .WithErrorMessage("MaxPoolSize must be >= MaxConcurrentOperations");
+    }
+
+    [Fact]
+    public void should_pass_when_max_pool_size_equals_concurrent_ops()
+    {
+        // given
+        var options = _CreateValidOptions();
+        options.MaxConcurrentOperations = 10;
+        options.MaxPoolSize = 10;
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldNotHaveValidationErrorFor(x => x.MaxPoolSize);
+    }
+
+    [Fact]
+    public void should_pass_for_valid_options()
+    {
+        // given
+        var options = _CreateValidOptions();
+
+        // when
+        var result = _sut.TestValidate(options);
+
+        // then
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static SshBlobStorageOptions _CreateValidOptions()
+    {
+        return new SshBlobStorageOptions
+        {
+            ConnectionString = "sftp://user:pass@localhost:22",
+            ProxyType = ProxyTypes.None,
+            MaxConcurrentOperations = 4,
+            MaxPoolSize = 4,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for all 6 Framework.Blobs.* packages
- Focus on security-critical PathValidation, provider-specific naming normalization, and options validation
- Total: **233 new unit tests**

## Test Coverage by Package

| Package | Tests | Focus Areas |
|---------|-------|-------------|
| **Abstractions** | 121 | PathValidation (security), BlobStorageHelpers, Extensions, ContractTypes |
| **AWS** | 45 | AwsBlobNamingNormalizer - S3 bucket naming rules |
| **Azure** | 21 | NormalizeContainerName edge cases (added to existing) |
| **FileSystem** | 13 | OptionsValidator, CrossOsNamingNormalizer |
| **Redis** | 10 | RedisBlobStorageOptionsValidator |
| **SshNet** | 18 | OptionsValidator, SftpClientPool |

## Test Categories

### Security-Critical (Abstractions)
- Path traversal detection (`../`, `..\\`, `/..`)
- Absolute path detection (`/`, `\\` at start)
- Control character detection (chars < 32)
- Container validation for all segments

### Provider Naming Normalization
- S3 bucket rules: 3-63 chars, lowercase, no consecutive periods/hyphens
- Azure container rules: 3-63 chars, lowercase, only alphanumeric and dash
- FileSystem: Cross-OS invalid character removal

### Options Validation
- FluentValidation rules for all provider options
- Connection string validation, pool size constraints

## Testing
All 233 tests pass locally:
```
Abstractions: 121 passed
AWS: 45 passed
Azure: 26 passed (5 existing + 21 new)
FileSystem: 13 passed
Redis: 10 passed
SshNet: 18 passed
```