### PR TITLE
fix: align messaging bootstrap readiness

### DIFF
--- a/docs/plans/2026-03-29-002-fix-messaging-bootstrap-readiness-plan.md
+++ b/docs/plans/2026-03-29-002-fix-messaging-bootstrap-readiness-plan.md
@@ -1,0 +1,206 @@
+---
+title: "fix: align messaging bootstrap readiness with subscription registration"
+type: fix
+date: 2026-03-29
+status: active
+---
+
+# fix: align messaging bootstrap readiness with subscription registration
+
+## Overview
+
+`IBootstrapper.IsStarted` currently flips to `true` as soon as `Bootstrapper` creates `_cts`, even though `ConsumerRegister.StartAsync(...)` has not finished discovering topics, creating clients, and binding subscriptions yet. That violates the `IBootstrapper` contract and creates a real readiness race for in-memory messaging, runtime subscriptions, and any caller that coordinates startup through `BootstrapAsync(...)` or `IsStarted`.
+
+The proposed issue solution fixes the boolean but also makes `MemoryQueue.Send(...)` lenient. After reviewing the code, that is too shallow. The stricter and more correct fix is to make bootstrap readiness awaitable for concurrent callers, require full successful startup before reporting `IsStarted == true`, introduce a consumer-registration readiness boundary for runtime subscriptions, and preserve `InMemoryQueue`'s fail-fast behavior for genuinely unbound topics.
+
+## Problem Statement / Motivation
+
+The bug is not just a misleading property:
+
+- [`IBootstrapper.IsStarted`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/IBootstrapper.cs#L25) promises readiness only after full initialization.
+- [`Bootstrapper.IsStarted`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs#L21) currently derives readiness from `_cts`, which is set before `_BootstrapCoreAsync()` runs.
+- [`BootstrapAsync(...)`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs#L23) also returns early for any second caller once `_cts` exists, even if bootstrap is still in progress.
+- [`RuntimeSubscriber`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs#L32) relies on `bootstrapper.IsStarted` to decide whether runtime registration should restart consumers immediately or be picked up by the initial startup path.
+- [`MemoryQueue.Send(...)`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.InMemoryQueue/MemoryQueue.cs#L62) intentionally throws when no topic binding exists, which is useful for catching incorrect test setup and invalid publish targets.
+
+So the core problem is lifecycle correctness. Making `MemoryQueue` lenient would hide one manifestation of the race while keeping bootstrap state incorrect and leaving concurrent `BootstrapAsync(...)` callers with a false sense of readiness.
+
+## Proposed Solution
+
+Implement bootstrap as a single in-flight operation with explicit readiness signals, fail startup when required processors cannot start, and add regression coverage across the messaging surfaces that depend on it.
+
+### 1. Replace implicit `_cts`-based readiness with explicit startup signals
+
+Update [`Bootstrapper`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs) so it distinguishes:
+
+- bootstrap in flight
+- consumer registration ready
+- bootstrap completed
+
+`IsStarted` should return `true` only after `_BootstrapCoreAsync()` completes successfully and the full bootstrap sequence is finished.
+
+Runtime subscription restart behavior should not key off that final `IsStarted` flag alone. It needs a readiness signal that flips as soon as `IConsumerRegister` has completed its initial startup and topic snapshot, because that is the point after which a new runtime registration can be missed unless consumers are restarted.
+
+Required processor startup failures should no longer be treated as "log and continue" for readiness purposes. In this greenfield codebase, correct behavior is preferred over compatibility with misleading partial-start semantics.
+
+### 2. Make concurrent `BootstrapAsync(...)` callers await the same startup work
+
+The first caller should create and own the bootstrap task.
+Subsequent callers during startup should await that same task instead of returning early.
+
+Cancellation needs to be defined explicitly:
+
+- the bootstrap owner may cancel the shared startup operation
+- later callers may cancel only their own wait
+- the shared bootstrap task and any owner-only bootstrap CTS must be cleared on success, failure, stop, or dispose so future callers do not inherit stale state
+
+If startup fails because a required processor cannot start, the shared bootstrap task should complete as failed and `IsStarted` must remain `false`.
+
+This closes the broader readiness gap for:
+
+- hosted startup paths
+- manual `bootstrapper.BootstrapAsync(...)` callers
+- test harness setup
+- any code that races a second bootstrap invocation against the first
+
+### 3. Keep `MemoryQueue` strict for truly missing subscriptions
+
+Do not change [`MemoryQueue.Send(...)`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.InMemoryQueue/MemoryQueue.cs).
+
+Reasoning:
+
+- the current throw is the only fail-fast signal in the in-memory transport when a topic is genuinely unbound
+- making it lenient would silently swallow invalid test setup and invalid publish targets
+- the transport provider guidance says transports should not hide failures; the race should be fixed at the bootstrap boundary instead
+
+### 4. Verify runtime subscription parity with initial consumer registration
+
+Keep [`RuntimeSubscriber`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs) behavior aligned with the corrected readiness state:
+
+- before `IConsumerRegister` reaches its initial ready point: register in the runtime registry and let the initial startup pass pick it up
+- after `IConsumerRegister` is ready, even if overall bootstrap has not fully completed: restart consumers immediately so the new runtime registration is not missed
+- after bootstrap completion: continue using the same restart path
+
+That preserves parity between static `IConsume<TMessage>` subscriptions and runtime-attached delegates.
+
+### 5. Update docs to match the actual lifecycle contract
+
+Refresh XML docs and package docs in the same change, but limit the scope to lifecycle-semantic updates so the public guidance stays aligned with the corrected behavior without turning this change into a general messaging docs sweep:
+
+- `IBootstrapper.IsStarted` means required messaging startup completed successfully
+- manual callers should await `BootstrapAsync(...)` before publishing
+- shared bootstrap callers may cancel their own wait without aborting bootstrap unless they own the startup operation
+- `InMemoryQueue` remains strict for unbound topics
+- any runtime-subscription docs that describe when registrations are picked up should be updated only if they are affected by the new readiness boundary
+
+## Technical Considerations
+
+- Use a shared bootstrap task plus a small set of explicit readiness signals, not only a `_started` bool. A bool fixes the property but not concurrent `BootstrapAsync(...)` reentry or the runtime-subscription window after consumer registration has started.
+- If bootstrap faults before reaching the completed state, the implementation should not remain permanently stuck behind a non-null `_cts`, stale bootstrap task, or stale consumer-ready signal.
+- Required processors should be explicit in behavior: if one fails to start, bootstrap fails. Optional processors, if they exist later, should be modeled intentionally rather than inheriting a default "catch/log/continue" policy.
+- Stop and dispose paths are in scope for this change. The goal is the wider lifecycle correction, not only the narrow startup symptom, so bootstrap bookkeeping should be made consistent across success, failure, stop, and dispose paths without introducing unnecessary public API surface.
+- Preserve existing logging semantics unless a new lifecycle transition genuinely needs additional diagnostics.
+- Avoid broad public API expansion unless the implementation cannot safely express the behavior behind the existing `IBootstrapper` contract.
+
+## System-Wide Impact
+
+- **Interaction graph**: `AddHeadlessMessaging(...)` registers `Bootstrapper` as hosted service, which starts `IConsumerRegister`, which creates consumer clients, fetches topics, subscribes groups, and starts listening loops. `RuntimeSubscriber.SubscribeAsync(...)` mutates the same selector and conditionally restarts `IConsumerRegister`. Readiness must be correct across that whole chain.
+- **Error propagation**: `MemoryQueue.Send(...)` throws for missing subscriptions, `InMemoryQueueTransport.SendAsync(...)` wraps transport failures in `PublisherSentFailedException`, and `DirectPublisher` turns failed `OperateResult` values back into publish exceptions. Required processor startup failures should likewise propagate as bootstrap failure instead of being logged and treated as successful startup.
+- **State lifecycle risks**: today `_cts` doubles as both cancellation state and readiness signal, which conflates "startup began" with "startup completed". There is also a narrower readiness boundary inside startup: `IConsumerRegister` can become live before overall bootstrap completion, and runtime subscriptions added after that point can be missed unless the plan handles that intermediate state.
+- **API surface parity**: the same readiness contract affects class-based consumers, runtime subscriptions, `MessagingTestHarness.CreateAsync(...)`, and direct manual bootstrap in tests and applications.
+- **Integration test scenarios**: unit tests need one blocked-start regression and one post-start runtime-restart regression; integration tests should prove publish succeeds after awaited bootstrap and still fails for a truly unknown topic.
+
+## Acceptance Criteria
+
+- [x] `IBootstrapper.IsStarted` stays `false` until the full required messaging startup succeeds.
+- [x] Concurrent `BootstrapAsync(...)` callers await the same in-flight bootstrap and do not observe early completion.
+- [x] Runtime subscriptions added before `IConsumerRegister` is initially ready are picked up by the initial startup path.
+- [x] Runtime subscriptions added after `IConsumerRegister` is initially ready are not missed, even if overall bootstrap has not fully completed yet.
+- [x] Shared bootstrap callers can cancel their own wait without aborting another caller's startup unless they own the bootstrap operation.
+- [x] If a required processor fails to start, bootstrap fails and `IsStarted` remains `false`.
+- [x] `MemoryQueue.Send(...)` still throws for genuinely unbound topics after startup.
+- [x] Manual bootstrap paths and hosted/test harness paths behave consistently.
+- [x] XML/package docs reflect the corrected lifecycle semantics.
+- [x] XML and package README updates ship in the same change as the lifecycle fix.
+- [x] Doc edits remain limited to lifecycle semantics changed by this work, not a broader messaging documentation refresh.
+
+## Implementation Units
+
+- [x] **Bootstrap lifecycle**
+  - Update [`src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs)
+  - Introduce a shared bootstrap task plus explicit owner/caller cancellation rules
+  - Ensure repeated callers await readiness instead of returning early
+  - Replace blanket "log and continue" startup success semantics for required processors with fail-fast bootstrap behavior
+  - Clear bootstrap bookkeeping on success, failure, stop, or dispose
+
+- [x] **Consumer-register readiness**
+  - Define the exact ready point after `IConsumerRegister` finishes its initial topic snapshot and live clients are in place
+  - Expose that boundary to `RuntimeSubscriber` through an internal signal or equivalent collaboration point
+  - Ensure runtime registrations crossing that boundary are either captured by initial startup or force a restart immediately
+
+- [x] **Regression tests**
+  - Add or extend tests under [`tests/Headless.Messaging.Core.Tests.Unit`](/Users/xshaheen/Dev/framework/headless-framework/tests/Headless.Messaging.Core.Tests.Unit)
+  - Add a regression proving `IsStarted == false` while startup is blocked before subscription registration completes
+  - Add a regression proving a second `BootstrapAsync(...)` call waits for the first
+  - Add a regression proving a second caller can cancel its wait without aborting shared bootstrap
+  - Add a regression proving bootstrap fails when a required processor fails to start
+  - Add coverage for runtime subscription behavior around startup completion
+
+- [x] **Transport guardrails**
+  - Keep [`tests/Headless.Messaging.InMemoryQueue.Tests.Unit/MemoryQueueTests.cs`](/Users/xshaheen/Dev/framework/headless-framework/tests/Headless.Messaging.InMemoryQueue.Tests.Unit/MemoryQueueTests.cs) strict-topic behavior intact
+  - Add or keep a test demonstrating unknown-topic publish still fails after startup
+
+- [x] **Docs**
+  - Update [`src/Headless.Messaging.Core/IBootstrapper.cs`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/IBootstrapper.cs)
+  - Update relevant README sections in [`src/Headless.Messaging.Core/README.md`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/README.md) and [`src/Headless.Messaging.InMemoryQueue/README.md`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.InMemoryQueue/README.md)
+  - Ship those doc changes in the same PR so callers do not read stale lifecycle guidance after the behavior changes
+  - Keep the edits narrowly scoped to bootstrap/readiness/runtime-subscription lifecycle semantics affected by this implementation
+
+## Alternative Approaches Considered
+
+### Keep the current bootstrap flow and only add `_started`
+
+Rejected. It fixes the property but not the fact that a second `BootstrapAsync(...)` caller can return before the first one finishes.
+
+### Use only overall bootstrap completion as the runtime-subscription boundary
+
+Rejected. `IConsumerRegister` can reach a live topic snapshot before the rest of bootstrap finishes, so using only final bootstrap completion still leaves a window where a runtime registration can be missed.
+
+### Keep swallow-and-continue startup semantics for required processors
+
+Rejected. In a greenfield project, `IsStarted` should be trustworthy. Treating required processor startup failures as logged degradation would preserve ambiguous semantics instead of correcting them.
+
+### Make `MemoryQueue.Send(...)` lenient
+
+Rejected. That masks invalid configuration and test setup, diverges from the current in-memory transport contract, and leaves bootstrap readiness broken for runtime subscriptions and concurrent bootstrap callers.
+
+### Add a brand-new public readiness API
+
+Deferred unless implementation work proves the current contract cannot safely model shared startup. The existing `BootstrapAsync(...)` contract should be enough if it becomes awaitable and idempotent in the correct way.
+
+## Success Metrics
+
+- The startup race described in #204 is covered by regression tests and no longer reproducible.
+- `IsStarted` is trustworthy: it becomes `true` only after required messaging startup succeeds.
+- In-memory publish failures only occur for real unknown-topic cases, not because readiness was reported early.
+- Runtime subscription behavior is consistent before consumer-register readiness, during the intermediate startup window, and after overall bootstrap completion.
+- Docs no longer describe stronger guarantees than the implementation actually provides.
+
+## Dependencies & Risks
+
+- Bootstrapper synchronization changes are concurrency-sensitive; tests must control startup timing explicitly instead of relying on sleeps.
+- The plan now depends on identifying the correct consumer-register ready point. If that boundary is chosen too early, runtime registrations can still be lost; if chosen too late, the change regresses to the original race.
+- Changing required processor startup failures from logged degradation to bootstrap failure is an intentional behavior change. That is acceptable for this greenfield project, but the implementation should make the required/optional distinction explicit if optional processors are introduced later.
+- README changes must stay aligned with the actual transport behavior to avoid another docs/runtime mismatch.
+- The wider solution includes stop and dispose consistency. That broadens the change surface, so implementation should still prefer the smallest internal mechanism that makes lifecycle behavior coherent end to end.
+- If doc edits expand beyond lifecycle semantics, the PR will accumulate review noise and increase the risk of unrelated doc drift.
+
+## Sources & References
+
+- Related issue: [#204](https://github.com/xshaheen/headless-framework/issues/204)
+- Internal reference: [`src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs)
+- Internal reference: [`src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs)
+- Internal reference: [`src/Headless.Messaging.InMemoryQueue/MemoryQueue.cs`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.InMemoryQueue/MemoryQueue.cs)
+- Internal reference: [`src/Headless.Messaging.Testing/MessagingTestHarness.cs`](/Users/xshaheen/Dev/framework/headless-framework/src/Headless.Messaging.Testing/MessagingTestHarness.cs)
+- Institutional learning: [`docs/solutions/concurrency/startup-pause-gating-and-half-open-recovery.md`](/Users/xshaheen/Dev/framework/headless-framework/docs/solutions/concurrency/startup-pause-gating-and-half-open-recovery.md)
+- Institutional learning: [`docs/solutions/guides/messaging-transport-provider-guide.md`](/Users/xshaheen/Dev/framework/headless-framework/docs/solutions/guides/messaging-transport-provider-guide.md)

--- a/src/Headless.Messaging.Core/IBootstrapper.cs
+++ b/src/Headless.Messaging.Core/IBootstrapper.cs
@@ -11,7 +11,7 @@ namespace Headless.Messaging;
 /// <list type="bullet">
 /// <item><description>Initializing storage tables or schema if not already present.</description></item>
 /// <item><description>Registering consumer subscribers from discovered assemblies.</description></item>
-/// <item><description>Verifying connection to message brokers and storage backends.</description></item>
+/// <item><description>Starting required messaging processors and verifying they can initialize successfully.</description></item>
 /// <item><description>Preparing the system for message publishing and consuming operations.</description></item>
 /// </list>
 /// The bootstrapper is registered as a hosted service and automatically starts when the application starts.
@@ -20,7 +20,8 @@ public interface IBootstrapper : IAsyncDisposable
 {
     /// <summary>
     /// Gets a value indicating whether the bootstrap process has completed successfully.
-    /// Returns true if the system is fully initialized; false if bootstrap is still in progress or failed.
+    /// Returns true only after the required messaging startup sequence completes successfully.
+    /// Returns false while bootstrap is still in progress, after shutdown begins, or when startup failed.
     /// </summary>
     bool IsStarted { get; }
 
@@ -30,5 +31,9 @@ public interface IBootstrapper : IAsyncDisposable
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous bootstrap operation.</returns>
+    /// <remarks>
+    /// Concurrent callers await the same in-flight bootstrap operation.
+    /// Canceling a later caller's wait does not cancel shared startup unless that caller owns the bootstrap operation.
+    /// </remarks>
     Task BootstrapAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -22,6 +22,9 @@ internal sealed class Bootstrapper(
     private CancellationTokenSource? _runtimeCts;
     private CancellationTokenRegistration _stoppingRegistration;
     private Task? _bootstrapTask;
+
+    // Plain access under _bootstrapLock (the lock provides a full fence).
+    // Volatile.Read in IsStarted for lock-free snapshot by external callers.
     private bool _isStarted;
 
     public bool IsStarted => Volatile.Read(ref _isStarted);

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -98,12 +98,31 @@ internal sealed class Bootstrapper(
 
             await _BootstrapCoreAsync(startupToken).ConfigureAwait(false);
 
-            _stoppingRegistration = runtimeCts.Token.Register(_StopProcessors);
+            var registration = runtimeCts.Token.Register(_StopProcessors);
 
             lock (_bootstrapLock)
             {
-                _isStarted = true;
-                _bootstrapTask = null;
+                if (_isStopping)
+                {
+                    // Shutdown began while we were starting — undo immediately.
+                    _bootstrapTask = null;
+                    _isStarted = false;
+                    _stoppingRegistration = default;
+                }
+                else
+                {
+                    _stoppingRegistration = registration;
+                    _isStarted = true;
+                    _bootstrapTask = null;
+                }
+            }
+
+            if (_isStopping)
+            {
+                await registration.DisposeAsync().ConfigureAwait(false);
+                _StopProcessors();
+                runtimeCts.Dispose();
+                return;
             }
 
             logger.MessagingStarted();
@@ -206,6 +225,7 @@ internal sealed class Bootstrapper(
         }
 
         await stoppingRegistration.DisposeAsync().ConfigureAwait(false);
+        runtimeCts?.Dispose();
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -16,75 +16,138 @@ internal sealed class Bootstrapper(
     ILogger<IBootstrapper> logger
 ) : BackgroundService, IBootstrapper
 {
+    private readonly Lock _bootstrapLock = new();
     private bool _disposed;
     private CancellationTokenSource? _cts;
-    public bool IsStarted => !_cts?.IsCancellationRequested ?? false;
+    private CancellationTokenRegistration _stoppingRegistration;
+    private Task? _bootstrapTask;
+    private bool _isStarted;
+
+    public bool IsStarted => Volatile.Read(ref _isStarted);
 
     public async Task BootstrapAsync(CancellationToken cancellationToken = default)
     {
-        if (_cts is not null)
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Task bootstrapTask;
+        var createdByCaller = false;
+
+        lock (_bootstrapLock)
         {
-            logger.MessagingAlreadyStarted();
+            ObjectDisposedException.ThrowIf(_disposed, typeof(Bootstrapper));
 
-            return;
-        }
-
-        logger.MessagingStarting();
-
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        _CheckRequirement();
-
-        try
-        {
-            await storageInitializer.InitializeAsync(_cts.Token).ConfigureAwait(false);
-        }
-        catch (Exception e) when (e is not InvalidOperationException)
-        {
-            logger.StorageInitFailed(e);
-        }
-
-        _cts.Token.Register(() =>
-        {
-            logger.MessagingStopping();
-
-            foreach (var item in processors)
+            if (_isStarted)
             {
-                try
-                {
-                    item.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                }
-                catch (OperationCanceledException ex)
-                {
-                    logger.ExpectedOperationCanceledException(ex, ex.Message);
-                }
+                logger.MessagingAlreadyStarted();
+                return;
             }
-        });
 
-        await _BootstrapCoreAsync().ConfigureAwait(false);
+            if (_bootstrapTask is not null)
+            {
+                logger.MessagingAlreadyStarted();
+                bootstrapTask = _bootstrapTask;
+            }
+            else
+            {
+                logger.MessagingStarting();
 
-        _disposed = false;
-        logger.MessagingStarted();
+                _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                bootstrapTask = _BootstrapAsyncCore(_cts, _cts.Token);
+                _bootstrapTask = bootstrapTask;
+                createdByCaller = true;
+            }
+        }
+
+        if (createdByCaller)
+        {
+            await bootstrapTask.ConfigureAwait(false);
+        }
+        else
+        {
+            await bootstrapTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
-    private async Task _BootstrapCoreAsync()
+    private async Task _BootstrapAsyncCore(CancellationTokenSource bootstrapCts, CancellationToken cancellationToken)
     {
+        try
+        {
+            _CheckRequirement();
+
+            try
+            {
+                await storageInitializer.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is not InvalidOperationException)
+            {
+                logger.StorageInitFailed(e);
+            }
+
+            _stoppingRegistration = cancellationToken.Register(_StopProcessors);
+
+            await _BootstrapCoreAsync(cancellationToken).ConfigureAwait(false);
+
+            lock (_bootstrapLock)
+            {
+                _isStarted = true;
+                _bootstrapTask = null;
+            }
+
+            _disposed = false;
+            logger.MessagingStarted();
+        }
+        catch
+        {
+            await _stoppingRegistration.DisposeAsync().ConfigureAwait(false);
+
+            lock (_bootstrapLock)
+            {
+                if (ReferenceEquals(_cts, bootstrapCts))
+                {
+                    _cts = null;
+                }
+
+                _bootstrapTask = null;
+                _isStarted = false;
+            }
+
+            bootstrapCts.Dispose();
+            throw;
+        }
+    }
+
+    private async Task _BootstrapCoreAsync(CancellationToken cancellationToken)
+    {
+        List<Exception>? failures = null;
+
         foreach (var item in processors)
         {
             try
             {
-                _cts!.Token.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-                await item.StartAsync(_cts!.Token);
+                await item.StartAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                // ignore
+                throw;
             }
             catch (Exception ex)
             {
                 logger.ProcessorsStartedError(ex);
+                failures ??= [];
+                failures.Add(ex);
             }
+        }
+
+        if (failures is { Count: > 0 })
+        {
+            if (failures.Count == 1)
+            {
+                throw failures[0];
+            }
+
+            throw new AggregateException("One or more messaging processors failed to start.", failures);
         }
     }
 
@@ -95,11 +158,14 @@ internal sealed class Bootstrapper(
 
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
+        _isStarted = false;
+
         if (_cts != null)
         {
             await _cts.CancelAsync();
         }
 
+        await _stoppingRegistration.DisposeAsync().ConfigureAwait(false);
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -150,9 +216,12 @@ internal sealed class Bootstrapper(
             return;
         }
 
+        _isStarted = false;
         _cts?.Cancel();
+        _stoppingRegistration.Dispose();
         _cts?.Dispose();
         _cts = null;
+        _bootstrapTask = null;
         _disposed = true;
 
         base.Dispose();
@@ -163,5 +232,22 @@ internal sealed class Bootstrapper(
         Dispose();
 
         return ValueTask.CompletedTask;
+    }
+
+    private void _StopProcessors()
+    {
+        logger.MessagingStopping();
+
+        foreach (var item in processors)
+        {
+            try
+            {
+                item.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException ex)
+            {
+                logger.ExpectedOperationCanceledException(ex, ex.Message);
+            }
+        }
     }
 }

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -18,7 +18,7 @@ internal sealed class Bootstrapper(
 {
     private readonly Lock _bootstrapLock = new();
     private bool _disposed;
-    private CancellationTokenSource? _cts;
+    private CancellationTokenSource? _runtimeCts;
     private CancellationTokenRegistration _stoppingRegistration;
     private Task? _bootstrapTask;
     private bool _isStarted;
@@ -51,8 +51,9 @@ internal sealed class Bootstrapper(
             {
                 logger.MessagingStarting();
 
-                _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                bootstrapTask = _BootstrapAsyncCore(_cts, _cts.Token);
+                var runtimeCts = new CancellationTokenSource();
+                _runtimeCts = runtimeCts;
+                bootstrapTask = _BootstrapAsyncCore(runtimeCts, cancellationToken);
                 _bootstrapTask = bootstrapTask;
                 createdByCaller = true;
             }
@@ -68,24 +69,30 @@ internal sealed class Bootstrapper(
         }
     }
 
-    private async Task _BootstrapAsyncCore(CancellationTokenSource bootstrapCts, CancellationToken cancellationToken)
+    private async Task _BootstrapAsyncCore(CancellationTokenSource runtimeCts, CancellationToken ownerCancellationToken)
     {
+        using var startupCts = CancellationTokenSource.CreateLinkedTokenSource(
+            runtimeCts.Token,
+            ownerCancellationToken
+        );
+        var startupToken = startupCts.Token;
+
         try
         {
             _CheckRequirement();
 
             try
             {
-                await storageInitializer.InitializeAsync(cancellationToken).ConfigureAwait(false);
+                await storageInitializer.InitializeAsync(startupToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is not InvalidOperationException)
             {
                 logger.StorageInitFailed(e);
             }
 
-            _stoppingRegistration = cancellationToken.Register(_StopProcessors);
+            await _BootstrapCoreAsync(startupToken).ConfigureAwait(false);
 
-            await _BootstrapCoreAsync(cancellationToken).ConfigureAwait(false);
+            _stoppingRegistration = runtimeCts.Token.Register(_StopProcessors);
 
             lock (_bootstrapLock)
             {
@@ -98,20 +105,30 @@ internal sealed class Bootstrapper(
         }
         catch
         {
+            try
+            {
+                await runtimeCts.CancelAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore races with external disposal during startup failure cleanup.
+            }
+
+            _StopProcessors();
             await _stoppingRegistration.DisposeAsync().ConfigureAwait(false);
 
             lock (_bootstrapLock)
             {
-                if (ReferenceEquals(_cts, bootstrapCts))
+                if (ReferenceEquals(_runtimeCts, runtimeCts))
                 {
-                    _cts = null;
+                    _runtimeCts = null;
                 }
 
                 _bootstrapTask = null;
                 _isStarted = false;
             }
 
-            bootstrapCts.Dispose();
+            runtimeCts.Dispose();
             throw;
         }
     }
@@ -160,9 +177,9 @@ internal sealed class Bootstrapper(
     {
         _isStarted = false;
 
-        if (_cts != null)
+        if (_runtimeCts != null)
         {
-            await _cts.CancelAsync();
+            await _runtimeCts.CancelAsync().ConfigureAwait(false);
         }
 
         await _stoppingRegistration.DisposeAsync().ConfigureAwait(false);
@@ -217,10 +234,10 @@ internal sealed class Bootstrapper(
         }
 
         _isStarted = false;
-        _cts?.Cancel();
+        _runtimeCts?.Cancel();
         _stoppingRegistration.Dispose();
-        _cts?.Dispose();
-        _cts = null;
+        _runtimeCts?.Dispose();
+        _runtimeCts = null;
         _bootstrapTask = null;
         _disposed = true;
 

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -286,23 +286,64 @@ internal sealed class Bootstrapper(
             Volatile.Write(ref _isStarted, false);
             runtimeCts = _runtimeCts;
             _runtimeCts = null;
-            stoppingRegistration = _stoppingRegistration;
             _stoppingRegistration = default;
             _bootstrapTask = null;
+            stoppingRegistration = default;
         }
 
+#pragma warning disable VSTHRD103 // Dispose is synchronous by contract — CancelAsync is not available here.
         runtimeCts?.Cancel();
+#pragma warning restore VSTHRD103
         stoppingRegistration.Dispose();
         runtimeCts?.Dispose();
 
         base.Dispose();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Dispose();
+        Task? pendingBootstrap;
+        CancellationTokenSource? runtimeCts;
+        CancellationTokenRegistration stoppingRegistration;
 
-        return ValueTask.CompletedTask;
+        lock (_bootstrapLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _isStopping = true;
+            Volatile.Write(ref _isStarted, false);
+            pendingBootstrap = _bootstrapTask;
+            _bootstrapTask = null;
+            runtimeCts = _runtimeCts;
+            _runtimeCts = null;
+            stoppingRegistration = _stoppingRegistration;
+            _stoppingRegistration = default;
+        }
+
+        if (runtimeCts is not null)
+        {
+            await runtimeCts.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (pendingBootstrap is not null)
+        {
+#pragma warning disable ERP022 // We just need the in-flight bootstrap to finish its cleanup; the outcome does not matter.
+            try
+            {
+                await pendingBootstrap.ConfigureAwait(false);
+            }
+            catch { }
+#pragma warning restore ERP022
+        }
+
+        await stoppingRegistration.DisposeAsync().ConfigureAwait(false);
+        runtimeCts?.Dispose();
+
+        base.Dispose();
     }
 
     private void _StopProcessors()

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -18,6 +18,7 @@ internal sealed class Bootstrapper(
 {
     private readonly Lock _bootstrapLock = new();
     private bool _disposed;
+    private bool _isStopping;
     private CancellationTokenSource? _runtimeCts;
     private CancellationTokenRegistration _stoppingRegistration;
     private Task? _bootstrapTask;
@@ -35,6 +36,11 @@ internal sealed class Bootstrapper(
         lock (_bootstrapLock)
         {
             ObjectDisposedException.ThrowIf(_disposed, typeof(Bootstrapper));
+
+            if (_isStopping)
+            {
+                throw new InvalidOperationException("Cannot bootstrap after shutdown has begun.");
+            }
 
             if (_isStarted)
             {
@@ -100,7 +106,6 @@ internal sealed class Bootstrapper(
                 _bootstrapTask = null;
             }
 
-            _disposed = false;
             logger.MessagingStarted();
         }
         catch
@@ -175,14 +180,32 @@ internal sealed class Bootstrapper(
 
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
-        _isStarted = false;
+        CancellationTokenSource? runtimeCts;
+        CancellationTokenRegistration stoppingRegistration;
 
-        if (_runtimeCts != null)
+        lock (_bootstrapLock)
         {
-            await _runtimeCts.CancelAsync().ConfigureAwait(false);
+            _isStopping = true;
+            Volatile.Write(ref _isStarted, false);
+            runtimeCts = _runtimeCts;
+            _runtimeCts = null;
+            stoppingRegistration = _stoppingRegistration;
+            _stoppingRegistration = default;
         }
 
-        await _stoppingRegistration.DisposeAsync().ConfigureAwait(false);
+        if (runtimeCts is not null)
+        {
+            try
+            {
+                await runtimeCts.CancelAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore races with concurrent startup failure cleanup.
+            }
+        }
+
+        await stoppingRegistration.DisposeAsync().ConfigureAwait(false);
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -228,18 +251,29 @@ internal sealed class Bootstrapper(
 
     public override void Dispose()
     {
-        if (_disposed)
+        CancellationTokenSource? runtimeCts;
+        CancellationTokenRegistration stoppingRegistration;
+
+        lock (_bootstrapLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _isStopping = true;
+            Volatile.Write(ref _isStarted, false);
+            runtimeCts = _runtimeCts;
+            _runtimeCts = null;
+            stoppingRegistration = _stoppingRegistration;
+            _stoppingRegistration = default;
+            _bootstrapTask = null;
         }
 
-        _isStarted = false;
-        _runtimeCts?.Cancel();
-        _stoppingRegistration.Dispose();
-        _runtimeCts?.Dispose();
-        _runtimeCts = null;
-        _bootstrapTask = null;
-        _disposed = true;
+        runtimeCts?.Cancel();
+        stoppingRegistration.Dispose();
+        runtimeCts?.Dispose();
 
         base.Dispose();
     }

--- a/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
+++ b/src/Headless.Messaging.Core/Internal/IBootstrapper.Default.cs
@@ -99,6 +99,7 @@ internal sealed class Bootstrapper(
             await _BootstrapCoreAsync(startupToken).ConfigureAwait(false);
 
             var registration = runtimeCts.Token.Register(_StopProcessors);
+            var wasStopping = false;
 
             lock (_bootstrapLock)
             {
@@ -108,6 +109,7 @@ internal sealed class Bootstrapper(
                     _bootstrapTask = null;
                     _isStarted = false;
                     _stoppingRegistration = default;
+                    wasStopping = true;
                 }
                 else
                 {
@@ -117,7 +119,7 @@ internal sealed class Bootstrapper(
                 }
             }
 
-            if (_isStopping)
+            if (wasStopping)
             {
                 await registration.DisposeAsync().ConfigureAwait(false);
                 _StopProcessors();
@@ -286,9 +288,9 @@ internal sealed class Bootstrapper(
             Volatile.Write(ref _isStarted, false);
             runtimeCts = _runtimeCts;
             _runtimeCts = null;
+            stoppingRegistration = _stoppingRegistration;
             _stoppingRegistration = default;
             _bootstrapTask = null;
-            stoppingRegistration = default;
         }
 
 #pragma warning disable VSTHRD103 // Dispose is synchronous by contract — CancelAsync is not available here.

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -22,7 +22,6 @@ namespace Headless.Messaging.Internal;
 public interface IConsumerRegister : IProcessingServer
 {
     bool IsHealthy();
-    bool IsSubscriptionTopologyReady { get; }
 
     ValueTask ReStartAsync(bool force = false);
     ValueTask OnTopologyChangedAsync();
@@ -44,8 +43,8 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     private IConsumerClientFactory _consumerClientFactory = null!;
     private IDispatcher _dispatcher = null!;
     private int _state = (int)LifecycleState.NotStarted;
+    private readonly SemaphoreSlim _restartGate = new(1, 1);
     private volatile bool _isHealthy = true;
-    private bool _hasCapturedInitialTopology;
     private int _pendingTopologyRefresh;
 
     private MethodMatcherCache _selector = null!;
@@ -61,15 +60,12 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         return _isHealthy;
     }
 
-    public bool IsSubscriptionTopologyReady => (LifecycleState)Volatile.Read(ref _state) == LifecycleState.Running;
-
     public async ValueTask StartAsync(CancellationToken stoppingToken)
     {
         _hostStoppingToken = stoppingToken;
         _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
         _stoppingCtsRegistration = _stoppingCts.Token.Register(_OnCancellationRequested);
         Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
-        Volatile.Write(ref _hasCapturedInitialTopology, false);
         Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
 
         _selector = serviceProvider.GetRequiredService<MethodMatcherCache>();
@@ -82,15 +78,32 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         try
         {
             await ExecuteAsync().ConfigureAwait(false);
-            Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
-            await _DrainPendingTopologyRefreshesAsync().ConfigureAwait(false);
+
+            // Acquire the restart gate so topology-change-driven restarts cannot overlap
+            // with the drain loop that follows the initial startup.
+            await _restartGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
+                await _DrainPendingTopologyRefreshesAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _restartGate.Release();
+            }
         }
         catch
         {
-            await _stoppingCtsRegistration.DisposeAsync().ConfigureAwait(false);
-            _stoppingCts.Dispose();
+            // Clean up any partially created consumer handles before resetting state.
+            try
+            {
+                await PulseAsync().ConfigureAwait(false);
+            }
+#pragma warning disable ERP022 // Best-effort cleanup — state reset below prevents stale handles from being accessible.
+            catch { }
+#pragma warning restore ERP022
+
             Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
-            Volatile.Write(ref _hasCapturedInitialTopology, false);
             Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
             throw;
         }
@@ -100,8 +113,16 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     {
         if (!IsHealthy() || force)
         {
-            await _RestartCoreAsync().ConfigureAwait(false);
-            await _DrainPendingTopologyRefreshesAsync().ConfigureAwait(false);
+            await _restartGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await _RestartCoreAsync().ConfigureAwait(false);
+                await _DrainPendingTopologyRefreshesAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _restartGate.Release();
+            }
         }
     }
 
@@ -183,6 +204,7 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
                 await _dispatcher.DisposeAsync();
             }
 
+            _restartGate.Dispose();
             Interlocked.Exchange(ref _state, (int)LifecycleState.Disposed);
         }
     }
@@ -234,7 +256,6 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     public async ValueTask ExecuteAsync()
     {
         var groupingMatches = _selector.GetCandidatesMethodsOfGroupNameGrouped();
-        Volatile.Write(ref _hasCapturedInitialTopology, true);
 
         // Arm the OTel cardinality guard so unrecognized group names are rejected.
         _circuitBreakerStateManager?.RegisterKnownGroups(groupingMatches.Keys);
@@ -335,7 +356,6 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     private async ValueTask _RestartCoreAsync()
     {
         Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
-        Volatile.Write(ref _hasCapturedInitialTopology, false);
         Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
 
         // Preserve circuit breaker state across transport restarts — broker reconnects
@@ -352,12 +372,16 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         }
         catch
         {
-            // ExecuteAsync failed — the CTS created above will never be cleaned up by a
-            // subsequent PulseAsync call, so dispose it here to prevent a leak.
-            await _stoppingCtsRegistration.DisposeAsync().ConfigureAwait(false);
-            _stoppingCts.Dispose();
+            // Clean up any partially created consumer handles and the CTS created above.
+            try
+            {
+                await PulseAsync().ConfigureAwait(false);
+            }
+#pragma warning disable ERP022 // Best-effort cleanup — state reset below prevents stale handles from being accessible.
+            catch { }
+#pragma warning restore ERP022
+
             Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
-            Volatile.Write(ref _hasCapturedInitialTopology, false);
             Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
             throw;
         }

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -23,8 +23,8 @@ public interface IConsumerRegister : IProcessingServer
 {
     bool IsHealthy();
 
-    ValueTask ReStartAsync(bool force = false);
-    ValueTask OnTopologyChangedAsync();
+    ValueTask ReStartAsync(bool force = false, CancellationToken cancellationToken = default);
+    ValueTask OnTopologyChangedAsync(CancellationToken cancellationToken = default);
 }
 
 internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServiceProvider serviceProvider)
@@ -81,7 +81,7 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
 
             // Acquire the restart gate so topology-change-driven restarts cannot overlap
             // with the drain loop that follows the initial startup.
-            await _restartGate.WaitAsync().ConfigureAwait(false);
+            await _restartGate.WaitAsync(stoppingToken).ConfigureAwait(false);
             try
             {
                 Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
@@ -116,11 +116,11 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         }
     }
 
-    public async ValueTask ReStartAsync(bool force = false)
+    public async ValueTask ReStartAsync(bool force = false, CancellationToken cancellationToken = default)
     {
         if (!IsHealthy() || force)
         {
-            await _restartGate.WaitAsync().ConfigureAwait(false);
+            await _restartGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 await _RestartCoreAsync().ConfigureAwait(false);
@@ -137,13 +137,13 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         }
     }
 
-    public async ValueTask OnTopologyChangedAsync()
+    public async ValueTask OnTopologyChangedAsync(CancellationToken cancellationToken = default)
     {
         var current = (LifecycleState)Volatile.Read(ref _state);
 
         if (current == LifecycleState.Running)
         {
-            await ReStartAsync(force: true).ConfigureAwait(false);
+            await ReStartAsync(force: true, cancellationToken).ConfigureAwait(false);
             return;
         }
 

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -44,7 +44,7 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     private IConsumerClientFactory _consumerClientFactory = null!;
     private IDispatcher _dispatcher = null!;
     private int _state = (int)LifecycleState.NotStarted;
-    private bool _isHealthy = true;
+    private volatile bool _isHealthy = true;
     private bool _hasCapturedInitialTopology;
     private int _pendingTopologyRefresh;
 
@@ -70,6 +70,7 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         _stoppingCtsRegistration = _stoppingCts.Token.Register(_OnCancellationRequested);
         Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
         Volatile.Write(ref _hasCapturedInitialTopology, false);
+        Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
 
         _selector = serviceProvider.GetRequiredService<MethodMatcherCache>();
         _dispatcher = serviceProvider.GetRequiredService<IDispatcher>();
@@ -80,21 +81,17 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
 
         try
         {
-            await ExecuteAsync();
-
+            await ExecuteAsync().ConfigureAwait(false);
             Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
-
-            if (Interlocked.Exchange(ref _pendingTopologyRefresh, 0) == 1)
-            {
-                await ReStartAsync(force: true);
-            }
+            await _DrainPendingTopologyRefreshesAsync().ConfigureAwait(false);
         }
         catch
         {
-            await _stoppingCtsRegistration.DisposeAsync();
+            await _stoppingCtsRegistration.DisposeAsync().ConfigureAwait(false);
             _stoppingCts.Dispose();
             Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
             Volatile.Write(ref _hasCapturedInitialTopology, false);
+            Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
             throw;
         }
     }
@@ -103,38 +100,8 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     {
         if (!IsHealthy() || force)
         {
-            Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
-            Volatile.Write(ref _hasCapturedInitialTopology, false);
-
-            // Preserve circuit breaker state across transport restarts — broker reconnects
-            // are orthogonal to handler failures tracked by the circuit breaker.
-            await PulseAsync(removeCircuitState: false);
-
-            _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(_hostStoppingToken);
-            _stoppingCtsRegistration = _stoppingCts.Token.Register(_OnCancellationRequested);
-            _isHealthy = true;
-
-            try
-            {
-                await ExecuteAsync();
-            }
-            catch
-            {
-                // ExecuteAsync failed — the CTS created above will never be cleaned up by a
-                // subsequent PulseAsync call, so dispose it here to prevent a leak.
-                await _stoppingCtsRegistration.DisposeAsync();
-                _stoppingCts.Dispose();
-                Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
-                Volatile.Write(ref _hasCapturedInitialTopology, false);
-                throw;
-            }
-
-            Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
-
-            if (Interlocked.Exchange(ref _pendingTopologyRefresh, 0) == 1)
-            {
-                await ReStartAsync(force: true);
-            }
+            await _RestartCoreAsync().ConfigureAwait(false);
+            await _DrainPendingTopologyRefreshesAsync().ConfigureAwait(false);
         }
     }
 
@@ -362,6 +329,47 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
 
                 handle.ConsumerTasks.Add(task);
             }
+        }
+    }
+
+    private async ValueTask _RestartCoreAsync()
+    {
+        Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
+        Volatile.Write(ref _hasCapturedInitialTopology, false);
+        Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
+
+        // Preserve circuit breaker state across transport restarts — broker reconnects
+        // are orthogonal to handler failures tracked by the circuit breaker.
+        await PulseAsync(removeCircuitState: false).ConfigureAwait(false);
+
+        _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(_hostStoppingToken);
+        _stoppingCtsRegistration = _stoppingCts.Token.Register(_OnCancellationRequested);
+        _isHealthy = true;
+
+        try
+        {
+            await ExecuteAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // ExecuteAsync failed — the CTS created above will never be cleaned up by a
+            // subsequent PulseAsync call, so dispose it here to prevent a leak.
+            await _stoppingCtsRegistration.DisposeAsync().ConfigureAwait(false);
+            _stoppingCts.Dispose();
+            Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
+            Volatile.Write(ref _hasCapturedInitialTopology, false);
+            Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
+            throw;
+        }
+
+        Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
+    }
+
+    private async ValueTask _DrainPendingTopologyRefreshesAsync()
+    {
+        while (Interlocked.Exchange(ref _pendingTopologyRefresh, 0) == 1)
+        {
+            await _RestartCoreAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -22,8 +22,10 @@ namespace Headless.Messaging.Internal;
 public interface IConsumerRegister : IProcessingServer
 {
     bool IsHealthy();
+    bool IsSubscriptionTopologyReady { get; }
 
     ValueTask ReStartAsync(bool force = false);
+    ValueTask OnTopologyChangedAsync();
 }
 
 internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServiceProvider serviceProvider)
@@ -42,7 +44,9 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     private IConsumerClientFactory _consumerClientFactory = null!;
     private IDispatcher _dispatcher = null!;
     private int _state = (int)LifecycleState.NotStarted;
-    private volatile bool _isHealthy = true;
+    private bool _isHealthy = true;
+    private bool _hasCapturedInitialTopology;
+    private int _pendingTopologyRefresh;
 
     private MethodMatcherCache _selector = null!;
     private ISerializer _serializer = null!;
@@ -57,11 +61,15 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         return _isHealthy;
     }
 
+    public bool IsSubscriptionTopologyReady => (LifecycleState)Volatile.Read(ref _state) == LifecycleState.Running;
+
     public async ValueTask StartAsync(CancellationToken stoppingToken)
     {
         _hostStoppingToken = stoppingToken;
         _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
         _stoppingCtsRegistration = _stoppingCts.Token.Register(_OnCancellationRequested);
+        Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
+        Volatile.Write(ref _hasCapturedInitialTopology, false);
 
         _selector = serviceProvider.GetRequiredService<MethodMatcherCache>();
         _dispatcher = serviceProvider.GetRequiredService<IDispatcher>();
@@ -70,15 +78,34 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
         _consumerClientFactory = serviceProvider.GetRequiredService<IConsumerClientFactory>();
         _circuitBreakerStateManager = serviceProvider.GetService<ICircuitBreakerStateManager>();
 
-        await ExecuteAsync();
+        try
+        {
+            await ExecuteAsync();
 
-        Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
+            Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
+
+            if (Interlocked.Exchange(ref _pendingTopologyRefresh, 0) == 1)
+            {
+                await ReStartAsync(force: true);
+            }
+        }
+        catch
+        {
+            await _stoppingCtsRegistration.DisposeAsync();
+            _stoppingCts.Dispose();
+            Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
+            Volatile.Write(ref _hasCapturedInitialTopology, false);
+            throw;
+        }
     }
 
     public async ValueTask ReStartAsync(bool force = false)
     {
         if (!IsHealthy() || force)
         {
+            Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
+            Volatile.Write(ref _hasCapturedInitialTopology, false);
+
             // Preserve circuit breaker state across transport restarts — broker reconnects
             // are orthogonal to handler failures tracked by the circuit breaker.
             await PulseAsync(removeCircuitState: false);
@@ -97,10 +124,33 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
                 // subsequent PulseAsync call, so dispose it here to prevent a leak.
                 await _stoppingCtsRegistration.DisposeAsync();
                 _stoppingCts.Dispose();
+                Interlocked.Exchange(ref _state, (int)LifecycleState.NotStarted);
+                Volatile.Write(ref _hasCapturedInitialTopology, false);
                 throw;
             }
 
             Interlocked.Exchange(ref _state, (int)LifecycleState.Running);
+
+            if (Interlocked.Exchange(ref _pendingTopologyRefresh, 0) == 1)
+            {
+                await ReStartAsync(force: true);
+            }
+        }
+    }
+
+    public async ValueTask OnTopologyChangedAsync()
+    {
+        var current = (LifecycleState)Volatile.Read(ref _state);
+
+        if (current == LifecycleState.Running)
+        {
+            await ReStartAsync(force: true).ConfigureAwait(false);
+            return;
+        }
+
+        if (current == LifecycleState.Starting && Volatile.Read(ref _hasCapturedInitialTopology))
+        {
+            Interlocked.Exchange(ref _pendingTopologyRefresh, 1);
         }
     }
 
@@ -217,6 +267,7 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     public async ValueTask ExecuteAsync()
     {
         var groupingMatches = _selector.GetCandidatesMethodsOfGroupNameGrouped();
+        Volatile.Write(ref _hasCapturedInitialTopology, true);
 
         // Arm the OTel cardinality guard so unrecognized group names are rejected.
         _circuitBreakerStateManager?.RegisterKnownGroups(groupingMatches.Keys);
@@ -618,9 +669,10 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
     private enum LifecycleState
     {
         NotStarted = 0,
-        Running = 1,
-        Disposing = 2,
-        Disposed = 3,
+        Starting = 1,
+        Running = 2,
+        Disposing = 3,
+        Disposed = 4,
     }
 
     private sealed class GroupHandle : IAsyncDisposable

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -89,7 +89,14 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
             }
             finally
             {
-                _restartGate.Release();
+                try
+                {
+                    _restartGate.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // If we failed to acquire the gate above, it means DisposeAsync has already run and we should not attempt to release.
+                }
             }
         }
         catch
@@ -121,7 +128,11 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
             }
             finally
             {
-                _restartGate.Release();
+                try
+                {
+                    _restartGate.Release();
+                }
+                catch (ObjectDisposedException) { }
             }
         }
     }
@@ -355,6 +366,12 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
 
     private async ValueTask _RestartCoreAsync()
     {
+        var current = (LifecycleState)Volatile.Read(ref _state);
+        if (current is LifecycleState.Disposing or LifecycleState.Disposed)
+        {
+            return;
+        }
+
         Interlocked.Exchange(ref _state, (int)LifecycleState.Starting);
         Interlocked.Exchange(ref _pendingTopologyRefresh, 0);
 

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -115,7 +115,7 @@ internal sealed class ConsumerRegister(ILogger<ConsumerRegister> logger, IServic
             return;
         }
 
-        if (current == LifecycleState.Starting && Volatile.Read(ref _hasCapturedInitialTopology))
+        if (current == LifecycleState.Starting)
         {
             Interlocked.Exchange(ref _pendingTopologyRefresh, 1);
         }

--- a/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs
+++ b/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs
@@ -8,7 +8,6 @@ internal sealed class RuntimeSubscriber(
     IRuntimeConsumerRegistry runtimeRegistry,
     MethodMatcherCache methodMatcherCache,
     IConsumerRegister consumerRegister,
-    IBootstrapper bootstrapper,
     ILogger<RuntimeSubscriber> logger
 ) : IRuntimeSubscriber, IDisposable
 {
@@ -27,12 +26,6 @@ internal sealed class RuntimeSubscriber(
         try
         {
             var result = runtimeRegistry.Register(handler, options);
-            methodMatcherCache.Invalidate();
-
-            if (bootstrapper.IsStarted)
-            {
-                await consumerRegister.ReStartAsync(force: true).ConfigureAwait(false);
-            }
 
             if (result.Status == RuntimeConsumerRegistrationStatus.Ignored)
             {
@@ -44,6 +37,8 @@ internal sealed class RuntimeSubscriber(
                 );
             }
 
+            methodMatcherCache.Invalidate();
+            await consumerRegister.OnTopologyChangedAsync().ConfigureAwait(false);
             logger.RuntimeSubscriptionAttached(result.SubscriptionId, result.Topic, result.Group, result.HandlerId);
 
             return RuntimeSubscriptionHandle.Attached(
@@ -77,11 +72,7 @@ internal sealed class RuntimeSubscriber(
             }
 
             methodMatcherCache.Invalidate();
-
-            if (bootstrapper.IsStarted)
-            {
-                await consumerRegister.ReStartAsync(force: true).ConfigureAwait(false);
-            }
+            await consumerRegister.OnTopologyChangedAsync().ConfigureAwait(false);
 
             logger.RuntimeSubscriptionDetached(subscriptionId);
             return true;

--- a/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs
+++ b/src/Headless.Messaging.Core/Internal/RuntimeSubscriber.cs
@@ -38,7 +38,7 @@ internal sealed class RuntimeSubscriber(
             }
 
             methodMatcherCache.Invalidate();
-            await consumerRegister.OnTopologyChangedAsync().ConfigureAwait(false);
+            await consumerRegister.OnTopologyChangedAsync(cancellationToken).ConfigureAwait(false);
             logger.RuntimeSubscriptionAttached(result.SubscriptionId, result.Topic, result.Group, result.HandlerId);
 
             return RuntimeSubscriptionHandle.Attached(
@@ -72,7 +72,7 @@ internal sealed class RuntimeSubscriber(
             }
 
             methodMatcherCache.Invalidate();
-            await consumerRegister.OnTopologyChangedAsync().ConfigureAwait(false);
+            await consumerRegister.OnTopologyChangedAsync(cancellationToken).ConfigureAwait(false);
 
             logger.RuntimeSubscriptionDetached(subscriptionId);
             return true;

--- a/src/Headless.Messaging.Core/Processor/IProcessor.TransportCheck.cs
+++ b/src/Headless.Messaging.Core/Processor/IProcessor.TransportCheck.cs
@@ -23,7 +23,7 @@ public sealed class TransportCheckProcessor(ILogger<TransportCheckProcessor> log
         {
             logger.TransportUnhealthy();
 
-            await register.ReStartAsync();
+            await register.ReStartAsync(cancellationToken: context.CancellationToken);
         }
         else
         {

--- a/src/Headless.Messaging.Core/README.md
+++ b/src/Headless.Messaging.Core/README.md
@@ -90,6 +90,16 @@ public sealed class MetricsService(IDirectPublisher publisher)
 - direct publish, outbox publish, and runtime delegates preserve the existing diagnostic listener and metric names used by dashboards.
 - runtime delegates execute through the same scoped consume pipeline as class handlers, so diagnostics, filters, and correlation behavior stay aligned.
 - `IConsumerLifecycle` hooks run per delivery on the scoped consumer instance, not once for application startup or shutdown.
+- `IBootstrapper.IsStarted` becomes `true` only after required messaging processors finish startup successfully.
+- Concurrent `BootstrapAsync(...)` callers share the same in-flight startup work; canceling a later caller's wait does not abort the shared bootstrap.
+
+## Bootstrap Lifecycle
+
+- `BootstrapAsync(...)` is the readiness boundary for manual startup paths such as tests or custom hosts.
+- Wait for `BootstrapAsync(...)` to complete before publishing when you bootstrap manually.
+- Startup fails when a required messaging processor cannot start; partial logged startup is not treated as success.
+- Runtime delegate subscriptions attached before the consumer register is ready are picked up by the initial startup path.
+- Runtime delegate subscriptions attached after the consumer register is ready trigger a consumer refresh so they are not missed during late startup.
 
 ## Publisher Options
 
@@ -169,6 +179,8 @@ public sealed class ProjectionSubscriptions(IRuntimeSubscriber subscriber)
     }
 }
 ```
+
+When runtime delegates are attached during application startup, the messaging runtime ensures they are either included in the initial consumer registration pass or trigger a refresh once the consumer register is live. You do not need to manually restart messaging after calling `SubscribeAsync(...)`.
 
 ## Configuration
 

--- a/src/Headless.Messaging.InMemoryQueue/README.md
+++ b/src/Headless.Messaging.InMemoryQueue/README.md
@@ -40,9 +40,11 @@ No configuration required. Just call `UseInMemoryQueue()`.
 
 - Publish and consume happen in process only. Headers and payload never leave memory.
 - Delay stays in the core pipeline. There is no broker-native scheduling layer.
+- Manual callers should await `IBootstrapper.BootstrapAsync(...)` before publishing or attaching runtime subscriptions.
 - Commit is a no-op.
 - Reject is a no-op. There is no durable redelivery or dead-letter queue.
 - `SubscribeAsync(...)` only registers in-memory topic bindings for the current process.
+- Publishing to an unbound topic still fails fast. `InMemoryQueue` is intentionally strict so tests and local development do not silently hide invalid publish targets or missing consumer registration.
 - Single-threaded consumption preserves queue order. Higher `ConsumerThreadCount` can reorder concurrent handlers.
 - Payload size is limited by process memory.
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/BootstrapperTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/BootstrapperTests.cs
@@ -1,0 +1,142 @@
+using Headless.Messaging;
+using Headless.Messaging.Configuration;
+using Headless.Messaging.Internal;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Tests;
+
+public sealed class BootstrapperTests : TestBase
+{
+    [Fact]
+    public async Task should_report_started_only_after_bootstrap_completes()
+    {
+        var blocker = new BlockingProcessingServer();
+        await using var provider = _CreateProvider(beforeMessaging: blocker);
+        var bootstrapper = provider.GetRequiredService<IBootstrapper>();
+
+        var bootstrapTask = bootstrapper.BootstrapAsync(AbortToken);
+        await blocker.WaitUntilStartedAsync(AbortToken);
+
+        bootstrapper.IsStarted.Should().BeFalse();
+
+        blocker.Release();
+        await bootstrapTask;
+
+        bootstrapper.IsStarted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_allow_non_owner_callers_to_cancel_wait_without_canceling_shared_bootstrap()
+    {
+        var blocker = new BlockingProcessingServer();
+        await using var provider = _CreateProvider(beforeMessaging: blocker);
+        var bootstrapper = provider.GetRequiredService<IBootstrapper>();
+
+        var ownerTask = bootstrapper.BootstrapAsync(AbortToken);
+        await blocker.WaitUntilStartedAsync(AbortToken);
+
+        using var waiterCts = new CancellationTokenSource();
+        var waiterTask = bootstrapper.BootstrapAsync(waiterCts.Token);
+        await waiterCts.CancelAsync();
+
+        var act = async () => await waiterTask;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        ownerTask.IsCompleted.Should().BeFalse();
+        bootstrapper.IsStarted.Should().BeFalse();
+
+        blocker.Release();
+        await ownerTask;
+
+        bootstrapper.IsStarted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_fail_bootstrap_when_required_processor_fails_to_start()
+    {
+        var failure = new InvalidOperationException("processor boom");
+        await using var provider = _CreateProvider(beforeMessaging: new FailingProcessingServer(failure));
+        var bootstrapper = provider.GetRequiredService<IBootstrapper>();
+
+        var act = async () => await bootstrapper.BootstrapAsync(AbortToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("processor boom");
+        bootstrapper.IsStarted.Should().BeFalse();
+    }
+
+    private ServiceProvider _CreateProvider(
+        IProcessingServer? beforeMessaging = null,
+        IProcessingServer? afterMessaging = null
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.AddProvider(LoggerProvider);
+            builder.SetMinimumLevel(LogLevel.Debug);
+        });
+
+        if (beforeMessaging is not null)
+        {
+            services.AddSingleton<IProcessingServer>(beforeMessaging);
+        }
+
+        services.AddHeadlessMessaging(options =>
+        {
+            options.UseInMemoryMessageQueue();
+            options.UseInMemoryStorage();
+            options.UseConventions(c =>
+            {
+                c.UseApplicationId("bootstrap-tests");
+                c.UseVersion("v1");
+            });
+        });
+
+        if (afterMessaging is not null)
+        {
+            services.AddSingleton<IProcessingServer>(afterMessaging);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class BlockingProcessingServer : IProcessingServer
+    {
+        private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask StartAsync(CancellationToken stoppingToken)
+        {
+            _started.TrySetResult();
+            await _release.Task.WaitAsync(stoppingToken);
+        }
+
+        public async ValueTask WaitUntilStartedAsync(CancellationToken cancellationToken)
+        {
+            await _started.Task.WaitAsync(cancellationToken);
+        }
+
+        public void Release()
+        {
+            _release.TrySetResult();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _release.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FailingProcessingServer(Exception exception) : IProcessingServer
+    {
+        public ValueTask StartAsync(CancellationToken stoppingToken)
+        {
+            return ValueTask.FromException(exception);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Headless.Messaging.Core.Tests.Unit/BootstrapperTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/BootstrapperTests.cs
@@ -66,6 +66,43 @@ public sealed class BootstrapperTests : TestBase
         bootstrapper.IsStarted.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task should_not_stop_runtime_when_owner_bootstrap_token_is_canceled_after_startup()
+    {
+        var processor = new TrackingProcessingServer();
+        await using var provider = _CreateProvider(beforeMessaging: processor);
+        var bootstrapper = provider.GetRequiredService<IBootstrapper>();
+        using var ownerCts = new CancellationTokenSource();
+
+        await bootstrapper.BootstrapAsync(ownerCts.Token);
+        bootstrapper.IsStarted.Should().BeTrue();
+
+        await ownerCts.CancelAsync();
+
+        await Task.Delay(100, AbortToken);
+
+        processor.DisposeCount.Should().Be(0);
+        bootstrapper.IsStarted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_stop_started_processors_when_later_processor_fails_during_bootstrap()
+    {
+        var startedProcessor = new TrackingProcessingServer();
+        var failure = new InvalidOperationException("processor boom");
+        await using var provider = _CreateProvider(
+            beforeMessaging: startedProcessor,
+            afterMessaging: new FailingProcessingServer(failure)
+        );
+        var bootstrapper = provider.GetRequiredService<IBootstrapper>();
+
+        var act = async () => await bootstrapper.BootstrapAsync(AbortToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("processor boom");
+        startedProcessor.DisposeCount.Should().BeGreaterThan(0);
+        bootstrapper.IsStarted.Should().BeFalse();
+    }
+
     private ServiceProvider _CreateProvider(
         IProcessingServer? beforeMessaging = null,
         IProcessingServer? afterMessaging = null
@@ -138,5 +175,23 @@ public sealed class BootstrapperTests : TestBase
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class TrackingProcessingServer : IProcessingServer
+    {
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        private int _disposeCount;
+
+        public ValueTask StartAsync(CancellationToken stoppingToken)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _disposeCount);
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
@@ -247,17 +247,15 @@ public sealed class ConsumerRegisterTests : TestBase
     }
 
     [Fact]
-    public async Task topology_change_during_startup_queues_refresh_before_initial_snapshot_is_marked_ready()
+    public async Task should_queue_topology_refresh_when_change_occurs_during_startup()
     {
         await using var provider = _CreateProvider();
         var register = (ConsumerRegister)provider.GetRequiredService<IConsumerRegister>();
 
+        // Set state to Starting (1) to simulate mid-startup.
         typeof(ConsumerRegister)
             .GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)!
             .SetValue(register, 1);
-        typeof(ConsumerRegister)
-            .GetField("_hasCapturedInitialTopology", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .SetValue(register, false);
 
         await register.OnTopologyChangedAsync();
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
@@ -246,6 +246,28 @@ public sealed class ConsumerRegisterTests : TestBase
         await register.DisposeAsync();
     }
 
+    [Fact]
+    public async Task topology_change_during_startup_queues_refresh_before_initial_snapshot_is_marked_ready()
+    {
+        await using var provider = _CreateProvider();
+        var register = (ConsumerRegister)provider.GetRequiredService<IConsumerRegister>();
+
+        typeof(ConsumerRegister)
+            .GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(register, 1);
+        typeof(ConsumerRegister)
+            .GetField("_hasCapturedInitialTopology", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(register, false);
+
+        await register.OnTopologyChangedAsync();
+
+        var pendingRefresh = typeof(ConsumerRegister)
+            .GetField("_pendingTopologyRefresh", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(register);
+
+        pendingRefresh.Should().Be(1);
+    }
+
     private ServiceProvider _CreateProvider(ICircuitBreakerStateManager? circuitBreakerStateManager = null)
     {
         var services = new ServiceCollection();

--- a/tests/Headless.Messaging.Core.Tests.Unit/IntegrationTests/RuntimeSubscriberIntegrationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/IntegrationTests/RuntimeSubscriberIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Headless.Messaging;
+using Headless.Messaging.Internal;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -74,7 +75,47 @@ public sealed class RuntimeSubscriberIntegrationTests : TestBase
         probe.ProcessedMessageIds.Should().ContainSingle().Which.Should().Be("first");
     }
 
+    [Fact]
+    public async Task should_restart_consumers_for_runtime_subscription_added_after_consumer_register_is_ready()
+    {
+        var blocker = new BlockingProcessingServer();
+        await using var provider = _CreateProvider(blocker);
+        var bootstrapper = provider.GetRequiredService<IBootstrapper>();
+        var runtimeSubscriber = provider.GetRequiredService<IRuntimeSubscriber>();
+        var publisher = provider.GetRequiredService<IOutboxPublisher>();
+        var probe = provider.GetRequiredService<RecordingRuntimeProbe>();
+
+        var bootstrapTask = bootstrapper.BootstrapAsync(AbortToken);
+        await blocker.WaitUntilStartedAsync(AbortToken);
+        bootstrapper.IsStarted.Should().BeFalse();
+
+        await runtimeSubscriber.SubscribeAsync<RuntimeMessage>(
+            probe.HandleAsync,
+            new RuntimeSubscriptionOptions { Topic = "runtime.mid-bootstrap", Group = "runtime.mid-bootstrap" },
+            AbortToken
+        );
+
+        blocker.Release();
+        await bootstrapTask;
+
+        await publisher.PublishAsync(
+            new RuntimeMessage("mid-bootstrap"),
+            new PublishOptions { Topic = "runtime.mid-bootstrap" },
+            AbortToken
+        );
+
+        var consumed = await probe.WaitForMessageAsync(AbortToken);
+        consumed.Message.Id.Should().Be("mid-bootstrap");
+    }
+
     private async Task<ServiceProvider> _CreateStartedProviderAsync()
+    {
+        var provider = _CreateProvider();
+        await provider.GetRequiredService<IBootstrapper>().BootstrapAsync(AbortToken);
+        return provider;
+    }
+
+    private ServiceProvider _CreateProvider(IProcessingServer? additionalProcessor = null)
     {
         var services = new ServiceCollection();
         services.AddLogging(builder =>
@@ -100,9 +141,12 @@ public sealed class RuntimeSubscriberIntegrationTests : TestBase
             });
         });
 
-        var provider = services.BuildServiceProvider();
-        await provider.GetRequiredService<IBootstrapper>().BootstrapAsync(AbortToken);
-        return provider;
+        if (additionalProcessor is not null)
+        {
+            services.AddSingleton<IProcessingServer>(additionalProcessor);
+        }
+
+        return services.BuildServiceProvider();
     }
 
     private sealed record RuntimeMessage(string Id);
@@ -194,5 +238,33 @@ public sealed class RuntimeSubscriberIntegrationTests : TestBase
         }
 
         public void Release() => _release.TrySetResult();
+    }
+
+    private sealed class BlockingProcessingServer : IProcessingServer
+    {
+        private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask StartAsync(CancellationToken stoppingToken)
+        {
+            _started.TrySetResult();
+            return new ValueTask(_release.Task.WaitAsync(stoppingToken));
+        }
+
+        public async Task WaitUntilStartedAsync(CancellationToken cancellationToken)
+        {
+            await _started.Task.WaitAsync(cancellationToken);
+        }
+
+        public void Release()
+        {
+            _release.TrySetResult();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _release.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make messaging bootstrap share one in-flight startup task and report `IsStarted` only after required startup succeeds
- fail bootstrap when required processors cannot start and coordinate runtime subscription refreshes through the consumer-register readiness boundary
- add focused bootstrap/runtime subscription regressions and update lifecycle-semantic docs in the same change

## Testing
- `bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh build tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj`
- `bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh run-built --filter-class "*BootstrapperTests" --filter-class "*RuntimeSubscriberIntegrationTests" --filter-class "*RuntimeSubscriberTests" tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj`
- `bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh build tests/Headless.Messaging.Testing.Tests.Unit/Headless.Messaging.Testing.Tests.Unit.csproj`
- `bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh run-built --filter-class "*EndToEndTests" tests/Headless.Messaging.Testing.Tests.Unit/Headless.Messaging.Testing.Tests.Unit.csproj`
- `bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh build tests/Headless.Messaging.InMemoryQueue.Tests.Unit/Headless.Messaging.InMemoryQueue.Tests.Unit.csproj`
- `bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh run-built --filter-class "*MemoryQueueTests" --filter-class "*InMemoryQueueTransportTests" tests/Headless.Messaging.InMemoryQueue.Tests.Unit/Headless.Messaging.InMemoryQueue.Tests.Unit.csproj`

## Notes
- this intentionally changes startup behavior in the greenfield messaging runtime so `IsStarted` is trustworthy and required processor startup failures fail bootstrap

Closes #204