### PR TITLE
Add E2E cache invalidation messaging tests

### DIFF
--- a/tests/Headless.Features.Tests.Integration/FeatureManagerTests.cs
+++ b/tests/Headless.Features.Tests.Integration/FeatureManagerTests.cs
@@ -2,6 +2,8 @@ using Headless.Exceptions;
 using Headless.Features;
 using Headless.Features.Definitions;
 using Headless.Features.Models;
+using Headless.Features.Repositories;
+using Headless.Features.Entities;
 using Headless.Features.ValueProviders;
 using Headless.Features.Values;
 using Microsoft.Extensions.DependencyInjection;
@@ -190,6 +192,65 @@ public sealed class FeatureManagerTests(FeaturesTestFixture fixture) : FeaturesT
         feature.Provider.Should().NotBeNull();
         feature.Provider.Name.Should().Be(EditionFeatureValueProvider.ProviderName);
         feature.Provider.Key.Should().Be(editionId);
+    }
+
+    [Fact]
+    public async Task should_invalidate_cached_feature_end_to_end_when_repository_updates_record()
+    {
+        // given
+        await Fixture.ResetAsync();
+        using var host = CreateHost(b => b.Services.AddFeatureDefinitionProvider<Feature1FeaturesDefinitionProvider>());
+        await using var scope = host.Services.CreateAsyncScope();
+        var featureManager = scope.ServiceProvider.GetRequiredService<IFeatureManager>();
+        var valueRepository = scope.ServiceProvider.GetRequiredService<IFeatureValueRecordRepository>();
+        const string featureName = "Feature1";
+        const string editionId = "AnyEditionId";
+        const string updatedValue = "UpdatedByRepository";
+
+        await featureManager.SetAsync(
+            featureName,
+            "true",
+            FeatureValueProviderNames.Edition,
+            editionId,
+            cancellationToken: AbortToken
+        );
+
+        (await featureManager.GetAsync(
+            featureName,
+            FeatureValueProviderNames.Edition,
+            editionId,
+            cancellationToken: AbortToken
+        ))
+            .Value.Should()
+            .Be("true");
+
+        var record = await valueRepository.FindAsync(
+            featureName,
+            EditionFeatureValueProvider.ProviderName,
+            editionId,
+            AbortToken
+        );
+        record.Should().NotBeNull();
+
+        // when
+        var updatedRecord = new FeatureValueRecord(
+            record!.Id,
+            record.Name,
+            updatedValue,
+            record.ProviderName,
+            record.ProviderKey
+        );
+        await valueRepository.UpdateAsync(updatedRecord, AbortToken);
+
+        // then
+        (await featureManager.GetAsync(
+            featureName,
+            FeatureValueProviderNames.Edition,
+            editionId,
+            cancellationToken: AbortToken
+        ))
+            .Value.Should()
+            .Be(updatedValue);
     }
 
     [Fact]

--- a/tests/Headless.Permissions.Tests.Integration/PermissionManagerTests.cs
+++ b/tests/Headless.Permissions.Tests.Integration/PermissionManagerTests.cs
@@ -3,6 +3,7 @@ using Headless.Permissions.Definitions;
 using Headless.Permissions.GrantProviders;
 using Headless.Permissions.Grants;
 using Headless.Permissions.Models;
+using Headless.Permissions.Repositories;
 using Headless.Primitives;
 using Headless.Testing.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -215,6 +216,48 @@ public sealed class PermissionManagerTests(PermissionsTestFixture fixture) : Per
         permission = await permissionManager.GetAsync(somePermission.Name, currentUser, cancellationToken: AbortToken);
         permission.IsGranted.Should().BeTrue();
         permission.Providers.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task should_invalidate_cached_permission_end_to_end_when_repository_deletes_grant()
+    {
+        // given
+        await Fixture.ResetAsync();
+        using var host = CreateHost(b => b.Services.AddPermissionDefinitionProvider<PermissionsDefinitionProvider>());
+        await using var scope = host.Services.CreateAsyncScope();
+        var permissionManager = scope.ServiceProvider.GetRequiredService<IPermissionManager>();
+        var grantRepository = scope.ServiceProvider.GetRequiredService<IPermissionGrantRepository>();
+        const string roleName = "Role1";
+        var permissionName = _GroupDefinitions[0].Permissions[0].Name;
+
+        var currentUser = new TestCurrentUser
+        {
+            IsAuthenticated = true,
+            UserId = new UserId("123"),
+            WritableRoles = { roleName },
+        };
+
+        await permissionManager.GrantToRoleAsync(permissionName, roleName, AbortToken);
+
+        (await permissionManager.GetAsync(permissionName, currentUser, cancellationToken: AbortToken))
+            .IsGranted.Should()
+            .BeTrue();
+
+        var record = await grantRepository.FindAsync(
+            permissionName,
+            RolePermissionGrantProvider.ProviderName,
+            roleName,
+            AbortToken
+        );
+        record.Should().NotBeNull();
+
+        // when
+        await grantRepository.DeleteAsync(record!, AbortToken);
+
+        // then
+        (await permissionManager.GetAsync(permissionName, currentUser, cancellationToken: AbortToken))
+            .IsGranted.Should()
+            .BeFalse();
     }
 
     [Fact]

--- a/tests/Headless.Settings.Tests.Integration/SettingManagerTests.cs
+++ b/tests/Headless.Settings.Tests.Integration/SettingManagerTests.cs
@@ -147,6 +147,50 @@ public sealed class SettingManagerTests(SettingsTestFixture fixture) : SettingsT
     }
 
     [Fact]
+    public async Task should_invalidate_cached_user_setting_end_to_end_when_repository_updates_record()
+    {
+        // given
+        await Fixture.ResetAsync();
+        using var host = CreateHost(b => b.Services.AddSettingDefinitionProvider<SettingsDefinitionProvider>());
+        await using var scope = host.Services.CreateAsyncScope();
+        var settingManager = scope.ServiceProvider.GetRequiredService<ISettingManager>();
+        var valueRepository = scope.ServiceProvider.GetRequiredService<ISettingValueRecordRepository>();
+        var userId = Guid.NewGuid().ToString();
+        const string settingName = "Setting1";
+        const string initialValue = "InitialValue";
+        const string updatedValue = "UpdatedByRepository";
+
+        await settingManager.SetForUserAsync(userId, settingName, initialValue, cancellationToken: AbortToken);
+
+        (await settingManager.FindForUserAsync(userId, settingName, cancellationToken: AbortToken))
+            .Should()
+            .Be(initialValue);
+
+        var record = await valueRepository.FindAsync(
+            settingName,
+            UserSettingValueProvider.ProviderName,
+            userId,
+            AbortToken
+        );
+        record.Should().NotBeNull();
+
+        // when
+        var updatedRecord = new Headless.Settings.Entities.SettingValueRecord(
+            record!.Id,
+            record.Name,
+            updatedValue,
+            record.ProviderName,
+            record.ProviderKey
+        );
+        await valueRepository.UpdateAsync(updatedRecord, AbortToken);
+
+        // then
+        (await settingManager.FindForUserAsync(userId, settingName, cancellationToken: AbortToken))
+            .Should()
+            .Be(updatedValue);
+    }
+
+    [Fact]
     public async Task should_get_dynamic_settings()
     {
         // given: host1 with dynamic setting store enabled


### PR DESCRIPTION
## Summary
Add explicit end-to-end coverage for the local messaging cache invalidation path in Settings, Features, and Permissions.

The new tests prime cached state through the public managers, mutate persistence through the EF repositories, and then assert the managers observe the refreshed value or grant after the local message handlers invalidate cache entries.

## What Changed
- add a Settings integration test covering repository update -> local publisher -> setting cache invalidation
- add a Features integration test covering repository update -> local publisher -> feature cache invalidation
- add a Permissions integration test covering repository delete -> local publisher -> permission cache invalidation

## Test Plan
- bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh run tests/Headless.Settings.Tests.Integration/Headless.Settings.Tests.Integration.csproj -- --filter-class '*SettingManagerTests'
- bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh run tests/Headless.Features.Tests.Integration/Headless.Features.Tests.Integration.csproj -- --filter-class '*FeatureManagerTests'
- bash /Users/xshaheen/Dev/sys-prep/config/codex/skills/dotnet-test/scripts/test.sh run tests/Headless.Permissions.Tests.Integration/Headless.Permissions.Tests.Integration.csproj -- --filter-class '*PermissionManagerTests'