### PR TITLE
test(redis): add unit and integration tests for Framework.Redis

### DIFF
--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -200,6 +200,11 @@
         <File Path="nuget.config" />
         <File Path="README.md" />
     </Folder>
+    <Folder Name="/src/" />
+    <Folder Name="/tests/">
+        <Project Path="tests/Framework.Redis.Tests.Integration/Framework.Redis.Tests.Integration.csproj" />
+        <Project Path="tests/Framework.Redis.Tests.Unit/Framework.Redis.Tests.Unit.csproj" />
+    </Folder>
     <Folder Name="/Validations/">
         <Project Path="src/Framework.FluentValidation/Framework.FluentValidation.csproj" />
         <Project Path="tests/Framework.FluentValidation.Tests.Unit/Framework.FluentValidation.Tests.Unit.csproj" />

--- a/tests/Framework.Redis.Tests.Integration/ConnectionMultiplexerExtensionsTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/ConnectionMultiplexerExtensionsTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class ConnectionMultiplexerExtensionsTests(RedisTestFixture fixture)
+{
+    private ConnectionMultiplexer Multiplexer => fixture.ConnectionMultiplexer;
+    private IDatabase Db => Multiplexer.GetDatabase();
+
+    [Fact]
+    public async Task FlushAllAsync_should_remove_all_keys()
+    {
+        // given - ensure clean state
+        await Multiplexer.FlushAllAsync();
+
+        await Db.StringSetAsync("key1", "value1");
+        await Db.StringSetAsync("key2", "value2");
+        await Db.StringSetAsync("key3", "value3");
+
+        // when
+        await Multiplexer.FlushAllAsync();
+
+        // then
+        var count = await Multiplexer.CountAllKeysAsync();
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task FlushAllAsync_should_handle_empty_database()
+    {
+        // given - ensure clean state
+        await Multiplexer.FlushAllAsync();
+
+        // when / then - no exception
+        var act = async () => await Multiplexer.FlushAllAsync();
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task CountAllKeysAsync_should_return_total_key_count()
+    {
+        // given - ensure clean state
+        await Multiplexer.FlushAllAsync();
+
+        await Db.StringSetAsync("count-key1", "value1");
+        await Db.StringSetAsync("count-key2", "value2");
+        await Db.StringSetAsync("count-key3", "value3");
+        await Db.StringSetAsync("count-key4", "value4");
+        await Db.StringSetAsync("count-key5", "value5");
+
+        // when
+        var count = await Multiplexer.CountAllKeysAsync();
+
+        // then
+        count.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CountAllKeysAsync_should_return_zero_for_empty_database()
+    {
+        // given - ensure clean state
+        await Multiplexer.FlushAllAsync();
+
+        // when
+        var count = await Multiplexer.CountAllKeysAsync();
+
+        // then
+        count.Should().Be(0);
+    }
+}

--- a/tests/Framework.Redis.Tests.Integration/Framework.Redis.Tests.Integration.csproj
+++ b/tests/Framework.Redis.Tests.Integration/Framework.Redis.Tests.Integration.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.Redis" />
+    <PackageReference Include="Testcontainers.XunitV3" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Redis\Framework.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Redis.Tests.Integration/HeadlessRedisScriptsLoaderLoadingTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/HeadlessRedisScriptsLoaderLoadingTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using AwesomeAssertions;
+using Framework.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class HeadlessRedisScriptsLoaderLoadingTests(RedisTestFixture fixture)
+{
+    [Fact]
+    public async Task LoadScriptsAsync_should_load_all_scripts()
+    {
+        // given
+        var loader = new HeadlessRedisScriptsLoader(fixture.ConnectionMultiplexer);
+
+        // when
+        var act = async () => await loader.LoadScriptsAsync();
+
+        // then
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task LoadScriptsAsync_should_populate_script_properties()
+    {
+        // given
+        var loader = new HeadlessRedisScriptsLoader(fixture.ConnectionMultiplexer);
+
+        // when
+        await loader.LoadScriptsAsync();
+
+        // then
+        loader.IncrementWithExpireScript.Should().NotBeNull();
+        loader.RemoveIfEqualScript.Should().NotBeNull();
+        loader.ReplaceIfEqualScript.Should().NotBeNull();
+        loader.SetIfHigherScript.Should().NotBeNull();
+        loader.SetIfLowerScript.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task LoadScriptsAsync_should_be_idempotent()
+    {
+        // given
+        var loader = new HeadlessRedisScriptsLoader(fixture.ConnectionMultiplexer);
+
+        // when
+        await loader.LoadScriptsAsync();
+        var act = async () => await loader.LoadScriptsAsync();
+
+        // then
+        await act.Should().NotThrowAsync();
+        loader.IncrementWithExpireScript.Should().NotBeNull();
+        loader.RemoveIfEqualScript.Should().NotBeNull();
+        loader.ReplaceIfEqualScript.Should().NotBeNull();
+        loader.SetIfHigherScript.Should().NotBeNull();
+        loader.SetIfLowerScript.Should().NotBeNull();
+    }
+}

--- a/tests/Framework.Redis.Tests.Integration/IncrementAsyncTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/IncrementAsyncTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using AwesomeAssertions;
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class IncrementAsyncTests(RedisTestFixture fixture)
+{
+    private IDatabase Db => fixture.ConnectionMultiplexer.GetDatabase();
+    private HeadlessRedisScriptsLoader Loader => fixture.ScriptsLoader;
+
+    private async Task FlushAsync() => await fixture.ConnectionMultiplexer.FlushAllAsync();
+
+    #region Long tests
+
+    [Fact]
+    public async Task should_increment_existing_value_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "counter-long";
+        await Db.StringSetAsync(key, "10");
+
+        // when
+        var result = await Loader.IncrementAsync(Db, key, 5L, TimeSpan.FromMinutes(5));
+
+        // then
+        result.Should().Be(15);
+    }
+
+    [Fact]
+    public async Task should_create_key_with_value_when_not_exists_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "new-counter-long";
+
+        // when
+        var result = await Loader.IncrementAsync(Db, key, 10L, TimeSpan.FromMinutes(5));
+
+        // then
+        result.Should().Be(10);
+        var storedValue = await Db.StringGetAsync(key);
+        storedValue.ToString().Should().Be("10");
+    }
+
+    [Fact]
+    public async Task should_set_ttl_on_increment_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "counter-with-ttl-long";
+        var ttl = TimeSpan.FromMinutes(5);
+
+        // when
+        await Loader.IncrementAsync(Db, key, 1L, ttl);
+
+        // then
+        var actualTtl = await Db.KeyTimeToLiveAsync(key);
+        actualTtl.Should().NotBeNull();
+        actualTtl!.Value.TotalSeconds.Should().BeGreaterThan(0);
+        actualTtl.Value.TotalMinutes.Should().BeLessThanOrEqualTo(5);
+    }
+
+    [Fact]
+    public async Task should_handle_negative_increment_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "counter-negative-long";
+        await Db.StringSetAsync(key, "10");
+
+        // when
+        var result = await Loader.IncrementAsync(Db, key, -3L, TimeSpan.FromMinutes(5));
+
+        // then
+        result.Should().Be(7);
+    }
+
+    #endregion
+
+    #region Double tests
+
+    [Fact]
+    public async Task should_increment_existing_value_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "counter-double";
+        await Db.StringSetAsync(key, "10.5");
+
+        // when
+        var result = await Loader.IncrementAsync(Db, key, 2.5, TimeSpan.FromMinutes(5));
+
+        // then
+        result.Should().Be(13.0);
+    }
+
+    [Fact]
+    public async Task should_create_key_with_value_when_not_exists_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "new-counter-double";
+
+        // when
+        var result = await Loader.IncrementAsync(Db, key, 5.5, TimeSpan.FromMinutes(5));
+
+        // then
+        result.Should().Be(5.5);
+        var storedValue = await Db.StringGetAsync(key);
+        storedValue.ToString().Should().Be("5.5");
+    }
+
+    [Fact]
+    public async Task should_set_ttl_on_increment_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "counter-with-ttl-double";
+        var ttl = TimeSpan.FromMinutes(5);
+
+        // when
+        await Loader.IncrementAsync(Db, key, 1.5, ttl);
+
+        // then
+        var actualTtl = await Db.KeyTimeToLiveAsync(key);
+        actualTtl.Should().NotBeNull();
+        actualTtl!.Value.TotalSeconds.Should().BeGreaterThan(0);
+        actualTtl.Value.TotalMinutes.Should().BeLessThanOrEqualTo(5);
+    }
+
+    [Fact]
+    public async Task should_handle_negative_increment_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "counter-negative-double";
+        await Db.StringSetAsync(key, "10.0");
+
+        // when
+        var result = await Loader.IncrementAsync(Db, key, -3.5, TimeSpan.FromMinutes(5));
+
+        // then
+        result.Should().Be(6.5);
+    }
+
+    #endregion
+}

--- a/tests/Framework.Redis.Tests.Integration/RedisTestFixture.cs
+++ b/tests/Framework.Redis.Tests.Integration/RedisTestFixture.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Redis;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+using Testcontainers.Xunit;
+using Xunit.Sdk;
+
+namespace Tests;
+
+[CollectionDefinition(nameof(RedisTestFixture), DisableParallelization = false)]
+public sealed class RedisTestFixture(IMessageSink messageSink)
+    : ContainerFixture<RedisBuilder, RedisContainer>(messageSink),
+        ICollectionFixture<RedisTestFixture>
+{
+    public ConnectionMultiplexer ConnectionMultiplexer { get; private set; } = null!;
+
+    public HeadlessRedisScriptsLoader ScriptsLoader { get; private set; } = null!;
+
+    protected override RedisBuilder Configure()
+    {
+        return base.Configure().WithImage("redis:7-alpine");
+    }
+
+    protected override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        var connectionString = Container.GetConnectionString() + ",allowAdmin=true";
+
+        ConnectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(connectionString);
+        await ConnectionMultiplexer.FlushAllAsync();
+
+        ScriptsLoader = new HeadlessRedisScriptsLoader(ConnectionMultiplexer);
+        await ScriptsLoader.LoadScriptsAsync();
+    }
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        await base.DisposeAsyncCore();
+        await ConnectionMultiplexer.DisposeAsync();
+    }
+}

--- a/tests/Framework.Redis.Tests.Integration/RemoveIfEqualAsyncTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/RemoveIfEqualAsyncTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using AwesomeAssertions;
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class RemoveIfEqualAsyncTests(RedisTestFixture fixture)
+{
+    private IDatabase Db => fixture.ConnectionMultiplexer.GetDatabase();
+    private HeadlessRedisScriptsLoader Loader => fixture.ScriptsLoader;
+
+    private async Task FlushAsync() => await fixture.ConnectionMultiplexer.FlushAllAsync();
+
+    [Fact]
+    public async Task should_remove_when_expected_value_matches()
+    {
+        // given
+        await FlushAsync();
+        var key = "test-key";
+        await Db.StringSetAsync(key, "value");
+
+        // when
+        var result = await Loader.RemoveIfEqualAsync(Db, key, expectedValue: "value");
+
+        // then
+        result.Should().BeTrue();
+        var exists = await Db.KeyExistsAsync(key);
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_remove_when_expected_value_differs()
+    {
+        // given
+        await FlushAsync();
+        var key = "test-key";
+        await Db.StringSetAsync(key, "value");
+
+        // when
+        var result = await Loader.RemoveIfEqualAsync(Db, key, expectedValue: "wrong");
+
+        // then
+        result.Should().BeFalse();
+        var exists = await Db.KeyExistsAsync(key);
+        exists.Should().BeTrue();
+        var currentValue = await Db.StringGetAsync(key);
+        currentValue.ToString().Should().Be("value");
+    }
+
+    [Fact]
+    public async Task should_not_remove_when_key_not_exists()
+    {
+        // given
+        await FlushAsync();
+        var key = "nonexistent-key";
+
+        // when
+        var result = await Loader.RemoveIfEqualAsync(Db, key, expectedValue: "any-value");
+
+        // then
+        result.Should().BeFalse();
+    }
+}

--- a/tests/Framework.Redis.Tests.Integration/ReplaceIfEqualAsyncTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/ReplaceIfEqualAsyncTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class ReplaceIfEqualAsyncTests(RedisTestFixture fixture)
+{
+    private IDatabase Db => fixture.ConnectionMultiplexer.GetDatabase();
+    private HeadlessRedisScriptsLoader Loader => fixture.ScriptsLoader;
+
+    private async Task FlushAsync() => await fixture.ConnectionMultiplexer.FlushAllAsync();
+
+    [Fact]
+    public async Task should_replace_when_expected_value_matches()
+    {
+        // given
+        await FlushAsync();
+        var key = "test-key";
+        await Db.StringSetAsync(key, "old-value");
+
+        // when
+        var result = await Loader.ReplaceIfEqualAsync(Db, key, expectedValue: "old-value", newValue: "new-value");
+
+        // then
+        result.Should().BeTrue();
+        var value = await Db.StringGetAsync(key);
+        value.ToString().Should().Be("new-value");
+    }
+
+    [Fact]
+    public async Task should_replace_when_key_not_exists()
+    {
+        // given
+        await FlushAsync();
+        var key = "non-existent-key";
+
+        // when
+        var result = await Loader.ReplaceIfEqualAsync(Db, key, expectedValue: null, newValue: "new-value");
+
+        // then
+        result.Should().BeTrue();
+        var value = await Db.StringGetAsync(key);
+        value.ToString().Should().Be("new-value");
+    }
+
+    [Fact]
+    public async Task should_not_replace_when_expected_value_differs()
+    {
+        // given
+        await FlushAsync();
+        var key = "test-key";
+        await Db.StringSetAsync(key, "old-value");
+
+        // when
+        var result = await Loader.ReplaceIfEqualAsync(Db, key, expectedValue: "wrong-value", newValue: "new-value");
+
+        // then
+        result.Should().BeFalse();
+        var value = await Db.StringGetAsync(key);
+        value.ToString().Should().Be("old-value");
+    }
+
+    [Fact]
+    public async Task should_set_ttl_when_provided()
+    {
+        // given
+        await FlushAsync();
+        var key = "test-key-with-ttl";
+        await Db.StringSetAsync(key, "old-value");
+        var ttl = TimeSpan.FromMinutes(5);
+
+        // when
+        var result = await Loader.ReplaceIfEqualAsync(
+            Db,
+            key,
+            expectedValue: "old-value",
+            newValue: "new-value",
+            newTtl: ttl
+        );
+
+        // then
+        result.Should().BeTrue();
+        var keyTtl = await Db.KeyTimeToLiveAsync(key);
+        keyTtl.Should().NotBeNull();
+        keyTtl!.Value.Should().BeCloseTo(ttl, precision: TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task should_not_set_ttl_when_null()
+    {
+        // given
+        await FlushAsync();
+        var key = "test-key-no-ttl";
+        await Db.StringSetAsync(key, "old-value");
+
+        // when
+        var result = await Loader.ReplaceIfEqualAsync(
+            Db,
+            key,
+            expectedValue: "old-value",
+            newValue: "new-value",
+            newTtl: null
+        );
+
+        // then
+        result.Should().BeTrue();
+        var keyTtl = await Db.KeyTimeToLiveAsync(key);
+        keyTtl.Should().BeNull(); // no expiry means TTL is null (or -1 in raw Redis)
+    }
+}

--- a/tests/Framework.Redis.Tests.Integration/SetIfHigherAsyncTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/SetIfHigherAsyncTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using AwesomeAssertions;
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class SetIfHigherAsyncTests(RedisTestFixture fixture)
+{
+    private IDatabase Db => fixture.ConnectionMultiplexer.GetDatabase();
+    private HeadlessRedisScriptsLoader Loader => fixture.ScriptsLoader;
+
+    private async Task FlushAsync() => await fixture.ConnectionMultiplexer.FlushAllAsync();
+
+    #region Long overload tests
+
+    [Fact]
+    public async Task should_set_when_value_is_higher_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value";
+        await Db.StringSetAsync(key, "10");
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 15L);
+
+        // then
+        result.Should().Be(5); // delta = 15 - 10
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(15);
+    }
+
+    [Fact]
+    public async Task should_not_set_when_value_is_lower_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value";
+        await Db.StringSetAsync(key, "10");
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 5L);
+
+        // then
+        result.Should().Be(0);
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(10);
+    }
+
+    [Fact]
+    public async Task should_set_when_key_not_exists_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "nonexistent-key";
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 10L);
+
+        // then
+        result.Should().Be(10); // returns new value when key doesn't exist
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(10);
+    }
+
+    [Fact]
+    public async Task should_return_difference_when_set_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value";
+        await Db.StringSetAsync(key, "7");
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 12L);
+
+        // then
+        result.Should().Be(5); // delta = 12 - 7
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(12);
+    }
+
+    [Fact]
+    public async Task should_set_ttl_when_provided_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value-with-ttl";
+        var ttl = TimeSpan.FromSeconds(60);
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 10L, ttl);
+
+        // then
+        result.Should().Be(10);
+        var actualTtl = await Db.KeyTimeToLiveAsync(key);
+        actualTtl.Should().NotBeNull();
+        actualTtl!.Value.TotalSeconds.Should().BeInRange(55, 60);
+    }
+
+    #endregion
+
+    #region Double overload tests
+
+    [Fact]
+    public async Task should_set_when_value_is_higher_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value-double";
+        await Db.StringSetAsync(key, "10.5");
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 15.5);
+
+        // then
+        result.Should().Be(5.0); // delta = 15.5 - 10.5
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(15.5);
+    }
+
+    [Fact]
+    public async Task should_not_set_when_value_is_lower_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value-double";
+        await Db.StringSetAsync(key, "10.5");
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 5.5);
+
+        // then
+        result.Should().Be(0);
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(10.5);
+    }
+
+    [Fact]
+    public async Task should_set_when_key_not_exists_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "nonexistent-key-double";
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 10.5);
+
+        // then
+        result.Should().Be(10.5); // returns new value when key doesn't exist
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(10.5);
+    }
+
+    [Fact]
+    public async Task should_return_difference_when_set_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "max-value-double";
+        await Db.StringSetAsync(key, "7.5");
+
+        // when
+        var result = await Loader.SetIfHigherAsync(Db, key, 12.5);
+
+        // then
+        result.Should().Be(5.0); // delta = 12.5 - 7.5
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(12.5);
+    }
+
+    #endregion
+}

--- a/tests/Framework.Redis.Tests.Integration/SetIfLowerAsyncTests.cs
+++ b/tests/Framework.Redis.Tests.Integration/SetIfLowerAsyncTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using AwesomeAssertions;
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+[Collection(nameof(RedisTestFixture))]
+public sealed class SetIfLowerAsyncTests(RedisTestFixture fixture)
+{
+    private IDatabase Db => fixture.ConnectionMultiplexer.GetDatabase();
+    private HeadlessRedisScriptsLoader Loader => fixture.ScriptsLoader;
+
+    private async Task FlushAsync() => await fixture.ConnectionMultiplexer.FlushAllAsync();
+
+    #region Long overload tests
+
+    [Fact]
+    public async Task should_set_when_value_is_lower_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value";
+        await Db.StringSetAsync(key, "10");
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 5L);
+
+        // then
+        result.Should().Be(5); // delta = 10 - 5
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(5);
+    }
+
+    [Fact]
+    public async Task should_not_set_when_value_is_higher_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value";
+        await Db.StringSetAsync(key, "10");
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 15L);
+
+        // then
+        result.Should().Be(0);
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(10);
+    }
+
+    [Fact]
+    public async Task should_set_when_key_not_exists_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value-nonexistent";
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 10L);
+
+        // then
+        result.Should().Be(10);
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(10);
+    }
+
+    [Fact]
+    public async Task should_return_difference_when_set_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value";
+        await Db.StringSetAsync(key, "12");
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 7L);
+
+        // then
+        result.Should().Be(5); // 12 - 7 = 5
+        var value = await Db.StringGetAsync(key);
+        ((long)value).Should().Be(7);
+    }
+
+    [Fact]
+    public async Task should_set_ttl_when_provided_long()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value-with-ttl";
+        var ttl = TimeSpan.FromSeconds(60);
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 10L, ttl);
+
+        // then
+        result.Should().Be(10);
+        var actualTtl = await Db.KeyTimeToLiveAsync(key);
+        actualTtl.Should().NotBeNull();
+        actualTtl!.Value.TotalSeconds.Should().BeGreaterThan(50);
+        actualTtl.Value.TotalSeconds.Should().BeLessThanOrEqualTo(60);
+    }
+
+    #endregion
+
+    #region Double overload tests
+
+    [Fact]
+    public async Task should_set_when_value_is_lower_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value-double";
+        await Db.StringSetAsync(key, "10.5");
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 5.5);
+
+        // then
+        result.Should().Be(5.0); // delta = 10.5 - 5.5
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(5.5);
+    }
+
+    [Fact]
+    public async Task should_not_set_when_value_is_higher_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value-double";
+        await Db.StringSetAsync(key, "10.5");
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 15.5);
+
+        // then
+        result.Should().Be(0);
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(10.5);
+    }
+
+    [Fact]
+    public async Task should_set_when_key_not_exists_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value-double-nonexistent";
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 10.5);
+
+        // then
+        result.Should().Be(10.5);
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(10.5);
+    }
+
+    [Fact]
+    public async Task should_return_difference_when_set_double()
+    {
+        // given
+        await FlushAsync();
+        var key = "min-value-double";
+        await Db.StringSetAsync(key, "12.5");
+
+        // when
+        var result = await Loader.SetIfLowerAsync(Db, key, 7.5);
+
+        // then
+        result.Should().Be(5.0); // 12.5 - 7.5 = 5.0
+        var value = await Db.StringGetAsync(key);
+        ((double)value).Should().Be(7.5);
+    }
+
+    #endregion
+}

--- a/tests/Framework.Redis.Tests.Unit/Framework.Redis.Tests.Unit.csproj
+++ b/tests/Framework.Redis.Tests.Unit/Framework.Redis.Tests.Unit.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Framework.Redis\Framework.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Framework.Testing\Framework.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Framework.Redis.Tests.Unit/HeadlessRedisScriptsLoaderTests.cs
+++ b/tests/Framework.Redis.Tests.Unit/HeadlessRedisScriptsLoaderTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Redis;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Tests;
+
+public sealed class HeadlessRedisScriptsLoaderTests
+{
+    [Fact]
+    public void should_accept_null_timeProvider_and_use_system()
+    {
+        // given
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        // when
+        var act = () => new HeadlessRedisScriptsLoader(multiplexer, timeProvider: null);
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_accept_null_logger()
+    {
+        // given
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        // when
+        var act = () => new HeadlessRedisScriptsLoader(multiplexer, logger: null);
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_initialize_with_scripts_not_loaded()
+    {
+        // given
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        // when
+        var sut = new HeadlessRedisScriptsLoader(multiplexer);
+
+        // then
+        sut.IncrementWithExpireScript.Should().BeNull();
+        sut.RemoveIfEqualScript.Should().BeNull();
+        sut.ReplaceIfEqualScript.Should().BeNull();
+        sut.SetIfHigherScript.Should().BeNull();
+        sut.SetIfLowerScript.Should().BeNull();
+    }
+}

--- a/tests/Framework.Redis.Tests.Unit/RedisScriptsTests.cs
+++ b/tests/Framework.Redis.Tests.Unit/RedisScriptsTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Framework.Redis;
+using StackExchange.Redis;
+
+namespace Tests;
+
+public sealed class RedisScriptsTests
+{
+    [Fact]
+    public void ReplaceIfEqual_script_should_be_valid_lua()
+    {
+        // when
+        var act = () => LuaScript.Prepare(RedisScripts.ReplaceIfEqual);
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RemoveIfEqual_script_should_be_valid_lua()
+    {
+        // when
+        var act = () => LuaScript.Prepare(RedisScripts.RemoveIfEqual);
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SetIfHigher_script_should_be_valid_lua()
+    {
+        // when
+        var act = () => LuaScript.Prepare(RedisScripts.SetIfHigher);
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SetIfLower_script_should_be_valid_lua()
+    {
+        // when
+        var act = () => LuaScript.Prepare(RedisScripts.SetIfLower);
+
+        // then
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void IncrementWithExpire_script_should_be_valid_lua()
+    {
+        // when
+        var act = () => LuaScript.Prepare(RedisScripts.IncrementWithExpire);
+
+        // then
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit and integration tests for `Framework.Redis` package
- 43 total tests (8 unit + 35 integration)
- Uses Testcontainers.Redis for integration tests with real Redis

## Test Coverage

### Unit Tests (8)
| Component | Tests |
|-----------|-------|
| `RedisScripts` Lua validation | 5 |
| `HeadlessRedisScriptsLoader` constructor | 3 |

### Integration Tests (35)
| Component | Tests |
|-----------|-------|
| `ConnectionMultiplexerExtensions` | 4 |
| `LoadScriptsAsync` | 3 |
| `ReplaceIfEqualAsync` | 5 |
| `RemoveIfEqualAsync` | 3 |
| `IncrementAsync` (long+double) | 8 |
| `SetIfHigherAsync` (long+double) | 9 |
| `SetIfLowerAsync` (long+double) | 9 |

## Test Plan
- [x] Unit tests pass locally
- [ ] Integration tests require Docker (Testcontainers)