### PR TITLE
test(serializer): add unit tests for extensions and converters

### DIFF
--- a/tests/Headless.Serializer.Tests.Unit/Converters/EmptyStringAsNullJsonConverterTests.cs
+++ b/tests/Headless.Serializer.Tests.Unit/Converters/EmptyStringAsNullJsonConverterTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Serializer.Converters;
+
+namespace Tests.Converters;
+
+public sealed class EmptyStringAsNullJsonConverterTests
+{
+    private readonly JsonSerializerOptions _options = new()
+    {
+        Converters = { new EmptyStringAsNullJsonConverter<string>() },
+    };
+
+    [Fact]
+    public void should_convert_empty_string_to_null()
+    {
+        // given
+        const string json = """{"value":""}""";
+
+        // when
+        var result = JsonSerializer.Deserialize<TestModel>(json, _options);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_preserve_non_empty_string()
+    {
+        // given
+        const string json = """{"value":"hello"}""";
+
+        // when
+        var result = JsonSerializer.Deserialize<TestModel>(json, _options);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void should_preserve_null_value()
+    {
+        // given
+        const string json = """{"value":null}""";
+
+        // when
+        var result = JsonSerializer.Deserialize<TestModel>(json, _options);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_preserve_whitespace_string()
+    {
+        // given - converter only converts empty string, not whitespace
+        const string json = """{"value":" "}""";
+
+        // when
+        var result = JsonSerializer.Deserialize<TestModel>(json, _options);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(" ");
+    }
+
+    [Fact]
+    public void should_write_null_as_null()
+    {
+        // given
+        var model = new TestModel { Value = null };
+
+        // when
+        var json = JsonSerializer.Serialize(model, _options);
+
+        // then
+        json.Should().Be("""{"value":null}""");
+    }
+
+    [Fact]
+    public void should_write_empty_string_as_null()
+    {
+        // given
+        var model = new TestModel { Value = "" };
+
+        // when
+        var json = JsonSerializer.Serialize(model, _options);
+
+        // then
+        json.Should().Be("""{"value":null}""");
+    }
+
+    [Fact]
+    public void should_write_non_empty_string_as_string()
+    {
+        // given
+        var model = new TestModel { Value = "hello" };
+
+        // when
+        var json = JsonSerializer.Serialize(model, _options);
+
+        // then
+        json.Should().Be("""{"value":"hello"}""");
+    }
+
+    private sealed class TestModel
+    {
+        [JsonPropertyName("value")]
+        [JsonConverter(typeof(EmptyStringAsNullJsonConverter<string>))]
+        public string? Value { get; set; }
+    }
+}

--- a/tests/Headless.Serializer.Tests.Unit/MessagePackSerializerTests.cs
+++ b/tests/Headless.Serializer.Tests.Unit/MessagePackSerializerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using MessagePack;
 using MessagePackSerializer = Headless.Serializer.MessagePackSerializer;
 
@@ -14,6 +15,36 @@ public sealed class MessagePackSerializerTests
         public required string Name { get; init; }
 
         public int Age { get; init; }
+    }
+
+    public sealed class ComplexObject
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required List<string> Tags { get; init; }
+
+        public required Dictionary<string, int> Metadata { get; init; }
+
+        public required NestedObject Nested { get; init; }
+    }
+
+    public sealed class NestedObject
+    {
+        public required string Value { get; init; }
+
+        public int Count { get; init; }
+    }
+
+    public sealed class DateTimeContainer
+    {
+        public required DateTime Timestamp { get; init; }
+    }
+
+    public sealed class GuidContainer
+    {
+        public required Guid Id { get; init; }
     }
 
     public sealed class NonSerializable
@@ -173,5 +204,123 @@ public sealed class MessagePackSerializerTests
 
         // then
         act.Should().Throw<MessagePackSerializationException>();
+    }
+
+    [Fact]
+    public void should_serialize_and_deserialize_complex_object()
+    {
+        // given
+        var complex = new ComplexObject
+        {
+            Id = "test-123",
+            Name = "Test Object",
+            Tags = ["tag1", "tag2", "tag3"],
+            Metadata = new Dictionary<string, int>(StringComparer.Ordinal) { ["key1"] = 100, ["key2"] = 200 },
+            Nested = new NestedObject { Value = "nested-value", Count = 42 },
+        };
+        using var memoryStream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(complex, memoryStream);
+        memoryStream.Position = 0;
+        var result = _serializer.Deserialize<ComplexObject>(memoryStream);
+
+        // then
+        result.Should().NotBeNull();
+        result.Id.Should().Be("test-123");
+        result.Name.Should().Be("Test Object");
+        result.Tags.Should().BeEquivalentTo(["tag1", "tag2", "tag3"]);
+        result.Metadata.Should().ContainKey("key1").WhoseValue.Should().Be(100);
+        result.Metadata.Should().ContainKey("key2").WhoseValue.Should().Be(200);
+        result.Nested.Value.Should().Be("nested-value");
+        result.Nested.Count.Should().Be(42);
+    }
+
+    [Fact]
+    public void should_handle_null_value()
+    {
+        // given
+        Person? nullPerson = null;
+        using var memoryStream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(nullPerson, memoryStream);
+        memoryStream.Position = 0;
+        var result = _serializer.Deserialize<Person>(memoryStream);
+
+        // then
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_be_smaller_than_json()
+    {
+        // given
+        var person = new Person { Name = "Test Person With A Longer Name", Age = 12345 };
+        using var msgpackStream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(person, msgpackStream);
+        var msgpackSize = msgpackStream.ToArray().Length;
+        var jsonSize = JsonSerializer.SerializeToUtf8Bytes(person).Length;
+
+        // then
+        msgpackSize.Should().BeLessThan(jsonSize);
+    }
+
+    [Fact]
+    public void should_handle_datetime()
+    {
+        // given
+        var timestamp = new DateTime(2025, 6, 15, 10, 30, 45, DateTimeKind.Utc);
+        var container = new DateTimeContainer { Timestamp = timestamp };
+        using var memoryStream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(container, memoryStream);
+        memoryStream.Position = 0;
+        var result = _serializer.Deserialize<DateTimeContainer>(memoryStream);
+
+        // then
+        result.Should().NotBeNull();
+        result.Timestamp.Should().Be(timestamp);
+    }
+
+    [Fact]
+    public void should_handle_guid()
+    {
+        // given
+        var guid = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+        var container = new GuidContainer { Id = guid };
+        using var memoryStream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(container, memoryStream);
+        memoryStream.Position = 0;
+        var result = _serializer.Deserialize<GuidContainer>(memoryStream);
+
+        // then
+        result.Should().NotBeNull();
+        result.Id.Should().Be(guid);
+    }
+
+    [Fact]
+    public void should_deserialize_with_type_parameter()
+    {
+        // given
+        var person = new Person { Name = "TypeTest", Age = 99 };
+        using var memoryStream = new MemoryStream();
+        _serializer.Serialize(person, memoryStream);
+        memoryStream.Position = 0;
+
+        // when
+        var result = _serializer.Deserialize(memoryStream, typeof(Person));
+
+        // then
+        result.Should().NotBeNull();
+        result.Should().BeOfType<Person>();
+        var typedResult = (Person)result!;
+        typedResult.Name.Should().Be("TypeTest");
+        typedResult.Age.Should().Be(99);
     }
 }

--- a/tests/Headless.Serializer.Tests.Unit/SerializerExtensionsTests.cs
+++ b/tests/Headless.Serializer.Tests.Unit/SerializerExtensionsTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Serializer;
+
+namespace Tests;
+
+public sealed class SerializerExtensionsTests
+{
+    private readonly ISerializer _serializer = Substitute.For<ISerializer>();
+    private readonly ITextSerializer _textSerializer = Substitute.For<ITextSerializer>();
+
+    [Fact]
+    public void should_serialize_to_bytes()
+    {
+        // given
+        var obj = new TestClass { Name = "Test", Value = 42 };
+        _serializer
+            .When(s => s.Serialize(Arg.Any<TestClass>(), Arg.Any<Stream>()))
+            .Do(c =>
+            {
+                var stream = c.Arg<Stream>();
+                var bytes = Encoding.UTF8.GetBytes("{\"name\":\"Test\",\"value\":42}");
+                stream.Write(bytes);
+            });
+
+        // when
+        var result = _serializer.SerializeToBytes(obj);
+
+        // then
+        result.Should().NotBeNull();
+        Encoding.UTF8.GetString(result!).Should().Be("{\"name\":\"Test\",\"value\":42}");
+    }
+
+    [Fact]
+    public void should_serialize_to_bytes_return_null_when_value_is_null()
+    {
+        // when
+        var result = _serializer.SerializeToBytes<TestClass>(null);
+
+        // then
+        result.Should().BeNull();
+        _serializer.DidNotReceive().Serialize(Arg.Any<TestClass>(), Arg.Any<Stream>());
+    }
+
+    [Fact]
+    public void should_deserialize_from_bytes()
+    {
+        // given
+        var expected = new TestClass { Name = "Test", Value = 42 };
+        var bytes = Encoding.UTF8.GetBytes("{\"name\":\"Test\",\"value\":42}");
+        _serializer.Deserialize<TestClass>(Arg.Any<Stream>()).Returns(expected);
+
+        // when
+        var result = _serializer.Deserialize<TestClass>(bytes);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test");
+        result.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void should_serialize_to_string_for_text_serializer()
+    {
+        // given
+        var obj = new TestClass { Name = "Test", Value = 42 };
+        _textSerializer
+            .When(s => s.Serialize(Arg.Any<TestClass>(), Arg.Any<Stream>()))
+            .Do(c =>
+            {
+                var stream = c.Arg<Stream>();
+                var bytes = Encoding.UTF8.GetBytes("{\"name\":\"Test\",\"value\":42}");
+                stream.Write(bytes);
+            });
+
+        // when
+        var result = _textSerializer.SerializeToString(obj);
+
+        // then
+        result.Should().NotBeNull();
+        result.Should().Be("{\"name\":\"Test\",\"value\":42}");
+    }
+
+    [Fact]
+    public void should_serialize_to_string_return_null_when_value_is_null()
+    {
+        // when
+        var result = _textSerializer.SerializeToString<TestClass>(null);
+
+        // then
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_serialize_to_string_as_base64_for_binary_serializer()
+    {
+        // given
+        var obj = new TestClass { Name = "Test", Value = 42 };
+        byte[] binaryBytes = [0x01, 0x02, 0x03, 0x04];
+        _serializer
+            .When(s => s.Serialize(Arg.Any<TestClass>(), Arg.Any<Stream>()))
+            .Do(c =>
+            {
+                var stream = c.Arg<Stream>();
+                stream.Write(binaryBytes);
+            });
+
+        // when
+        var result = _serializer.SerializeToString(obj);
+
+        // then
+        result.Should().NotBeNull();
+        result.Should().Be(Convert.ToBase64String(binaryBytes));
+    }
+
+    [Fact]
+    public void should_deserialize_from_string_for_text_serializer()
+    {
+        // given
+        const string json = "{\"name\":\"Test\",\"value\":42}";
+        var expected = new TestClass { Name = "Test", Value = 42 };
+        _textSerializer.Deserialize<TestClass>(Arg.Any<Stream>()).Returns(expected);
+
+        // when
+        var result = _textSerializer.Deserialize<TestClass>(json);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test");
+        result.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void should_deserialize_from_string_with_base64_for_binary_serializer()
+    {
+        // given
+        var binaryBytes = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        var base64 = Convert.ToBase64String(binaryBytes);
+        var expected = new TestClass { Name = "Test", Value = 42 };
+        _serializer.Deserialize<TestClass>(Arg.Any<Stream>()).Returns(expected);
+
+        // when
+        var result = _serializer.Deserialize<TestClass>(base64);
+
+        // then
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test");
+    }
+
+    [Fact]
+    public void should_deserialize_from_null_string()
+    {
+        // given
+        _serializer.Deserialize<TestClass>(Arg.Any<Stream>()).Returns((TestClass?)null);
+
+        // when
+        var result = _serializer.Deserialize<TestClass>((string?)null);
+
+        // then
+        _serializer.Received(1).Deserialize<TestClass>(Arg.Any<Stream>());
+    }
+
+    private sealed class TestClass
+    {
+        public required string Name { get; init; }
+
+        public required int Value { get; init; }
+    }
+}

--- a/tests/Headless.Serializer.Tests.Unit/SystemJsonSerializerTests.cs
+++ b/tests/Headless.Serializer.Tests.Unit/SystemJsonSerializerTests.cs
@@ -106,10 +106,183 @@ public sealed class SystemJsonSerializerTests
         options.Converters.Should().Contain(c => c is IpAddressJsonConverter);
     }
 
+    [Fact]
+    public void should_use_custom_options_provider()
+    {
+        // given
+        var customOptions = new JsonSerializerOptions { PropertyNamingPolicy = null };
+        var optionsProvider = Substitute.For<IJsonOptionsProvider>();
+        optionsProvider.GetSerializeOptions().Returns(customOptions);
+        optionsProvider.GetDeserializeOptions().Returns(customOptions);
+
+        var serializer = new SystemJsonSerializer(optionsProvider);
+        var obj = new TestClass { Name = "Test", Age = 25 };
+        using var stream = new MemoryStream();
+
+        // when
+        serializer.Serialize(obj, stream);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream);
+        var result = reader.ReadToEnd();
+
+        // then - PascalCase since PropertyNamingPolicy is null
+        result.Should().Be("{\"Name\":\"Test\",\"Age\":25}");
+        optionsProvider.Received(1).GetSerializeOptions();
+    }
+
+    [Fact]
+    public void should_deserialize_with_type_parameter()
+    {
+        // given
+        const string json = "{\"name\":\"John\",\"age\":42}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        // when
+        var result = _serializer.Deserialize(stream, typeof(TestClass));
+
+        // then
+        result.Should().NotBeNull();
+        result.Should().BeOfType<TestClass>();
+        var typedResult = (TestClass)result!;
+        typedResult.Name.Should().Be("John");
+        typedResult.Age.Should().Be(42);
+    }
+
+    [Fact]
+    public void should_handle_complex_nested_objects()
+    {
+        // given
+        var nested = new NestedClass
+        {
+            Id = 1,
+            Inner = new InnerClass
+            {
+                Value = "inner-value",
+                Deeper = new DeeperClass { Code = "ABC123" },
+            },
+        };
+        using var stream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(nested, stream);
+        stream.Position = 0;
+        var deserialized = _serializer.Deserialize<NestedClass>(stream);
+
+        // then
+        deserialized.Should().NotBeNull();
+        deserialized!.Id.Should().Be(1);
+        deserialized.Inner.Should().NotBeNull();
+        deserialized.Inner!.Value.Should().Be("inner-value");
+        deserialized.Inner.Deeper.Should().NotBeNull();
+        deserialized.Inner.Deeper!.Code.Should().Be("ABC123");
+    }
+
+    [Fact]
+    public void should_handle_collections()
+    {
+        // given
+        var collection = new CollectionClass
+        {
+            Items = ["one", "two", "three"],
+            Numbers = [1, 2, 3],
+            Children =
+            [
+                new TestClass { Name = "Child1", Age = 10 },
+                new TestClass { Name = "Child2", Age = 20 },
+            ],
+        };
+        using var stream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(collection, stream);
+        stream.Position = 0;
+        var deserialized = _serializer.Deserialize<CollectionClass>(stream);
+
+        // then
+        deserialized.Should().NotBeNull();
+        deserialized!.Items.Should().BeEquivalentTo(["one", "two", "three"]);
+        deserialized.Numbers.Should().BeEquivalentTo([1, 2, 3]);
+        deserialized.Children.Should().HaveCount(2);
+        deserialized.Children[0].Name.Should().Be("Child1");
+        deserialized.Children[1].Name.Should().Be("Child2");
+    }
+
+    [Fact]
+    public void should_respect_json_attributes()
+    {
+        // given
+        var obj = new AttributedClass
+        {
+            CustomName = "visible",
+            IgnoredProperty = "should-not-appear",
+            RegularProperty = "regular",
+        };
+        using var stream = new MemoryStream();
+
+        // when
+        _serializer.Serialize(obj, stream);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
+
+        // then
+        json.Should().Contain("\"custom_name\"");
+        json.Should().Contain("\"visible\"");
+        json.Should().NotContain("IgnoredProperty");
+        json.Should().NotContain("should-not-appear");
+        json.Should().Contain("\"regularProperty\"");
+
+        // verify deserialization respects JsonPropertyName
+        using var deserializeStream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var deserialized = _serializer.Deserialize<AttributedClass>(deserializeStream);
+        deserialized.Should().NotBeNull();
+        deserialized!.CustomName.Should().Be("visible");
+        deserialized.RegularProperty.Should().Be("regular");
+    }
+
     private sealed class TestClass
     {
         public required string Name { get; init; }
 
         public required int Age { get; init; }
+    }
+
+    private sealed class NestedClass
+    {
+        public required int Id { get; init; }
+
+        public InnerClass? Inner { get; init; }
+    }
+
+    private sealed class InnerClass
+    {
+        public required string Value { get; init; }
+
+        public DeeperClass? Deeper { get; init; }
+    }
+
+    private sealed class DeeperClass
+    {
+        public required string Code { get; init; }
+    }
+
+    private sealed class CollectionClass
+    {
+        public required string[] Items { get; init; }
+
+        public required List<int> Numbers { get; init; }
+
+        public required List<TestClass> Children { get; init; }
+    }
+
+    private sealed class AttributedClass
+    {
+        [JsonPropertyName("custom_name")]
+        public required string CustomName { get; init; }
+
+        [JsonIgnore]
+        public string IgnoredProperty { get; set; } = string.Empty;
+
+        public required string RegularProperty { get; init; }
     }
 }


### PR DESCRIPTION
## Summary
- Add 27 new unit tests for serializer packages
- SerializerExtensions: 9 tests (byte/string serialization, null handling, base64)
- EmptyStringAsNullJsonConverter: 7 tests (read/write, null/empty/whitespace)
- SystemJsonSerializer: 5 tests (custom options, type param, nesting, collections, attributes)
- MessagePackSerializer: 6 tests (complex objects, null, size comparison, datetime, guid)

## Test Plan
- [x] All 136 tests pass in Headless.Serializer.Tests.Unit
- [x] Code formatted with csharpier