### PR TITLE
feat: add IInitializer completion-signal to background services

### DIFF
--- a/docs/plans/2026-04-06-001-feat-initializer-completion-signal-plan.md
+++ b/docs/plans/2026-04-06-001-feat-initializer-completion-signal-plan.md
@@ -1,0 +1,229 @@
+---
+title: "feat: Add IInitializer completion signal for background initialization services"
+type: feat
+status: active
+date: 2026-04-06
+---
+
+# feat: Add IInitializer completion signal for background initialization services
+
+## Overview
+
+Add an `IInitializer` interface to `Headless.Hosting` so that `FeaturesInitializationBackgroundService`, `PermissionsInitializationBackgroundService`, and `SettingsInitializationBackgroundService` can signal initialization completion. `HeadlessTestServer` auto-discovers all `IInitializer` registrations and awaits them, eliminating the current `RemoveHostedService` workarounds that prevent integration tests from exercising initialization code.
+
+## Problem Frame
+
+The three initialization services fire async work in `StartAsync` using Polly retry pipelines configured with `TimeProvider`. In tests, `FakeTimeProvider` is injected but never advanced, causing retry delays to hang indefinitely if the first attempt fails. More fundamentally, there is **no completion signal** — tests cannot know when initialization finishes. The only workaround is `RemoveHostedService<T>()`, which means initialization logic is never tested, and downstream consumers must replicate all three removals.
+
+Related: xshaheen/headless-framework#212
+
+## Requirements Trace
+
+- R1. `IInitializer` interface in `Headless.Hosting` with `IsInitialized` property and `WaitForInitializationAsync` method
+- R2. All three initialization services implement `IInitializer` and signal completion via `TaskCompletionSource`
+- R3. Each service registered as both `IHostedService` and `IInitializer` via singleton forwarding
+- R4. `HeadlessTestServer` auto-awaits all `IInitializer` registrations during `InitializeAsync` with timeout
+- R5. `RemoveHostedService` workarounds removed from all framework test bases
+- R6. Integration tests pass with services running (not removed)
+
+## Scope Boundaries
+
+- **In scope**: IInitializer interface, three service implementations, test infrastructure, workaround removal
+- **Out of scope**: Unifying `IBootstrapper` (Messaging) with `IInitializer` — possible follow-up but different semantics (imperative trigger vs passive wait). Messaging keeps its own pattern.
+- **Out of scope**: Fixing Polly/FakeTimeProvider retry hang — with Testcontainers providing a real DB, first attempt succeeds. The timeout on `WaitForInitializationAsync` provides a clear error if it doesn't.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **IBootstrapper precedent** (`src/Headless.Messaging.Core/IBootstrapper.cs`): singleton interface with `IsStarted` + `BootstrapAsync`, registered via singleton forwarding pattern (`TryAddSingleton<Concrete>` + `TryAddSingleton<IInterface>(sp => ...)` + `AddHostedService(sp => ...)`). Tests call `BootstrapAsync` directly.
+- **Three initialization services** (`src/Headless.*.Core/Seeders/*InitializationBackgroundService.cs`): identical pattern — implement `IHostedService, IDisposable`, fire-and-forget background task from `StartAsync`, Polly retry with `TimeProvider`. No completion signal. Minor differences in `StopAsync` behavior (Features awaits task, Permissions only cancels, Settings uses linked CTS + WaitAsync).
+- **Current registration** (`src/Headless.*.Core/Setup.cs`): plain `AddHostedService<T>()` — services not resolvable by concrete type.
+- **HeadlessTestServer** (`src/Headless.Testing.AspNetCore/HeadlessTestServer.cs`): has `WaitForReadiness(Func<IServiceProvider, Task>, TimeSpan?)` callback pattern. Injects `FakeTimeProvider` via `AddTestTimeProvider()`.
+- **RemoveHostedService helper** (`src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs:332`): matches on `ImplementationType == typeof(T)`. Does NOT work for factory-based registrations — relevant for the new singleton forwarding pattern.
+
+### Institutional Learnings
+
+- **Use `TaskCompletionSource` with `RunContinuationsAsynchronously`** — never `ManualResetEventSlim.Wait()` on ThreadPool threads (from `docs/solutions/concurrency/circuit-breaker-transport-thread-safety-patterns.md`)
+- **Fire-and-forget tasks must be observed** — attach fault observers to `Task.Run` calls (same source)
+- **Treat startup gates as first-class concerns** — new components added to an already-active system must honor current state (from `docs/solutions/concurrency/startup-pause-gating-and-half-open-recovery.md`)
+
+## Key Technical Decisions
+
+- **New `IInitializer` rather than generalizing `IBootstrapper`**: `IBootstrapper` has imperative "trigger" semantics (`BootstrapAsync`) plus `IAsyncDisposable`. `IInitializer` has passive "wait" semantics — more appropriate for services that start automatically via `IHostedService`. Keeps concerns separate; unification is a future option.
+- **`TaskCompletionSource` with `RunContinuationsAsynchronously`**: thread-safe, non-blocking, matches institutional learnings. Concurrent callers share the same in-flight `Task`.
+- **Auto-discovery in `HeadlessTestServer`**: safer than opt-in — tests that forget to opt-in currently deadlock silently. Auto-await with timeout converts silent hangs to clear `TimeoutException`.
+- **Singleton forwarding registration**: same pattern as Messaging's `IBootstrapper`. Required because `RemoveHostedService<T>` matches on `ImplementationType` — factory registrations need the concrete singleton to be independently registered first.
+- **Exception propagation**: if initialization fails permanently (after all retries), `TrySetException` on the TCS so `WaitForInitializationAsync` throws rather than hanging.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `HeadlessTestServer` auto-await or require opt-in?**: Auto-await. Silent deadlocks are worse than explicit timeouts. Tests that need to bypass can use `RemoveHostedService` or a config flag.
+- **Should we also fix the Polly/FakeTimeProvider interaction?**: No — with Testcontainers providing a real DB, first attempt succeeds. The timeout on `WaitForInitializationAsync` is the safety net. Fixing Polly timing is orthogonal.
+
+### Deferred to Implementation
+
+- **Exact timeout value for auto-await**: likely 30s (matching existing `WaitForReadiness` default), but confirm during implementation
+- **Premature shutdown timeout message**: if `DisposeAsync` is called before initialization completes, cancellation fires and the background task returns early without calling `TrySetResult/Exception`. Consider `TrySetCanceled(cancellationToken)` in `StopAsync` for a cleaner error than a generic timeout
+
+## Implementation Units
+
+- [ ] **Unit 1: Add `IInitializer` interface to `Headless.Hosting`**
+
+  **Goal:** Define the public contract for initialization completion signaling.
+
+  **Requirements:** R1
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `src/Headless.Hosting/Initialization/IInitializer.cs`
+
+  **Approach:**
+  - Interface with `bool IsInitialized { get; }` and `Task WaitForInitializationAsync(CancellationToken cancellationToken = default)`
+  - Place in `Headless.Hosting.Initialization` namespace (or just `Headless.Hosting` — follow existing namespace conventions in the package)
+  - XML docs explaining: `IsInitialized` returns true only after successful completion; `WaitForInitializationAsync` allows concurrent callers to share the same wait
+
+  **Patterns to follow:**
+  - `IBootstrapper` in `src/Headless.Messaging.Core/IBootstrapper.cs` for shape/naming
+  - `ISeeder` in `src/Headless.Hosting/Seeders/ISeeder.cs` for placement conventions
+
+  **Test expectation:** none — pure interface, no behavior
+
+  **Verification:**
+  - Interface compiles and is publicly visible from `Headless.Hosting`
+
+- [ ] **Unit 2: Implement `IInitializer` on all three initialization services**
+
+  **Goal:** Each service signals completion/failure through `IInitializer`, with updated DI registration using singleton forwarding.
+
+  **Requirements:** R2, R3
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs`
+  - Modify: `src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs`
+  - Modify: `src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs`
+  - Modify: `src/Headless.Features.Core/Setup.cs`
+  - Modify: `src/Headless.Permissions.Core/Setup.cs`
+  - Modify: `src/Headless.Settings.Core/Setup.cs`
+
+  **Approach:**
+  - Add `TaskCompletionSource` field with `TaskCreationOptions.RunContinuationsAsynchronously`
+  - Implement `IsInitialized => _tcs.Task.IsCompletedSuccessfully`
+  - Implement `WaitForInitializationAsync` => `_tcs.Task.WaitAsync(cancellationToken)`
+  - In the background initialization method: `_tcs.TrySetResult()` on success, `_tcs.TrySetException(ex)` on permanent failure
+  - **Conditional skip / early-return**: if initialization is guarded by an options flag and skipped, call `_tcs.TrySetResult()` in the early-return branch — otherwise `WaitForInitializationAsync` hangs until timeout
+  - Use `TryAddSingleton` for concrete and interface registrations (guards against double-registration if `_AddCore` is called more than once), `AddHostedService` for the hosted service:
+    ```
+    services.TryAddSingleton<ConcreteService>();
+    services.TryAddSingleton<IInitializer>(sp => sp.GetRequiredService<ConcreteService>());
+    services.AddHostedService(sp => sp.GetRequiredService<ConcreteService>());
+    ```
+    This matches the `IBootstrapper` registration pattern exactly (see `Setup.cs:210-212`)
+  - **StopAsync normalization**: normalize all three services during this unit while the files are open — `PermissionsInitializationBackgroundService.StopAsync` currently only cancels the CTS without awaiting the task; this risks unobserved exceptions when TCS is added. Align all three to: cancel CTS, await background task, handle `OperationCanceledException`
+  - Each `.csproj` may need a project reference to `Headless.Hosting` if not already present (check existing references)
+
+  **Patterns to follow:**
+  - Messaging's `Bootstrapper` registration in `src/Headless.Messaging.Core/Setup.cs:210-212`
+  - `TaskCompletionSource` with `RunContinuationsAsynchronously` per institutional learnings
+
+  **Test scenarios:**
+  - Happy path: Service initializes successfully → `IsInitialized` is true, `WaitForInitializationAsync` completes immediately
+  - Happy path: `WaitForInitializationAsync` called before initialization completes → awaits until completion
+  - Edge case: Multiple concurrent callers of `WaitForInitializationAsync` → all complete when initialization finishes
+  - Error path: Initialization fails permanently → `WaitForInitializationAsync` throws the exception
+  - Edge case: `WaitForInitializationAsync` with already-cancelled token → throws `OperationCanceledException`
+
+  **Verification:**
+  - Each service resolves as both `IHostedService` and `IInitializer` from DI
+  - Existing unit tests still pass
+
+- [ ] **Unit 3: Update `HeadlessTestServer` to auto-await `IInitializer` services**
+
+  **Goal:** Test infrastructure automatically waits for all registered initializers during startup, with timeout protection.
+
+  **Requirements:** R4
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `src/Headless.Testing.AspNetCore/HeadlessTestServer.cs`
+  - Modify: `src/Headless.Testing.AspNetCore/Headless.Testing.AspNetCore.csproj` — add `ProjectReference` to `Headless.Hosting` (required for `IInitializer` resolution)
+
+  **Approach:**
+  - During `InitializeAsync` (after host starts), resolve `IEnumerable<IInitializer>` and await all via `Task.WhenAll` with timeout
+  - Use existing `WaitForReadiness` pattern or add a dedicated step — whichever integrates more cleanly
+  - Timeout should produce a clear error message naming which initializer(s) haven't completed
+
+  **Patterns to follow:**
+  - Existing `WaitForReadiness` callback in `HeadlessTestServer`
+  - Messaging's test harness at `src/Headless.Messaging.Testing/MessagingTestHarness.cs:85-86`
+
+  **Test scenarios:**
+  - Happy path: All initializers complete within timeout → `InitializeAsync` succeeds
+  - Error path: An initializer times out → `TimeoutException` with descriptive message
+  - Edge case: No `IInitializer` registrations → `InitializeAsync` succeeds without waiting
+  - Error path: An initializer throws during initialization → exception propagates to test setup
+
+  **Verification:**
+  - `HeadlessTestServer.InitializeAsync` completes successfully when initializers succeed
+  - Tests get a clear error (not a silent hang) when initialization fails
+
+- [ ] **Unit 4: Remove `RemoveHostedService` workarounds from framework test bases**
+
+  **Goal:** Framework integration tests exercise the actual initialization code path instead of bypassing it.
+
+  **Requirements:** R5, R6
+
+  **Dependencies:** Units 2, 3
+
+  **Files:**
+  - Modify: `tests/Headless.Features.Tests.Integration/TestSetup/FeaturesTestBase.cs`
+  - Modify: `tests/Headless.Settings.Tests.Integration/TestSetup/SettingsTestBase.cs`
+  - Modify: `tests/Headless.Permissions.Tests.Integration/TestSetup/SettingsTestBase.cs`
+
+  **Approach:**
+  - Remove `RemoveHostedService<*InitializationBackgroundService>()` calls
+  - Verify integration tests pass with services running — initialization should succeed against Testcontainers DB on first attempt
+
+  **Test scenarios:**
+  - Integration: All existing integration tests pass without the workaround
+  - Integration: Initialization actually runs (services seed data) — verify by checking seeded data exists
+
+  **Verification:**
+  - All integration test suites pass
+  - No `RemoveHostedService<*InitializationBackgroundService>` references remain in the codebase
+
+## System-Wide Impact
+
+- **Interaction graph:** `HeadlessTestServer.InitializeAsync` → resolves `IInitializer[]` → awaits each service's TCS. Production is unaffected — `IInitializer` is only consumed by test infrastructure.
+- **Error propagation:** Initialization failure flows: service catches final exception → `TrySetException` on TCS → `WaitForInitializationAsync` throws → `HeadlessTestServer.InitializeAsync` fails → test fixture setup fails with clear error.
+- **API surface parity:** `RemoveHostedService<T>` matches on `ImplementationType` and won't find factory-registered services after singleton forwarding. Since the goal is to stop removing these services entirely, this is expected.
+- **Unchanged invariants:** Production startup behavior is unchanged — services still fire-and-forget. The `IInitializer` TCS is only awaited by test infrastructure.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Initialization hangs in tests (Polly + FakeTimeProvider) if first DB attempt fails | Testcontainers ensures DB is ready; timeout on `WaitForInitializationAsync` converts silent hang to clear `TimeoutException` |
+| Conditional skip path leaves TCS never completed → timeout hang | Call `_tcs.TrySetResult()` in every early-return branch of initialization (addressed in Unit 2) |
+| `PermissionsInitializationBackgroundService.StopAsync` doesn't await background task | Normalize all three `StopAsync` implementations in Unit 2 |
+| `Headless.Testing.AspNetCore` doesn't reference `Headless.Hosting` — won't compile | Add `ProjectReference` in Unit 3 (addressed explicitly) |
+| Singleton forwarding changes DI resolution behavior | Follows established Messaging pattern; test DI resolution explicitly |
+
+## Future Considerations
+
+- **Unify `IBootstrapper` and `IInitializer`**: `IBootstrapper` could implement `IInitializer`, giving Messaging services auto-discovery in `HeadlessTestServer`. Separate issue — different semantics and scope.
+- **Configurable retry for tests**: If tests need to verify retry behavior, provide a way to configure shorter delays or advance `FakeTimeProvider`.
+
+## Sources & References
+
+- Related issue: xshaheen/headless-framework#212
+- IBootstrapper pattern: `src/Headless.Messaging.Core/IBootstrapper.cs`
+- Messaging registration: `src/Headless.Messaging.Core/Setup.cs:210-212`
+- Institutional learning: `docs/solutions/concurrency/circuit-breaker-transport-thread-safety-patterns.md`
+- Institutional learning: `docs/solutions/concurrency/startup-pause-gating-and-half-open-recovery.md`

--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -106,6 +106,7 @@
         <Project Path="src\Headless.Features.Core\Headless.Features.Core.csproj" />
         <Project Path="src\Headless.Features.Storage.EntityFramework\Headless.Features.Storage.EntityFramework.csproj" />
         <Project Path="tests\Headless.Features.Tests.Integration\Headless.Features.Tests.Integration.csproj" />
+        <Project Path="tests\Headless.Features.Tests.Unit\Headless.Features.Tests.Unit.csproj" />
     </Folder>
     <Folder Name="/Generators/">
         <Project Path="src\Headless.Generator.Primitives.Abstractions\Headless.Generator.Primitives.Abstractions.csproj" />

--- a/nuget.config
+++ b/nuget.config
@@ -23,7 +23,7 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="github.com">
-      <package pattern="Headless.Defaults" />
+      <package pattern="Headless.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs
+++ b/src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs
@@ -22,6 +22,7 @@ public sealed class FeaturesInitializationBackgroundService(
     private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly FeatureManagementOptions _options = optionsAccessor.Value;
+    private CancellationTokenSource? _linkedCts;
     private Task? _initializeDynamicFeaturesTask;
 
     public bool IsInitialized => _tcs.Task.IsCompletedSuccessfully;
@@ -31,15 +32,16 @@ public sealed class FeaturesInitializationBackgroundService(
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (_options is not { SaveStaticFeaturesToDatabase: false, IsDynamicFeatureStoreEnabled: false })
-        {
-            _initializeDynamicFeaturesTask = _InitializeDynamicFeaturesAsync(cancellationToken);
-        }
-        else
+        if (_options is { SaveStaticFeaturesToDatabase: false, IsDynamicFeatureStoreEnabled: false })
         {
             // Both features disabled — initialization is a no-op; signal completion immediately.
             _tcs.TrySetResult();
+
+            return Task.CompletedTask;
         }
+
+        _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancellationTokenSource.Token);
+        _initializeDynamicFeaturesTask = _InitializeDynamicFeaturesAsync(_linkedCts.Token);
 
         return Task.CompletedTask;
     }
@@ -53,22 +55,16 @@ public sealed class FeaturesInitializationBackgroundService(
             try
             {
 #pragma warning disable VSTHRD003 // IHostedService pattern: task started in StartAsync, awaited in StopAsync
-                await _initializeDynamicFeaturesTask.ConfigureAwait(false);
+                await _initializeDynamicFeaturesTask.WaitAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning restore VSTHRD003
             }
-            catch (OperationCanceledException)
-            {
-                // Expected during shutdown
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Background initialization task faulted");
-            }
+            catch (OperationCanceledException) { }
         }
     }
 
     public void Dispose()
     {
+        _linkedCts?.Dispose();
         _cancellationTokenSource.Dispose();
     }
 
@@ -83,7 +79,7 @@ public sealed class FeaturesInitializationBackgroundService(
 
             await using var scope = serviceScopeFactory.CreateAsyncScope();
 
-            await _SaveStaticFeaturesToDatabaseAsync(scope, cancellationToken);
+            await _SaveStaticFeaturesToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
 
             if (cancellationToken.IsCancellationRequested)
             {
@@ -96,7 +92,7 @@ public sealed class FeaturesInitializationBackgroundService(
         }
         catch (OperationCanceledException)
         {
-            // Shutdown before completion — leave TCS incomplete so waiters get a timeout.
+            _tcs.TrySetCanceled(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs
+++ b/src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs
@@ -2,6 +2,7 @@
 
 using Headless.Features.Definitions;
 using Headless.Features.Models;
+using Headless.Hosting.Initialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,17 +17,28 @@ public sealed class FeaturesInitializationBackgroundService(
     IServiceScopeFactory serviceScopeFactory,
     IOptions<FeatureManagementOptions> optionsAccessor,
     ILogger<FeaturesInitializationBackgroundService> logger
-) : IHostedService, IDisposable
+) : IHostedService, IDisposable, IInitializer
 {
+    private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly FeatureManagementOptions _options = optionsAccessor.Value;
     private Task? _initializeDynamicFeaturesTask;
+
+    public bool IsInitialized => _tcs.Task.IsCompletedSuccessfully;
+
+    public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
+        _tcs.Task.WaitAsync(cancellationToken);
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
         if (_options is not { SaveStaticFeaturesToDatabase: false, IsDynamicFeatureStoreEnabled: false })
         {
             _initializeDynamicFeaturesTask = _InitializeDynamicFeaturesAsync(cancellationToken);
+        }
+        else
+        {
+            // Both features disabled — initialization is a no-op; signal completion immediately.
+            _tcs.TrySetResult();
         }
 
         return Task.CompletedTask;
@@ -62,21 +74,34 @@ public sealed class FeaturesInitializationBackgroundService(
 
     private async Task _InitializeDynamicFeaturesAsync(CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
+        try
         {
-            return;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await using var scope = serviceScopeFactory.CreateAsyncScope();
+
+            await _SaveStaticFeaturesToDatabaseAsync(scope, cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await _PreCacheDynamicFeaturesAsync(scope, cancellationToken).ConfigureAwait(false);
+
+            _tcs.TrySetResult();
         }
-
-        await using var scope = serviceScopeFactory.CreateAsyncScope();
-
-        await _SaveStaticFeaturesToDatabaseAsync(scope, cancellationToken);
-
-        if (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            return;
+            // Shutdown before completion — leave TCS incomplete so waiters get a timeout.
         }
-
-        await _PreCacheDynamicFeaturesAsync(scope, cancellationToken).ConfigureAwait(false);
+        catch (Exception ex)
+        {
+            _tcs.TrySetException(ex);
+        }
     }
 
     private async Task _SaveStaticFeaturesToDatabaseAsync(AsyncServiceScope scope, CancellationToken cancellationToken)

--- a/src/Headless.Features.Core/Setup.cs
+++ b/src/Headless.Features.Core/Setup.cs
@@ -9,6 +9,7 @@ using Headless.Features.Resources;
 using Headless.Features.Seeders;
 using Headless.Features.ValueProviders;
 using Headless.Features.Values;
+using Headless.Hosting.Initialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -93,7 +94,7 @@ public static class CoreSetup
     private static IServiceCollection _AddCore(IServiceCollection services)
     {
         services._AddCoreValueProviders();
-        services.AddHostedService<FeaturesInitializationBackgroundService>();
+        services.AddInitializerHostedService<FeaturesInitializationBackgroundService>();
 
         services.AddTransient<
             ILocalMessageHandler<EntityChangedEventData<FeatureValueRecord>>,

--- a/src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs
+++ b/src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Checks;
+using Headless.Hosting.Initialization;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 #pragma warning disable IDE0130
@@ -342,6 +344,41 @@ public static class DependencyInjectionExtensions
         {
             services.Remove(hostedServiceDescriptor);
         }
+
+        return services;
+    }
+
+    #endregion
+
+    #region AddInitializerHostedService
+
+    /// <summary>
+    /// Registers <typeparamref name="T"/> as a singleton, forwards it as <see cref="IInitializer"/>,
+    /// and registers it as a hosted service — all using the same singleton instance.
+    /// </summary>
+    /// <typeparam name="T">
+    /// A type that implements both <see cref="IHostedService"/> and <see cref="IInitializer"/>.
+    /// </typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection.</returns>
+    /// <remarks>
+    /// Equivalent to:
+    /// <code>
+    /// services.TryAddSingleton&lt;T&gt;();
+    /// services.TryAddEnumerable(ServiceDescriptor.Singleton&lt;IInitializer&gt;(sp => sp.GetRequiredService&lt;T&gt;()));
+    /// services.AddHostedService(sp => sp.GetRequiredService&lt;T&gt;());
+    /// </code>
+    /// Using <c>TryAddSingleton</c> and <c>TryAddEnumerable</c> guards against double-registration
+    /// when the setup method is called more than once.
+    /// </remarks>
+    public static IServiceCollection AddInitializerHostedService<T>(this IServiceCollection services)
+        where T : class, IHostedService, IInitializer
+    {
+        Argument.IsNotNull(services);
+
+        services.TryAddSingleton<T>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializer>(sp => sp.GetRequiredService<T>()));
+        services.AddHostedService(sp => sp.GetRequiredService<T>());
 
         return services;
     }

--- a/src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs
+++ b/src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs
@@ -365,11 +365,13 @@ public static class DependencyInjectionExtensions
     /// Equivalent to:
     /// <code>
     /// services.TryAddSingleton&lt;T&gt;();
-    /// services.TryAddEnumerable(ServiceDescriptor.Singleton&lt;IInitializer&gt;(sp => sp.GetRequiredService&lt;T&gt;()));
-    /// services.AddHostedService(sp => sp.GetRequiredService&lt;T&gt;());
+    /// services.TryAddEnumerable(ServiceDescriptor.Singleton&lt;IInitializer, T&gt;(sp => sp.GetRequiredService&lt;T&gt;()));
+    /// services.TryAddEnumerable(ServiceDescriptor.Singleton&lt;IHostedService, T&gt;(sp => sp.GetRequiredService&lt;T&gt;()));
     /// </code>
     /// Using <c>TryAddSingleton</c> and <c>TryAddEnumerable</c> guards against double-registration
-    /// when the setup method is called more than once.
+    /// when the setup method is called more than once. The <c>ImplementationType</c> carried by the
+    /// two-argument overload of <c>ServiceDescriptor.Singleton&lt;TService, TImplementation&gt;</c>
+    /// is what allows <c>TryAddEnumerable</c> to deduplicate by implementation type.
     /// </remarks>
     public static IServiceCollection AddInitializerHostedService<T>(this IServiceCollection services)
         where T : class, IHostedService, IInitializer
@@ -377,8 +379,8 @@ public static class DependencyInjectionExtensions
         Argument.IsNotNull(services);
 
         services.TryAddSingleton<T>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializer>(sp => sp.GetRequiredService<T>()));
-        services.AddHostedService(sp => sp.GetRequiredService<T>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializer, T>(sp => sp.GetRequiredService<T>()));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, T>(sp => sp.GetRequiredService<T>()));
 
         return services;
     }

--- a/src/Headless.Hosting/Initialization/IInitializer.cs
+++ b/src/Headless.Hosting/Initialization/IInitializer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Hosting.Initialization;
+
+/// <summary>
+/// Defines the contract for a background service that signals when its initialization is complete.
+/// </summary>
+/// <remarks>
+/// Unlike <c>IBootstrapper</c> which requires an explicit imperative trigger, <c>IInitializer</c> uses
+/// passive wait semantics — the service starts automatically via <see cref="Microsoft.Extensions.Hosting.IHostedService"/>
+/// and callers simply wait for it to finish. Concurrent callers share the same in-flight wait operation.
+/// </remarks>
+public interface IInitializer
+{
+    /// <summary>
+    /// Gets a value indicating whether initialization has completed successfully.
+    /// Returns <c>true</c> only after the initialization sequence finishes without error.
+    /// Returns <c>false</c> while initialization is still in progress, if it was skipped, or if it failed.
+    /// </summary>
+    bool IsInitialized { get; }
+
+    /// <summary>
+    /// Asynchronously waits until initialization completes.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the wait. Does not cancel the underlying initialization.</param>
+    /// <returns>A task that completes when initialization finishes successfully, or faults if initialization fails permanently.</returns>
+    Task WaitForInitializationAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Headless.Hosting/Initialization/IInitializer.cs
+++ b/src/Headless.Hosting/Initialization/IInitializer.cs
@@ -14,8 +14,8 @@ public interface IInitializer
 {
     /// <summary>
     /// Gets a value indicating whether initialization has completed successfully.
-    /// Returns <c>true</c> only after the initialization sequence finishes without error.
-    /// Returns <c>false</c> while initialization is still in progress, if it was skipped, or if it failed.
+    /// Returns <c>true</c> after the initialization sequence finishes without error, or when it is skipped (no-op).
+    /// Returns <c>false</c> while initialization is still in progress or if it failed.
     /// </summary>
     bool IsInitialized { get; }
 

--- a/src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs
+++ b/src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Hosting.Initialization;
 using Headless.Permissions.Definitions;
 using Headless.Permissions.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,16 +17,25 @@ public sealed class PermissionsInitializationBackgroundService(
     IServiceScopeFactory serviceScopeFactory,
     IOptions<PermissionManagementOptions> optionsAccessor,
     ILogger<PermissionsInitializationBackgroundService> logger
-) : IHostedService, IDisposable
+) : IHostedService, IDisposable, IInitializer
 {
+    private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly PermissionManagementOptions _options = optionsAccessor.Value;
     private Task? _initializeDynamicPermissionsTask;
+
+    public bool IsInitialized => _tcs.Task.IsCompletedSuccessfully;
+
+    public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
+        _tcs.Task.WaitAsync(cancellationToken);
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
         if (_options is { SaveStaticPermissionsToDatabase: false, IsDynamicPermissionStoreEnabled: false })
         {
+            // Both features disabled — initialization is a no-op; signal completion immediately.
+            _tcs.TrySetResult();
+
             return Task.CompletedTask;
         }
 
@@ -36,32 +46,62 @@ public sealed class PermissionsInitializationBackgroundService(
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        await _cancellationTokenSource.CancelAsync();
+        await _cancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
+        if (_initializeDynamicPermissionsTask is not null)
+        {
+            try
+            {
+#pragma warning disable VSTHRD003 // IHostedService pattern: task started in StartAsync, awaited in StopAsync
+                await _initializeDynamicPermissionsTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected during shutdown
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Background initialization task faulted");
+            }
+        }
     }
 
     public void Dispose()
     {
         _cancellationTokenSource.Dispose();
-        _initializeDynamicPermissionsTask?.Dispose();
     }
 
     private async Task _InitializeDynamicPermissionsAsync(CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
+        try
         {
-            return;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await using var scope = serviceScopeFactory.CreateAsyncScope();
+
+            await _SaveStaticPermissionsToDatabaseAsync(scope, cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await _PreCacheDynamicPermissionsAsync(scope, cancellationToken);
+
+            _tcs.TrySetResult();
         }
-
-        await using var scope = serviceScopeFactory.CreateAsyncScope();
-
-        await _SaveStaticPermissionsToDatabaseAsync(scope, cancellationToken);
-
-        if (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            return;
+            // Shutdown before completion — leave TCS incomplete so waiters get a timeout.
         }
-
-        await _PreCacheDynamicPermissionsAsync(scope, cancellationToken);
+        catch (Exception ex)
+        {
+            _tcs.TrySetException(ex);
+        }
     }
 
     private async Task _SaveStaticPermissionsToDatabaseAsync(

--- a/src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs
+++ b/src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs
@@ -22,6 +22,7 @@ public sealed class PermissionsInitializationBackgroundService(
     private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly PermissionManagementOptions _options = optionsAccessor.Value;
+    private CancellationTokenSource? _linkedCts;
     private Task? _initializeDynamicPermissionsTask;
 
     public bool IsInitialized => _tcs.Task.IsCompletedSuccessfully;
@@ -39,7 +40,8 @@ public sealed class PermissionsInitializationBackgroundService(
             return Task.CompletedTask;
         }
 
-        _initializeDynamicPermissionsTask = _InitializeDynamicPermissionsAsync(cancellationToken);
+        _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cancellationTokenSource.Token);
+        _initializeDynamicPermissionsTask = _InitializeDynamicPermissionsAsync(_linkedCts.Token);
 
         return Task.CompletedTask;
     }
@@ -53,22 +55,16 @@ public sealed class PermissionsInitializationBackgroundService(
             try
             {
 #pragma warning disable VSTHRD003 // IHostedService pattern: task started in StartAsync, awaited in StopAsync
-                await _initializeDynamicPermissionsTask.ConfigureAwait(false);
+                await _initializeDynamicPermissionsTask.WaitAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning restore VSTHRD003
             }
-            catch (OperationCanceledException)
-            {
-                // Expected during shutdown
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Background initialization task faulted");
-            }
+            catch (OperationCanceledException) { }
         }
     }
 
     public void Dispose()
     {
+        _linkedCts?.Dispose();
         _cancellationTokenSource.Dispose();
     }
 
@@ -83,20 +79,20 @@ public sealed class PermissionsInitializationBackgroundService(
 
             await using var scope = serviceScopeFactory.CreateAsyncScope();
 
-            await _SaveStaticPermissionsToDatabaseAsync(scope, cancellationToken);
+            await _SaveStaticPermissionsToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
 
             if (cancellationToken.IsCancellationRequested)
             {
                 return;
             }
 
-            await _PreCacheDynamicPermissionsAsync(scope, cancellationToken);
+            await _PreCacheDynamicPermissionsAsync(scope, cancellationToken).ConfigureAwait(false);
 
             _tcs.TrySetResult();
         }
         catch (OperationCanceledException)
         {
-            // Shutdown before completion — leave TCS incomplete so waiters get a timeout.
+            _tcs.TrySetCanceled(cancellationToken);
         }
         catch (Exception ex)
         {
@@ -136,7 +132,7 @@ public sealed class PermissionsInitializationBackgroundService(
 
                 try
                 {
-                    await store.SaveAsync(cancellationToken);
+                    await store.SaveAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -162,7 +158,7 @@ public sealed class PermissionsInitializationBackgroundService(
         try
         {
             // Pre-cache permissions, so first request doesn't wait
-            await store.GetGroupsAsync(cancellationToken);
+            await store.GetGroupsAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/src/Headless.Permissions.Core/Setup.cs
+++ b/src/Headless.Permissions.Core/Setup.cs
@@ -3,6 +3,7 @@
 using Headless.Abstractions;
 using Headless.Caching;
 using Headless.Domain;
+using Headless.Hosting.Initialization;
 using Headless.Permissions.Definitions;
 using Headless.Permissions.Entities;
 using Headless.Permissions.GrantProviders;
@@ -93,7 +94,7 @@ public static class PermissionsSetup
     private static IServiceCollection _AddCore(IServiceCollection services)
     {
         services._AddCoreValueProvider();
-        services.AddHostedService<PermissionsInitializationBackgroundService>();
+        services.AddInitializerHostedService<PermissionsInitializationBackgroundService>();
         services.AddTransient<IGrantPermissionsSeedHelper, GrantPermissionsSeedHelper>();
 
         services.AddTransient<
@@ -117,12 +118,10 @@ public static class PermissionsSetup
         /*
          * You need to provide a storage implementation for `IPermissionGrantRecordRepository`
          */
-        services.AddSingleton<ICache<PermissionGrantCacheItem>>(sp =>
-            new ScopedCache<PermissionGrantCacheItem>(
-                sp.GetRequiredService<ICache>(),
-                () => $"t:{sp.GetRequiredService<ICurrentTenant>().Id}"
-            )
-        );
+        services.AddSingleton<ICache<PermissionGrantCacheItem>>(sp => new ScopedCache<PermissionGrantCacheItem>(
+            sp.GetRequiredService<ICache>(),
+            () => $"t:{sp.GetRequiredService<ICurrentTenant>().Id}"
+        ));
 
         services.TryAddSingleton<IPermissionGrantStore, PermissionGrantStore>();
         services.TryAddSingleton<IPermissionGrantProviderManager, PermissionGrantProviderManager>();

--- a/src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs
+++ b/src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Hosting.Initialization;
 using Headless.Settings.Definitions;
 using Headless.Settings.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,17 +17,26 @@ public sealed class SettingsInitializationBackgroundService(
     IServiceScopeFactory serviceScopeFactory,
     IOptions<SettingManagementOptions> optionsAccessor,
     ILogger<SettingsInitializationBackgroundService> logger
-) : IHostedService, IDisposable
+) : IHostedService, IDisposable, IInitializer
 {
+    private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly SettingManagementOptions _options = optionsAccessor.Value;
     private CancellationTokenSource? _linkedCts;
     private Task? _initializeDynamicSettingsTask;
 
+    public bool IsInitialized => _tcs.Task.IsCompletedSuccessfully;
+
+    public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
+        _tcs.Task.WaitAsync(cancellationToken);
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         if (_options is { SaveStaticSettingsToDatabase: false, IsDynamicSettingStoreEnabled: false })
         {
+            // Both features disabled — initialization is a no-op; signal completion immediately.
+            _tcs.TrySetResult();
+
             return Task.CompletedTask;
         }
 
@@ -44,7 +54,9 @@ public sealed class SettingsInitializationBackgroundService(
         {
             try
             {
+#pragma warning disable VSTHRD003 // IHostedService pattern: task started in StartAsync, awaited in StopAsync
                 await _initializeDynamicSettingsTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore VSTHRD003
             }
             catch (OperationCanceledException) { }
         }
@@ -58,21 +70,34 @@ public sealed class SettingsInitializationBackgroundService(
 
     private async Task _InitializeDynamicSettingsAsync(CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
+        try
         {
-            return;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await using var scope = serviceScopeFactory.CreateAsyncScope();
+
+            await _SaveStaticSettingsToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await _PreCacheDynamicSettingsAsync(scope, cancellationToken).ConfigureAwait(false);
+
+            _tcs.TrySetResult();
         }
-
-        await using var scope = serviceScopeFactory.CreateAsyncScope();
-
-        await _SaveStaticSettingsToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
-
-        if (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            return;
+            // Shutdown before completion — leave TCS incomplete so waiters get a timeout.
         }
-
-        await _PreCacheDynamicSettingsAsync(scope, cancellationToken).ConfigureAwait(false);
+        catch (Exception ex)
+        {
+            _tcs.TrySetException(ex);
+        }
     }
 
     private async Task _SaveStaticSettingsToDatabaseAsync(AsyncServiceScope scope, CancellationToken cancellationToken)

--- a/src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs
+++ b/src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs
@@ -92,7 +92,7 @@ public sealed class SettingsInitializationBackgroundService(
         }
         catch (OperationCanceledException)
         {
-            // Shutdown before completion — leave TCS incomplete so waiters get a timeout.
+            _tcs.TrySetCanceled(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Headless.Settings.Core/Setup.cs
+++ b/src/Headless.Settings.Core/Setup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Domain;
+using Headless.Hosting.Initialization;
 using Headless.Settings.Definitions;
 using Headless.Settings.Entities;
 using Headless.Settings.Helpers;
@@ -98,7 +99,7 @@ public static class CoreSettingsSetup
     {
         services._AddCoreValueProvider();
 
-        services.AddHostedService<SettingsInitializationBackgroundService>();
+        services.AddInitializerHostedService<SettingsInitializationBackgroundService>();
 
         services.TryAddTransient<
             ILocalMessageHandler<EntityChangedEventData<SettingValueRecord>>,

--- a/src/Headless.Testing.AspNetCore/Headless.Testing.AspNetCore.csproj
+++ b/src/Headless.Testing.AspNetCore/Headless.Testing.AspNetCore.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Respawn" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Headless.Hosting\Headless.Hosting.csproj" />
     <ProjectReference Include="..\Headless.Testing\Headless.Testing.csproj" />
     <ProjectReference Include="..\Headless.Messaging.Testing\Headless.Messaging.Testing.csproj" />
   </ItemGroup>

--- a/src/Headless.Testing.AspNetCore/HeadlessTestServer.cs
+++ b/src/Headless.Testing.AspNetCore/HeadlessTestServer.cs
@@ -2,6 +2,7 @@
 
 using System.Data.Common;
 using System.Security.Claims;
+using Headless.Hosting.Initialization;
 using Headless.Messaging.Testing;
 using Headless.Testing.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
@@ -268,6 +269,25 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
             _ = factory.Services;
 
             TimeProvider = (FakeTimeProvider)factory.Services.GetRequiredService<TimeProvider>();
+
+            // Await all IInitializer services (e.g. settings/permissions/features sync)
+            var initializers = factory.Services.GetServices<IInitializer>();
+
+            foreach (var initializer in initializers)
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+                try
+                {
+                    await initializer.WaitForInitializationAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"Initializer '{initializer.GetType().Name}' did not complete within 60s."
+                    );
+                }
+            }
 
             // Execute readiness checks sequentially
             foreach (var (check, timeout) in _readinessChecks)

--- a/src/Headless.Testing.AspNetCore/HeadlessTestServer.cs
+++ b/src/Headless.Testing.AspNetCore/HeadlessTestServer.cs
@@ -28,6 +28,7 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
 {
     private readonly Action<IServiceCollection>? _configureTestServices;
     private readonly Action<IWebHostBuilder>? _configureWebHost;
+    private readonly TimeSpan _initializerTimeout;
     private readonly List<(Func<IServiceProvider, Task> Check, TimeSpan Timeout)> _readinessChecks = [];
     private Action<DatabaseResetOptions>? _configureDatabaseReset;
     private readonly SemaphoreSlim _initGate = new(1, 1);
@@ -42,11 +43,13 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
 
     public HeadlessTestServer(
         Action<IServiceCollection>? configureTestServices = null,
-        Action<IWebHostBuilder>? configureWebHost = null
+        Action<IWebHostBuilder>? configureWebHost = null,
+        TimeSpan? initializerTimeout = null
     )
     {
         _configureTestServices = configureTestServices;
         _configureWebHost = configureWebHost;
+        _initializerTimeout = initializerTimeout ?? TimeSpan.FromSeconds(60);
     }
 
     /// <summary>The fake time provider registered in the test host.</summary>
@@ -252,7 +255,6 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
         await _initGate.WaitAsync().ConfigureAwait(false);
 
         WebApplicationFactory<TProgram>? factory = null;
-        var success = false;
 
         try
         {
@@ -263,7 +265,9 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
                 return;
             }
 
+#pragma warning disable CA2000 // Ownership transferred to _factory on success; finally disposes on failure
             factory = new ServerFactory(_configureTestServices, _configureWebHost);
+#pragma warning restore CA2000
 
             // Force host startup — triggers ConfigureTestServices
             _ = factory.Services;
@@ -275,7 +279,7 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
 
             foreach (var initializer in initializers)
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+                using var cts = new CancellationTokenSource(_initializerTimeout);
 
                 try
                 {
@@ -284,7 +288,14 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {
                     throw new TimeoutException(
-                        $"Initializer '{initializer.GetType().Name}' did not complete within 60s."
+                        $"Initializer '{initializer.GetType().Name}' did not complete within {_initializerTimeout.TotalSeconds:F0}s."
+                    );
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    throw new InvalidOperationException(
+                        $"Initializer '{initializer.GetType().Name}' faulted during test initialization.",
+                        ex
                     );
                 }
             }
@@ -305,11 +316,11 @@ public sealed class HeadlessTestServer<TProgram> : IAsyncLifetime, IAsyncDisposa
             }
 
             _factory = factory;
-            success = true;
+            factory = null; // ownership transferred; suppress CA2000
         }
         finally
         {
-            if (!success && factory is not null)
+            if (factory is not null)
             {
                 await factory.DisposeAsync().ConfigureAwait(false);
             }

--- a/tests/Headless.Features.Tests.Integration/TestSetup/FeaturesTestBase.cs
+++ b/tests/Headless.Features.Tests.Integration/TestSetup/FeaturesTestBase.cs
@@ -6,7 +6,6 @@ using Headless.DistributedLocks;
 using Headless.DistributedLocks.Redis;
 using Headless.Domain;
 using Headless.Features;
-using Headless.Features.Seeders;
 using Headless.Redis;
 using Headless.Testing.Tests;
 using Microsoft.EntityFrameworkCore;
@@ -67,7 +66,5 @@ public abstract class FeaturesTestBase(FeaturesTestFixture fixture) : TestBase
         services
             .AddFeaturesManagementCore()
             .AddFeaturesManagementDbContextStorage(options => options.UseNpgsql(Fixture.SqlConnectionString));
-
-        services.RemoveHostedService<FeaturesInitializationBackgroundService>();
     }
 }

--- a/tests/Headless.Features.Tests.Unit/Headless.Features.Tests.Unit.csproj
+++ b/tests/Headless.Features.Tests.Unit/Headless.Features.Tests.Unit.csproj
@@ -3,14 +3,20 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Tests</RootNamespace>
     <OutputType>Exe</OutputType>
+    <!-- Code coverage thresholds -->
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <Threshold>80</Threshold>
+    <ThresholdType>line,branch</ThresholdType>
+    <ThresholdStat>total</ThresholdStat>
+    <ExcludeByAttribute>CompilerGenerated,GeneratedCode,ExcludeFromCodeCoverage</ExcludeByAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Headless.Settings.Abstractions\Headless.Settings.Abstractions.csproj" />
-    <ProjectReference Include="..\..\src\Headless.Settings.Core\Headless.Settings.Core.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Features.Core\Headless.Features.Core.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Headless.Features.Tests.Unit/Seeders/FeaturesInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Features.Tests.Unit/Seeders/FeaturesInitializationBackgroundServiceTests.cs
@@ -1,29 +1,29 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Permissions.Definitions;
-using Headless.Permissions.Models;
-using Headless.Permissions.Seeders;
+using Headless.Features.Definitions;
+using Headless.Features.Models;
+using Headless.Features.Seeders;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 
-namespace Tests.Services;
+namespace Tests.Seeders;
 
-public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
+public sealed class FeaturesInitializationBackgroundServiceTests : TestBase
 {
     private readonly IServiceScopeFactory _serviceScopeFactory = Substitute.For<IServiceScopeFactory>();
     private readonly IServiceScope _serviceScope = Substitute.For<IServiceScope>();
     private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
-    private readonly IDynamicPermissionDefinitionStore _store = Substitute.For<IDynamicPermissionDefinitionStore>();
+    private readonly IDynamicFeatureDefinitionStore _store = Substitute.For<IDynamicFeatureDefinitionStore>();
     private readonly FakeTimeProvider _timeProvider = new();
 
-    public PermissionsInitializationBackgroundServiceTests()
+    public FeaturesInitializationBackgroundServiceTests()
     {
         _serviceScopeFactory.CreateScope().Returns(_serviceScope);
         _serviceScope.ServiceProvider.Returns(_serviceProvider);
-        _serviceProvider.GetService(typeof(IDynamicPermissionDefinitionStore)).Returns(_store);
+        _serviceProvider.GetService(typeof(IDynamicFeatureDefinitionStore)).Returns(_store);
     }
 
     #region IInitializer Contract
@@ -33,11 +33,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     {
         // given
         var sut = _CreateSut(
-            new PermissionManagementOptions
-            {
-                SaveStaticPermissionsToDatabase = true,
-                IsDynamicPermissionStoreEnabled = false,
-            }
+            new FeatureManagementOptions { SaveStaticFeaturesToDatabase = true, IsDynamicFeatureStoreEnabled = false }
         );
 
         // then
@@ -49,11 +45,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     {
         // given
         var sut = _CreateSut(
-            new PermissionManagementOptions
-            {
-                SaveStaticPermissionsToDatabase = false,
-                IsDynamicPermissionStoreEnabled = false,
-            }
+            new FeatureManagementOptions { SaveStaticFeaturesToDatabase = false, IsDynamicFeatureStoreEnabled = false }
         );
 
         // when
@@ -67,10 +59,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_report_initialized_after_successful_completion()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         var saveDone = new TaskCompletionSource();
@@ -97,10 +89,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_wait_for_initialization_async_completes_after_success()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         _store.SaveAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
@@ -120,17 +112,17 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_propagate_fault_to_wait_for_initialization_async()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = true,
+            SaveStaticFeaturesToDatabase = false,
+            IsDynamicFeatureStoreEnabled = true,
         };
 
         var exception = new InvalidOperationException("Store exploded");
 
         _store
             .GetGroupsAsync(Arg.Any<CancellationToken>())
-            .Returns<IReadOnlyList<PermissionGroupDefinition>>(_ => throw exception);
+            .Returns<IReadOnlyList<FeatureGroupDefinition>>(_ => throw exception);
 
         var sut = _CreateSut(options);
 
@@ -148,10 +140,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_propagate_cancellation_to_wait_for_initialization_async_when_stopped()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         var saveStarted = new TaskCompletionSource();
@@ -184,10 +176,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_not_start_when_both_options_disabled()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = false,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         var sut = _CreateSut(options);
@@ -205,16 +197,16 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
     #endregion
 
-    #region Save Static Permissions
+    #region Save Static Features
 
     [Fact]
-    public async Task should_save_static_permissions_when_enabled()
+    public async Task should_save_static_features_when_enabled()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         var saveCalled = new TaskCompletionSource();
@@ -238,16 +230,16 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
     #endregion
 
-    #region Pre-cache Dynamic Permissions
+    #region Pre-cache Dynamic Features
 
     [Fact]
-    public async Task should_pre_cache_dynamic_permissions_when_enabled()
+    public async Task should_pre_cache_dynamic_features_when_enabled()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = true,
+            SaveStaticFeaturesToDatabase = false,
+            IsDynamicFeatureStoreEnabled = true,
         };
 
         var preCacheCalled = new TaskCompletionSource();
@@ -256,7 +248,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
             .Returns(callInfo =>
             {
                 preCacheCalled.TrySetResult();
-                return Task.FromResult<IReadOnlyList<PermissionGroupDefinition>>([]);
+                return Task.FromResult<IReadOnlyList<FeatureGroupDefinition>>([]);
             });
 
         var sut = _CreateSut(options);
@@ -277,10 +269,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_retry_on_save_failure()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         var callCount = 0;
@@ -318,44 +310,6 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         callCount.Should().BeGreaterThanOrEqualTo(3);
     }
 
-    [Fact]
-    public async Task should_use_10_retries_max()
-    {
-        // given
-        var options = new PermissionManagementOptions
-        {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
-        };
-
-        var callCount = 0;
-
-        _store
-            .SaveAsync(Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                callCount++;
-
-                throw new InvalidOperationException("Always fails");
-            });
-
-        using var sut = _CreateSut(options);
-
-        // when
-        await sut.StartAsync(CancellationToken.None);
-
-        // Advance time significantly to allow all retries
-        // Total delay for 10 retries: 2+4+8+16+32+64+128+256+512+1024 = 2046 seconds ~= 34 minutes
-        for (var i = 0; i < 20; i++)
-        {
-            _timeProvider.Advance(TimeSpan.FromMinutes(5));
-            await Task.Delay(50);
-        }
-
-        // then - should have exactly 11 attempts (1 initial + 10 retries)
-        callCount.Should().Be(11);
-    }
-
     #endregion
 
     #region Cancellation
@@ -363,11 +317,11 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     [Fact]
     public async Task should_cancel_on_start_token_cancellation()
     {
-        // given - test that cancellation via input token works
-        var options = new PermissionManagementOptions
+        // given
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         using var cts = new CancellationTokenSource();
@@ -384,7 +338,6 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
                 try
                 {
-                    // Wait for cancellation using the provided CancellationToken
                     await Task.Delay(Timeout.Infinite, ct);
                 }
                 catch (OperationCanceledException)
@@ -402,16 +355,13 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         await sut.StartAsync(cts.Token);
         await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // Cancel the token
         await cts.CancelAsync();
 
-        // Wait for cancellation to be observed
         var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
 
-        // then - the save operation should have been cancelled
+        // then
         cancelledTask.Should().Be(saveCancelled.Task, "cancellation token should cancel the background task");
 
-        // Wait for task completion before dispose
         await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1)));
     }
 
@@ -423,10 +373,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_dispose_cancellation_token_source()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new FeatureManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticFeaturesToDatabase = false,
+            IsDynamicFeatureStoreEnabled = false,
         };
 
         var sut = _CreateSut(options);
@@ -436,55 +386,20 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         sut.Dispose();
 
         // then - should not throw on dispose (proper cleanup)
-        // Calling dispose again should also not throw (idempotent)
         var action = () => sut.Dispose();
         action.Should().NotThrow();
     }
 
     #endregion
 
-    #region Error Logging
-
-    [Fact]
-    public async Task should_call_get_groups_on_pre_cache_failure()
-    {
-        // given
-        var options = new PermissionManagementOptions
-        {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = true,
-        };
-
-        var getGroupsCalled = new TaskCompletionSource();
-
-        _store
-            .GetGroupsAsync(Arg.Any<CancellationToken>())
-            .Returns<IReadOnlyList<PermissionGroupDefinition>>(_ =>
-            {
-                getGroupsCalled.TrySetResult();
-                throw new InvalidOperationException("Pre-cache failed");
-            });
-
-        var sut = _CreateSut(options);
-
-        // when
-        await sut.StartAsync(CancellationToken.None);
-        await getGroupsCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        // then
-        await _store.Received(1).GetGroupsAsync(Arg.Any<CancellationToken>());
-    }
-
-    #endregion
-
     #region Helpers
 
-    private PermissionsInitializationBackgroundService _CreateSut(PermissionManagementOptions options)
+    private FeaturesInitializationBackgroundService _CreateSut(FeatureManagementOptions options)
     {
         var optionsAccessor = Options.Create(options);
-        var logger = LoggerFactory.CreateLogger<PermissionsInitializationBackgroundService>();
+        var logger = LoggerFactory.CreateLogger<FeaturesInitializationBackgroundService>();
 
-        return new PermissionsInitializationBackgroundService(
+        return new FeaturesInitializationBackgroundService(
             _timeProvider,
             _serviceScopeFactory,
             optionsAccessor,

--- a/tests/Headless.Hosting.Tests.Unit/DependencyInjection/DependencyInjectionExtensionsTests.cs
+++ b/tests/Headless.Hosting.Tests.Unit/DependencyInjection/DependencyInjectionExtensionsTests.cs
@@ -1,4 +1,6 @@
+using Headless.Hosting.Initialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Tests.DependencyInjection;
 
@@ -552,6 +554,97 @@ public sealed class DependencyInjectionExtensionsTests
         // then
         myServiceWithoutKey.Should().BeNull();
     }
+
+    #region AddInitializerHostedService
+
+    [Fact]
+    public void add_initializer_hosted_service_should_register_T_as_singleton()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddInitializerHostedService<MyInitializerService>();
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<MyInitializerService>();
+
+        // then
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<MyInitializerService>();
+    }
+
+    [Fact]
+    public void add_initializer_hosted_service_should_forward_as_IInitializer_using_same_singleton_instance()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddInitializerHostedService<MyInitializerService>();
+        var provider = services.BuildServiceProvider();
+
+        var singleton = provider.GetRequiredService<MyInitializerService>();
+        var initializer = provider.GetServices<IInitializer>().OfType<MyInitializerService>().Single();
+
+        // then
+        initializer.Should().BeSameAs(singleton);
+    }
+
+    [Fact]
+    public void add_initializer_hosted_service_should_forward_as_IHostedService_using_same_singleton_instance()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddInitializerHostedService<MyInitializerService>();
+        var provider = services.BuildServiceProvider();
+
+        var singleton = provider.GetRequiredService<MyInitializerService>();
+        var hostedService = provider.GetServices<IHostedService>().OfType<MyInitializerService>().Single();
+
+        // then
+        hostedService.Should().BeSameAs(singleton);
+    }
+
+    [Fact]
+    public void add_initializer_hosted_service_should_be_idempotent_when_called_twice()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddInitializerHostedService<MyInitializerService>();
+        services.AddInitializerHostedService<MyInitializerService>();
+        var provider = services.BuildServiceProvider();
+
+        // then — no duplicates
+        provider.GetServices<IInitializer>().OfType<MyInitializerService>().Should().HaveCount(1);
+        provider.GetServices<IHostedService>().OfType<MyInitializerService>().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void add_initializer_hosted_service_should_register_multiple_distinct_types_independently()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddInitializerHostedService<MyInitializerService>();
+        services.AddInitializerHostedService<AnotherInitializerService>();
+        var provider = services.BuildServiceProvider();
+
+        // then — each type gets its own IInitializer and IHostedService entry
+        var initializers = provider.GetServices<IInitializer>().ToList();
+        initializers.Should().ContainSingle(i => i is MyInitializerService);
+        initializers.Should().ContainSingle(i => i is AnotherInitializerService);
+
+        var hostedServices = provider.GetServices<IHostedService>().ToList();
+        hostedServices.Should().ContainSingle(h => h is MyInitializerService);
+        hostedServices.Should().ContainSingle(h => h is AnotherInitializerService);
+    }
+
+    #endregion
 }
 
 public interface IMyService
@@ -567,4 +660,27 @@ public sealed class MyService : IMyService
 public sealed class ReplacementService : IMyService
 {
     public string Greet() => "replacement";
+}
+
+// Helpers for AddInitializerHostedService<T> tests
+public sealed class MyInitializerService : IHostedService, IInitializer
+{
+    public bool IsInitialized => true;
+
+    public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+public sealed class AnotherInitializerService : IHostedService, IInitializer
+{
+    public bool IsInitialized => true;
+
+    public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/tests/Headless.Permissions.Tests.Integration/TestSetup/SettingsTestBase.cs
+++ b/tests/Headless.Permissions.Tests.Integration/TestSetup/SettingsTestBase.cs
@@ -5,7 +5,6 @@ using Headless.DistributedLocks.Redis;
 using Headless.Domain;
 using Headless.Messaging;
 using Headless.Permissions;
-using Headless.Permissions.Seeders;
 using Headless.Permissions.Storage.EntityFramework;
 using Headless.Redis;
 using Headless.Testing.Tests;
@@ -69,7 +68,5 @@ public abstract class PermissionsTestBase(PermissionsTestFixture fixture) : Test
         services
             .AddPermissionsManagementCore()
             .AddPermissionsManagementDbContextStorage(options => options.UseNpgsql(Fixture.SqlConnectionString));
-
-        services.RemoveHostedService<PermissionsInitializationBackgroundService>();
     }
 }

--- a/tests/Headless.Settings.Tests.Integration/TestSetup/SettingsTestBase.cs
+++ b/tests/Headless.Settings.Tests.Integration/TestSetup/SettingsTestBase.cs
@@ -6,7 +6,6 @@ using Headless.DistributedLocks.Redis;
 using Headless.Domain;
 using Headless.Redis;
 using Headless.Settings;
-using Headless.Settings.Seeders;
 using Headless.Settings.Storage.EntityFramework;
 using Headless.Testing.Tests;
 using Microsoft.EntityFrameworkCore;
@@ -69,8 +68,6 @@ public abstract class SettingsTestBase(SettingsTestFixture fixture) : TestBase
         services
             .AddSettingsManagementCore()
             .AddSettingsManagementDbContextStorage(options => options.UseNpgsql(Fixture.SqlConnectionString));
-
-        services.RemoveHostedService<SettingsInitializationBackgroundService>();
     }
 
     private static void _AddDefaultStringEncryptionConfiguration(IConfigurationBuilder configuration)

--- a/tests/Headless.Settings.Tests.Unit/Seeders/SettingsInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Settings.Tests.Unit/Seeders/SettingsInitializationBackgroundServiceTests.cs
@@ -1,29 +1,29 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Permissions.Definitions;
-using Headless.Permissions.Models;
-using Headless.Permissions.Seeders;
+using Headless.Settings.Definitions;
+using Headless.Settings.Models;
+using Headless.Settings.Seeders;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 
-namespace Tests.Services;
+namespace Tests.Seeders;
 
-public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
+public sealed class SettingsInitializationBackgroundServiceTests : TestBase
 {
     private readonly IServiceScopeFactory _serviceScopeFactory = Substitute.For<IServiceScopeFactory>();
     private readonly IServiceScope _serviceScope = Substitute.For<IServiceScope>();
     private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
-    private readonly IDynamicPermissionDefinitionStore _store = Substitute.For<IDynamicPermissionDefinitionStore>();
+    private readonly IDynamicSettingDefinitionStore _store = Substitute.For<IDynamicSettingDefinitionStore>();
     private readonly FakeTimeProvider _timeProvider = new();
 
-    public PermissionsInitializationBackgroundServiceTests()
+    public SettingsInitializationBackgroundServiceTests()
     {
         _serviceScopeFactory.CreateScope().Returns(_serviceScope);
         _serviceScope.ServiceProvider.Returns(_serviceProvider);
-        _serviceProvider.GetService(typeof(IDynamicPermissionDefinitionStore)).Returns(_store);
+        _serviceProvider.GetService(typeof(IDynamicSettingDefinitionStore)).Returns(_store);
     }
 
     #region IInitializer Contract
@@ -33,11 +33,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     {
         // given
         var sut = _CreateSut(
-            new PermissionManagementOptions
-            {
-                SaveStaticPermissionsToDatabase = true,
-                IsDynamicPermissionStoreEnabled = false,
-            }
+            new SettingManagementOptions { SaveStaticSettingsToDatabase = true, IsDynamicSettingStoreEnabled = false }
         );
 
         // then
@@ -49,11 +45,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     {
         // given
         var sut = _CreateSut(
-            new PermissionManagementOptions
-            {
-                SaveStaticPermissionsToDatabase = false,
-                IsDynamicPermissionStoreEnabled = false,
-            }
+            new SettingManagementOptions { SaveStaticSettingsToDatabase = false, IsDynamicSettingStoreEnabled = false }
         );
 
         // when
@@ -67,10 +59,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_report_initialized_after_successful_completion()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         var saveDone = new TaskCompletionSource();
@@ -97,10 +89,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_wait_for_initialization_async_completes_after_success()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         _store.SaveAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
@@ -120,17 +112,17 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_propagate_fault_to_wait_for_initialization_async()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = true,
+            SaveStaticSettingsToDatabase = false,
+            IsDynamicSettingStoreEnabled = true,
         };
 
         var exception = new InvalidOperationException("Store exploded");
 
         _store
-            .GetGroupsAsync(Arg.Any<CancellationToken>())
-            .Returns<IReadOnlyList<PermissionGroupDefinition>>(_ => throw exception);
+            .GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<SettingDefinition>>(_ => throw exception);
 
         var sut = _CreateSut(options);
 
@@ -148,10 +140,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_propagate_cancellation_to_wait_for_initialization_async_when_stopped()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         var saveStarted = new TaskCompletionSource();
@@ -184,10 +176,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_not_start_when_both_options_disabled()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = false,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         var sut = _CreateSut(options);
@@ -200,21 +192,21 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
         // then - store should never be touched
         await _store.DidNotReceive().SaveAsync(Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().GetGroupsAsync(Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
     }
 
     #endregion
 
-    #region Save Static Permissions
+    #region Save Static Settings
 
     [Fact]
-    public async Task should_save_static_permissions_when_enabled()
+    public async Task should_save_static_settings_when_enabled()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         var saveCalled = new TaskCompletionSource();
@@ -238,25 +230,25 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
     #endregion
 
-    #region Pre-cache Dynamic Permissions
+    #region Pre-cache Dynamic Settings
 
     [Fact]
-    public async Task should_pre_cache_dynamic_permissions_when_enabled()
+    public async Task should_pre_cache_dynamic_settings_when_enabled()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = true,
+            SaveStaticSettingsToDatabase = false,
+            IsDynamicSettingStoreEnabled = true,
         };
 
         var preCacheCalled = new TaskCompletionSource();
         _store
-            .GetGroupsAsync(Arg.Any<CancellationToken>())
+            .GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
                 preCacheCalled.TrySetResult();
-                return Task.FromResult<IReadOnlyList<PermissionGroupDefinition>>([]);
+                return Task.FromResult<IReadOnlyList<SettingDefinition>>([]);
             });
 
         var sut = _CreateSut(options);
@@ -265,8 +257,8 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         await sut.StartAsync(AbortToken);
         await preCacheCalled.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
-        // then - GetGroupsAsync is used to pre-cache
-        await _store.Received(1).GetGroupsAsync(Arg.Any<CancellationToken>());
+        // then - GetAllAsync is used to pre-cache
+        await _store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -277,10 +269,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_retry_on_save_failure()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         var callCount = 0;
@@ -318,44 +310,6 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         callCount.Should().BeGreaterThanOrEqualTo(3);
     }
 
-    [Fact]
-    public async Task should_use_10_retries_max()
-    {
-        // given
-        var options = new PermissionManagementOptions
-        {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
-        };
-
-        var callCount = 0;
-
-        _store
-            .SaveAsync(Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                callCount++;
-
-                throw new InvalidOperationException("Always fails");
-            });
-
-        using var sut = _CreateSut(options);
-
-        // when
-        await sut.StartAsync(CancellationToken.None);
-
-        // Advance time significantly to allow all retries
-        // Total delay for 10 retries: 2+4+8+16+32+64+128+256+512+1024 = 2046 seconds ~= 34 minutes
-        for (var i = 0; i < 20; i++)
-        {
-            _timeProvider.Advance(TimeSpan.FromMinutes(5));
-            await Task.Delay(50);
-        }
-
-        // then - should have exactly 11 attempts (1 initial + 10 retries)
-        callCount.Should().Be(11);
-    }
-
     #endregion
 
     #region Cancellation
@@ -363,11 +317,11 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     [Fact]
     public async Task should_cancel_on_start_token_cancellation()
     {
-        // given - test that cancellation via input token works
-        var options = new PermissionManagementOptions
+        // given
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = true,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         using var cts = new CancellationTokenSource();
@@ -384,7 +338,6 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
                 try
                 {
-                    // Wait for cancellation using the provided CancellationToken
                     await Task.Delay(Timeout.Infinite, ct);
                 }
                 catch (OperationCanceledException)
@@ -402,16 +355,13 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         await sut.StartAsync(cts.Token);
         await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // Cancel the token
         await cts.CancelAsync();
 
-        // Wait for cancellation to be observed
         var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
 
-        // then - the save operation should have been cancelled
+        // then
         cancelledTask.Should().Be(saveCancelled.Task, "cancellation token should cancel the background task");
 
-        // Wait for task completion before dispose
         await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1)));
     }
 
@@ -423,10 +373,10 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     public async Task should_dispose_cancellation_token_source()
     {
         // given
-        var options = new PermissionManagementOptions
+        var options = new SettingManagementOptions
         {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = false,
+            SaveStaticSettingsToDatabase = false,
+            IsDynamicSettingStoreEnabled = false,
         };
 
         var sut = _CreateSut(options);
@@ -436,55 +386,20 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         sut.Dispose();
 
         // then - should not throw on dispose (proper cleanup)
-        // Calling dispose again should also not throw (idempotent)
         var action = () => sut.Dispose();
         action.Should().NotThrow();
     }
 
     #endregion
 
-    #region Error Logging
-
-    [Fact]
-    public async Task should_call_get_groups_on_pre_cache_failure()
-    {
-        // given
-        var options = new PermissionManagementOptions
-        {
-            SaveStaticPermissionsToDatabase = false,
-            IsDynamicPermissionStoreEnabled = true,
-        };
-
-        var getGroupsCalled = new TaskCompletionSource();
-
-        _store
-            .GetGroupsAsync(Arg.Any<CancellationToken>())
-            .Returns<IReadOnlyList<PermissionGroupDefinition>>(_ =>
-            {
-                getGroupsCalled.TrySetResult();
-                throw new InvalidOperationException("Pre-cache failed");
-            });
-
-        var sut = _CreateSut(options);
-
-        // when
-        await sut.StartAsync(CancellationToken.None);
-        await getGroupsCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        // then
-        await _store.Received(1).GetGroupsAsync(Arg.Any<CancellationToken>());
-    }
-
-    #endregion
-
     #region Helpers
 
-    private PermissionsInitializationBackgroundService _CreateSut(PermissionManagementOptions options)
+    private SettingsInitializationBackgroundService _CreateSut(SettingManagementOptions options)
     {
         var optionsAccessor = Options.Create(options);
-        var logger = LoggerFactory.CreateLogger<PermissionsInitializationBackgroundService>();
+        var logger = LoggerFactory.CreateLogger<SettingsInitializationBackgroundService>();
 
-        return new PermissionsInitializationBackgroundService(
+        return new SettingsInitializationBackgroundService(
             _timeProvider,
             _serviceScopeFactory,
             optionsAccessor,

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerTests.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Concurrent;
 using Headless.Abstractions;
+using Headless.Hosting.Initialization;
 using Headless.Testing.AspNetCore;
 using Headless.Testing.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -275,5 +276,46 @@ public sealed class HeadlessTestServerTests : IAsyncLifetime
         providers.Distinct().Should().HaveCount(3);
     }
 
+    [Fact]
+    public async Task should_throw_timeout_when_initializer_exceeds_timeout()
+    {
+        _server = new HeadlessTestServer<Program>(
+            configureTestServices: services => services.AddSingleton<IInitializer>(new NeverCompletesInitializer()),
+            initializerTimeout: TimeSpan.FromMilliseconds(100)
+        );
+
+        Func<Task> act = async () => await _server.InitializeAsync();
+
+        await act.Should().ThrowExactlyAsync<TimeoutException>().WithMessage("*NeverCompletesInitializer*");
+    }
+
+    [Fact]
+    public async Task should_throw_when_initializer_faults()
+    {
+        _server = new HeadlessTestServer<Program>(configureTestServices: services =>
+            services.AddSingleton<IInitializer>(new FaultingInitializer())
+        );
+
+        Func<Task> act = async () => await _server.InitializeAsync();
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>().WithMessage("*FaultingInitializer*faulted*");
+    }
+
     private sealed class MarkerService;
+
+    private sealed class NeverCompletesInitializer : IInitializer
+    {
+        public bool IsInitialized => false;
+
+        public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
+            Task.Delay(Timeout.Infinite, cancellationToken);
+    }
+
+    private sealed class FaultingInitializer : IInitializer
+    {
+        public bool IsInitialized => false;
+
+        public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
+            Task.FromException(new InvalidOperationException("Initializer exploded"));
+    }
 }


### PR DESCRIPTION
Closes #212

## Summary

- Adds `IInitializer` interface (`IsInitialized` + `WaitForInitializationAsync`) to `Headless.Hosting`
- Implements `IInitializer` on `FeaturesInitializationBackgroundService`, `PermissionsInitializationBackgroundService`, and `SettingsInitializationBackgroundService` — all three signal completion via `TaskCompletionSource` (success, exception, or silent cancellation on shutdown)
- Adds `AddInitializerHostedService<T>()` extension in `Headless.Hosting` that encapsulates the singleton-forwarding registration pattern (`TryAddSingleton<T>` + `TryAddEnumerable<IInitializer>` + `AddHostedService`)
- `HeadlessTestServer.InitializeAsync` now auto-resolves all `IEnumerable<IInitializer>` and awaits each with a 60s timeout before running user-defined readiness checks
- Removes `RemoveHostedService<*InitializationBackgroundService>()` workarounds from all three integration test bases

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a test infrastructure and DI registration change with no runtime production code path added.