### PR TITLE
feat(api): add SkipTenantResolution endpoint-level opt-out (#251)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -132,7 +132,7 @@ dotnet_diagnostic.ca1000.severity = suggestion
 # CA1032: Implement standard exception constructors
 dotnet_diagnostic.ca1032.severity = silent
 # CA2016: Forward the CancellationToken parameter to methods that take one
-dotnet_diagnostic.ca2016.severity = suggestion
+dotnet_diagnostic.ca2016.severity = warning
 # CA1859: Use concrete types when possible for improved performance
 dotnet_diagnostic.ca1859.severity = suggestion
 # CA1024: Use properties where appropriate

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,11 +18,11 @@
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageVersion Include="AwesomeAssertions.Json" Version="9.0.0" />
-    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.38" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.23.1" />
-    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.12.14" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.31" />
-    <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.29" />
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.40" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.23.3" />
+    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.12.16" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.33" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.31" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
@@ -37,13 +37,13 @@
     <PackageVersion Include="Couchbase.Extensions.MultiOp" Version="5.0.1" />
     <PackageVersion Include="Couchbase.Transactions" Version="3.9.0" />
     <PackageVersion Include="CouchbaseNetClient" Version="3.9.2" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="DeepCloner" Version="0.10.4" />
     <PackageVersion Include="DeviceDetector.NET" Version="6.5.0" />
     <PackageVersion Include="DistributedLock.Core" Version="1.0.7" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageVersion Include="EFCore.CheckConstraints" Version="10.0.0" />
-    <PackageVersion Include="FileSignatures" Version="7.2.0" />
+    <PackageVersion Include="FileSignatures" Version="7.2.1" />
     <PackageVersion Include="FastExpressionCompiler" Version="5.4.1" />
     <PackageVersion Include="FirebaseAdmin" Version="3.5.0" />
     <PackageVersion Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />
@@ -62,7 +62,7 @@
     <PackageVersion Include="MassTransit" Version="9.0.0" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
-    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit.v3" Version="2.0.0" />
+    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit.v3" Version="2.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />
@@ -133,7 +133,7 @@
     <PackageVersion Include="NSwag.AspNetCore" Version="14.7.1" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <!-- Transitive override (NSwag -> SkiaSharp dependency chain): pinned to clear GHSA-jxpf-xq2m-q525 (OpenMcdf < 3.1.3 DoS). -->
-    <PackageVersion Include="OpenMcdf" Version="3.1.3" />
+    <PackageVersion Include="OpenMcdf" Version="3.1.4" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
@@ -151,7 +151,7 @@
     <PackageVersion Include="Pulsar.Client" Version="3.15.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.11" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Enrichers.ClientInfo" Version="2.9.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
@@ -177,15 +177,15 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.9" />
     <PackageVersion Include="System.Text.Json" Version="9.0.9" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.LocalStack" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Nats" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.XunitV3" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.LocalStack" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Nats" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.XunitV3" Version="4.12.0" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
     <PackageVersion Include="tusdotnet" Version="2.11.1" />
     <PackageVersion Include="Twilio" Version="7.13.1" />

--- a/docs/llms/multi-tenancy.md
+++ b/docs/llms/multi-tenancy.md
@@ -10,6 +10,7 @@ packages: MultiTenancy, Api.Core, Api.ServiceDefaults, Core, Messaging.Core, Orm
 - [Quick Orientation](#quick-orientation)
 - [Agent Instructions](#agent-instructions)
 - [HTTP Setup](#http-setup)
+- [Skipping Tenant Resolution](#skipping-tenant-resolution)
 - [HTTP Failure Mapping](#http-failure-mapping)
 - [HTTP Authorization Requirement](#http-authorization-requirement)
 - [Tenant Semantics](#tenant-semantics)
@@ -64,6 +65,7 @@ app.UseAuthorization();
 - In tenant-aware hosts, prefer `builder.AddHeadlessTenancy(...)` so HTTP, Authorization, Messaging, and EF posture is visible in one block.
 - In HTTP apps, use `.Http(http => http.ResolveFromClaims())` and `app.UseHeadlessTenancy()` in the middleware pipeline.
 - For HTTP request boundaries, use `.Authorization(auth => auth.RequireTenant())`, add `TenantRequirement` to the app's `FallbackPolicy` or `DefaultPolicy`, mark intentional host-level endpoints with `[AllowMissingTenant]` or `.AllowMissingTenant()`, and use `[RequireTenant]` / `.RequireTenant()` to opt back in under broader allow-missing metadata.
+- Use `[SkipTenantResolution]` / `.SkipTenantResolution()` to opt an endpoint out of claim extraction entirely (not just authorization enforcement). The middleware skips `ICurrentTenant.Change(...)` and leaves `ICurrentTenant.IsAvailable` false. Combine with `.AllowMissingTenant()` when the endpoint also sits under a tenant-required policy.
 - The default claim type is `tenant_id`. Override it with `ResolveFromClaims(options => options.ClaimType = "...")` only when your identity system uses a different claim name.
 - Mint the tenant claim only on principals that are actually scoped to a tenant. Host-level, admin, service-account, or cross-tenant principal types should not carry the claim — `ICurrentTenant.IsAvailable` stays false for them by design.
 - When no tenant claim is present, the middleware intentionally skips `Change(null)`. This preserves the distinction between "never set" and "explicitly null".
@@ -122,6 +124,49 @@ app.UseAuthorization();
 - Uses `MultiTenancyOptions.ClaimType` when configured
 - Calls `currentTenant.Change(tenantId)` only when the principal is authenticated and the tenant claim is not blank
 - Restores the previous tenant automatically when the request finishes
+
+## Skipping Tenant Resolution
+
+Apply `[SkipTenantResolution]` or `.SkipTenantResolution()` to opt an endpoint, route group, or MVC controller/action out of HTTP claim extraction. `TenantResolutionMiddleware` still marks the request as processed (`HeadlessTenancyResolutionApplied`) but returns immediately without calling `ICurrentTenant.Change(...)`. `ICurrentTenant.Id` remains null and `IsAvailable` stays false for the entire request.
+
+```csharp
+// Minimal API — single endpoint
+app.MapGet("/health", () => Results.Ok()).SkipTenantResolution();
+
+// Minimal API — route group
+var publicGroup = app.MapGroup("/public").SkipTenantResolution();
+publicGroup.MapGet("/status", () => Results.Ok());
+
+// MVC — controller (applies to all actions)
+[SkipTenantResolution]
+[Route("admin")]
+public sealed class AdminController : ControllerBase { ... }
+
+// MVC — individual action
+[Route("users")]
+public sealed class UsersController : ControllerBase
+{
+    [HttpGet("me")]
+    [SkipTenantResolution]
+    public IActionResult Profile() => Ok();
+}
+```
+
+When the endpoint also lives under a tenant-required authorization policy, compose `.SkipTenantResolution()` with `.AllowMissingTenant()` so the authorization requirement is satisfied:
+
+```csharp
+app.MapGet("/webhook", (ICurrentTenant t) => Results.Ok())
+    .SkipTenantResolution()
+    .AllowMissingTenant();
+```
+
+**When to use** — prefer `[SkipTenantResolution]` over `[AllowMissingTenant]` when the endpoint must not even attempt claim extraction, for example:
+
+- The authenticated principal type can never carry a tenant claim (service-account, monitoring agent, webhook receiver).
+- Claim extraction itself has measurable overhead on a hot path and the request is guaranteed to not need tenant context.
+- The endpoint is unauthenticated and you want to suppress the middleware ordering warning.
+
+For endpoints that may or may not carry a tenant claim depending on the caller, `[AllowMissingTenant]` is the right choice — it runs extraction and simply permits the authorization requirement to pass when no claim is found.
 
 ## HTTP Failure Mapping
 

--- a/docs/llms/multi-tenancy.md
+++ b/docs/llms/multi-tenancy.md
@@ -65,7 +65,7 @@ app.UseAuthorization();
 - In tenant-aware hosts, prefer `builder.AddHeadlessTenancy(...)` so HTTP, Authorization, Messaging, and EF posture is visible in one block.
 - In HTTP apps, use `.Http(http => http.ResolveFromClaims())` and `app.UseHeadlessTenancy()` in the middleware pipeline.
 - For HTTP request boundaries, use `.Authorization(auth => auth.RequireTenant())`, add `TenantRequirement` to the app's `FallbackPolicy` or `DefaultPolicy`, mark intentional host-level endpoints with `[AllowMissingTenant]` or `.AllowMissingTenant()`, and use `[RequireTenant]` / `.RequireTenant()` to opt back in under broader allow-missing metadata.
-- Use `[SkipTenantResolution]` / `.SkipTenantResolution()` to opt an endpoint out of claim extraction entirely (not just authorization enforcement). The middleware skips `ICurrentTenant.Change(...)` and leaves `ICurrentTenant.IsAvailable` false. Combine with `.AllowMissingTenant()` when the endpoint also sits under a tenant-required policy.
+- Use `[SkipTenantResolution]` / `.SkipTenantResolution()` to opt an endpoint out of claim extraction entirely (not just authorization enforcement). The middleware skips `ICurrentTenant.Change(...)` — if no other resolver runs, `ICurrentTenant.IsAvailable` stays false. Apply when an endpoint is reached by principals that legitimately carry a tenant claim but must not have `ICurrentTenant` populated — for example, admin or cross-tenant endpoints where the claim would silently scope EF global filters to a single tenant. Combine with `.AllowMissingTenant()` when the endpoint also sits under a tenant-required policy.
 - The default claim type is `tenant_id`. Override it with `ResolveFromClaims(options => options.ClaimType = "...")` only when your identity system uses a different claim name.
 - Mint the tenant claim only on principals that are actually scoped to a tenant. Host-level, admin, service-account, or cross-tenant principal types should not carry the claim — `ICurrentTenant.IsAvailable` stays false for them by design.
 - When no tenant claim is present, the middleware intentionally skips `Change(null)`. This preserves the distinction between "never set" and "explicitly null".
@@ -127,7 +127,9 @@ app.UseAuthorization();
 
 ## Skipping Tenant Resolution
 
-Apply `[SkipTenantResolution]` or `.SkipTenantResolution()` to opt an endpoint, route group, or MVC controller/action out of HTTP claim extraction. `TenantResolutionMiddleware` still marks the request as processed (`HeadlessTenancyResolutionApplied`) but returns immediately without calling `ICurrentTenant.Change(...)`. `ICurrentTenant.Id` remains null and `IsAvailable` stays false for the entire request.
+Apply `[SkipTenantResolution]` or `.SkipTenantResolution()` to opt an endpoint, route group, or MVC controller/action out of HTTP claim extraction. `TenantResolutionMiddleware` still marks the request as processed (`HeadlessTenancyResolutionApplied`) but returns immediately without calling `ICurrentTenant.Change(...)` — if no other resolver runs, `ICurrentTenant.Id` stays unset and `IsAvailable` stays false for the entire request.
+
+This marker is HTTP-layer only — Mediator tenant guards, EF write guards, and messaging publish guards still enforce `ICurrentTenant.Id`. A handler running under this marker that calls a tenant-required downstream service will still throw `MissingTenantContextException`.
 
 ```csharp
 // Minimal API — single endpoint
@@ -165,8 +167,11 @@ app.MapGet("/webhook", (ICurrentTenant t) => Results.Ok())
 - The authenticated principal type can never carry a tenant claim (service-account, monitoring agent, webhook receiver).
 - Claim extraction itself has measurable overhead on a hot path and the request is guaranteed to not need tenant context.
 - The endpoint is unauthenticated and you want to suppress the middleware ordering warning.
+- The endpoint uses a non-claim tenant resolver (subdomain, path segment, webhook signature) and you want to prevent the claim-based middleware from overriding it.
 
 For endpoints that may or may not carry a tenant claim depending on the caller, `[AllowMissingTenant]` is the right choice — it runs extraction and simply permits the authorization requirement to pass when no claim is found.
+
+**Ordering requirement** — `UseHeadlessTenancy()` (or the lower-level `UseTenantResolution()`) must run after `UseRouting()` so endpoint metadata is available when the middleware checks for `[SkipTenantResolution]`. Without that ordering, `HttpContext.GetEndpoint()` returns `null` and the skip marker silently has no effect — claim extraction runs as if the marker were absent. The recommended `UseAuthentication() -> UseHeadlessTenancy() -> UseAuthorization()` pipeline already satisfies this when `WebApplication` auto-injects routing for you, but consumers calling `UseRouting()` explicitly must place it before `UseHeadlessTenancy()`.
 
 ## HTTP Failure Mapping
 

--- a/docs/plans/2026-05-20-002-feat-skip-tenant-resolution-metadata-plan.md
+++ b/docs/plans/2026-05-20-002-feat-skip-tenant-resolution-metadata-plan.md
@@ -1,0 +1,394 @@
+---
+title: "feat(api): add SkipTenantResolution endpoint metadata"
+type: feat
+status: active
+depth: standard
+created: 2026-05-20
+issue: 251
+---
+
+# feat(api): add SkipTenantResolution endpoint metadata
+
+**Origin:** GitHub issue [#251](https://github.com/xshaheen/headless-framework/issues/251). Spec adjusted during planning — see Key Technical Decisions for the deltas from the issue body.
+
+## Summary
+
+Add an endpoint-level opt-out from HTTP claims-based tenant resolution. Endpoints (or route groups, or MVC controllers/actions) marked with `[SkipTenantResolution]` / `.SkipTenantResolution()` will not have `ICurrentTenant` mutated by `TenantResolutionMiddleware`, even when the authenticated principal carries a tenant claim. Mediator, EF write-guards, and messaging tenant requirements stay enforced — this is an HTTP-layer marker only.
+
+The opt-out mirrors the existing `[AllowMissingTenant]` / `.AllowMissingTenant()` shape exactly: bare sealed attribute that doubles as endpoint metadata, member of the existing `EndpointConventionBuilderExtensions` extension block, attribute targets `Class | Method` so it works on Minimal API, route groups, and MVC controllers/actions out of the box.
+
+---
+
+## Problem Frame
+
+`TenantResolutionMiddleware` (`src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs`) currently mutates `ICurrentTenant` for **every authenticated request whose principal carries the configured tenant claim**. This is the right default for tenant-scoped users but breaks two real scenarios:
+
+1. **Host / cross-tenant / admin endpoints reached by claim-carrying principals.** Documented framework guidance (`docs/llms/multi-tenancy.md` line 68) is "do not mint the tenant claim on admin / host / service-account principals." That guidance is enforced by convention, not by the framework. When a platform-admin principal who also belongs to a tenant (legitimately, as a user) hits `GET /admin/tenants`, the middleware sets `ICurrentTenant` from that user-side claim, and any downstream EF global filter on tenant silently scopes the cross-tenant query to one row. Silent wrong-answer, not an exception.
+
+2. **Endpoints whose tenant comes from a non-claim source.** Subdomain (`acme.example.com`), path segment (`/t/{tenantId}/...`), or webhook signature verification. The claim-based middleware fights the alternate resolver — whichever runs last wins, and the result depends on registration order rather than the endpoint's stated intent.
+
+Today the only mitigations are pipeline-level branching (brittle, invisible at the endpoint definition site) or carefully scrubbing the tenant claim from admin principals (orthogonal concern, not the framework's job). The opt-out marker makes intent first-class at the endpoint.
+
+**What the issue lists but is *not* the real motivation:** health probes, OpenAPI, public unauthenticated endpoints. The current middleware is already a no-op pass-through for unauthenticated requests and for authenticated requests without a tenant claim. Those endpoints do not need the marker for correctness — see Scope Boundaries.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+
+- New `SkipTenantResolutionAttribute` in `src/Headless.Api.Core/MultiTenancy/`.
+- New `.SkipTenantResolution()` extension on `IEndpointConventionBuilder`, added to the existing `EndpointConventionBuilderExtensions` block (same folder).
+- `TenantResolutionMiddleware` honors the new metadata — bypasses claim resolution and the misordering warning, still sets the `HeadlessTenancyResolutionApplied` feature flag so downstream exception handling stays consistent.
+- Integration test coverage for the four endpoint topologies (Minimal API, route group, MVC action, MVC class-level) plus the composition with `[AllowMissingTenant]`.
+- Doc updates to `src/Headless.Api.Core/README.md` and `docs/llms/multi-tenancy.md` distinguishing the new *resolution* opt-out from the existing *authorization* opt-out.
+
+**Out of scope:**
+
+- Mediator tenant guards, EF write guards, messaging tenant requirements. The marker is HTTP-layer; downstream guards keep enforcing tenant context. Explicit non-goal in issue #251.
+- Tenant-resolution-skip vocabulary in `Headless.MultiTenancy` (the abstraction-only package). The metadata lives where the consumer lives — `Headless.Api.Core`.
+- Per-request runtime conditional skip (e.g., "skip when header X is present"). The marker is endpoint-static metadata; runtime conditionals belong in custom middleware.
+- Host-mode global skip (a startup flag that disables claim resolution for the whole app). YAGNI; the existing path of "don't call `tenancy.Http(...)`" already covers that.
+
+### Deferred to Follow-Up Work
+
+- **Opt-back-in inverse (`[RequireTenantResolution]` / `.RequireTenantResolution()`).** Would let a route group declare `.SkipTenantResolution()` and a single child opt back in. The "last attribute wins" reverse-iteration pattern in `TenantRequirementHandler._AllowsMissingTenant` already proves the framework can support this trivially. No real consumer yet; defer until one shows up.
+- **MVC controller-style integration tests with their own fixture.** The attribute targets `Class | Method` so it works on controllers/actions for free, but dedicated MVC integration tests (mirroring `PublicTenantRequirementController` in `TenantRequirementTests.cs`) are deferred to a follow-up if MVC adoption justifies the surface. The attribute itself remains functional on controllers.
+- **`docs/solutions/` entry on claim-based tenant resolution as a privilege-escalation surface.** Learnings-research flagged that no `docs/solutions/` entry covers middleware-level tenant resolution despite multiple footguns documented in `docs/llms/multi-tenancy.md`. Worth a `/dev-compound` entry post-ship.
+
+---
+
+## Requirements Traceability
+
+| Origin requirement (issue #251) | Plan disposition |
+|---|---|
+| Add endpoint metadata that tells the middleware to skip resolution | Honored — `SkipTenantResolutionAttribute` (U1), middleware check (U2) |
+| Minimal API endpoint can call `.SkipTenantResolution()` | Honored — extension member, tested in U3 |
+| Route groups can call `.SkipTenantResolution()` and metadata applies to children | Honored — same extension covers `IEndpointConventionBuilder` (groups implement it), tested in U3 |
+| MVC controllers/actions can use `[SkipTenantResolution]` | Honored at attribute level via `AttributeTargets.Class | Method`; dedicated MVC integration tests deferred (see Deferred) |
+| Middleware skips resolution when metadata present | Honored — U2 |
+| Skipped endpoints do not mutate `ICurrentTenant` even with tenant claim | Honored — U2; tested in U3 |
+| Skipped endpoints do not emit misordering warning | Honored — bypass `_WarnIfMiddlewareLikelyMisordered` for marked endpoints (U2) |
+| Non-skipped endpoints retain current behavior | Honored — regression coverage in U3 |
+| `UseHeadlessTenancy()` startup validation unchanged; remains idempotent | Honored — no changes to `SetupApiTenancy` / `HeadlessTenancyBuilder` |
+| Integration tests cover Minimal API skip, route group skip, MVC attribute skip, normal resolution | Honored at attribute/extension level in U3; MVC-specific harness deferred |
+| README + multi-tenancy.md updated | Honored — U4, target paths corrected (issue's `src/Headless.Api/README.md` does not exist) |
+| Marker must not bypass Mediator / EF / messaging tenant guards | Honored — explicit non-goal carried forward to Scope Boundaries |
+| `ISkipTenantResolutionMetadata` marker interface | **Rejected** — see Key Technical Decisions #1. The existing `[AllowMissingTenant]` / `[RequireTenant]` pattern uses the attribute *as* the metadata; introducing a marker interface here would diverge from the established convention without a concrete consumer to justify the indirection. |
+
+---
+
+## Key Technical Decisions
+
+### 1. Attribute-as-metadata, no marker interface
+
+**Decision:** Drop the issue's `ISkipTenantResolutionMetadata` marker interface. The attribute IS the metadata, consumed via `endpoint.Metadata.GetMetadata<SkipTenantResolutionAttribute>()`.
+
+**Rationale:** `AllowMissingTenantAttribute` and `RequireTenantAttribute` already follow this shape exactly. Introducing a marker interface here adds an abstraction layer that no consumer needs (no scenario where a non-attribute type would implement the marker). The cost is consistency with the sibling tenancy markers; the only gained flexibility is "consumers could attach arbitrary metadata implementing the marker," which has no requested use case. Greenfield framework — favor the simpler shape.
+
+**Reversibility:** Trivial. If a marker-interface consumer appears later, add the interface, have the attribute implement it, change the middleware check from `GetMetadata<SkipTenantResolutionAttribute>()` to `GetMetadata<ISkipTenantResolutionMetadata>()`. No breaking change.
+
+### 2. Naming: `SkipTenantResolution` matches the issue, distinguishes from `AllowMissingTenant`
+
+**Decision:** Type name `SkipTenantResolutionAttribute`, extension method `.SkipTenantResolution()`.
+
+**Rationale:** The existing tenancy verbs are `AllowMissingTenant` (authorization opt-out — "this endpoint doesn't require a tenant in scope") and `RequireTenant` (opt-back-in). The new attribute is the **resolution** opt-out — "this endpoint doesn't run the claim-based resolver." The two are conceptually distinct (`docs/llms/multi-tenancy.md` already explicitly differentiates `[AllowMissingTenant]` from `[AllowAnonymous]`; the new attribute is a third axis). `Skip` is more precise than `Disable` or `Without` for this semantics: the middleware skips a step rather than turning a feature off.
+
+### 3. Middleware bypass set, including misordering warning
+
+**Decision:** When the marker is present, the middleware sets `HeadlessTenancyResolutionApplied` (the feature flag consumed by `HeadlessApiExceptionHandler`), calls `next`, and returns. No claim read, no `ICurrentTenant.Change`, no `_WarnIfMiddlewareLikelyMisordered` call.
+
+**Rationale:**
+- Setting the feature flag preserves the "middleware ran" invariant from the exception-handler perspective. If a handler on a skipped endpoint accidentally reads `ICurrentTenant.Id` and throws `MissingTenantContextException`, the exception handler should NOT emit "you forgot to wire up `UseHeadlessTenancy()`" — the middleware did run; the user explicitly chose to skip. The misleading-warning surface is what the feature flag is for; setting it on the skip path keeps that semantic correct.
+- Bypassing `_WarnIfMiddlewareLikelyMisordered` is the right call because the warning is about middleware ordering relative to `UseAuthentication`. A skipped endpoint doesn't care whether claims were ever parsed; emitting the warning would be misleading.
+
+### 4. Reverse-iteration "last attribute wins" semantics
+
+**Decision:** Use `endpoint.Metadata.GetMetadata<SkipTenantResolutionAttribute>()` (returns the *last* match in metadata order). This naturally gives "action overrides controller, member overrides group" behavior consistent with the existing `[AllowMissingTenant]` convention.
+
+**Rationale:** Matches `TenantRequirementHandler._AllowsMissingTenant`'s reverse-iteration discipline and the test invariant `should_require_tenant_when_minimal_api_endpoint_overrides_group_allow_missing`. No opt-back-in inverse (`[RequireTenantResolution]`) is shipped (see Deferred), so a richer reverse-iteration switch is not needed — single-attribute lookup is sufficient and simpler.
+
+### 5. File layout — extend, do not create
+
+**Decision:**
+- New file: `src/Headless.Api.Core/MultiTenancy/SkipTenantResolutionAttribute.cs` (mirrors `AllowMissingTenantAttribute.cs` byte-for-byte in shape).
+- Modify: `src/Headless.Api.Core/MultiTenancy/EndpointConventionBuilderExtensions.cs` to add the `.SkipTenantResolution()` member alongside `AllowMissingTenant` / `RequireTenant`.
+- Modify: `src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs` for the metadata check.
+
+**Rationale:** AUTHORING.md "append, don't rewrite" rule; sibling-pattern consistency.
+
+---
+
+## High-Level Technical Design
+
+Directional pseudo-shape of the updated `TenantResolutionMiddleware.InvokeAsync` decision flow. **This is review guidance, not implementation specification** — the implementer should treat shape and ordering as fixed but invent concrete syntax.
+
+```text
+InvokeAsync(context, currentTenant):
+    context.Features.Set(HeadlessTenancyResolutionApplied.Instance)
+
+    endpoint = context.GetEndpoint()
+    skipMarker = endpoint?.Metadata.GetMetadata<SkipTenantResolutionAttribute>()
+    if skipMarker is not null:
+        await next(context)                 # skip claim read, skip warning
+        return
+
+    if not authenticated:
+        _WarnIfMiddlewareLikelyMisordered(context)
+        await next(context)
+        return
+
+    tenantId = _GetTenantId(user)
+    if tenantId is null/whitespace:
+        await next(context)
+        return
+
+    using scope = currentTenant.Change(tenantId)
+    await next(context)
+```
+
+Decision-matrix the integration tests should anchor on:
+
+| Endpoint marked | Principal | Tenant claim | Expected `ICurrentTenant.Id` | Misordering warning fires |
+|---|---|---|---|---|
+| `[SkipTenantResolution]` | unauthenticated | — | null | no |
+| `[SkipTenantResolution]` | authenticated | absent | null | no |
+| `[SkipTenantResolution]` | authenticated | present | **null (key behavior)** | no |
+| unmarked | authenticated | present | claim value | no |
+| unmarked | unauthenticated | — | null | conditional (existing logic) |
+
+---
+
+## Implementation Units
+
+### U1. SkipTenantResolutionAttribute and endpoint extension
+
+**Goal:** Introduce the public API surface — the attribute and the `.SkipTenantResolution()` extension member. Mirror `AllowMissingTenantAttribute` byte-for-byte in shape.
+
+**Requirements:** Issue #251 — endpoint metadata + Minimal API extension + route group extension + MVC attribute targets.
+
+**Dependencies:** none.
+
+**Files:**
+
+- `src/Headless.Api.Core/MultiTenancy/SkipTenantResolutionAttribute.cs` (new)
+- `src/Headless.Api.Core/MultiTenancy/EndpointConventionBuilderExtensions.cs` (modify — add member)
+
+**Approach:**
+
+- `SkipTenantResolutionAttribute` is `[PublicAPI] [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false, AllowMultiple = false)] public sealed class ... : Attribute;` — body-less primary syntax, same as `AllowMissingTenantAttribute`.
+- Add `.SkipTenantResolution()` extension member to the existing `EndpointConventionBuilderExtensions` block inside the `extension<TBuilder>(TBuilder builder) where TBuilder : IEndpointConventionBuilder` declaration. Delegates to `builder.WithMetadata(new SkipTenantResolutionAttribute())`. No `With…` prefix on the method name (matches `AllowMissingTenant` / `RequireTenant` convention; `WithIdempotency` carries config, this does not).
+- File-level `#pragma warning disable IDE0130` + namespace shim to `Microsoft.AspNetCore.Builder` is already in place — do not re-introduce or move.
+
+**Patterns to follow:**
+
+- `src/Headless.Api.Core/MultiTenancy/AllowMissingTenantAttribute.cs` for the attribute shape.
+- `src/Headless.Api.Core/MultiTenancy/EndpointConventionBuilderExtensions.cs` for the extension member shape (C# 14 extension members, not classic extension methods).
+
+**Test suite design:** No standalone tests — the attribute's only observable behavior is via the middleware. Verification happens in U3 via integration tests that mark endpoints and assert `ICurrentTenant.Id`.
+
+**Test scenarios:** `Test expectation: none — pure API-surface declaration with no behavior; observable effect is covered by U3 integration tests against the middleware.`
+
+**Verification:**
+
+- `make build` succeeds with no new warnings.
+- `make format-check` passes.
+- The new file starts with the copyright header.
+- IntelliSense surfaces `.SkipTenantResolution()` on `RouteHandlerBuilder` and `RouteGroupBuilder` (both implement `IEndpointConventionBuilder`).
+
+---
+
+### U2. TenantResolutionMiddleware honors the metadata
+
+**Goal:** Make `TenantResolutionMiddleware` short-circuit when the resolved endpoint carries `SkipTenantResolutionAttribute`.
+
+**Requirements:** Issue #251 — middleware skips resolution; no `ICurrentTenant` mutation; no misordering warning; idempotency of `UseHeadlessTenancy()` preserved.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs` (modify)
+
+**Approach:**
+
+- Add metadata lookup immediately after setting `HeadlessTenancyResolutionApplied` (so the feature flag is still recorded — see Key Technical Decision #3).
+- Use `context.GetEndpoint()?.Metadata.GetMetadata<SkipTenantResolutionAttribute>()`. If non-null, `await next(context)` and return.
+- Crucially, this short-circuit precedes the `if (context.User.Identity?.IsAuthenticated != true)` check — skipping should suppress both the claim read AND the misordering warning.
+- No new options, no new public API on the middleware itself, no new log message (a future "skipped due to endpoint metadata" debug log is YAGNI — defer if ops asks for it).
+- The middleware's existing `Argument.IsNotNull` discipline stays.
+
+**Patterns to follow:**
+
+- `TenantRequirementHandler._AllowsMissingTenant` in the same folder for the metadata-lookup idiom (though it uses reverse iteration; here single-attribute `GetMetadata<T>` is enough — see Key Technical Decision #4).
+
+**Test suite design:** Covered by U3 integration tests. No unit-test layer added — existing `TenantResolutionMiddleware` coverage is integration-only and the dependency on `HttpContext`/`Endpoint`/`ClaimsPrincipal` makes integration the natural seam.
+
+**Test scenarios:** Covered in U3. No new scenarios localized to this unit; the middleware change is observed end-to-end.
+
+**Verification:**
+
+- `make build` succeeds, no new warnings.
+- All U3 scenarios pass.
+- Existing `TenantResolutionMiddlewareTests` continue to pass — regression check for non-skipped endpoints.
+
+---
+
+### U3. Integration tests for the four endpoint topologies
+
+**Goal:** Cover the decision matrix from High-Level Technical Design with integration tests that drive a real `WebApplication` and assert observable `ICurrentTenant` state via a captured endpoint response.
+
+**Requirements:** Issue #251 acceptance criteria — Minimal API skip, route group skip, MVC attribute skip (at attribute level — full MVC harness deferred per Scope), normal non-skipped resolution stays correct.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+
+- `tests/Headless.Api.Tests.Integration/TenantResolutionMiddlewareTests.cs` (modify — extend `_CreateAppAsync` and add scenarios) OR
+- `tests/Headless.Api.Tests.Integration/SkipTenantResolutionMiddlewareTests.cs` (new — preferred if the additions exceed ~5 scenarios; mirror the existing file's harness verbatim).
+
+Implementer chooses one; the test harness is identical either way. The plan's recommendation: new file if more than three scenarios are added (current file is already ~430 lines).
+
+**Approach:**
+
+- Reuse the in-process `WebApplication.CreateBuilder` + ephemeral-port + `HttpClient` harness from `TenantResolutionMiddlewareTests` and `TenantRequirementTests`.
+- Reuse the `TestAuthenticationHandler` pattern (reads `X-Test-User`, `X-Test-Tenant`, `X-Test-Unauthenticated` headers to materialize a `ClaimsPrincipal`).
+- Reuse the `TenantResponse` capture endpoint pattern: `app.MapGet("/probe", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))` — mark the probe variants with `.SkipTenantResolution()` / `[SkipTenantResolution]`.
+- Reuse `CapturingLoggerProvider` to assert that the misordering warning is NOT emitted on skip-marked endpoints.
+- For MVC at the attribute level (no full controller harness shipped — see Deferred), one test that marks the controller via `[ApiController]` + `[SkipTenantResolution]` + ` [Route("/mvc-skip")]` and asserts the same `ICurrentTenant.Id == null` behavior.
+
+**Patterns to follow:**
+
+- `tests/Headless.Api.Tests.Integration/TenantResolutionMiddlewareTests.cs` for the auth + endpoint-probe + log-capture pattern.
+- `tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs` lines 265–274 for the route-group + member-override pattern.
+- `tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs` lines 383–412 for the bottom-of-file controller declaration convention.
+
+**Test suite design:** All scenarios are integration. They live in `Headless.Api.Tests.Integration`. No new fixture is needed; the existing per-test `WebApplication.CreateBuilder` pattern is sufficient. Reuse `TestAuthenticationHandler`, `CapturingLoggerProvider`, and `_AddDefaultHeadlessSecurityConfiguration` helpers verbatim — extract to a shared partial if duplicated, otherwise keep inline.
+
+**Test scenarios:**
+
+*Skip behavior (claim-carrying principal):*
+
+1. `should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_claim_present` — Minimal API endpoint with `.SkipTenantResolution()`, authenticated principal with valid tenant claim → `ICurrentTenant.Id == null`, `IsAvailable == false`. **(Primary correctness scenario.)**
+2. `should_not_mutate_current_tenant_when_route_group_marked_skip_resolution_and_claim_present` — `app.MapGroup("/grouped").SkipTenantResolution()`, child Minimal API endpoint → same as #1.
+3. `should_not_mutate_current_tenant_when_mvc_controller_marked_skip_resolution_and_claim_present` — Controller class with `[SkipTenantResolution]`, action with route `/mvc-skip` → same as #1.
+4. `should_not_mutate_current_tenant_when_mvc_action_marked_skip_resolution_and_claim_present` — Plain controller, action method decorated with `[SkipTenantResolution]` → same as #1.
+
+*Skip behavior (no claim / no principal):*
+
+5. `should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_unauthenticated` — Same endpoint as #1, no principal → `ICurrentTenant.Id == null`. Regression: confirms skip path doesn't accidentally read claims.
+6. `should_not_emit_middleware_ordering_warning_when_endpoint_marked_skip_resolution_and_unauthenticated` — Use `CapturingLoggerProvider`; assert no entry with EventId name `HEADLESS_TENANCY_MIDDLEWARE_ORDERING` is captured for a skip-marked endpoint reached pre-`UseAuthentication`.
+
+*Non-skip regression (must stay correct):*
+
+7. `should_mutate_current_tenant_for_unmarked_endpoint_when_claim_present` — Existing behavior preserved; an unmarked endpoint adjacent to a marked one still resolves tenant from claim.
+8. `should_mutate_current_tenant_for_unmarked_endpoint_in_route_group_that_does_not_skip` — Group without `.SkipTenantResolution()`, child endpoint → tenant claim resolved as today.
+
+*Composition with sibling markers:*
+
+9. `should_compose_skip_resolution_with_allow_missing_tenant_independently` — Endpoint marked with both `.SkipTenantResolution()` and `.AllowMissingTenant()`, authenticated principal without tenant claim → `ICurrentTenant.Id == null` AND request not rejected by authorization (proves they're independent opt-outs solving different problems; the docs explicitly call out this distinction).
+
+*Feature-flag invariant:*
+
+10. `should_set_tenancy_resolution_applied_feature_when_endpoint_marked_skip_resolution` — Inspect `HttpContext.Features.Get<HeadlessTenancyResolutionApplied>()` from a probe endpoint marked skip; expect non-null. Confirms the exception-handler invariant from Key Technical Decision #3. (`HeadlessTenancyResolutionApplied` is currently `internal sealed`; if `[InternalsVisibleTo("Headless.Api.Tests.Integration")]` is already declared, assert directly; otherwise, assert the consequent — that `MissingTenantContextException` thrown in a skip-marked handler does NOT log the "middleware-not-applied" warning. Implementer to pick the lower-friction shape.)
+
+**Verification:**
+
+- All 10 scenarios above implemented and passing.
+- `make test-project TEST_PROJECT=tests/Headless.Api.Tests.Integration` runs cleanly.
+- No new failures in `TenantResolutionMiddlewareTests` or `TenantRequirementTests`.
+- Line coverage for `src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs` stays at or above the project minimum (≥85% line, ≥80% branch per `CLAUDE.md`).
+
+---
+
+### U4. Documentation — distinguish resolution opt-out from authorization opt-out
+
+**Goal:** Add the new opt-out to both consumer-facing surfaces, taking care to differentiate it from `[AllowMissingTenant]` (authorization-pipeline opt-out) and `[AllowAnonymous]` (auth opt-out). All three are independent.
+
+**Requirements:** Issue #251 — README + multi-tenancy.md updated. AUTHORING.md "same-commit drift" rule for API-surface changes.
+
+**Dependencies:** U1, U2 (so the docs match what shipped).
+
+**Files:**
+
+- `src/Headless.Api.Core/README.md` (modify) — issue body's path `src/Headless.Api/README.md` does not exist; this is the correct target.
+- `docs/llms/multi-tenancy.md` (modify)
+
+**Approach:**
+
+- **`src/Headless.Api.Core/README.md`:**
+  - `Key Features` bullet list — add a one-line bullet for `[SkipTenantResolution]` / `.SkipTenantResolution()` alongside the existing `[AllowMissingTenant]` bullet.
+  - `Building Blocks Quick Reference` (or the equivalent Quick Start section in the existing file shape) — add a usage example. Match the file's existing section order; do not restructure.
+  - One sentence distinguishing the new opt-out from `[AllowMissingTenant]`: "`[SkipTenantResolution]` prevents the resolution middleware from mutating `ICurrentTenant`; `[AllowMissingTenant]` prevents the authorization pipeline from rejecting requests without a tenant. They solve different problems and are independently composable."
+
+- **`docs/llms/multi-tenancy.md`:**
+  - Lines around 117–119 (the `UseHeadlessTenancy()` runtime description) — add a bullet: middleware now also consults `[SkipTenantResolution]` endpoint metadata before mutating `ICurrentTenant`.
+  - `## HTTP Authorization Requirement` section (lines around 168–219) — add a sibling subsection `## HTTP Resolution Opt-Out` that mirrors the existing prose template ("Mark intentional X with `[Attribute]` or `.Method()`."), names the two real use cases from Problem Frame (claim-carrying admin principals, alternate resolvers), and includes the explicit "different from `[AllowMissingTenant]`" distinction.
+  - Lines around 234 (the three-tenant-states paragraph: never set / explicit host / tenant-scoped) — one sentence noting `[SkipTenantResolution]` as a fourth case in the same vocabulary ("middleware ran but explicitly opted out").
+  - `Agent Instructions` section (lines around 65–77 per AUTHORING.md) — add one instruction line about choosing `[SkipTenantResolution]` for cross-tenant / admin / alternate-resolver endpoints. This is the highest-leverage doc edit per the research findings.
+
+- Tone and naming: follow the file's existing template ("Mark intentional host-level, public, system, or console-bootstrap endpoints with `[AllowMissingTenant]` or `.AllowMissingTenant()`."). No emojis, no marketing adjectives, no version numbers, no dates in headings. AUTHORING.md "append, don't rewrite" — do not restructure README sections; integrate inside the existing H2s.
+
+- Both files updated in the **same commit** per AUTHORING.md "Public API surface change triggers both docs in same commit; files must not disagree on facts."
+
+**Patterns to follow:**
+
+- `docs/authoring/AUTHORING.md` for the drift checklist.
+- Existing `[AllowMissingTenant]` prose in both files as the template for the new sections.
+
+**Test suite design:** No automated tests. Doc accuracy is verified by review against U1–U3 surfaces.
+
+**Test scenarios:** `Test expectation: none — documentation update; correctness verified by review against the shipped API surface from U1–U3.`
+
+**Verification:**
+
+- Both files reference the new attribute and extension.
+- The distinction between resolution opt-out (`[SkipTenantResolution]`) and authorization opt-out (`[AllowMissingTenant]`) is stated explicitly in both files.
+- The example snippets compile mentally against the shipped API (attribute targets, extension signature).
+- AUTHORING.md drift checklist passes: same-commit update, no emojis/dates/version-numbers in headings, install commands unchanged, banned hedging/marketing prose absent.
+
+---
+
+## System-Wide Impact
+
+| Surface | Impact |
+|---|---|
+| `Headless.Api.Core` public API | One new attribute, one new extension member. Additive — no breaking changes. |
+| `TenantResolutionMiddleware` runtime | One new branch at the top of `InvokeAsync`. Hot-path cost: a single `Endpoint.Metadata.GetMetadata<T>` lookup per request (cheap, ~constant-time, ASP.NET Core does this in many places). |
+| `HeadlessApiExceptionHandler` | No code change. The `HeadlessTenancyResolutionApplied` feature flag is still set on skipped requests, so the "middleware-not-applied" surface stays consistent. |
+| `HeadlessTenancyBuilder` / `SetupApiTenancy` / startup validation | No change. Issue's "remains idempotent and startup validation still fails when HTTP tenancy is configured but the middleware is not applied" is preserved. |
+| Downstream tenant guards (`Headless.Mediator.*`, `Headless.Orm.EntityFramework`, `Headless.Messaging.Core`) | No change. The marker is HTTP-only. Any handler that reads `ICurrentTenant.Id` on a skip-marked endpoint will still raise `MissingTenantContextException` — that's the intended UX. The marker says "don't auto-resolve," not "downstream guards stop working." |
+| Consumers of `[AllowMissingTenant]` / `[RequireTenant]` | No change. The two markers compose orthogonally with the new one. Coverage scenario #9 in U3 anchors this. |
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Implementer mirrors the marker-interface design from the issue body, ignoring Key Technical Decision #1 | Medium | Decision #1 is the first KTD and explicitly calls out the deviation from the issue. The Requirements Traceability row also flags the rejection. |
+| Skip metadata at a route-group level doesn't propagate to children because of how ASP.NET Core's endpoint metadata resolves | Low | The existing `[AllowMissingTenant]` route-group test (`TenantRequirementTests` lines 265–274 + assertions) already proves the convention works for this metadata shape. The new attribute mirrors it byte-for-byte. |
+| `HeadlessTenancyResolutionApplied` flag interaction with the exception handler regresses | Low | Decision #3 documents the intent; scenario #10 anchors the invariant in tests. |
+| Doc drift between `src/Headless.Api.Core/README.md` and `docs/llms/multi-tenancy.md` | Medium | AUTHORING.md mandates same-commit updates. U4 includes a doc-drift verification step. |
+| MVC attribute targets work in principle but no MVC-specific integration test catches a subtle controller-metadata bug | Low-Medium | Scenarios #3 and #4 cover MVC at the attribute level using the existing inline-controller pattern; dedicated MVC harness deferred (see Scope) on the assumption that the controller surface in this framework is thin. If MVC adoption grows, revisit. |
+| Future demand for `[RequireTenantResolution]` opt-back-in surfaces after ship, requiring a richer reverse-iteration semantics | Low | Deferred follow-up explicitly recognizes this. The change is backwards-compatible — add the inverse attribute and switch `GetMetadata<T>()` to a reverse-iteration switch (the same pattern `TenantRequirementHandler._AllowsMissingTenant` uses). No public-API rework. |
+
+---
+
+## Deferred Implementation Notes
+
+- **Exact integration-test file choice (extend existing vs. new file)** — decide at implementation time based on how much the U3 scenarios bloat `TenantResolutionMiddlewareTests.cs`. Plan recommendation: new file if >3 scenarios added; otherwise extend.
+- **`HeadlessTenancyResolutionApplied` visibility** — currently `internal sealed`. If scenario #10 needs to assert on it directly, implementer either (a) adds `[assembly: InternalsVisibleTo("Headless.Api.Tests.Integration")]` to `Headless.Api.Core` if not already present, or (b) asserts the consequent (no misordering log emitted) instead of the cause. Both work; pick the lower-friction shape.
+- **Optional `LoggerMessage` debug log for "skipped due to endpoint metadata"** — not in scope. Add only if ops reports the lack hurts triage.
+
+---
+
+## Verification
+
+The plan is complete when:
+
+- U1: New attribute and extension member compile, are `[PublicAPI]`, mirror `[AllowMissingTenant]` shape.
+- U2: Middleware short-circuits on the marker; existing tests still pass.
+- U3: All 10 scenarios in U3 pass. `make test-project TEST_PROJECT=tests/Headless.Api.Tests.Integration` is green. No regressions in `TenantResolutionMiddlewareTests` or `TenantRequirementTests`.
+- U4: Both doc files updated in the same commit; AUTHORING.md drift checklist passes; `[SkipTenantResolution]` vs. `[AllowMissingTenant]` distinction is stated explicitly in both.
+- Project-wide: `make format-check`, `make build`, `make test` all green.

--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Headless.NET.Sdk": "0.0.107",
-    "Headless.NET.Sdk.Web": "0.0.107",
-    "Headless.NET.Sdk.Test": "0.0.107",
-    "Headless.NET.Sdk.Razor": "0.0.107",
-    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.107",
-    "Headless.NET.Sdk.WindowsDesktop": "0.0.107"
+    "Headless.NET.Sdk": "0.0.110",
+    "Headless.NET.Sdk.Web": "0.0.110",
+    "Headless.NET.Sdk.Test": "0.0.110",
+    "Headless.NET.Sdk.Razor": "0.0.110",
+    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.110",
+    "Headless.NET.Sdk.WindowsDesktop": "0.0.110"
   }
 }

--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Headless.NET.Sdk": "0.0.106",
-    "Headless.NET.Sdk.Web": "0.0.106",
-    "Headless.NET.Sdk.Test": "0.0.106",
-    "Headless.NET.Sdk.Razor": "0.0.106",
-    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.106",
-    "Headless.NET.Sdk.WindowsDesktop": "0.0.106"
+    "Headless.NET.Sdk": "0.0.107",
+    "Headless.NET.Sdk.Web": "0.0.107",
+    "Headless.NET.Sdk.Test": "0.0.107",
+    "Headless.NET.Sdk.Razor": "0.0.107",
+    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.107",
+    "Headless.NET.Sdk.WindowsDesktop": "0.0.107"
   }
 }

--- a/src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs
+++ b/src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs
@@ -2,6 +2,7 @@
 
 using System.Security.Claims;
 using Headless.Abstractions;
+using Headless.Api.MultiTenancy;
 using Headless.Checks;
 using Headless.Constants;
 using Microsoft.AspNetCore.Authentication;
@@ -31,6 +32,12 @@ public sealed partial class TenantResolutionMiddleware(
         Argument.IsNotNull(currentTenant);
 
         context.Features.Set(HeadlessTenancyResolutionApplied.Instance);
+
+        if (context.GetEndpoint()?.Metadata.GetMetadata<SkipTenantResolutionAttribute>() is not null)
+        {
+            await next(context);
+            return;
+        }
 
         if (context.User.Identity?.IsAuthenticated != true)
         {

--- a/src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs
+++ b/src/Headless.Api.Core/Middlewares/TenantResolutionMiddleware.cs
@@ -71,6 +71,15 @@ public sealed partial class TenantResolutionMiddleware(
             : principal.FindFirst(claimType)?.Value;
     }
 
+    /// <summary>
+    /// Test seam: resets the once-per-process ordering warning flag so that tests asserting on the
+    /// HEADLESS_TENANCY_MIDDLEWARE_ORDERING log entry can run in any order.
+    /// </summary>
+    internal static void ResetOrderingWarningForTesting()
+    {
+        Volatile.Write(ref _orderingWarningEmitted, 0);
+    }
+
     private void _WarnIfMiddlewareLikelyMisordered(HttpContext context)
     {
         // If AuthenticationMiddleware has not run yet, the consumer almost certainly placed

--- a/src/Headless.Api.Core/MultiTenancy/EndpointConventionBuilderExtensions.cs
+++ b/src/Headless.Api.Core/MultiTenancy/EndpointConventionBuilderExtensions.cs
@@ -21,5 +21,10 @@ public static class EndpointConventionBuilderExtensions
         {
             return builder.WithMetadata(new RequireTenantAttribute());
         }
+
+        public TBuilder SkipTenantResolution()
+        {
+            return builder.WithMetadata(new SkipTenantResolutionAttribute());
+        }
     }
 }

--- a/src/Headless.Api.Core/MultiTenancy/SkipTenantResolutionAttribute.cs
+++ b/src/Headless.Api.Core/MultiTenancy/SkipTenantResolutionAttribute.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Api.MultiTenancy;
+
+[PublicAPI]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+public sealed class SkipTenantResolutionAttribute : Attribute;

--- a/src/Headless.Api.Core/README.md
+++ b/src/Headless.Api.Core/README.md
@@ -29,6 +29,7 @@ dotnet add package Headless.Api.Core
 - Request cancellation handling
 - Diagnostic listeners for debugging (`AddHeadlessApiDiagnosticListeners`)
 - Status codes rewriter (`AddStatusCodesRewriterMiddleware()`)
+- HTTP tenant resolution opt-out (`[SkipTenantResolution]`, `.SkipTenantResolution()`) — skips claim extraction for an endpoint or controller while still marking the request as processed
 - HTTP tenant authorization (`TenantRequirement`, `[AllowMissingTenant]`, `.AllowMissingTenant()`, `[RequireTenant]`, `.RequireTenant()`)
 - Kestrel limits and default API conventions via `ConfigureHeadlessDefaultApi()`
 
@@ -69,6 +70,8 @@ var publicGroup = app.MapGroup("/public").AllowMissingTenant();
 publicGroup.MapGet("/status", () => Results.Ok());
 publicGroup.MapGet("/tenant-data", () => Results.Ok()).RequireTenant();
 ```
+
+Use `[SkipTenantResolution]` / `.SkipTenantResolution()` on an endpoint, route group, or MVC controller/action to bypass claim extraction entirely. The middleware marks the request as processed (`HeadlessTenancyResolutionApplied`) and passes through without calling `ICurrentTenant.Change(...)`. `ICurrentTenant.Id` remains null and `ICurrentTenant.IsAvailable` stays false.
 
 `TenantRequirement` succeeds when `ICurrentTenant.Id` is present or the latest tenant metadata marker is `[AllowMissingTenant]` / `.AllowMissingTenant()`. Use `[RequireTenant]` / `.RequireTenant()` to opt an action or endpoint back into tenant enforcement under broader allow-missing metadata. Tenant failures return the same structured 403 `g:tenant_required` ProblemDetails shape as the exception-handler fallback.
 

--- a/src/Headless.Api.Core/README.md
+++ b/src/Headless.Api.Core/README.md
@@ -71,7 +71,17 @@ publicGroup.MapGet("/status", () => Results.Ok());
 publicGroup.MapGet("/tenant-data", () => Results.Ok()).RequireTenant();
 ```
 
-Use `[SkipTenantResolution]` / `.SkipTenantResolution()` on an endpoint, route group, or MVC controller/action to bypass claim extraction entirely. The middleware marks the request as processed (`HeadlessTenancyResolutionApplied`) and passes through without calling `ICurrentTenant.Change(...)`. `ICurrentTenant.Id` remains null and `ICurrentTenant.IsAvailable` stays false.
+Use `[SkipTenantResolution]` / `.SkipTenantResolution()` on an endpoint, route group, or MVC controller/action to bypass claim extraction entirely. The middleware marks the request as processed (`HeadlessTenancyResolutionApplied`) and passes through without calling `ICurrentTenant.Change(...)` — if no other resolver runs, `ICurrentTenant.Id` stays unset and `ICurrentTenant.IsAvailable` stays false.
+
+This marker is HTTP-layer only — Mediator tenant guards, EF write guards, and messaging publish guards still enforce `ICurrentTenant.Id`. A handler running under this marker that calls a tenant-required downstream service will still throw `MissingTenantContextException`.
+
+When the endpoint also lives under a tenant-required authorization policy (`TenantRequirement` in `DefaultPolicy` / `FallbackPolicy`), compose with `.AllowMissingTenant()` so the requirement is satisfied:
+
+```csharp
+app.MapGet("/webhook", handler)
+   .SkipTenantResolution()
+   .AllowMissingTenant();
+```
 
 `TenantRequirement` succeeds when `ICurrentTenant.Id` is present or the latest tenant metadata marker is `[AllowMissingTenant]` / `.AllowMissingTenant()`. Use `[RequireTenant]` / `.RequireTenant()` to opt an action or endpoint back into tenant enforcement under broader allow-missing metadata. Tenant failures return the same structured 403 `g:tenant_required` ProblemDetails shape as the exception-handler fallback.
 
@@ -80,6 +90,7 @@ Use `[SkipTenantResolution]` / `.SkipTenantResolution()` on an endpoint, route g
 - **Place `TenantRequirement` in `DefaultPolicy` or `FallbackPolicy`** for framework-level enforcement. The startup validator does NOT inspect named policies (`options.AddPolicy("name", ...)`), and `[Authorize("NamedPolicy")]` endpoints bypass `DefaultPolicy` / `FallbackPolicy` per ASP.NET Core's combinator semantics. If you use named policies, composing `TenantRequirement` into each is your responsibility.
 - **Register custom `IAuthorizationMiddlewareResultHandler` instances BEFORE `.Authorization(auth => auth.RequireTenant())`.** ASP.NET Core resolves the last-registered handler; later registrations silently replace the framework's tenant mapper. Startup validation emits `HEADLESS_TENANCY_AUTHORIZATION_RESULT_HANDLER_REPLACED` when the resolved handler is not Headless's.
 - **`[AllowAnonymous]` endpoints bypass the authorization pipeline**, so `TenantRequirement` does not fire. If the handler reads `ICurrentTenant.Id` it throws `MissingTenantContextException`, which `HeadlessApiExceptionHandler` remaps to the same `g:tenant_required` 403. Prefer not reading `ICurrentTenant.Id` from anonymous endpoints; use `[AllowMissingTenant]` only when you want the authorization-pipeline opt-out specifically.
+- **`UseHeadlessTenancy()` / `UseTenantResolution()` must run after `UseRouting()`** so endpoint metadata is available when the middleware checks for `[SkipTenantResolution]`. Without that ordering, `HttpContext.GetEndpoint()` returns `null` and the skip marker silently has no effect — claim extraction runs as if the marker were absent.
 
 ## Exception Mapping
 

--- a/src/Headless.Api.Idempotency/ApplicationBuilderExtensions.cs
+++ b/src/Headless.Api.Idempotency/ApplicationBuilderExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using IdempotencyMiddleware = Headless.Api.IdempotencyMiddleware;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace

--- a/src/Headless.Api.Idempotency/CaptureStream.cs
+++ b/src/Headless.Api.Idempotency/CaptureStream.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>
 /// Tee-style stream decorator: forwards all writes to the inner stream and simultaneously
@@ -65,7 +65,10 @@ internal sealed class CaptureStream : Stream
         await _inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
     }
 
-    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    public override async ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer,
+        CancellationToken cancellationToken = default
+    )
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         _AppendToBuffer(buffer.Span);

--- a/src/Headless.Api.Idempotency/DefaultCachePredicate.cs
+++ b/src/Headless.Api.Idempotency/DefaultCachePredicate.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Http;
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>
 /// Default predicate that decides whether a completed response should be cached for replay.
@@ -11,9 +11,23 @@ namespace Headless.Api.Idempotency;
 /// </summary>
 internal static class DefaultCachePredicate
 {
-    private static readonly HashSet<int> _Cacheable4xx =
+    private static readonly HashSet<int> _Cacheable4Xx =
     [
-        400, 401, 403, 404, 405, 409, 410, 411, 412, 413, 414, 415, 416, 422, 451,
+        400,
+        401,
+        403,
+        404,
+        405,
+        409,
+        410,
+        411,
+        412,
+        413,
+        414,
+        415,
+        416,
+        422,
+        451,
     ];
 
     public static readonly Func<HttpContext, bool> Instance = ctx =>
@@ -27,7 +41,7 @@ internal static class DefaultCachePredicate
 
         if (status is >= 400 and <= 499)
         {
-            return _Cacheable4xx.Contains(status);
+            return _Cacheable4Xx.Contains(status);
         }
 
         return false;

--- a/src/Headless.Api.Idempotency/EndpointConventionBuilderExtensions.cs
+++ b/src/Headless.Api.Idempotency/EndpointConventionBuilderExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace

--- a/src/Headless.Api.Idempotency/IdempotencyErrorCodes.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyErrorCodes.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>
 /// Stable machine-readable error codes emitted by the idempotency middleware in

--- a/src/Headless.Api.Idempotency/IdempotencyMetadata.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyMetadata.cs
@@ -2,7 +2,7 @@
 
 using Headless.Checks;
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>Endpoint metadata that carries per-endpoint idempotency option overrides.</summary>
 /// <remarks>

--- a/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
@@ -4,6 +4,7 @@ using System.Buffers;
 using System.Security.Cryptography;
 using Headless.Abstractions;
 using Headless.Api.Abstractions;
+using Headless.Api.Resources;
 using Headless.Caching;
 using Headless.Constants;
 using Headless.DistributedLocks;
@@ -15,7 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 internal sealed partial class IdempotencyMiddleware(
     IOptionsSnapshot<IdempotencyOptions> optionsSnapshot,
@@ -144,7 +145,8 @@ internal sealed partial class IdempotencyMiddleware(
 
         if (existing.HasValue)
         {
-            await _DispatchExistingRecordAsync(context, existing.Value!, options, fingerprint, cacheKey, ct).ConfigureAwait(false);
+            await _DispatchExistingRecordAsync(context, existing.Value!, options, fingerprint, cacheKey, ct)
+                .ConfigureAwait(false);
             return;
         }
 
@@ -161,12 +163,14 @@ internal sealed partial class IdempotencyMiddleware(
             var lockProvider = _serviceProvider.GetRequiredService<IDistributedLockProvider>();
             try
             {
-                winnerLock = await lockProvider.TryAcquireAsync(
-                    $"lock:{cacheKey}",
-                    timeUntilExpires: options.WinnerLockLease,
-                    acquireTimeout: TimeSpan.Zero,
-                    cancellationToken: ct
-                ).ConfigureAwait(false);
+                winnerLock = await lockProvider
+                    .TryAcquireAsync(
+                        $"lock:{cacheKey}",
+                        timeUntilExpires: options.WinnerLockLease,
+                        acquireTimeout: TimeSpan.Zero,
+                        cancellationToken: ct
+                    )
+                    .ConfigureAwait(false);
             }
             catch (Exception lockEx)
             {
@@ -210,7 +214,9 @@ internal sealed partial class IdempotencyMiddleware(
                 bool inserted;
                 try
                 {
-                    inserted = await cache.TryInsertAsync(cacheKey, marker, options.IdempotencyKeyExpiration, ct).ConfigureAwait(false);
+                    inserted = await cache
+                        .TryInsertAsync(cacheKey, marker, options.IdempotencyKeyExpiration, ct)
+                        .ConfigureAwait(false);
                 }
                 catch (Exception cacheEx)
                 {
@@ -226,7 +232,8 @@ internal sealed partial class IdempotencyMiddleware(
 
                 if (inserted)
                 {
-                    await _ExecuteAndFinalizeCoreAsync(context, next, cacheKey, marker, fingerprint, options, ct).ConfigureAwait(false);
+                    await _ExecuteAndFinalizeCoreAsync(context, next, cacheKey, marker, fingerprint, options, ct)
+                        .ConfigureAwait(false);
                     return;
                 }
 
@@ -253,7 +260,8 @@ internal sealed partial class IdempotencyMiddleware(
                     continue;
                 }
 
-                await _DispatchExistingRecordAsync(context, racePeek.Value!, options, fingerprint, cacheKey, ct).ConfigureAwait(false);
+                await _DispatchExistingRecordAsync(context, racePeek.Value!, options, fingerprint, cacheKey, ct)
+                    .ConfigureAwait(false);
                 return;
             }
 
@@ -282,7 +290,7 @@ internal sealed partial class IdempotencyMiddleware(
         {
             throw new InvalidOperationException(
                 "Cannot replay idempotent response: HttpResponse has already started. "
-                + "Ensure UseIdempotency() is registered before any middleware that writes to the response body."
+                    + "Ensure UseIdempotency() is registered before any middleware that writes to the response body."
             );
         }
 
@@ -358,14 +366,26 @@ internal sealed partial class IdempotencyMiddleware(
         LogFingerprintMismatch(cacheKey);
         var descriptor = IdempotencyMessageDescriber.KeyReused();
 
-        ProblemDetails pd = options.MismatchStatusCode == 409
-            ? _problemDetailsCreator.Conflict(descriptor)
-            : _problemDetailsCreator.UnprocessableEntity(new Dictionary<string, List<ErrorDescriptor>>(StringComparer.Ordinal) { ["idempotency_key"] = [descriptor] });
+        var pd =
+            options.MismatchStatusCode == 409
+                ? _problemDetailsCreator.Conflict(descriptor)
+                : _problemDetailsCreator.UnprocessableEntity(
+                    new Dictionary<string, List<ErrorDescriptor>>(StringComparer.Ordinal)
+                    {
+                        ["idempotency_key"] = [descriptor],
+                    }
+                );
 
         await Results.Problem(pd).ExecuteAsync(context).ConfigureAwait(false);
     }
 
-    private async Task _WriteInFlightResponseAsync(HttpContext context, IdempotencyOptions options, byte[] fingerprint, string cacheKey, CancellationToken ct)
+    private async Task _WriteInFlightResponseAsync(
+        HttpContext context,
+        IdempotencyOptions options,
+        byte[] fingerprint,
+        string cacheKey,
+        CancellationToken ct
+    )
     {
         if (options.InFlightStrategy == InFlightStrategy.WaitAndReplay)
         {
@@ -384,7 +404,13 @@ internal sealed partial class IdempotencyMiddleware(
         await Results.Problem(pd).ExecuteAsync(context).ConfigureAwait(false);
     }
 
-    private async Task _WaitAndReplayAsync(HttpContext context, IdempotencyOptions options, byte[] fingerprint, string cacheKey, CancellationToken ct)
+    private async Task _WaitAndReplayAsync(
+        HttpContext context,
+        IdempotencyOptions options,
+        byte[] fingerprint,
+        string cacheKey,
+        CancellationToken ct
+    )
     {
         var lockProvider = _serviceProvider.GetRequiredService<IDistributedLockProvider>();
         var lockKey = $"lock:{cacheKey}";
@@ -393,12 +419,14 @@ internal sealed partial class IdempotencyMiddleware(
         IDistributedLock? dlock;
         try
         {
-            dlock = await lockProvider.TryAcquireAsync(
-                lockKey,
-                timeUntilExpires: options.WinnerLockLease,
-                acquireTimeout: options.InFlightLockTimeout,
-                cancellationToken: ct
-            ).ConfigureAwait(false);
+            dlock = await lockProvider
+                .TryAcquireAsync(
+                    lockKey,
+                    timeUntilExpires: options.WinnerLockLease,
+                    acquireTimeout: options.InFlightLockTimeout,
+                    cancellationToken: ct
+                )
+                .ConfigureAwait(false);
         }
         catch (Exception lockEx)
         {
@@ -548,13 +576,15 @@ internal sealed partial class IdempotencyMiddleware(
                 bool replaced;
                 try
                 {
-                    replaced = await cache.TryReplaceIfEqualAsync(
-                        cacheKey,
-                        insertedMarker,
-                        completeRecord,
-                        options.IdempotencyKeyExpiration,
-                        CancellationToken.None
-                    ).ConfigureAwait(false);
+                    replaced = await cache
+                        .TryReplaceIfEqualAsync(
+                            cacheKey,
+                            insertedMarker,
+                            completeRecord,
+                            options.IdempotencyKeyExpiration,
+                            CancellationToken.None
+                        )
+                        .ConfigureAwait(false);
                 }
                 catch (Exception casEx)
                 {
@@ -674,19 +704,20 @@ internal sealed partial class IdempotencyMiddleware(
     /// and the corresponding constant is an interned string, so a request arriving with any
     /// casing of a known method maps to the same constant reference.
     /// </summary>
-    private static string _CanonicalMethod(string method) => method switch
-    {
-        _ when HttpMethods.IsPost(method) => HttpMethods.Post,
-        _ when HttpMethods.IsPut(method) => HttpMethods.Put,
-        _ when HttpMethods.IsPatch(method) => HttpMethods.Patch,
-        _ when HttpMethods.IsDelete(method) => HttpMethods.Delete,
-        _ when HttpMethods.IsGet(method) => HttpMethods.Get,
-        _ when HttpMethods.IsHead(method) => HttpMethods.Head,
-        _ when HttpMethods.IsOptions(method) => HttpMethods.Options,
-        _ when HttpMethods.IsTrace(method) => HttpMethods.Trace,
-        _ when HttpMethods.IsConnect(method) => HttpMethods.Connect,
-        _ => method.ToUpperInvariant(),
-    };
+    private static string _CanonicalMethod(string method) =>
+        method switch
+        {
+            _ when HttpMethods.IsPost(method) => HttpMethods.Post,
+            _ when HttpMethods.IsPut(method) => HttpMethods.Put,
+            _ when HttpMethods.IsPatch(method) => HttpMethods.Patch,
+            _ when HttpMethods.IsDelete(method) => HttpMethods.Delete,
+            _ when HttpMethods.IsGet(method) => HttpMethods.Get,
+            _ when HttpMethods.IsHead(method) => HttpMethods.Head,
+            _ when HttpMethods.IsOptions(method) => HttpMethods.Options,
+            _ when HttpMethods.IsTrace(method) => HttpMethods.Trace,
+            _ when HttpMethods.IsConnect(method) => HttpMethods.Connect,
+            _ => method.ToUpperInvariant(),
+        };
 
     /// <summary>
     /// Validates an idempotency-key header value: single-valued, length &lt;= 255, no control
@@ -780,7 +811,7 @@ internal sealed partial class IdempotencyMiddleware(
                 {
                     throw new InvalidOperationException(
                         "IdempotencyOptions.RequestFingerprint returned null or an empty byte[]; "
-                        + "the delegate must produce a non-empty hash of the request payload."
+                            + "the delegate must produce a non-empty hash of the request payload."
                     );
                 }
 
@@ -807,36 +838,60 @@ internal sealed partial class IdempotencyMiddleware(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency in-flight timeout for key {CacheKey}")]
     private partial void LogInFlightTimeout(string cacheKey);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency request body exceeded cap {Cap}; rejecting with 413")]
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency request body exceeded cap {Cap}; rejecting with 413"
+    )]
     private partial void LogBodyTooLarge(int cap);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency request body exceeded cap {Cap}; passing through without idempotency guarantees")]
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency request body exceeded cap {Cap}; passing through without idempotency guarantees"
+    )]
     private partial void LogBodyCapPassThrough(int cap);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency-Key header rejected: {Reason}")]
     private partial void LogKeyMalformed(string reason);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency skipped: neither tenant nor user identity is present and no KeyDeriver is configured")]
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency skipped: neither tenant nor user identity is present and no KeyDeriver is configured"
+    )]
     private partial void LogSkippedNoIdentity();
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Idempotency finalize (UpsertAsync) failed for key {CacheKey}")]
     private partial void LogFinalizeFailed(string cacheKey, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency finalize skipped: marker for key {CacheKey} no longer owned by this request")]
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency finalize skipped: marker for key {CacheKey} no longer owned by this request"
+    )]
     private partial void LogFinalizeSkippedMarkerChanged(string cacheKey);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency marker cleanup failed for key {CacheKey}")]
     private partial void LogMarkerCleanupFailed(string cacheKey, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency cache call failed at {Site} for key {CacheKey}; behavior={Behavior}")]
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency cache call failed at {Site} for key {CacheKey}; behavior={Behavior}"
+    )]
     private partial void LogCacheFailure(string site, string cacheKey, string behavior, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Idempotency lock-provider call failed at {Site} for key {CacheKey}; behavior={Behavior}")]
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency lock-provider call failed at {Site} for key {CacheKey}; behavior={Behavior}"
+    )]
     private partial void LogLockProviderFailure(string site, string cacheKey, string behavior, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Idempotency winner-lock contended for key {CacheKey}; deferring to in-flight response path")]
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Idempotency winner-lock contended for key {CacheKey}; deferring to in-flight response path"
+    )]
     private partial void LogWinnerLockContended(string cacheKey);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Idempotency handler threw for key {CacheKey}; removing in-flight marker before propagating")]
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Idempotency handler threw for key {CacheKey}; removing in-flight marker before propagating"
+    )]
     private partial void LogHandlerThrew(string cacheKey, Exception exception);
 }

--- a/src/Headless.Api.Idempotency/IdempotencyOptions.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 [PublicAPI]
 public sealed class IdempotencyOptions
@@ -25,9 +25,8 @@ public sealed class IdempotencyOptions
     /// middleware clones the set per request before invoking the delegate, so consumer mutation
     /// is safe and does not leak to other requests.
     /// </remarks>
-    public ISet<string> Methods { get; set; } = new HashSet<string>(
-        ["POST", "PUT", "PATCH", "DELETE"],
-        StringComparer.OrdinalIgnoreCase);
+    public ISet<string> Methods { get; set; } =
+        new HashSet<string>(["POST", "PUT", "PATCH", "DELETE"], StringComparer.OrdinalIgnoreCase);
 
     /// <summary>How concurrent in-flight requests with the same key are handled.</summary>
     public InFlightStrategy InFlightStrategy { get; set; } = InFlightStrategy.Reject;
@@ -96,9 +95,22 @@ public sealed class IdempotencyOptions
     /// Exposed as <see cref="ISet{T}"/> so per-endpoint overrides can extend or trim the allowlist
     /// in place. The middleware clones the set per request before delegate invocation.
     /// </remarks>
-    public ISet<string> ReplayHeaderAllowlist { get; set; } = new HashSet<string>(
-        ["Content-Type", "Content-Language", "Content-Encoding", "Content-Disposition", "Location", "Link", "ETag", "Last-Modified", "Cache-Control", "Vary"],
-        StringComparer.OrdinalIgnoreCase);
+    public ISet<string> ReplayHeaderAllowlist { get; set; } =
+        new HashSet<string>(
+            [
+                "Content-Type",
+                "Content-Language",
+                "Content-Encoding",
+                "Content-Disposition",
+                "Location",
+                "Link",
+                "ETag",
+                "Last-Modified",
+                "Cache-Control",
+                "Vary",
+            ],
+            StringComparer.OrdinalIgnoreCase
+        );
 
     /// <summary>
     /// Determines whether a completed response should be cached for replay.
@@ -139,25 +151,26 @@ public sealed class IdempotencyOptions
     /// <see cref="ReplayHeaderAllowlist"/> without affecting the application-level options.
     /// </summary>
     [Pure]
-    internal IdempotencyOptions Clone() => new()
-    {
-        IdempotencyKeyExpiration = IdempotencyKeyExpiration,
-        HeaderName = HeaderName,
-        Methods = new HashSet<string>(Methods, StringComparer.OrdinalIgnoreCase),
-        InFlightStrategy = InFlightStrategy,
-        InFlightLockTimeout = InFlightLockTimeout,
-        WinnerLockLease = WinnerLockLease,
-        MaxBodySizeForHashing = MaxBodySizeForHashing,
-        OversizeBehavior = OversizeBehavior,
-        OnCacheError = OnCacheError,
-        RequireUserIdentity = RequireUserIdentity,
-        MismatchStatusCode = MismatchStatusCode,
-        ReplayHeaderAllowlist = new HashSet<string>(ReplayHeaderAllowlist, StringComparer.OrdinalIgnoreCase),
-        ShouldCacheResponse = ShouldCacheResponse,
-        ShouldApply = ShouldApply,
-        KeyDeriver = KeyDeriver,
-        RequestFingerprint = RequestFingerprint,
-    };
+    internal IdempotencyOptions Clone() =>
+        new()
+        {
+            IdempotencyKeyExpiration = IdempotencyKeyExpiration,
+            HeaderName = HeaderName,
+            Methods = new HashSet<string>(Methods, StringComparer.OrdinalIgnoreCase),
+            InFlightStrategy = InFlightStrategy,
+            InFlightLockTimeout = InFlightLockTimeout,
+            WinnerLockLease = WinnerLockLease,
+            MaxBodySizeForHashing = MaxBodySizeForHashing,
+            OversizeBehavior = OversizeBehavior,
+            OnCacheError = OnCacheError,
+            RequireUserIdentity = RequireUserIdentity,
+            MismatchStatusCode = MismatchStatusCode,
+            ReplayHeaderAllowlist = new HashSet<string>(ReplayHeaderAllowlist, StringComparer.OrdinalIgnoreCase),
+            ShouldCacheResponse = ShouldCacheResponse,
+            ShouldApply = ShouldApply,
+            KeyDeriver = KeyDeriver,
+            RequestFingerprint = RequestFingerprint,
+        };
 }
 
 internal sealed class IdempotencyOptionsValidator : AbstractValidator<IdempotencyOptions>
@@ -166,7 +179,14 @@ internal sealed class IdempotencyOptionsValidator : AbstractValidator<Idempotenc
 
     private static readonly HashSet<string> _ValidMethods = new(StringComparer.OrdinalIgnoreCase)
     {
-        "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE",
+        "HEAD",
+        "OPTIONS",
+        "CONNECT",
+        "TRACE",
     };
 
     public IdempotencyOptionsValidator()
@@ -189,21 +209,26 @@ internal sealed class IdempotencyOptionsValidator : AbstractValidator<Idempotenc
             .Must(c => c is StatusCodes.Status409Conflict or StatusCodes.Status422UnprocessableEntity)
             .WithMessage("MismatchStatusCode must be 409 or 422.");
         RuleFor(x => x.OnCacheError).IsInEnum();
-        When(x => x.InFlightStrategy == InFlightStrategy.WaitAndReplay, () =>
-        {
-            // Cap at 1 minute: each loser holds an ASP.NET worker thread for up to this duration.
-            // High retry concurrency × long timeout → thread-pool exhaustion. Operators with
-            // legitimate long-handler workloads should prefer Reject + client-side backoff
-            // (the pattern used by Stripe, AWS, Square, PayPal).
-            RuleFor(x => x.InFlightLockTimeout).LessThanOrEqualTo(TimeSpan.FromMinutes(1));
-            RuleFor(x => x.WinnerLockLease)
-                .GreaterThan(TimeSpan.Zero)
-                .LessThanOrEqualTo(TimeSpan.FromHours(1))
-                .WithMessage("WinnerLockLease must be <= 1 hour.");
-            RuleFor(x => x.WinnerLockLease)
-                .GreaterThanOrEqualTo(x => x.InFlightLockTimeout)
-                .WithMessage("WinnerLockLease must be >= InFlightLockTimeout (otherwise the lock can expire before the loser's acquire deadline).");
-        });
+        When(
+            x => x.InFlightStrategy == InFlightStrategy.WaitAndReplay,
+            () =>
+            {
+                // Cap at 1 minute: each loser holds an ASP.NET worker thread for up to this duration.
+                // High retry concurrency × long timeout → thread-pool exhaustion. Operators with
+                // legitimate long-handler workloads should prefer Reject + client-side backoff
+                // (the pattern used by Stripe, AWS, Square, PayPal).
+                RuleFor(x => x.InFlightLockTimeout).LessThanOrEqualTo(TimeSpan.FromMinutes(1));
+                RuleFor(x => x.WinnerLockLease)
+                    .GreaterThan(TimeSpan.Zero)
+                    .LessThanOrEqualTo(TimeSpan.FromHours(1))
+                    .WithMessage("WinnerLockLease must be <= 1 hour.");
+                RuleFor(x => x.WinnerLockLease)
+                    .GreaterThanOrEqualTo(x => x.InFlightLockTimeout)
+                    .WithMessage(
+                        "WinnerLockLease must be >= InFlightLockTimeout (otherwise the lock can expire before the loser's acquire deadline)."
+                    );
+            }
+        );
     }
 }
 
@@ -232,8 +257,8 @@ internal sealed class IdempotencyOptionsDIValidator(IServiceProvider serviceProv
 
         return ValidateOptionsResult.Fail(
             $"{nameof(IdempotencyOptions)}.{nameof(IdempotencyOptions.InFlightStrategy)} = "
-            + $"{nameof(InFlightStrategy.WaitAndReplay)} requires {nameof(IDistributedLockProvider)} "
-            + "to be registered. Either switch InFlightStrategy to Reject or register a distributed-lock provider."
+                + $"{nameof(InFlightStrategy.WaitAndReplay)} requires {nameof(IDistributedLockProvider)} "
+                + "to be registered. Either switch InFlightStrategy to Reject or register a distributed-lock provider."
         );
     }
 }

--- a/src/Headless.Api.Idempotency/IdempotencyRecord.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyRecord.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 internal enum RecordKind
 {
@@ -60,14 +57,8 @@ internal sealed class IdempotencyRecord : IEquatable<IdempotencyRecord>
 
     public override bool Equals(object? obj) => obj is IdempotencyRecord other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(
-        Kind,
-        StatusCode,
-        CreatedAt,
-        Body.Length,
-        Fingerprint?.Length ?? -1,
-        Headers.Count
-    );
+    public override int GetHashCode() =>
+        HashCode.Combine(Kind, StatusCode, CreatedAt, Body.Length, Fingerprint?.Length ?? -1, Headers.Count);
 
     private static bool _BytesEqual(byte[]? a, byte[]? b)
     {
@@ -156,11 +147,7 @@ internal sealed class OrdinalIgnoreCaseHeadersJsonConverter : JsonConverter<Dict
         throw new JsonException("Unexpected end of JSON while reading headers dictionary.");
     }
 
-    public override void Write(
-        Utf8JsonWriter writer,
-        Dictionary<string, string[]> value,
-        JsonSerializerOptions options
-    )
+    public override void Write(Utf8JsonWriter writer, Dictionary<string, string[]> value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
         foreach (var (key, values) in value)

--- a/src/Headless.Api.Idempotency/InFlightStrategy.cs
+++ b/src/Headless.Api.Idempotency/InFlightStrategy.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>How concurrent requests sharing the same idempotency key are resolved.</summary>
 [PublicAPI]

--- a/src/Headless.Api.Idempotency/OnCacheErrorBehavior.cs
+++ b/src/Headless.Api.Idempotency/OnCacheErrorBehavior.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>
 /// Behavior when the idempotency backing store throws — either the underlying

--- a/src/Headless.Api.Idempotency/OversizeBehavior.cs
+++ b/src/Headless.Api.Idempotency/OversizeBehavior.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>How request bodies exceeding <c>IdempotencyOptions.MaxBodySizeForHashing</c> are handled.</summary>
 [PublicAPI]

--- a/src/Headless.Api.Idempotency/README.md
+++ b/src/Headless.Api.Idempotency/README.md
@@ -34,7 +34,6 @@ dotnet add package Headless.Api.Idempotency
 ## Quick Start
 
 ```csharp
-using Headless.Api.Idempotency;
 using Microsoft.AspNetCore.Builder;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Headless.Api.Idempotency/Resources/IdempotencyMessageDescriber.cs
+++ b/src/Headless.Api.Idempotency/Resources/IdempotencyMessageDescriber.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Resources;
 using Headless.Primitives;
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api.Resources;
 
 internal static class IdempotencyMessageDescriber
 {

--- a/src/Headless.Api.Idempotency/Setup.cs
+++ b/src/Headless.Api.Idempotency/Setup.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
-namespace Headless.Api.Idempotency;
+namespace Headless.Api;
 
 /// <summary>
 /// Service-collection extensions that register the Stripe-style HTTP idempotency middleware and

--- a/src/Headless.Blobs.Redis/RedisBlobStorage.cs
+++ b/src/Headless.Blobs.Redis/RedisBlobStorage.cs
@@ -650,11 +650,14 @@ public sealed class RedisBlobStorage : IBlobStorage
             pagingLimit++;
         }
 
-        _logger.LogTrace(
-            s => s.Property("Limit", pagingLimit).Property("Skip", skip),
-            "Getting files matching {Prefix} and {Pattern}...",
-            args: [criteria.Prefix, criteria.Pattern]
-        );
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(
+                s => s.Property("Limit", pagingLimit).Property("Skip", skip),
+                "Getting files matching {Prefix} and {Pattern}...",
+                args: [criteria.Prefix, criteria.Pattern]
+            );
+        }
 
         var list = await _ScanBlobInfoListAsync(container, criteria, skip, pagingLimit, cancellationToken);
 
@@ -693,11 +696,14 @@ public sealed class RedisBlobStorage : IBlobStorage
 
         var pageSize = limit ?? int.MaxValue;
 
-        _logger.LogTrace(
-            s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list matching {Prefix} and {Pattern}...",
-            args: [criteria.Prefix, criteria.Pattern]
-        );
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(
+                s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
+                "Getting file list matching {Prefix} and {Pattern}...",
+                args: [criteria.Prefix, criteria.Pattern]
+            );
+        }
 
         var blobs = await _ScanBlobInfoListAsync(infoContainer, criteria, skip ?? 0, pageSize, cancellationToken);
 

--- a/src/Headless.Caching.Memory/InMemoryCache.cs
+++ b/src/Headless.Caching.Memory/InMemoryCache.cs
@@ -1428,7 +1428,7 @@ public sealed class InMemoryCache : IInMemoryCache, IDisposable
                     }
 
                     var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
-                    long localRemoved = updatedDict.Remove(stringValue) ? 1L : 0L;
+                    var localRemoved = updatedDict.Remove(stringValue) ? 1L : 0L;
                     removed = localRemoved;
 
                     var newExpiresAt = _ExpireAndGetMaxExpiration(updatedDict);

--- a/src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs
+++ b/src/Headless.Hosting/DependencyInjection/DependencyInjectionExtensions.cs
@@ -214,7 +214,7 @@ public static class DependencyInjectionExtensions
         return _TryDecorate(
             services,
             typeof(TService),
-            descriptor => _CreateDecoratedDescriptor<TService>(descriptor, decorator)
+            descriptor => _CreateDecoratedDescriptor(descriptor, decorator)
         );
     }
 

--- a/src/Headless.Jobs.Abstractions/Managers/FluentChainJobBuilder.cs
+++ b/src/Headless.Jobs.Abstractions/Managers/FluentChainJobBuilder.cs
@@ -26,7 +26,7 @@ public class FluentChainJobBuilder<TTimeJob>
         };
 
         // Initialize grandchildren tracking
-        for (int i = 0; i < 5; i++)
+        for (var i = 0; i < 5; i++)
         {
             _grandChildrenUsed[i] = new bool[5];
         }

--- a/src/Headless.Jobs.Abstractions/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Abstractions/Managers/InternalJobsManager.cs
@@ -37,8 +37,8 @@ internal class InternalJobsManager<TTimeJob, TCronJob>(
         }
 
         TimeSpan timeRemaining;
-        bool includeCron = false;
-        bool includeTimeJobs = false;
+        var includeCron = false;
+        var includeTimeJobs = false;
 
         if (cronTime is null)
         {

--- a/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
+++ b/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
@@ -442,18 +442,18 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             ?? new CronOccurrenceJobGraphData { Date = today, Results = [] };
         var futureData = grouped.Where(d => d.Date > today).OrderBy(d => d.Date).ToList();
 
-        int pastDaysWithData = pastData.Count;
-        int futureDaysWithData = futureData.Count;
+        var pastDaysWithData = pastData.Count;
+        var futureDaysWithData = futureData.Count;
 
-        int remainingSlots = maxTotalDays - 1; // Exclude today
-        int emptyPastSlots = Math.Max(0, (remainingSlots - futureDaysWithData) / 2);
-        int emptyFutureSlots = Math.Max(0, remainingSlots - pastDaysWithData - emptyPastSlots);
+        var remainingSlots = maxTotalDays - 1; // Exclude today
+        var emptyPastSlots = Math.Max(0, (remainingSlots - futureDaysWithData) / 2);
+        var emptyFutureSlots = Math.Max(0, remainingSlots - pastDaysWithData - emptyPastSlots);
 
         List<CronOccurrenceJobGraphData> emptyPastDays = [];
         if (emptyPastSlots > 0)
         {
             var firstPastDate = pastData.FirstOrDefault()?.Date ?? today.AddDays(-1);
-            for (int i = 1; i <= emptyPastSlots; i++)
+            for (var i = 1; i <= emptyPastSlots; i++)
             {
                 emptyPastDays.Add(new CronOccurrenceJobGraphData { Date = firstPastDate.AddDays(-i), Results = [] });
             }
@@ -463,7 +463,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
         if (emptyFutureSlots > 0)
         {
             var lastFutureDate = futureData.LastOrDefault()?.Date ?? today.AddDays(1);
-            for (int i = 1; i <= emptyFutureSlots; i++)
+            for (var i = 1; i <= emptyFutureSlots; i++)
             {
                 emptyFutureDays.Add(new CronOccurrenceJobGraphData { Date = lastFutureDate.AddDays(i), Results = [] });
             }

--- a/src/Headless.Messaging.Abstractions/ConsumeContext.cs
+++ b/src/Headless.Messaging.Abstractions/ConsumeContext.cs
@@ -11,7 +11,7 @@ namespace Headless.Messaging;
 /// This base type is used by object-typed consume middleware that should apply to every message type.
 /// Use <see cref="ConsumeContext{TMessage}"/> when the middleware or consumer needs strongly-typed payload access.
 /// </remarks>
-public record class ConsumeContext
+public record ConsumeContext
 {
     private CancellationToken _cancellationToken;
     private bool _isCompleted;
@@ -250,7 +250,7 @@ public record class ConsumeContext
 /// </list>
 /// </para>
 /// </remarks>
-public record class ConsumeContext<TMessage> : ConsumeContext
+public record ConsumeContext<TMessage> : ConsumeContext
     where TMessage : class
 {
     /// <summary>

--- a/src/Headless.Messaging.Core/Configuration/MessagingBuilder.cs
+++ b/src/Headless.Messaging.Core/Configuration/MessagingBuilder.cs
@@ -292,7 +292,7 @@ public sealed class MessagingBuilder(IServiceCollection services, MessagingOptio
         Argument.IsNotNull(provider);
 
         _RemoveExistingMessagingLockProvider();
-        Services.AddKeyedSingleton<IDistributedLockProvider>(MessagingKeys.LockProvider, provider);
+        Services.AddKeyedSingleton(MessagingKeys.LockProvider, provider);
         Services.Configure<MessagingOptions>(o => o.UseStorageLock = true);
         return this;
     }

--- a/src/Headless.Messaging.Core/Diagnostics/EventData.Message.P.cs
+++ b/src/Headless.Messaging.Core/Diagnostics/EventData.Message.P.cs
@@ -33,7 +33,7 @@ public class MessageEventDataPubSend
 
     public string Operation { get; set; } = null!;
 
-    public TransportMessage TransportMessage { get; set; } = default!;
+    public TransportMessage TransportMessage { get; set; }
 
     public BrokerAddress BrokerAddress { get; set; }
 

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -171,17 +171,20 @@ internal sealed class ConsumerRegister(
     /// </summary>
     private void _OnCancellationRequested()
     {
-        _ = Task.Run(async () =>
-        {
-            try
+        _ = Task.Run(
+            async () =>
             {
-                await DisposeAsync();
-            }
+                try
+                {
+                    await DisposeAsync();
+                }
 #pragma warning disable ERP022 // Best-effort teardown — nothing useful to do with the exception
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
+                // ReSharper disable once EmptyGeneralCatchClause
+                catch { }
 #pragma warning restore ERP022
-        });
+            },
+            CancellationToken.None
+        );
     }
 
     public async ValueTask DisposeAsync()
@@ -241,7 +244,7 @@ internal sealed class ConsumerRegister(
         {
             try
             {
-                await Task.WhenAll(allTasks).WaitAsync(TimeSpan.FromSeconds(2));
+                await Task.WhenAll(allTasks).WaitAsync(TimeSpan.FromSeconds(2), _timeProvider, CancellationToken.None);
             }
 #pragma warning disable ERP022, RCS1075 // Intentional: timeout or cancellation — proceed with cleanup
             // ReSharper disable once EmptyGeneralCatchClause
@@ -484,7 +487,7 @@ internal sealed class ConsumerRegister(
             {
                 try
                 {
-                    await client.PauseAsync();
+                    await client.PauseAsync(CancellationToken.None);
                 }
                 catch (Exception ex)
                 {
@@ -509,7 +512,7 @@ internal sealed class ConsumerRegister(
             {
                 try
                 {
-                    await client.ResumeAsync();
+                    await client.ResumeAsync(CancellationToken.None);
                 }
                 catch (Exception ex)
                 {
@@ -642,7 +645,7 @@ internal sealed class ConsumerRegister(
                     if (dispatchBypassException is not null && _circuitBreakerStateManager is not null)
                     {
                         await _circuitBreakerStateManager
-                            .ReportFailureAsync(group, dispatchBypassException)
+                            .ReportFailureAsync(group, dispatchBypassException, CancellationToken.None)
                             .ConfigureAwait(false);
                         probeOutcomeTransferred = true;
                     }
@@ -717,12 +720,17 @@ internal sealed class ConsumerRegister(
                 }
                 else
                 {
-                    var mediumMessage = await _storage.StoreReceivedMessageAsync(name, group, message);
+                    var mediumMessage = await _storage.StoreReceivedMessageAsync(
+                        name,
+                        group,
+                        message,
+                        CancellationToken.None
+                    );
                     mediumMessage.Origin = message;
 
                     _TracingAfter(tracingTimestamp, transportMessage, _serverAddress, hostShutdownToken);
 
-                    await _dispatcher.EnqueueToExecute(mediumMessage, executor!);
+                    await _dispatcher.EnqueueToExecute(mediumMessage, executor, CancellationToken.None);
                     probeOutcomeTransferred = true;
 
                     await client.CommitAsync(sender);

--- a/src/Headless.Messaging.Core/Internal/ISubscribeExecutor.cs
+++ b/src/Headless.Messaging.Core/Internal/ISubscribeExecutor.cs
@@ -365,8 +365,9 @@ internal sealed class SubscribeExecutor(
         if (circuitBreakerStateManager is not null && affected)
         {
             var reportedException = ex is SubscriberExecutionFailedException { InnerException: { } inner } ? inner : ex;
+
             await circuitBreakerStateManager
-                .ReportFailureAsync(message.Origin.GetGroup()!, reportedException)
+                .ReportFailureAsync(message.Origin.GetGroup()!, reportedException, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Headless.Messaging.Core/Internal/OutboxPublisher.cs
+++ b/src/Headless.Messaging.Core/Internal/OutboxPublisher.cs
@@ -85,10 +85,11 @@ internal sealed class OutboxPublisher(
             tracingTimestamp = _TracingBefore(publishRequest.Message, cancellationToken);
 
             var currentTransaction = transactionAccessor.Current;
+
             if (currentTransaction?.DbTransaction == null)
             {
                 var mediumMessage = await storage
-                    .StoreMessageAsync(publishRequest.Topic, publishRequest.Message)
+                    .StoreMessageAsync(publishRequest.Topic, publishRequest.Message, null, CancellationToken.None)
                     .ConfigureAwait(false);
 
                 _TracingAfter(tracingTimestamp, publishRequest.Message, cancellationToken);
@@ -115,7 +116,12 @@ internal sealed class OutboxPublisher(
                 }
 
                 var mediumMessage = await storage
-                    .StoreMessageAsync(publishRequest.Topic, publishRequest.Message, currentTransaction.DbTransaction)
+                    .StoreMessageAsync(
+                        publishRequest.Topic,
+                        publishRequest.Message,
+                        currentTransaction.DbTransaction,
+                        cancellationToken
+                    )
                     .ConfigureAwait(false);
 
                 _TracingAfter(tracingTimestamp, publishRequest.Message, cancellationToken);
@@ -136,7 +142,7 @@ internal sealed class OutboxPublisher(
         }
     }
 
-    #region tracing
+    #region Tracing
 
     private long? _TracingBefore(Message message, CancellationToken cancellationToken)
     {

--- a/src/Headless.Messaging.Core/Processor/Dispatcher.cs
+++ b/src/Headless.Messaging.Core/Processor/Dispatcher.cs
@@ -156,7 +156,10 @@ internal sealed class Dispatcher : IDispatcher
         var timeSpan = publishTime - _timeProvider.GetUtcNow().UtcDateTime;
         var statusName = timeSpan <= TimeSpan.FromMinutes(1) ? StatusName.Queued : StatusName.Delayed;
 
-        var changed = await _storage.ChangePublishStateAsync(message, statusName, transaction).ConfigureAwait(false);
+        var changed = await _storage
+            .ChangePublishStateAsync(message, statusName, transaction, cancellationToken: CancellationToken.None)
+            .ConfigureAwait(false);
+
         if (!changed)
         {
             return;

--- a/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
+++ b/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
@@ -262,7 +262,7 @@ public static class MessagingDashboardEndpoints
     {
         const string cacheKey = "dashboard.metrics.history";
         var cache = sp.GetRequiredService<IMemoryCache>();
-        if (cache.TryGetValue(cacheKey, out object? ret))
+        if (cache.TryGetValue(cacheKey, out var ret))
         {
             return Results.Json(ret);
         }

--- a/src/Headless.Messaging.OpenTelemetry/MessagingEnrichmentContext.cs
+++ b/src/Headless.Messaging.OpenTelemetry/MessagingEnrichmentContext.cs
@@ -15,7 +15,7 @@ namespace Headless.Messaging.OpenTelemetry;
 /// enrichers that write header values to sensitive sinks must sanitize at their own call site.
 /// </remarks>
 [PublicAPI]
-[System.Diagnostics.CodeAnalysis.SuppressMessage(
+[SuppressMessage(
     "Performance",
     "CA1815:Override equals and operator equals on value types",
     Justification = "Transient parameter passed `in` to enrichers; never compared or stored."

--- a/src/Headless.Messaging.OpenTelemetry/MessagingInstrumentationOptions.cs
+++ b/src/Headless.Messaging.OpenTelemetry/MessagingInstrumentationOptions.cs
@@ -58,7 +58,6 @@ public sealed class MessagingInstrumentationOptions
     /// </summary>
     /// <param name="enricher">The enricher to add. Must not be <see langword="null"/>.</param>
     /// <returns>The same options instance for chaining.</returns>
-    [MustUseReturnValue]
     public MessagingInstrumentationOptions AddEnricher(IActivityTagEnricher enricher)
     {
         Argument.IsNotNull(enricher);

--- a/src/Headless.Messaging.RabbitMq/RabbitMqConsumerClient.cs
+++ b/src/Headless.Messaging.RabbitMq/RabbitMqConsumerClient.cs
@@ -80,7 +80,7 @@ internal sealed class RabbitMqConsumerClient : IConsumerClient
         }
         else
         {
-            ushort prefetch = _groupConcurrent > 0 ? _groupConcurrent : (ushort)1;
+            var prefetch = _groupConcurrent > 0 ? _groupConcurrent : (ushort)1;
             await _channel!.BasicQosAsync(prefetchSize: 0, prefetchCount: prefetch, global: false, cancellationToken);
         }
 

--- a/src/Headless.Messaging.Testing/Internal/RecordingTransport.cs
+++ b/src/Headless.Messaging.Testing/Internal/RecordingTransport.cs
@@ -29,7 +29,7 @@ internal sealed class RecordingTransport(
             var messageTypeName = headers.TryGetValue(Headers.Type, out var typeName) ? typeName : null;
 
             object messageObj = message;
-            Type messageType = typeof(TransportMessage);
+            var messageType = typeof(TransportMessage);
 
             if (message.Body.Length > 0 && messageTypeName != null)
             {

--- a/src/Headless.Payments.Paymob.CashIn/PaymobCashInBroker.Helpers.cs
+++ b/src/Headless.Payments.Paymob.CashIn/PaymobCashInBroker.Helpers.cs
@@ -41,7 +41,7 @@ public partial class PaymobCashInBroker
         CancellationToken cancellationToken = default
     )
     {
-        var authToken = await authenticator.GetAuthenticationTokenAsync().ConfigureAwait(false);
+        var authToken = await authenticator.GetAuthenticationTokenAsync(cancellationToken).ConfigureAwait(false);
 
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
         httpRequest.Headers.Add("Authorization", $"Bearer {authToken}");

--- a/src/Headless.Testing.Testcontainers/HeadlessNatsFixture.cs
+++ b/src/Headless.Testing.Testcontainers/HeadlessNatsFixture.cs
@@ -18,6 +18,10 @@ public class HeadlessNatsFixture() : ContainerFixture<NatsBuilder, NatsContainer
         return base.Configure()
             .WithImage(TestImages.Nats)
             .WithReuse(true)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server is ready"));
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilMessageIsLogged("Server is ready")
+                    .UntilExternalTcpPortIsAvailable(NatsBuilder.NatsClientPort)
+            );
     }
 }

--- a/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyEndToEndTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyEndToEndTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
-using Headless.Api.Idempotency;
+using Headless.Api;
 using Headless.Caching;
 using Headless.Constants;
+using Headless.Testing.Tests;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Tests;
 
-public sealed class IdempotencyEndToEndTests
+public sealed class IdempotencyEndToEndTests : TestBase
 {
     // ── AE1: replay on identical retry ────────────────────────────────────────
 
@@ -31,8 +32,8 @@ public sealed class IdempotencyEndToEndTests
         first.StatusCode.Should().Be(HttpStatusCode.Created);
         second.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var firstBody = await first.Content.ReadAsStringAsync();
-        var secondBody = await second.Content.ReadAsStringAsync();
+        var firstBody = await first.Content.ReadAsStringAsync(AbortToken);
+        var secondBody = await second.Content.ReadAsStringAsync(AbortToken);
 
         secondBody.Should().Be(firstBody);
         first.Headers.Contains(HttpHeaderNames.IdempotentReplayed).Should().BeFalse();
@@ -200,11 +201,10 @@ public sealed class IdempotencyEndToEndTests
         await using var app = await IdempotencyTestApp.CreateAsync();
         using var client = IdempotencyTestApp.CreateClient(app);
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/echo")
-        {
-            Content = new StringContent("hello"),
-        };
-        using var response = await client.SendAsync(request);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/echo");
+
+        request.Content = new StringContent("hello");
+        using var response = await client.SendAsync(request, cancellationToken: AbortToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         response.Headers.Contains(HttpHeaderNames.IdempotentReplayed).Should().BeFalse();
@@ -219,8 +219,17 @@ public sealed class IdempotencyEndToEndTests
         await using var app = await IdempotencyTestApp.CreateAsync(tenantHeaderName: tenantHeader);
         using var client = IdempotencyTestApp.CreateClient(app);
 
-        async Task<HttpResponseMessage> postForTenant(string tenant) =>
-            await _Post(client, "/echo", key: "k1", body: "same-body", extraHeaders: new(StringComparer.Ordinal) { [tenantHeader] = tenant });
+        async Task<HttpResponseMessage> postForTenant(string tenant)
+        {
+            // ReSharper disable once AccessToDisposedClosure
+            return await _Post(
+                client,
+                "/echo",
+                key: "k1",
+                body: "same-body",
+                extraHeaders: new(StringComparer.Ordinal) { [tenantHeader] = tenant }
+            );
+        }
 
         var tenantA = await postForTenant("TENANT-A");
         var tenantB = await postForTenant("TENANT-B");
@@ -232,8 +241,8 @@ public sealed class IdempotencyEndToEndTests
         tenantB.Headers.Contains(HttpHeaderNames.IdempotentReplayed).Should().BeFalse();
 
         // Per-invocation GUID in body proves each tenant ran the handler independently
-        var bodyA = await tenantA.Content.ReadAsStringAsync();
-        var bodyB = await tenantB.Content.ReadAsStringAsync();
+        var bodyA = await tenantA.Content.ReadAsStringAsync(AbortToken);
+        var bodyB = await tenantB.Content.ReadAsStringAsync(AbortToken);
         bodyA.Should().NotBe(bodyB);
     }
 
@@ -242,15 +251,19 @@ public sealed class IdempotencyEndToEndTests
     [Fact]
     public async Task per_endpoint_with_idempotency_metadata_should_apply_overrides()
     {
-        await using var app = await IdempotencyTestApp.CreateAsync(
-            mapAdditionalEndpoints: a =>
-            {
-                a.MapPost("/strict", (HttpContext ctx) =>
-                {
-                    ctx.Response.StatusCode = StatusCodes.Status201Created;
-                    return Task.CompletedTask;
-                }).WithIdempotency(o => o.MismatchStatusCode = StatusCodes.Status409Conflict);
-            });
+        await using var app = await IdempotencyTestApp.CreateAsync(mapAdditionalEndpoints: a =>
+        {
+            a.MapPost(
+                    "/strict",
+                    ctx =>
+                    {
+                        ctx.Response.StatusCode = StatusCodes.Status201Created;
+                        return Task.CompletedTask;
+                    }
+                )
+                .WithIdempotency(o => o.MismatchStatusCode = StatusCodes.Status409Conflict);
+        });
+
         using var client = IdempotencyTestApp.CreateClient(app);
 
         await _Post(client, "/strict", key: "k1", body: "one");
@@ -277,9 +290,14 @@ public sealed class IdempotencyEndToEndTests
         // The loser should reject immediately on the in-flight marker without invoking the handler.
         var loser = await loserTask;
         loser.StatusCode.Should().Be(HttpStatusCode.Conflict);
-        var loserBody = await loser.Content.ReadAsStringAsync();
+        var loserBody = await loser.Content.ReadAsStringAsync(AbortToken);
         loserBody.Should().Contain("g:idempotency_in_flight");
-        loserBody.Should().NotContain("g:idempotency_in_flight_timeout", "Reject must surface g:idempotency_in_flight, not the WaitAndReplay timeout code");
+        loserBody
+            .Should()
+            .NotContain(
+                "g:idempotency_in_flight_timeout",
+                "Reject must surface g:idempotency_in_flight, not the WaitAndReplay timeout code"
+            );
 
         // Now release the winner and verify it completed normally.
         gate.Release();
@@ -297,9 +315,14 @@ public sealed class IdempotencyEndToEndTests
     {
         var gate = new IdempotencyTestApp.TestHandlerGate();
         await using var app = await IdempotencyTestApp.CreateAsync(
-            o => { o.InFlightStrategy = InFlightStrategy.WaitAndReplay; o.InFlightLockTimeout = TimeSpan.FromSeconds(10); },
+            o =>
+            {
+                o.InFlightStrategy = InFlightStrategy.WaitAndReplay;
+                o.InFlightLockTimeout = TimeSpan.FromSeconds(10);
+            },
             withLockProvider: true,
-            handlerGate: gate);
+            handlerGate: gate
+        );
         using var client = IdempotencyTestApp.CreateClient(app);
 
         var winnerTask = _Post(client, "/echo", key: "k1", body: "hello");
@@ -323,8 +346,8 @@ public sealed class IdempotencyEndToEndTests
         winner.Headers.Contains(HttpHeaderNames.IdempotentReplayed).Should().BeFalse("winner ran the handler");
         loser.Headers.Should().Contain(h => h.Key == HttpHeaderNames.IdempotentReplayed, "loser observed the replay");
 
-        var winnerBody = await winner.Content.ReadAsStringAsync();
-        var loserBody = await loser.Content.ReadAsStringAsync();
+        var winnerBody = await winner.Content.ReadAsStringAsync(AbortToken);
+        var loserBody = await loser.Content.ReadAsStringAsync(AbortToken);
         loserBody.Should().Be(winnerBody, "replay must be byte-equivalent to the original");
 
         gate.InvocationCount.Should().Be(1, "WaitAndReplay never invokes the handler twice for the same key");
@@ -370,6 +393,7 @@ public sealed class IdempotencyEndToEndTests
                     return;
                 }
 
+                // ReSharper disable once AccessToModifiedClosure
                 var cache = cacheRef;
                 if (cache is null)
                 {
@@ -384,14 +408,19 @@ public sealed class IdempotencyEndToEndTests
                     winnerInRaceWindow.TrySetResult();
                     await releaseRaceWindow.Task.WaitAsync(ct).ConfigureAwait(false);
                 }
-            }
+            },
         };
 
         var gate = new IdempotencyTestApp.TestHandlerGate();
         await using var app = await IdempotencyTestApp.CreateAsync(
-            o => { o.InFlightStrategy = InFlightStrategy.WaitAndReplay; o.InFlightLockTimeout = TimeSpan.FromSeconds(5); },
+            o =>
+            {
+                o.InFlightStrategy = InFlightStrategy.WaitAndReplay;
+                o.InFlightLockTimeout = TimeSpan.FromSeconds(5);
+            },
             handlerGate: gate,
-            lockProvider: lockProvider);
+            lockProvider: lockProvider
+        );
         cacheRef = app.Services.GetRequiredService<ICache>();
 
         using var client = IdempotencyTestApp.CreateClient(app);
@@ -400,10 +429,7 @@ public sealed class IdempotencyEndToEndTests
 
         // Winner advances to one of two states: gated inside the race window (pre-fix) or
         // gated inside the handler (post-fix). Whichever fires first is enough to send the loser.
-        await Task.WhenAny(
-            winnerInRaceWindow.Task,
-            gate.WaitForInvocationsAsync(1, TimeSpan.FromSeconds(5))
-        );
+        await Task.WhenAny(winnerInRaceWindow.Task, gate.WaitForInvocationsAsync(1, TimeSpan.FromSeconds(5)));
 
         var loserTask = _Post(client, "/echo", key: "race-k", body: "hello");
 
@@ -418,10 +444,12 @@ public sealed class IdempotencyEndToEndTests
         var loser = await loserTask;
 
         winner.StatusCode.Should().Be(HttpStatusCode.Created);
-        loser.StatusCode.Should().Be(
-            HttpStatusCode.Created,
-            "loser must replay the winner's response — not return 409 InFlightTimeout — when the winner is healthy"
-        );
+        loser
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.Created,
+                "loser must replay the winner's response — not return 409 InFlightTimeout — when the winner is healthy"
+            );
 
         gate.InvocationCount.Should().Be(1, "WaitAndReplay never invokes the handler twice for the same key");
     }
@@ -431,9 +459,14 @@ public sealed class IdempotencyEndToEndTests
     {
         var gate = new IdempotencyTestApp.TestHandlerGate();
         await using var app = await IdempotencyTestApp.CreateAsync(
-            o => { o.InFlightStrategy = InFlightStrategy.WaitAndReplay; o.InFlightLockTimeout = TimeSpan.FromMilliseconds(250); },
+            o =>
+            {
+                o.InFlightStrategy = InFlightStrategy.WaitAndReplay;
+                o.InFlightLockTimeout = TimeSpan.FromMilliseconds(250);
+            },
             withLockProvider: true,
-            handlerGate: gate);
+            handlerGate: gate
+        );
         using var client = IdempotencyTestApp.CreateClient(app);
 
         var winnerTask = _Post(client, "/echo", key: "k1", body: "hello");
@@ -505,7 +538,12 @@ public sealed class IdempotencyEndToEndTests
 
         var firstBody = await first.Content.ReadAsStringAsync();
         var secondBody = await second.Content.ReadAsStringAsync();
-        firstBody.Should().NotBe(secondBody, "tenant-anon pass-through under default RequireUserIdentity must not share a cache slot");
+        firstBody
+            .Should()
+            .NotBe(
+                secondBody,
+                "tenant-anon pass-through under default RequireUserIdentity must not share a cache slot"
+            );
     }
 
     [Fact]
@@ -515,7 +553,8 @@ public sealed class IdempotencyEndToEndTests
         // idempotency. Two retries sharing tenant + key + body replay byte-equivalently.
         await using var app = await IdempotencyTestApp.CreateAsync(
             o => o.RequireUserIdentity = false,
-            tenantHeaderName: "X-Tenant");
+            tenantHeaderName: "X-Tenant"
+        );
         var userState = app.Services.GetRequiredService<IdempotencyTestApp.TestCurrentUserState>();
         userState.SetAnonymous();
 
@@ -527,7 +566,12 @@ public sealed class IdempotencyEndToEndTests
 
         first.StatusCode.Should().Be(HttpStatusCode.Created);
         second.StatusCode.Should().Be(HttpStatusCode.Created);
-        second.Headers.GetValues(HttpHeaderNames.IdempotentReplayed).Should().ContainSingle().Which.Should().Be("true", "opt-in tenant-anon idempotency replays the original response");
+        second
+            .Headers.GetValues(HttpHeaderNames.IdempotentReplayed)
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("true", "opt-in tenant-anon idempotency replays the original response");
 
         var firstBody = await first.Content.ReadAsStringAsync();
         var secondBody = await second.Content.ReadAsStringAsync();
@@ -544,19 +588,24 @@ public sealed class IdempotencyEndToEndTests
         // warning and bypasses idempotency for this request, letting the handler run unguarded.
         // The trade-off — a single retry may execute its handler twice if the outage straddles
         // attempts — is the explicit Stripe/AWS default.
-        await using var app = await IdempotencyTestApp.CreateAsync(
-            configureServices: services =>
+        await using var app = await IdempotencyTestApp.CreateAsync(configureServices: services =>
+        {
+            var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICache));
+            if (descriptor is not null)
             {
-                var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(Headless.Caching.ICache));
-                if (descriptor is not null) { services.Remove(descriptor); }
-                services.AddSingleton<Headless.Caching.ICache, IdempotencyTestApp.ThrowingCache>();
-            });
+                services.Remove(descriptor);
+            }
+            services.AddSingleton<ICache, IdempotencyTestApp.ThrowingCache>();
+        });
         using var client = IdempotencyTestApp.CreateClient(app);
 
         var response = await _Post(client, "/echo", key: "cache-fail-open", body: "hello");
 
         response.StatusCode.Should().Be(HttpStatusCode.Created, "FailOpen bypasses idempotency and runs the handler");
-        response.Headers.Contains(HttpHeaderNames.IdempotentReplayed).Should().BeFalse("no replay attempted under cache outage");
+        response
+            .Headers.Contains(HttpHeaderNames.IdempotentReplayed)
+            .Should()
+            .BeFalse("no replay attempted under cache outage");
     }
 
     [Fact]
@@ -568,15 +617,21 @@ public sealed class IdempotencyEndToEndTests
             o => o.OnCacheError = OnCacheErrorBehavior.Throw,
             configureServices: services =>
             {
-                var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(Headless.Caching.ICache));
-                if (descriptor is not null) { services.Remove(descriptor); }
-                services.AddSingleton<Headless.Caching.ICache, IdempotencyTestApp.ThrowingCache>();
-            });
+                var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICache));
+                if (descriptor is not null)
+                {
+                    services.Remove(descriptor);
+                }
+                services.AddSingleton<ICache, IdempotencyTestApp.ThrowingCache>();
+            }
+        );
         using var client = IdempotencyTestApp.CreateClient(app);
 
         var response = await _Post(client, "/echo", key: "cache-throw", body: "hello");
 
-        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError, "Throw mode rethrows cache exceptions to the host pipeline");
+        response
+            .StatusCode.Should()
+            .Be(HttpStatusCode.InternalServerError, "Throw mode rethrows cache exceptions to the host pipeline");
     }
 
     // ── Default cache key includes query string ──────────────────────────────
@@ -600,8 +655,16 @@ public sealed class IdempotencyEndToEndTests
         var firstBody = await first.Content.ReadAsStringAsync();
         var secondBody = await second.Content.ReadAsStringAsync();
 
-        secondBody.Should().NotBe(firstBody, "different query strings yield distinct cache slots; each invocation produces its own response");
-        second.Headers.Contains(HttpHeaderNames.IdempotentReplayed).Should().BeFalse("the second request must execute the handler, not replay the first");
+        secondBody
+            .Should()
+            .NotBe(
+                firstBody,
+                "different query strings yield distinct cache slots; each invocation produces its own response"
+            );
+        second
+            .Headers.Contains(HttpHeaderNames.IdempotentReplayed)
+            .Should()
+            .BeFalse("the second request must execute the handler, not replay the first");
     }
 
     // ── Winner lock lease decoupled from InFlightLockTimeout ─────────────────
@@ -628,7 +691,7 @@ public sealed class IdempotencyEndToEndTests
                     winnerLeaseSeen = timeUntilExpires;
                 }
                 return Task.CompletedTask;
-            }
+            },
         };
 
         await using var app = await IdempotencyTestApp.CreateAsync(
@@ -638,13 +701,19 @@ public sealed class IdempotencyEndToEndTests
                 o.InFlightLockTimeout = configuredAcquireTimeout;
                 o.WinnerLockLease = configuredLease;
             },
-            lockProvider: lockProvider);
+            lockProvider: lockProvider
+        );
         using var client = IdempotencyTestApp.CreateClient(app);
 
         var response = await _Post(client, "/echo", key: "lease-1", body: "hello");
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        winnerLeaseSeen.Should().Be(configuredLease, "the winner's lock lease must come from WinnerLockLease, not InFlightLockTimeout + 5s");
+        winnerLeaseSeen
+            .Should()
+            .Be(
+                configuredLease,
+                "the winner's lock lease must come from WinnerLockLease, not InFlightLockTimeout + 5s"
+            );
         // Sanity: old formula would have produced 6 seconds, which is observably different.
         winnerLeaseSeen.Should().NotBe(configuredAcquireTimeout + TimeSpan.FromSeconds(5));
     }
@@ -667,17 +736,23 @@ public sealed class IdempotencyEndToEndTests
                     throw new InvalidOperationException("simulated lock-provider outage");
                 }
                 return Task.CompletedTask;
-            }
+            },
         };
 
         await using var app = await IdempotencyTestApp.CreateAsync(
             o => o.InFlightStrategy = InFlightStrategy.WaitAndReplay,
-            lockProvider: lockProvider);
+            lockProvider: lockProvider
+        );
         using var client = IdempotencyTestApp.CreateClient(app);
 
         var response = await _Post(client, "/echo", key: "lock-fail-open", body: "hello");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Created, "FailOpen bypasses idempotency and runs the handler when the lock provider is down");
+        response
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.Created,
+                "FailOpen bypasses idempotency and runs the handler when the lock provider is down"
+            );
     }
 
     [Fact]
@@ -696,7 +771,7 @@ public sealed class IdempotencyEndToEndTests
                     throw new InvalidOperationException("simulated lock-provider outage");
                 }
                 return Task.CompletedTask;
-            }
+            },
         };
 
         await using var app = await IdempotencyTestApp.CreateAsync(
@@ -706,7 +781,8 @@ public sealed class IdempotencyEndToEndTests
                 o.InFlightLockTimeout = TimeSpan.FromSeconds(5);
             },
             handlerGate: gate,
-            lockProvider: lockProvider);
+            lockProvider: lockProvider
+        );
         using var client = IdempotencyTestApp.CreateClient(app);
 
         // Winner enters the handler (gated) holding the lock.
@@ -733,10 +809,9 @@ public sealed class IdempotencyEndToEndTests
         Dictionary<string, string>? extraHeaders = null
     )
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, path)
-        {
-            Content = new StringContent(body),
-        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, path);
+
+        request.Content = new StringContent(body);
         request.Headers.Add(HttpHeaderNames.IdempotencyKey, key);
 
         if (extraHeaders is not null)
@@ -748,6 +823,6 @@ public sealed class IdempotencyEndToEndTests
         }
 
         // Disposed by caller via using
-        return await client.SendAsync(request);
+        return await client.SendAsync(request, cancellationToken: AbortToken);
     }
 }

--- a/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
@@ -2,8 +2,8 @@
 
 using System.Collections.Concurrent;
 using Headless.Abstractions;
+using Headless.Api;
 using Headless.Api.Abstractions;
-using Headless.Api.Idempotency;
 using Headless.Caching;
 using Headless.Core;
 using Headless.DistributedLocks;
@@ -34,9 +34,7 @@ internal static class IdempotencyTestApp
         Action<IServiceCollection>? configureServices = null
     )
     {
-        var builder = WebApplication.CreateBuilder(
-            new WebApplicationOptions { EnvironmentName = "Test" }
-        );
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Test" });
 
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         builder.Logging.ClearProviders();
@@ -45,7 +43,7 @@ internal static class IdempotencyTestApp
         builder.Services.AddProblemDetails();
 
         // Framework primitives required by IdempotencyMiddleware constructor
-        builder.Services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+        builder.Services.TryAddSingleton(TimeProvider.System);
         builder.Services.TryAddSingleton<IClock, Clock>();
         builder.Services.TryAddSingleton<ICancellationTokenProvider, HttpContextCancellationTokenProvider>();
         builder.Services.TryAddSingleton<IBuildInformationAccessor, NullBuildInformationAccessor>();
@@ -106,54 +104,62 @@ internal static class IdempotencyTestApp
         // Tenant resolution from a custom header BEFORE idempotency (so the cache-key sees the tenant)
         if (tenantHeaderName is not null)
         {
-            app.Use(async (ctx, next) =>
-            {
-                if (ctx.Request.Headers.TryGetValue(tenantHeaderName, out var t) && !string.IsNullOrWhiteSpace(t))
+            app.Use(
+                async (ctx, next) =>
                 {
-                    tenantState.SetForCurrentRequest(t.ToString());
-                }
-                else
-                {
-                    tenantState.SetForCurrentRequest(null);
-                }
+                    if (ctx.Request.Headers.TryGetValue(tenantHeaderName, out var t) && !string.IsNullOrWhiteSpace(t))
+                    {
+                        tenantState.SetForCurrentRequest(t.ToString());
+                    }
+                    else
+                    {
+                        tenantState.SetForCurrentRequest(null);
+                    }
 
-                await next();
-            });
+                    await next();
+                }
+            );
         }
 
         app.UseIdempotency();
 
         // Default endpoints used by most tests
-        app.MapPost("/echo", async (HttpContext ctx, [FromServices] TestHandlerGate? gate) =>
-        {
-            using var reader = new StreamReader(ctx.Request.Body, leaveOpen: true);
-            var body = await reader.ReadToEndAsync();
-
-            // When a gate is registered, count this invocation and wait for the test to
-            // release. Tests use this to hold the winner mid-handler so a concurrent
-            // request observes the InFlight state.
-            if (gate is not null)
+        app.MapPost(
+            "/echo",
+            async (HttpContext ctx, [FromServices] TestHandlerGate? gate) =>
             {
-                gate.OnHandlerEntered();
-                await gate.WaitForReleaseAsync(ctx.RequestAborted).ConfigureAwait(false);
+                using var reader = new StreamReader(ctx.Request.Body, leaveOpen: true);
+                var body = await reader.ReadToEndAsync();
+
+                // When a gate is registered, count this invocation and wait for the test to
+                // release. Tests use this to hold the winner mid-handler so a concurrent
+                // request observes the InFlight state.
+                if (gate is not null)
+                {
+                    gate.OnHandlerEntered();
+                    await gate.WaitForReleaseAsync(ctx.RequestAborted).ConfigureAwait(false);
+                }
+
+                // Per-invocation GUID embedded in the body — replay returns the cached GUID,
+                // so byte-equality across two retries proves the handler ran exactly once.
+                var invocationId = Guid.NewGuid();
+                ctx.Response.StatusCode = StatusCodes.Status201Created;
+                ctx.Response.Headers.Location = "/echo/1";
+                ctx.Response.Headers.ContentType = "application/json";
+                ctx.Response.Headers.Append("Set-Cookie", "session=abc; HttpOnly");
+                ctx.Response.Headers.Append("traceparent", "00-deadbeef-1-00");
+                await ctx.Response.WriteAsync($"{{\"invocation\":\"{invocationId}\",\"echo\":\"{body}\"}}");
             }
+        );
 
-            // Per-invocation GUID embedded in the body — replay returns the cached GUID,
-            // so byte-equality across two retries proves the handler ran exactly once.
-            var invocationId = Guid.NewGuid();
-            ctx.Response.StatusCode = StatusCodes.Status201Created;
-            ctx.Response.Headers.Location = "/echo/1";
-            ctx.Response.Headers.ContentType = "application/json";
-            ctx.Response.Headers.Append("Set-Cookie", "session=abc; HttpOnly");
-            ctx.Response.Headers.Append("traceparent", "00-deadbeef-1-00");
-            await ctx.Response.WriteAsync($"{{\"invocation\":\"{invocationId}\",\"echo\":\"{body}\"}}");
-        });
-
-        app.MapPost("/status", (HttpContext ctx, [FromQuery] int code) =>
-        {
-            ctx.Response.StatusCode = code;
-            return Task.CompletedTask;
-        });
+        app.MapPost(
+            "/status",
+            (HttpContext ctx, [FromQuery] int code) =>
+            {
+                ctx.Response.StatusCode = code;
+                return Task.CompletedTask;
+            }
+        );
 
         mapAdditionalEndpoints?.Invoke(app);
 
@@ -207,7 +213,7 @@ internal static class IdempotencyTestApp
         public void SetAuthenticated() => _anonymous = false;
 
         public ICurrentUser CurrentForRequest() =>
-            _anonymous ? new Headless.Abstractions.NullCurrentUser() : new TestCurrentUser(_DefaultUserId);
+            _anonymous ? new NullCurrentUser() : new TestCurrentUser(_DefaultUserId);
     }
 
     private sealed class TestCurrentUser(UserId? userId) : ICurrentUser
@@ -222,7 +228,7 @@ internal static class IdempotencyTestApp
 
         public AccountId? AccountId => null;
 
-        public IReadOnlySet<string> Roles => System.Collections.Immutable.ImmutableHashSet<string>.Empty;
+        public IReadOnlySet<string> Roles => ImmutableHashSet<string>.Empty;
     }
 
     private sealed class NullBuildInformationAccessor : IBuildInformationAccessor
@@ -257,7 +263,10 @@ internal static class IdempotencyTestApp
 
         public async Task WaitForReleaseAsync(CancellationToken cancellationToken)
         {
-            using var registration = cancellationToken.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), _release);
+            using var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource)state!).TrySetCanceled(),
+                _release
+            );
             await _release.Task.ConfigureAwait(false);
         }
 
@@ -357,7 +366,8 @@ internal static class IdempotencyTestApp
         {
             if (BeforeAcquireAsync is not null)
             {
-                await BeforeAcquireAsync(resource, timeUntilExpires, acquireTimeout, cancellationToken).ConfigureAwait(false);
+                await BeforeAcquireAsync(resource, timeUntilExpires, acquireTimeout, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             var lease = timeUntilExpires ?? DefaultTimeUntilExpires;
@@ -394,19 +404,30 @@ internal static class IdempotencyTestApp
             }
         }
 
-        public Task<bool> RenewAsync(string resource, string lockId, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> RenewAsync(
+            string resource,
+            string lockId,
+            TimeSpan? timeUntilExpires = null,
+            CancellationToken cancellationToken = default
+        ) => throw new NotSupportedException();
 
-        public Task ReleaseAsync(string resource, string lockId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task ReleaseAsync(string resource, string lockId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
 
-        public Task<bool> IsLockedAsync(string resource, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> IsLockedAsync(string resource, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
 
-        public Task<TimeSpan?> GetExpirationAsync(string resource, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TimeSpan?> GetExpirationAsync(string resource, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
 
-        public Task<LockInfo?> GetLockInfoAsync(string resource, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<LockInfo?> GetLockInfoAsync(string resource, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
 
-        public Task<IReadOnlyList<LockInfo>> ListActiveLocksAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<LockInfo>> ListActiveLocksAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
 
-        public Task<long> GetActiveLocksCountAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> GetActiveLocksCountAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
     }
 
     /// <summary>
@@ -415,61 +436,156 @@ internal static class IdempotencyTestApp
     /// idempotency middleware should either fail open (default) or rethrow depending on
     /// <see cref="IdempotencyOptions.OnCacheError"/>.
     /// </summary>
-    internal sealed class ThrowingCache : Headless.Caching.ICache
+    internal sealed class ThrowingCache : ICache
     {
         private static InvalidOperationException _Boom() => new("simulated cache outage");
 
-        public ValueTask<Headless.Caching.CacheValue<T>> GetOrAddAsync<T>(string key, Func<CancellationToken, ValueTask<T?>> factory, TimeSpan expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<CacheValue<T>> GetOrAddAsync<T>(
+            string key,
+            Func<CancellationToken, ValueTask<T?>> factory,
+            TimeSpan expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<bool> UpsertAsync<T>(string key, T? value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<bool> UpsertAsync<T>(
+            string key,
+            T? value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<int> UpsertAllAsync<T>(IDictionary<string, T> value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<int> UpsertAllAsync<T>(
+            IDictionary<string, T> value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<bool> TryInsertAsync<T>(string key, T? value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<bool> TryInsertAsync<T>(
+            string key,
+            T? value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<bool> TryReplaceAsync<T>(string key, T? value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<bool> TryReplaceAsync<T>(
+            string key,
+            T? value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<bool> TryReplaceIfEqualAsync<T>(string key, T? expected, T? value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<bool> TryReplaceIfEqualAsync<T>(
+            string key,
+            T? expected,
+            T? value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<double> IncrementAsync(string key, double amount, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<double> IncrementAsync(
+            string key,
+            double amount,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<long> IncrementAsync(string key, long amount, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<long> IncrementAsync(
+            string key,
+            long amount,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<double> SetIfHigherAsync(string key, double value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<double> SetIfHigherAsync(
+            string key,
+            double value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<long> SetIfHigherAsync(string key, long value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<long> SetIfHigherAsync(
+            string key,
+            long value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<double> SetIfLowerAsync(string key, double value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<double> SetIfLowerAsync(
+            string key,
+            double value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<long> SetIfLowerAsync(string key, long value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<long> SetIfLowerAsync(
+            string key,
+            long value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<long> SetAddAsync<T>(string key, IEnumerable<T> value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<long> SetAddAsync<T>(
+            string key,
+            IEnumerable<T> value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<IDictionary<string, Headless.Caching.CacheValue<T>>> GetAllAsync<T>(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(
+            IEnumerable<string> cacheKeys,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<IDictionary<string, Headless.Caching.CacheValue<T>>> GetByPrefixAsync<T>(string prefix, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<IDictionary<string, CacheValue<T>>> GetByPrefixAsync<T>(
+            string prefix,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<IReadOnlyList<string>> GetAllKeysByPrefixAsync(string prefix, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<IReadOnlyList<string>> GetAllKeysByPrefixAsync(
+            string prefix,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<Headless.Caching.CacheValue<T>> GetAsync<T>(string key, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<CacheValue<T>> GetAsync<T>(string key, CancellationToken cancellationToken = default) =>
+            throw _Boom();
 
-        public ValueTask<long> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<long> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default) =>
+            throw _Boom();
 
         public ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default) => throw _Boom();
 
-        public ValueTask<TimeSpan?> GetExpirationAsync(string key, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<TimeSpan?> GetExpirationAsync(string key, CancellationToken cancellationToken = default) =>
+            throw _Boom();
 
-        public ValueTask<Headless.Caching.CacheValue<ICollection<T>>> GetSetAsync<T>(string key, int? pageIndex = null, int pageSize = 100, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<CacheValue<ICollection<T>>> GetSetAsync<T>(
+            string key,
+            int? pageIndex = null,
+            int pageSize = 100,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
         public ValueTask<bool> RemoveAsync(string key, CancellationToken cancellationToken = default) => throw _Boom();
 
-        public ValueTask<bool> RemoveIfEqualAsync<T>(string key, T? expected, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<bool> RemoveIfEqualAsync<T>(
+            string key,
+            T? expected,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<int> RemoveAllAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<int> RemoveAllAsync(
+            IEnumerable<string> cacheKeys,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
-        public ValueTask<int> RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<int> RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default) =>
+            throw _Boom();
 
-        public ValueTask<long> SetRemoveAsync<T>(string key, IEnumerable<T> value, TimeSpan? expiration, CancellationToken cancellationToken = default) => throw _Boom();
+        public ValueTask<long> SetRemoveAsync<T>(
+            string key,
+            IEnumerable<T> value,
+            TimeSpan? expiration,
+            CancellationToken cancellationToken = default
+        ) => throw _Boom();
 
         public ValueTask FlushAsync(CancellationToken cancellationToken = default) => throw _Boom();
     }
@@ -499,7 +615,10 @@ internal static class IdempotencyTestApp
             return Task.CompletedTask;
         }
 
-        public Task<bool> RenewAsync(TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> RenewAsync(
+            TimeSpan? timeUntilExpires = null,
+            CancellationToken cancellationToken = default
+        ) => throw new NotSupportedException();
 
         public ValueTask DisposeAsync()
         {

--- a/tests/Headless.Api.Idempotency.Tests.Unit/CaptureStreamTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/CaptureStreamTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
+using Headless.Testing.Tests;
 
 namespace Tests;
 
-public sealed class CaptureStreamTests
+// ReSharper disable AccessToDisposedClosure
+public sealed class CaptureStreamTests : TestBase
 {
     private const int _Cap = 100;
 
@@ -26,10 +28,10 @@ public sealed class CaptureStreamTests
     public async Task write_async_forwards_correctly()
     {
         var inner = new MemoryStream();
-        using var capture = new CaptureStream(inner, _Cap);
+        await using var capture = new CaptureStream(inner, _Cap);
         byte[] data = [10, 20, 30];
 
-        await capture.WriteAsync(data.AsMemory());
+        await capture.WriteAsync(data.AsMemory(), AbortToken);
 
         inner.ToArray().Should().Equal(data);
         capture.CapturedBytes.Should().Equal(data);
@@ -39,7 +41,7 @@ public sealed class CaptureStreamTests
     public async Task write_async_memory_forwards_correctly()
     {
         var inner = new MemoryStream();
-        using var capture = new CaptureStream(inner, _Cap);
+        await using var capture = new CaptureStream(inner, _Cap);
         byte[] data = [5, 6, 7];
 
         await capture.WriteAsync(data.AsMemory());
@@ -69,8 +71,8 @@ public sealed class CaptureStreamTests
 
         capture.WriteByte(0x42);
 
-        inner.ToArray().Should().Equal((byte)0x42);
-        capture.CapturedBytes.Should().Equal((byte)0x42);
+        inner.ToArray().Should().Equal("B"u8.ToArray());
+        capture.CapturedBytes.Should().Equal("B"u8.ToArray());
     }
 
     [Fact]
@@ -129,10 +131,10 @@ public sealed class CaptureStreamTests
     public async Task flush_async_forwards_to_inner()
     {
         var inner = new MemoryStream();
-        using var capture = new CaptureStream(inner, _Cap);
-        await capture.WriteAsync(new byte[] { 3, 4 }.AsMemory());
+        await using var capture = new CaptureStream(inner, _Cap);
+        await capture.WriteAsync(new byte[] { 3, 4 }.AsMemory(), AbortToken);
 
-        await capture.FlushAsync();
+        await capture.FlushAsync(AbortToken);
 
         capture.CapturedBytes.Should().Equal(3, 4);
     }
@@ -181,7 +183,7 @@ public sealed class CaptureStreamTests
         using var capture = new CaptureStream(inner, cap: 3);
 
         capture.Write([1, 2, 3, 4], 0, 4); // fills cap, triggers truncation
-        capture.Write([5, 6], 0, 2);        // beyond cap, inner still gets it
+        capture.Write([5, 6], 0, 2); // beyond cap, inner still gets it
 
         inner.ToArray().Should().Equal(1, 2, 3, 4, 5, 6);
         capture.CapturedBytes.Length.Should().Be(3);

--- a/tests/Headless.Api.Idempotency.Tests.Unit/DefaultCachePredicateTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/DefaultCachePredicateTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
 using Microsoft.AspNetCore.Http;
 
 namespace Tests;

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMessageDescriberTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMessageDescriberTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
+using Headless.Api.Resources;
 
 namespace Tests;
 

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareCustomHooksTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareCustomHooksTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Abstractions;
-using Headless.Api.Idempotency;
+using Headless.Api;
 using Headless.Caching;
 using Headless.Primitives;
 using Microsoft.AspNetCore.Http;
@@ -9,12 +9,17 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using IdempotencyMiddleware = Headless.Api.IdempotencyMiddleware;
 
 namespace Tests;
 
 public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewareTestBase
 {
-    private IdempotencyMiddleware _CreateMiddlewareWithOptions(IdempotencyOptions options, ICache cache, ICurrentTenant? tenant = null)
+    private IdempotencyMiddleware _CreateMiddlewareWithOptions(
+        IdempotencyOptions options,
+        ICache cache,
+        ICurrentTenant? tenant = null
+    )
     {
         var snapshot = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
         snapshot.Value.Returns(options);
@@ -30,7 +35,12 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         return CreateMiddleware(options: snapshot, cache: cache, currentTenant: tenant);
     }
 
-    private static DefaultHttpContext _CreateLocalContext(string key = "k1", byte[]? body = null, string method = "POST", string path = "/v1/x")
+    private static DefaultHttpContext _CreateLocalContext(
+        string key = "k1",
+        byte[]? body = null,
+        string method = "POST",
+        string path = "/v1/x"
+    )
     {
         var ctx = CreateContext(idempotencyKey: key, method: method, path: path, body: body);
         return ctx;
@@ -42,25 +52,35 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     public async Task should_use_custom_key_deriver_when_provided()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
-        var options = new IdempotencyOptions
-        {
-            KeyDeriver = (_, header) => $"custom:user42:{header}",
-        };
+        var options = new IdempotencyOptions { KeyDeriver = (_, header) => $"custom:user42:{header}" };
 
         var middleware = _CreateMiddlewareWithOptions(options, cache);
         var context = _CreateLocalContext(key: "abc");
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
-
-        await cache.Received().GetAsync<IdempotencyRecord>(
-            Arg.Is<string>(k => k == "custom:user42:abc"),
-            Arg.Any<CancellationToken>()
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
         );
+
+        await cache
+            .Received()
+            .GetAsync<IdempotencyRecord>(Arg.Is<string>(k => k == "custom:user42:abc"), Arg.Any<CancellationToken>());
     }
 
     // ── RequestFingerprint (R24, AE13) ───────────────────────────────────────
@@ -69,23 +89,34 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     public async Task should_use_custom_fingerprint_when_provided()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
 
         byte[] capturedFingerprint = [];
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Do<IdempotencyRecord>(r => capturedFingerprint = r.Fingerprint!), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Do<IdempotencyRecord>(r => capturedFingerprint = r.Fingerprint!),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         byte[] customFp = [0xAA, 0xBB, 0xCC];
-        var options = new IdempotencyOptions
-        {
-            RequestFingerprint = _ => new ValueTask<byte[]>(customFp),
-        };
+        var options = new IdempotencyOptions { RequestFingerprint = _ => new ValueTask<byte[]>(customFp) };
 
         var middleware = _CreateMiddlewareWithOptions(options, cache);
         var context = _CreateLocalContext(body: [1, 2, 3]);
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         capturedFingerprint.Should().Equal(customFp);
     }
@@ -110,7 +141,14 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         var middleware = _CreateMiddlewareWithOptions(options, cache);
         var context = _CreateLocalContext(body: [1, 2, 3, 4, 5]); // 5 > cap=3
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         fingerprintInvoked.Should().BeFalse();
     }
@@ -119,10 +157,17 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     public async Task should_rewind_request_body_after_custom_fingerprint_returns()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         long innerHandlerStartPosition = -1;
         var options = new IdempotencyOptions
@@ -139,12 +184,15 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         var middleware = _CreateMiddlewareWithOptions(options, cache);
         var context = _CreateLocalContext(body: [1, 2, 3]);
 
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            innerHandlerStartPosition = ctx.Request.Body.Position;
-            ctx.Response.StatusCode = 200;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                innerHandlerStartPosition = ctx.Request.Body.Position;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         innerHandlerStartPosition.Should().Be(0L);
     }
@@ -156,16 +204,20 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     {
         var cache = Substitute.For<ICache>();
 
-        var options = new IdempotencyOptions
-        {
-            ShouldApply = _ => false,
-        };
+        var options = new IdempotencyOptions { ShouldApply = _ => false };
 
         var middleware = _CreateMiddlewareWithOptions(options, cache);
         var context = _CreateLocalContext();
         var nextCalled = false;
 
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeTrue();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -175,10 +227,17 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     public async Task should_apply_idempotency_when_should_apply_returns_true()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var options = new IdempotencyOptions
         {
@@ -188,7 +247,14 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         var middleware = _CreateMiddlewareWithOptions(options, cache);
         var context = _CreateLocalContext(path: "/v1/x");
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // Initial lookup happens (one or more times — marker re-check before upsert may add another).
         await cache.Received().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -200,17 +266,21 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     public async Task should_apply_per_endpoint_metadata_override()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
 
         TimeSpan? capturedTtl = null;
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Do<TimeSpan?>(ttl => capturedTtl = ttl), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Do<TimeSpan?>(ttl => capturedTtl = ttl),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
-        var appOptions = new IdempotencyOptions
-        {
-            IdempotencyKeyExpiration = TimeSpan.FromHours(24),
-        };
+        var appOptions = new IdempotencyOptions { IdempotencyKeyExpiration = TimeSpan.FromHours(24) };
 
         var middleware = _CreateMiddlewareWithOptions(appOptions, cache);
         var context = _CreateLocalContext();
@@ -218,11 +288,21 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         // Attach endpoint metadata: override expiration to 7 days
         var endpoint = new Endpoint(
             requestDelegate: _ => Task.CompletedTask,
-            metadata: new EndpointMetadataCollection(new IdempotencyMetadata(o => o.IdempotencyKeyExpiration = TimeSpan.FromDays(7))),
-            displayName: "test");
+            metadata: new EndpointMetadataCollection(
+                new IdempotencyMetadata(o => o.IdempotencyKeyExpiration = TimeSpan.FromDays(7))
+            ),
+            displayName: "test"
+        );
         context.Features.Set<IEndpointFeature>(new EndpointFeature { Endpoint = endpoint });
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // Marker TTL = InFlightLockTimeout + 5s (not the IdempotencyKeyExpiration); just verify the merged path was used by checking expiration applied to Complete record
         capturedTtl.Should().NotBeNull();
@@ -232,10 +312,17 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
     public async Task should_not_mutate_app_level_methods_when_endpoint_overrides_them()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var appOptions = new IdempotencyOptions
         {
@@ -249,14 +336,24 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         // Endpoint metadata adds PUT to the methods
         var endpoint = new Endpoint(
             _ => Task.CompletedTask,
-            new EndpointMetadataCollection(new IdempotencyMetadata(o =>
-            {
-                ((HashSet<string>)o.Methods).Add("PUT");
-            })),
-            "test");
+            new EndpointMetadataCollection(
+                new IdempotencyMetadata(o =>
+                {
+                    ((HashSet<string>)o.Methods).Add("PUT");
+                })
+            ),
+            "test"
+        );
         context.Features.Set<IEndpointFeature>(new EndpointFeature { Endpoint = endpoint });
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // App-level Methods set must be untouched (still POST-only)
         appOptions.Methods.Should().BeSameAs(originalMethodsRef);
@@ -271,23 +368,34 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         // override it to "X-Other-Header". The middleware reads the request header BEFORE
         // resolving endpoint metadata, so the metadata override is silently ignored.
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
-        var appOptions = new IdempotencyOptions
-        {
-            HeaderName = "X-Custom-Idempotency-Key",
-        };
+        var appOptions = new IdempotencyOptions { HeaderName = "X-Custom-Idempotency-Key" };
 
         var middleware = _CreateMiddlewareWithOptions(appOptions, cache);
-        var context = new DefaultHttpContext();
-        context.RequestServices = new Microsoft.Extensions.DependencyInjection.ServiceCollection().AddLogging().AddProblemDetails().BuildServiceProvider();
-        context.Request.Method = "POST";
-        context.Request.Path = "/v1/x";
-        context.Request.Body = new MemoryStream([1, 2, 3]);
-        context.Response.Body = new MemoryStream();
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().AddLogging().AddProblemDetails().BuildServiceProvider(),
+            Request =
+            {
+                Method = "POST",
+                Path = "/v1/x",
+                Body = new MemoryStream([1, 2, 3]),
+            },
+            Response = { Body = new MemoryStream() },
+        };
+
         // Carry the key under the APP-LEVEL header name; not the overridden one
         context.Request.Headers.Append("X-Custom-Idempotency-Key", "app-key");
         // The override would direct middleware to read from this header, but it must be ignored
@@ -296,16 +404,26 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         var endpoint = new Endpoint(
             _ => Task.CompletedTask,
             new EndpointMetadataCollection(new IdempotencyMetadata(o => o.HeaderName = "X-Other-Header")),
-            "test");
+            "test"
+        );
         context.Features.Set<IEndpointFeature>(new EndpointFeature { Endpoint = endpoint });
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // Cache key carries the app-level header value (app-key), not the override (ignored-override-key)
-        await cache.Received().GetAsync<IdempotencyRecord>(
-            Arg.Is<string>(k => k.EndsWith(":app-key", StringComparison.Ordinal)),
-            Arg.Any<CancellationToken>()
-        );
+        await cache
+            .Received()
+            .GetAsync<IdempotencyRecord>(
+                Arg.Is<string>(k => k.EndsWith(":app-key", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     private sealed class EndpointFeature : IEndpointFeature

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTestBase.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTestBase.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Abstractions;
+using Headless.Api;
 using Headless.Api.Abstractions;
-using Headless.Api.Idempotency;
 using Headless.Caching;
 using Headless.Constants;
 using Headless.Primitives;
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using IdempotencyMiddleware = Headless.Api.IdempotencyMiddleware;
 
 namespace Tests;
 
@@ -84,7 +85,8 @@ public abstract class IdempotencyMiddlewareTestBase : TestBase
             clock,
             cancellationTokenProvider,
             logger,
-            serviceProvider);
+            serviceProvider
+        );
     }
 
     protected static DefaultHttpContext CreateContext(

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
@@ -2,8 +2,8 @@
 
 using System.Security.Cryptography;
 using Headless.Abstractions;
+using Headless.Api;
 using Headless.Api.Abstractions;
-using Headless.Api.Idempotency;
 using Headless.Caching;
 using Headless.Constants;
 using Headless.DistributedLocks;
@@ -12,12 +12,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using IdempotencyMiddleware = Headless.Api.IdempotencyMiddleware;
 
 namespace Tests;
 
 public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 {
-
     // ── pass-through ──────────────────────────────────────────────────────────
 
     [Fact]
@@ -28,7 +28,14 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var context = CreateContext(); // no header
 
         var nextCalled = false;
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeTrue();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -42,7 +49,14 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var context = CreateContext(idempotencyKey: "k1", method: "GET");
 
         var nextCalled = false;
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeTrue();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -58,7 +72,14 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var context = CreateContext(idempotencyKey: key);
 
         var nextCalled = false;
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeTrue();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -71,7 +92,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         // given — a cached Complete record whose fingerprint matches the incoming body
         byte[] body = [1, 2, 3];
-        byte[] fingerprint = SHA256.HashData(body);
+        var fingerprint = SHA256.HashData(body);
         byte[] storedBody = [10, 20, 30];
 
         var record = new IdempotencyRecord
@@ -88,8 +109,9 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
 
         var tenant = Substitute.For<ICurrentTenant>();
         tenant.Id.Returns("t1");
@@ -99,7 +121,14 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var nextCalled = false;
 
         // when
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         // then
         nextCalled.Should().BeFalse();
@@ -116,7 +145,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     public async Task should_not_call_next_on_replay()
     {
         byte[] body = [1, 2, 3];
-        byte[] fingerprint = SHA256.HashData(body);
+        var fingerprint = SHA256.HashData(body);
 
         var record = new IdempotencyRecord
         {
@@ -128,17 +157,32 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
         var nextCalled = false;
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeFalse();
-        await cache.DidNotReceive().TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     // ── cache key composition ─────────────────────────────────────────────────
@@ -160,21 +204,43 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var context = CreateContext(idempotencyKey: "k1", path: "/v1/x");
         var nextCalled = false;
 
-        await middleware.InvokeAsync(context, ctx => { nextCalled = true; ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeTrue();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await cache.DidNotReceive().TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
     public async Task should_use_tenant_and_user_in_cache_key()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var tenant = Substitute.For<ICurrentTenant>();
         tenant.Id.Returns("T1");
@@ -184,12 +250,21 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var middleware = CreateMiddleware(cache: cache, currentTenant: tenant, currentUser: user);
         var context = CreateContext(idempotencyKey: "k1", path: "/v1/x");
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
-
-        await cache.Received().GetAsync<IdempotencyRecord>(
-            Arg.Is<string>(k => k == "idem:T1:U7:POST:/v1/x:k1"),
-            Arg.Any<CancellationToken>()
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
         );
+
+        await cache
+            .Received()
+            .GetAsync<IdempotencyRecord>(
+                Arg.Is<string>(k => k == "idem:T1:U7:POST:/v1/x:k1"),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -202,10 +277,17 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         opts.Value.Returns(new IdempotencyOptions { RequireUserIdentity = false });
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var tenant = Substitute.For<ICurrentTenant>();
         tenant.Id.Returns("T1");
@@ -215,12 +297,21 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var middleware = CreateMiddleware(options: opts, cache: cache, currentTenant: tenant, currentUser: user);
         var context = CreateContext(idempotencyKey: "k1", path: "/v1/x");
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
-
-        await cache.Received().GetAsync<IdempotencyRecord>(
-            Arg.Is<string>(k => k == "idem:T1::POST:/v1/x:k1"),
-            Arg.Any<CancellationToken>()
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
         );
+
+        await cache
+            .Received()
+            .GetAsync<IdempotencyRecord>(
+                Arg.Is<string>(k => k == "idem:T1::POST:/v1/x:k1"),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     // ── cache miss → execute + finalize ──────────────────────────────────────
@@ -230,65 +321,98 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         // given
         byte[] body = [5, 6, 7];
-        byte[] fingerprint = SHA256.HashData(body);
+        var fingerprint = SHA256.HashData(body);
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
-        cache.TryReplaceIfEqualAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+        cache
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
         var nextCalled = false;
 
         // when
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            nextCalled = true;
-            ctx.Response.StatusCode = 201;
-            return ctx.Response.Body.WriteAsync(new byte[] { 100, 101, 102 }).AsTask();
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 201;
+                return ctx.Response.Body.WriteAsync(new byte[] { 100, 101, 102 }).AsTask();
+            }
+        );
 
         // then
         nextCalled.Should().BeTrue();
 
-        await cache.Received(1).TryInsertAsync(
-            Arg.Any<string>(),
-            Arg.Is<IdempotencyRecord>(r => r.Kind == RecordKind.InFlight),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<CancellationToken>()
-        );
+        await cache
+            .Received(1)
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Is<IdempotencyRecord>(r => r.Kind == RecordKind.InFlight),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
 
         // Finalize uses TryReplaceIfEqualAsync (CAS) to swap the InFlight marker for the
         // Complete record in a single round trip. The `expected` argument is the marker we
         // inserted; the `value` argument is the Complete record built from the captured response.
-        await cache.Received(1).TryReplaceIfEqualAsync<IdempotencyRecord>(
-            Arg.Any<string>(),
-            Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.InFlight && r.Fingerprint != null && r.Fingerprint.SequenceEqual(fingerprint)),
-            Arg.Is<IdempotencyRecord?>(r =>
-                r != null &&
-                r.Kind == RecordKind.Complete &&
-                r.StatusCode == 201 &&
-                r.Fingerprint != null &&
-                r.Fingerprint.SequenceEqual(fingerprint) &&
-                r.Body.SequenceEqual(new byte[] { 100, 101, 102 })
-            ),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<CancellationToken>()
-        );
+        await cache
+            .Received(1)
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Is<IdempotencyRecord?>(r =>
+                    r != null
+                    && r.Kind == RecordKind.InFlight
+                    && r.Fingerprint != null
+                    && r.Fingerprint.SequenceEqual(fingerprint)
+                ),
+                Arg.Is<IdempotencyRecord?>(r =>
+                    r != null
+                    && r.Kind == RecordKind.Complete
+                    && r.StatusCode == 201
+                    && r.Fingerprint != null
+                    && r.Fingerprint.SequenceEqual(fingerprint)
+                    && r.Body.SequenceEqual(new byte[] { 100, 101, 102 })
+                ),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
     public async Task should_remove_inflight_marker_when_next_throws()
     {
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2]);
@@ -298,7 +422,14 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         await act.Should().ThrowAsync<InvalidOperationException>();
 
         await cache.Received(1).RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await cache.DidNotReceive().UpsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .UpsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     // ── mismatch (AE2) ───────────────────────────────────────────────────────
@@ -308,7 +439,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         // given — cached Complete record whose fingerprint does NOT match the incoming body
         byte[] body = [1, 2, 3];
-        byte[] differentFingerprint = SHA256.HashData([9, 9, 9]);
+        var differentFingerprint = SHA256.HashData([9, 9, 9]);
 
         var record = new IdempotencyRecord
         {
@@ -320,33 +451,44 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
+        problemDetailsCreator
+            .UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
             .Returns(new ProblemDetails { Status = 422 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
         var context = CreateContext(idempotencyKey: "k1", body: body);
         var nextCalled = false;
 
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeFalse();
-        problemDetailsCreator.Received(1).UnprocessableEntity(
-            Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
-                d.ContainsKey("idempotency_key") &&
-                d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
-            )
-        );
+        problemDetailsCreator
+            .Received(1)
+            .UnprocessableEntity(
+                Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
+                    d.ContainsKey("idempotency_key")
+                    && d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
+                )
+            );
     }
 
     [Fact]
     public async Task should_return_409_when_mismatch_status_code_is_409()
     {
         byte[] body = [1, 2, 3];
-        byte[] differentFingerprint = SHA256.HashData([9, 9, 9]);
+        var differentFingerprint = SHA256.HashData([9, 9, 9]);
 
         var record = new IdempotencyRecord
         {
@@ -358,11 +500,13 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
+        problemDetailsCreator
+            .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
         var options = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
@@ -373,9 +517,11 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).Conflict(
-            Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_key_reused"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .Conflict(
+                Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_key_reused"))
+            );
         problemDetailsCreator.DidNotReceive().UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>());
     }
 
@@ -392,23 +538,34 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
+        problemDetailsCreator
+            .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2, 3]);
         var nextCalled = false;
 
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeFalse();
-        problemDetailsCreator.Received(1).Conflict(
-            Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .Conflict(
+                Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight"))
+            );
     }
 
     [Fact]
@@ -422,25 +579,45 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue, new CacheValue<IdempotencyRecord>(inFlight, hasValue: true));
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(false);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                CacheValue<IdempotencyRecord>.NoValue,
+                new CacheValue<IdempotencyRecord>(inFlight, hasValue: true)
+            );
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(false);
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
+        problemDetailsCreator
+            .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2, 3]);
         var nextCalled = false;
 
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeFalse();
-        problemDetailsCreator.Received(1).Conflict(
-            Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .Conflict(
+                Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight"))
+            );
     }
 
     [Fact]
@@ -457,13 +634,24 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue, new CacheValue<IdempotencyRecord>(complete, hasValue: true));
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(false);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                CacheValue<IdempotencyRecord>.NoValue,
+                new CacheValue<IdempotencyRecord>(complete, hasValue: true)
+            );
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(false);
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
+        problemDetailsCreator
+            .UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
             .Returns(new ProblemDetails { Status = 422 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
@@ -471,27 +659,35 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).UnprocessableEntity(
-            Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
-                d.ContainsKey("idempotency_key") &&
-                d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
-            )
-        );
+        problemDetailsCreator
+            .Received(1)
+            .UnprocessableEntity(
+                Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
+                    d.ContainsKey("idempotency_key")
+                    && d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
+                )
+            );
     }
 
     // ── WaitAndReplay (AE4) ──────────────────────────────────────────────────
 
-    private IdempotencyMiddleware _CreateMiddlewareWithLock(ICache cache, IDistributedLockProvider lockProvider, IProblemDetailsCreator? problemDetailsCreator = null)
+    private IdempotencyMiddleware _CreateMiddlewareWithLock(
+        ICache cache,
+        IDistributedLockProvider lockProvider,
+        IProblemDetailsCreator? problemDetailsCreator = null
+    )
     {
-        var sp = new ServiceCollection()
-            .AddLogging()
-            .AddSingleton(lockProvider)
-            .BuildServiceProvider();
+        var sp = new ServiceCollection().AddLogging().AddSingleton(lockProvider).BuildServiceProvider();
 
         var options = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
         options.Value.Returns(new IdempotencyOptions { InFlightStrategy = InFlightStrategy.WaitAndReplay });
 
-        return CreateMiddleware(options: options, cache: cache, problemDetailsCreator: problemDetailsCreator, serviceProvider: sp);
+        return CreateMiddleware(
+            options: options,
+            cache: cache,
+            problemDetailsCreator: problemDetailsCreator,
+            serviceProvider: sp
+        );
     }
 
     [Fact]
@@ -500,34 +696,55 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         // Winner path: TryInsert succeeds → middleware should acquire the lock BEFORE invoking
         // next so losers actually block on lock contention rather than racing on an unrelated mutex.
         byte[] body = [1, 2, 3];
-        var marker = new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = SHA256.HashData(body), CreatedAt = DateTimeOffset.UtcNow };
+        var marker = new IdempotencyRecord
+        {
+            Kind = RecordKind.InFlight,
+            Fingerprint = SHA256.HashData(body),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue, new CacheValue<IdempotencyRecord>(marker, hasValue: true));
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue, new CacheValue<IdempotencyRecord>(marker, hasValue: true));
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var dlock = Substitute.For<IDistributedLock>();
         var lockProvider = Substitute.For<IDistributedLockProvider>();
         var lockAcquired = false;
-        lockProvider.TryAcquireAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-                    .Returns(_ =>
-                    {
-                        lockAcquired = true;
-                        return Task.FromResult<IDistributedLock?>(dlock);
-                    });
+        lockProvider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(_ =>
+            {
+                lockAcquired = true;
+                return Task.FromResult<IDistributedLock?>(dlock);
+            });
 
         var nextSawLock = false;
         var middleware = _CreateMiddlewareWithLock(cache, lockProvider);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            nextSawLock = lockAcquired;
-            ctx.Response.StatusCode = 200;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                nextSawLock = lockAcquired;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         nextSawLock.Should().BeTrue();
     }
@@ -536,10 +753,15 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     public async Task should_replay_on_wait_and_replay_when_lock_acquired_and_record_completes()
     {
         byte[] body = [1, 2, 3];
-        byte[] fingerprint = SHA256.HashData(body);
+        var fingerprint = SHA256.HashData(body);
         byte[] storedBody = [10, 20, 30];
 
-        var inFlight = new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = fingerprint, CreatedAt = DateTimeOffset.UtcNow };
+        var inFlight = new IdempotencyRecord
+        {
+            Kind = RecordKind.InFlight,
+            Fingerprint = fingerprint,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
         var complete = new IdempotencyRecord
         {
             Kind = RecordKind.Complete,
@@ -550,22 +772,36 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(
-                 new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
-                 new CacheValue<IdempotencyRecord>(complete, hasValue: true)
-             );
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
+                new CacheValue<IdempotencyRecord>(complete, hasValue: true)
+            );
 
         var dlock = Substitute.For<IDistributedLock>();
         var lockProvider = Substitute.For<IDistributedLockProvider>();
-        lockProvider.TryAcquireAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-                    .Returns(dlock);
+        lockProvider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(dlock);
 
         var middleware = _CreateMiddlewareWithLock(cache, lockProvider);
         var context = CreateContext(idempotencyKey: "k1", body: body);
         var nextCalled = false;
 
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         nextCalled.Should().BeFalse();
         context.Response.StatusCode.Should().Be(200);
@@ -576,18 +812,31 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     public async Task should_return_409_timeout_when_lock_acquisition_times_out()
     {
         byte[] body = [1, 2, 3];
-        var inFlight = new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = SHA256.HashData(body), CreatedAt = DateTimeOffset.UtcNow };
+        var inFlight = new IdempotencyRecord
+        {
+            Kind = RecordKind.InFlight,
+            Fingerprint = SHA256.HashData(body),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(inFlight, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(inFlight, hasValue: true));
 
         var lockProvider = Substitute.For<IDistributedLockProvider>();
-        lockProvider.TryAcquireAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-                    .Returns((IDistributedLock?)null);
+        lockProvider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns((IDistributedLock?)null);
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
+        problemDetailsCreator
+            .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
         var middleware = _CreateMiddlewareWithLock(cache, lockProvider, problemDetailsCreator);
@@ -595,16 +844,25 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).Conflict(
-            Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight_timeout"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .Conflict(
+                Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es =>
+                    es.Any(e => e.Code == "g:idempotency_in_flight_timeout")
+                )
+            );
     }
 
     [Fact]
     public async Task should_return_422_on_wait_and_replay_when_post_lock_record_has_mismatch()
     {
         byte[] body = [1, 2, 3];
-        var inFlight = new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = SHA256.HashData(body), CreatedAt = DateTimeOffset.UtcNow };
+        var inFlight = new IdempotencyRecord
+        {
+            Kind = RecordKind.InFlight,
+            Fingerprint = SHA256.HashData(body),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
         var complete = new IdempotencyRecord
         {
             Kind = RecordKind.Complete,
@@ -615,19 +873,27 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(
-                 new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
-                 new CacheValue<IdempotencyRecord>(complete, hasValue: true)
-             );
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
+                new CacheValue<IdempotencyRecord>(complete, hasValue: true)
+            );
 
         var dlock = Substitute.For<IDistributedLock>();
         var lockProvider = Substitute.For<IDistributedLockProvider>();
-        lockProvider.TryAcquireAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-                    .Returns(dlock);
+        lockProvider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(dlock);
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
+        problemDetailsCreator
+            .UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
             .Returns(new ProblemDetails { Status = 422 });
 
         var middleware = _CreateMiddlewareWithLock(cache, lockProvider, problemDetailsCreator);
@@ -635,34 +901,49 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).UnprocessableEntity(
-            Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
-                d.ContainsKey("idempotency_key") &&
-                d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
-            )
-        );
+        problemDetailsCreator
+            .Received(1)
+            .UnprocessableEntity(
+                Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
+                    d.ContainsKey("idempotency_key")
+                    && d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
+                )
+            );
     }
 
     [Fact]
     public async Task should_return_409_timeout_on_wait_and_replay_when_post_lock_record_is_inflight()
     {
         byte[] body = [1, 2, 3];
-        var inFlight = new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = SHA256.HashData(body), CreatedAt = DateTimeOffset.UtcNow };
+        var inFlight = new IdempotencyRecord
+        {
+            Kind = RecordKind.InFlight,
+            Fingerprint = SHA256.HashData(body),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(
-                 new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
-                 new CacheValue<IdempotencyRecord>(inFlight, hasValue: true) // still InFlight after lock
-             );
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
+                new CacheValue<IdempotencyRecord>(inFlight, hasValue: true) // still InFlight after lock
+            );
 
         var dlock = Substitute.For<IDistributedLock>();
         var lockProvider = Substitute.For<IDistributedLockProvider>();
-        lockProvider.TryAcquireAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-                    .Returns(dlock);
+        lockProvider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(dlock);
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
+        problemDetailsCreator
+            .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
         var middleware = _CreateMiddlewareWithLock(cache, lockProvider, problemDetailsCreator);
@@ -670,31 +951,48 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).Conflict(
-            Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight_timeout"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .Conflict(
+                Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es =>
+                    es.Any(e => e.Code == "g:idempotency_in_flight_timeout")
+                )
+            );
     }
 
     [Fact]
     public async Task should_return_409_timeout_on_wait_and_replay_when_post_lock_record_is_missing()
     {
         byte[] body = [1, 2, 3];
-        var inFlight = new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = SHA256.HashData(body), CreatedAt = DateTimeOffset.UtcNow };
+        var inFlight = new IdempotencyRecord
+        {
+            Kind = RecordKind.InFlight,
+            Fingerprint = SHA256.HashData(body),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(
-                 new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
-                 CacheValue<IdempotencyRecord>.NoValue // evicted after lock
-             );
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                new CacheValue<IdempotencyRecord>(inFlight, hasValue: true),
+                CacheValue<IdempotencyRecord>.NoValue // evicted after lock
+            );
 
         var dlock = Substitute.For<IDistributedLock>();
         var lockProvider = Substitute.For<IDistributedLockProvider>();
-        lockProvider.TryAcquireAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-                    .Returns(dlock);
+        lockProvider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(dlock);
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
+        problemDetailsCreator
+            .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
         var middleware = _CreateMiddlewareWithLock(cache, lockProvider, problemDetailsCreator);
@@ -702,21 +1000,24 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).Conflict(
-            Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es => es.Any(e => e.Code == "g:idempotency_in_flight_timeout"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .Conflict(
+                Arg.Is<IReadOnlyCollection<ErrorDescriptor>>(es =>
+                    es.Any(e => e.Code == "g:idempotency_in_flight_timeout")
+                )
+            );
     }
 
     // ── U8: oversize body (AE6) ───────────────────────────────────────────────
 
-    private static IOptionsSnapshot<IdempotencyOptions> _OptionsWithCap(int cap, OversizeBehavior behavior = OversizeBehavior.Reject)
+    private static IOptionsSnapshot<IdempotencyOptions> _OptionsWithCap(
+        int cap,
+        OversizeBehavior behavior = OversizeBehavior.Reject
+    )
     {
         var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions
-        {
-            MaxBodySizeForHashing = cap,
-            OversizeBehavior = behavior,
-        });
+        opts.Value.Returns(new IdempotencyOptions { MaxBodySizeForHashing = cap, OversizeBehavior = behavior });
         return opts;
     }
 
@@ -729,22 +1030,35 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         var pdNormalized = false;
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.When(p => p.Normalize(Arg.Any<ProblemDetails>()))
-                             .Do(_ => pdNormalized = true);
+        problemDetailsCreator.When(p => p.Normalize(Arg.Any<ProblemDetails>())).Do(_ => pdNormalized = true);
 
         var middleware = CreateMiddleware(options: options, cache: cache, problemDetailsCreator: problemDetailsCreator);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2, 3, 4, 5, 6, 7, 8]);
         var nextCalled = false;
 
         // when
-        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
 
         // then
         nextCalled.Should().BeFalse();
         context.Response.StatusCode.Should().Be(413);
         pdNormalized.Should().BeTrue();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await cache.DidNotReceive().TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -759,19 +1073,36 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         var nextCalled = false;
 
         // when
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            nextCalled = true;
-            ctx.Response.StatusCode = 200;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // then
         nextCalled.Should().BeTrue();
         context.Response.Headers.ContainsKey(HttpHeaderNames.IdempotentReplayed).Should().BeFalse();
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await cache.DidNotReceive().TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
-        await cache.DidNotReceive().UpsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
+        await cache
+            .DidNotReceive()
+            .UpsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -780,27 +1111,44 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         // given — cap == body length, accepted normally
         var options = _OptionsWithCap(cap: 5, behavior: OversizeBehavior.Reject);
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(options: options, cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2, 3, 4, 5]);
         var nextCalled = false;
 
         // when
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            nextCalled = true;
-            ctx.Response.StatusCode = 200;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // then
         nextCalled.Should().BeTrue();
         context.Response.StatusCode.Should().Be(200);
-        await cache.Received(1).TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .Received(1)
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     // ── U8: default cache predicate integration ───────────────────────────────
@@ -810,23 +1158,40 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         // given — no custom predicate, response is 503
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2, 3]);
 
         // when — handler returns 503
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            ctx.Response.StatusCode = 503;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 503;
+                return Task.CompletedTask;
+            }
+        );
 
         // then — should NOT cache (5xx is not in default predicate)
-        await cache.DidNotReceive().UpsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .UpsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
         // marker should be removed
         await cache.Received(1).RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -838,31 +1203,50 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         byte[] body = [1, 2, 3];
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
-        cache.TryReplaceIfEqualAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+        cache
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
         // when — handler returns 422
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            ctx.Response.StatusCode = 422;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 422;
+                return Task.CompletedTask;
+            }
+        );
 
         // then — finalize promotes the marker to a Complete 422 record via CAS
-        await cache.Received(1).TryReplaceIfEqualAsync<IdempotencyRecord>(
-            Arg.Any<string>(),
-            Arg.Any<IdempotencyRecord?>(),
-            Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.Complete && r.StatusCode == 422),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<CancellationToken>()
-        );
+        await cache
+            .Received(1)
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.Complete && r.StatusCode == 422),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -874,31 +1258,50 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         byte[] body = [1, 2, 3];
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
-        cache.TryReplaceIfEqualAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+        cache
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(options: opts, cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
         // when — handler returns 503
-        await middleware.InvokeAsync(context, ctx =>
-        {
-            ctx.Response.StatusCode = 503;
-            return Task.CompletedTask;
-        });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 503;
+                return Task.CompletedTask;
+            }
+        );
 
         // then — consumer override wins: 503 IS cached via CAS
-        await cache.Received(1).TryReplaceIfEqualAsync<IdempotencyRecord>(
-            Arg.Any<string>(),
-            Arg.Any<IdempotencyRecord?>(),
-            Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.Complete && r.StatusCode == 503),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<CancellationToken>()
-        );
+        await cache
+            .Received(1)
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.Complete && r.StatusCode == 503),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     // ── new behaviors introduced by middleware rewrite ───────────────────────
@@ -911,17 +1314,39 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         byte[] body = [1, 2, 3];
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
-        cache.TryReplaceIfEqualAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns<ValueTask<bool>>(_ => throw new InvalidOperationException("cache down"));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+        cache
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns<ValueTask<bool>>(_ => throw new InvalidOperationException("cache down"));
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
-        var act = () => middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        var act = () =>
+            middleware.InvokeAsync(
+                context,
+                ctx =>
+                {
+                    ctx.Response.StatusCode = 200;
+                    return Task.CompletedTask;
+                }
+            );
 
         await act.Should().ThrowAsync<InvalidOperationException>();
         await cache.Received(1).RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -935,27 +1360,57 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         // because it was evicted or overwritten), the middleware logs and does not retry.
         byte[] body = [1, 2, 3];
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
-        cache.TryReplaceIfEqualAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<IdempotencyRecord?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(false);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+        cache
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(false);
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
-
-        await cache.Received(1).TryReplaceIfEqualAsync<IdempotencyRecord>(
-            Arg.Any<string>(),
-            Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.InFlight),
-            Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.Complete && r.StatusCode == 200),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<CancellationToken>()
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
         );
+
+        await cache
+            .Received(1)
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.InFlight),
+                Arg.Is<IdempotencyRecord?>(r => r != null && r.Kind == RecordKind.Complete && r.StatusCode == 200),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
         // CAS returning false is the "marker no longer ours" path — middleware logs and exits.
-        await cache.DidNotReceive().UpsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+        await cache
+            .DidNotReceive()
+            .UpsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
         await cache.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
@@ -972,11 +1427,13 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(inFlight, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(inFlight, hasValue: true));
 
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
+        problemDetailsCreator
+            .UnprocessableEntity(Arg.Any<Dictionary<string, List<ErrorDescriptor>>>())
             .Returns(new ProblemDetails { Status = 422 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
@@ -985,20 +1442,25 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
         // mismatch wins over in-flight 409
-        problemDetailsCreator.Received(1).UnprocessableEntity(
-            Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d => d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused"))
-        );
+        problemDetailsCreator
+            .Received(1)
+            .UnprocessableEntity(
+                Arg.Is<Dictionary<string, List<ErrorDescriptor>>>(d =>
+                    d["idempotency_key"].Any(e => e.Code == "g:idempotency_key_reused")
+                )
+            );
     }
 
     [Theory]
-    [InlineData("abcd")]   // SOH control character
-    [InlineData("abcd")]   // DEL
-    [InlineData("ab\ncd")]       // newline
+    [InlineData("abcd")] // SOH control character
+    [InlineData("abcd")] // DEL
+    [InlineData("ab\ncd")] // newline
     public async Task should_reject_with_400_when_key_contains_control_characters(string malformedKey)
     {
         var cache = Substitute.For<ICache>();
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.BadRequest(Arg.Any<string?>(), Arg.Any<ErrorDescriptor?>())
+        problemDetailsCreator
+            .BadRequest(Arg.Any<string?>(), Arg.Any<ErrorDescriptor?>())
             .Returns(new ProblemDetails { Status = 400 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
@@ -1006,10 +1468,12 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).BadRequest(
-            Arg.Any<string?>(),
-            Arg.Is<ErrorDescriptor?>(e => e != null && e.Code == "g:idempotency_key_malformed")
-        );
+        problemDetailsCreator
+            .Received(1)
+            .BadRequest(
+                Arg.Any<string?>(),
+                Arg.Is<ErrorDescriptor?>(e => e != null && e.Code == "g:idempotency_key_malformed")
+            );
         await cache.DidNotReceive().GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
@@ -1020,7 +1484,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         var cache = Substitute.For<ICache>();
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.BadRequest(Arg.Any<string?>(), Arg.Any<ErrorDescriptor?>())
+        problemDetailsCreator
+            .BadRequest(Arg.Any<string?>(), Arg.Any<ErrorDescriptor?>())
             .Returns(new ProblemDetails { Status = 400 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
@@ -1028,10 +1493,12 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).BadRequest(
-            Arg.Any<string?>(),
-            Arg.Is<ErrorDescriptor?>(e => e != null && e.Code == "g:idempotency_key_malformed")
-        );
+        problemDetailsCreator
+            .Received(1)
+            .BadRequest(
+                Arg.Any<string?>(),
+                Arg.Is<ErrorDescriptor?>(e => e != null && e.Code == "g:idempotency_key_malformed")
+            );
     }
 
     [Fact]
@@ -1039,7 +1506,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         var cache = Substitute.For<ICache>();
         var problemDetailsCreator = Substitute.For<IProblemDetailsCreator>();
-        problemDetailsCreator.BadRequest(Arg.Any<string?>(), Arg.Any<ErrorDescriptor?>())
+        problemDetailsCreator
+            .BadRequest(Arg.Any<string?>(), Arg.Any<ErrorDescriptor?>())
             .Returns(new ProblemDetails { Status = 400 });
 
         var middleware = CreateMiddleware(cache: cache, problemDetailsCreator: problemDetailsCreator);
@@ -1048,10 +1516,12 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         await middleware.InvokeAsync(context, _ => Task.CompletedTask);
 
-        problemDetailsCreator.Received(1).BadRequest(
-            Arg.Any<string?>(),
-            Arg.Is<ErrorDescriptor?>(e => e != null && e.Code == "g:idempotency_key_malformed")
-        );
+        problemDetailsCreator
+            .Received(1)
+            .BadRequest(
+                Arg.Any<string?>(),
+                Arg.Is<ErrorDescriptor?>(e => e != null && e.Code == "g:idempotency_key_malformed")
+            );
     }
 
     [Fact]
@@ -1059,7 +1529,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         // given — Content-Type set upstream BEFORE idempotency middleware runs replay
         byte[] body = [1, 2, 3];
-        byte[] fingerprint = SHA256.HashData(body);
+        var fingerprint = SHA256.HashData(body);
         var record = new IdempotencyRecord
         {
             Kind = RecordKind.Complete,
@@ -1074,8 +1544,9 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         };
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CacheValue<IdempotencyRecord>(record, hasValue: true));
 
         var middleware = CreateMiddleware(cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
@@ -1095,31 +1566,53 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         byte[] fakeFingerprint = [0xDE, 0xAD, 0xBE, 0xEF];
 
         var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions
-        {
-            RequestFingerprint = _ => new ValueTask<byte[]>(fakeFingerprint),
-        });
+        opts.Value.Returns(new IdempotencyOptions { RequestFingerprint = _ => new ValueTask<byte[]>(fakeFingerprint) });
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue, new CacheValue<IdempotencyRecord>(
-                 new IdempotencyRecord { Kind = RecordKind.InFlight, Fingerprint = fakeFingerprint, CreatedAt = DateTimeOffset.UtcNow },
-                 hasValue: true));
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                CacheValue<IdempotencyRecord>.NoValue,
+                new CacheValue<IdempotencyRecord>(
+                    new IdempotencyRecord
+                    {
+                        Kind = RecordKind.InFlight,
+                        Fingerprint = fakeFingerprint,
+                        CreatedAt = DateTimeOffset.UtcNow,
+                    },
+                    hasValue: true
+                )
+            );
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(options: opts, cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         // Marker carries the custom fingerprint — SHA-256 path was skipped.
-        await cache.Received(1).TryInsertAsync(
-            Arg.Any<string>(),
-            Arg.Is<IdempotencyRecord>(r => r.Fingerprint != null && r.Fingerprint.SequenceEqual(fakeFingerprint)),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<CancellationToken>()
-        );
+        await cache
+            .Received(1)
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Is<IdempotencyRecord>(r => r.Fingerprint != null && r.Fingerprint.SequenceEqual(fakeFingerprint)),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -1130,19 +1623,29 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
         TimeSpan? capturedMarkerTtl = null;
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
                 Arg.Any<string>(),
                 Arg.Any<IdempotencyRecord>(),
                 Arg.Do<TimeSpan?>(t => capturedMarkerTtl = t),
-                Arg.Any<CancellationToken>())
-             .Returns(true);
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(options: opts, cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2, 3]);
 
-        await middleware.InvokeAsync(context, ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; });
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
 
         capturedMarkerTtl.Should().Be(TimeSpan.FromHours(7));
     }
@@ -1157,21 +1660,34 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         ctp.Token.Returns(cts.Token);
 
         var cache = Substitute.For<ICache>();
-        cache.GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-             .Returns(CacheValue<IdempotencyRecord>.NoValue);
-        cache.TryInsertAsync(Arg.Any<string>(), Arg.Any<IdempotencyRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-             .Returns(true);
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
 
         var middleware = CreateMiddleware(cache: cache, cancellationTokenProvider: ctp);
         var context = CreateContext(idempotencyKey: "k1", body: [1, 2]);
 
-        var act = () => middleware.InvokeAsync(context, async _ =>
-        {
-            await cts.CancelAsync();
-            throw new InvalidOperationException("boom");
-        });
+        var act = () =>
+            middleware.InvokeAsync(
+                context,
+                async _ =>
+                {
+                    await cts.CancelAsync();
+                    throw new InvalidOperationException("boom");
+                }
+            );
 
         await act.Should().ThrowAsync<InvalidOperationException>();
-        await cache.Received(1).RemoveAsync(Arg.Any<string>(), Arg.Is<CancellationToken>(c => !c.IsCancellationRequested));
+        await cache
+            .Received(1)
+            .RemoveAsync(Arg.Any<string>(), Arg.Is<CancellationToken>(c => !c.IsCancellationRequested));
     }
 }

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyOptionsValidatorTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyOptionsValidatorTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using FluentValidation.TestHelper;
-using Headless.Api.Idempotency;
+using Headless.Api;
 
 namespace Tests;
 

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyRecordCrossProviderSerializationTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyRecordCrossProviderSerializationTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
 using Headless.Serializer;
 using MessagePack;
 using MessagePack.Resolvers;

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyRecordSerializationTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyRecordSerializationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Text.Json;
-using Headless.Api.Idempotency;
+using Headless.Api;
 
 namespace Tests;
 

--- a/tests/Headless.Api.Idempotency.Tests.Unit/SetupIdempotencyTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/SetupIdempotencyTests.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
 using Headless.DistributedLocks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using IdempotencyMiddleware = Headless.Api.IdempotencyMiddleware;
 
 namespace Tests;
 
@@ -31,10 +32,13 @@ public sealed class SetupIdempotencyTests
 
         services.AddIdempotency(_ => { });
 
-        services.Any(s =>
-            s.ServiceType == typeof(IValidateOptions<IdempotencyOptions>)
-            && s.ImplementationType == typeof(IdempotencyOptionsDIValidator)
-        ).Should().BeTrue();
+        services
+            .Any(s =>
+                s.ServiceType == typeof(IValidateOptions<IdempotencyOptions>)
+                && s.ImplementationType == typeof(IdempotencyOptionsDIValidator)
+            )
+            .Should()
+            .BeTrue();
     }
 
     [Fact]
@@ -55,13 +59,15 @@ public sealed class SetupIdempotencyTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddSingleton<ConfigSource>(new ConfigSource(TimeSpan.FromHours(9)));
+        services.AddSingleton(new ConfigSource(TimeSpan.FromHours(9)));
 
-        services.AddIdempotency((o, sp) =>
-        {
-            var src = sp.GetRequiredService<ConfigSource>();
-            o.IdempotencyKeyExpiration = src.Expiration;
-        });
+        services.AddIdempotency(
+            (o, sp) =>
+            {
+                var src = sp.GetRequiredService<ConfigSource>();
+                o.IdempotencyKeyExpiration = src.Expiration;
+            }
+        );
 
         var resolved = services.BuildServiceProvider().GetRequiredService<IOptions<IdempotencyOptions>>().Value;
         resolved.IdempotencyKeyExpiration.Should().Be(TimeSpan.FromHours(9));
@@ -118,7 +124,10 @@ public sealed class SetupIdempotencyTests
         var sp = new ServiceCollection().BuildServiceProvider();
         var validator = new IdempotencyOptionsDIValidator(sp);
 
-        var result = validator.Validate(name: null, new IdempotencyOptions { InFlightStrategy = InFlightStrategy.Reject });
+        var result = validator.Validate(
+            name: null,
+            new IdempotencyOptions { InFlightStrategy = InFlightStrategy.Reject }
+        );
 
         result.Succeeded.Should().BeTrue();
     }
@@ -131,7 +140,10 @@ public sealed class SetupIdempotencyTests
         var sp = services.BuildServiceProvider();
         var validator = new IdempotencyOptionsDIValidator(sp);
 
-        var result = validator.Validate(name: null, new IdempotencyOptions { InFlightStrategy = InFlightStrategy.WaitAndReplay });
+        var result = validator.Validate(
+            name: null,
+            new IdempotencyOptions { InFlightStrategy = InFlightStrategy.WaitAndReplay }
+        );
 
         result.Succeeded.Should().BeTrue();
     }

--- a/tests/Headless.Api.Idempotency.Tests.Unit/WithIdempotencyEndpointMetadataTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/WithIdempotencyEndpointMetadataTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Headless.Api.Idempotency;
+using Headless.Api;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -53,7 +53,11 @@ public sealed class WithIdempotencyEndpointMetadataTests
         private sealed class StubEndpointBuilder : EndpointBuilder
         {
             public override Endpoint Build() =>
-                new(RequestDelegate ?? (_ => Task.CompletedTask), new EndpointMetadataCollection(Metadata), DisplayName);
+                new(
+                    RequestDelegate ?? (_ => Task.CompletedTask),
+                    new EndpointMetadataCollection(Metadata),
+                    DisplayName
+                );
         }
     }
 }

--- a/tests/Headless.Api.Tests.Integration/Extensions/EndpointsExtensionsWireShapeTests.cs
+++ b/tests/Headless.Api.Tests.Integration/Extensions/EndpointsExtensionsWireShapeTests.cs
@@ -67,7 +67,7 @@ public sealed class EndpointsExtensionsWireShapeTests : TestBase
         app.MapGet(
             "/redirect-mismatch",
             (IProblemDetailsCreator problemDetailsCreator) =>
-                Microsoft.AspNetCore.Builder.EndpointsExtensions.BuildRedirectResultOrBadRequest(
+                EndpointsExtensions.BuildRedirectResultOrBadRequest(
                     synthesizedRedirectUri,
                     mainHost,
                     problemDetailsCreator

--- a/tests/Headless.Api.Tests.Integration/HeadlessApiDefaultsTests.cs
+++ b/tests/Headless.Api.Tests.Integration/HeadlessApiDefaultsTests.cs
@@ -262,7 +262,7 @@ public sealed class HeadlessApiDefaultsTests : TestBase
             options.UseHsts = false;
         });
 
-        Func<Task> act = () => app.StartAsync(AbortToken);
+        var act = () => app.StartAsync(AbortToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*MapHeadlessEndpoints*");
     }

--- a/tests/Headless.Api.Tests.Integration/Helpers/HttpTenancyTestHarness.cs
+++ b/tests/Headless.Api.Tests.Integration/Helpers/HttpTenancyTestHarness.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Headless.Constants;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Tests.Helpers;
+
+/// <summary>
+/// Shared scaffolding for HTTP tenancy integration tests:
+/// <see cref="TestAuthenticationHandler"/>, <see cref="CapturingLoggerProvider"/>, default in-memory security config,
+/// and request helpers used by SkipTenantResolutionTests, TenantResolutionMiddlewareTests, and TenantRequirementTests.
+/// </summary>
+internal static class HttpTenancyTestHarness
+{
+    public const string Scheme = "Test";
+    public const string UserHeader = "X-Test-User";
+    public const string TenantHeader = "X-Test-Tenant";
+    public const string CustomTenantHeader = "X-Test-Custom-Tenant";
+    public const string UnauthenticatedHeader = "X-Test-Unauthenticated";
+    public const string CustomTenantClaimType = "custom_tenant_id";
+
+    public static void AddDefaultHeadlessSecurityConfiguration(IConfigurationBuilder configuration)
+    {
+        configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultPassPhrase", "TestPassPhrase123456"),
+            new KeyValuePair<string, string?>("Headless:StringEncryption:InitVectorBytes", "VGVzdElWMDEyMzQ1Njc4OQ=="),
+            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultSalt", "VGVzdFNhbHQ="),
+            new KeyValuePair<string, string?>("Headless:StringHash:DefaultSalt", "TestSalt"),
+        ]);
+    }
+
+    public static AuthenticationBuilder AddTestAuthentication(
+        this IServiceCollection services,
+        bool registerForbidScheme = false
+    )
+    {
+        return services
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = Scheme;
+                options.DefaultChallengeScheme = Scheme;
+
+                if (registerForbidScheme)
+                {
+                    options.DefaultForbidScheme = Scheme;
+                }
+            })
+            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(Scheme, _ => { });
+    }
+
+    public static HttpClient CreateClient(WebApplication app)
+    {
+        return new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
+    }
+
+    public static HttpRequestMessage CreateRequest(
+        HttpMethod method,
+        string path,
+        string? user = null,
+        string? tenantId = null,
+        string? customTenantId = null,
+        bool unauthenticated = false
+    )
+    {
+        var request = new HttpRequestMessage(method, path);
+
+        if (user is not null)
+        {
+            request.Headers.Add(UserHeader, user);
+        }
+
+        if (tenantId is not null)
+        {
+            request.Headers.Add(TenantHeader, tenantId);
+        }
+
+        if (customTenantId is not null)
+        {
+            request.Headers.Add(CustomTenantHeader, customTenantId);
+        }
+
+        if (unauthenticated)
+        {
+            request.Headers.Add(UnauthenticatedHeader, "true");
+        }
+
+        return request;
+    }
+}
+
+internal sealed record LogEntry(string Category, LogLevel Level, EventId EventId, string Message);
+
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentQueue<LogEntry> _entries = new();
+
+    public IReadOnlyCollection<LogEntry> Entries => _entries.ToArray();
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new CapturingLogger(categoryName, _entries);
+    }
+
+    public void Dispose() { }
+}
+
+internal sealed class CapturingLogger(string categoryName, ConcurrentQueue<LogEntry> entries) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    )
+    {
+        entries.Enqueue(new LogEntry(categoryName, logLevel, eventId, formatter(state, exception)));
+    }
+}
+
+internal sealed class TestAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder
+) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(HttpTenancyTestHarness.UserHeader, out var userValues))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var isUnauthenticated = Request.Headers.ContainsKey(HttpTenancyTestHarness.UnauthenticatedHeader);
+        var claims = new List<Claim> { new(UserClaimTypes.Name, userValues.ToString()) };
+
+        if (Request.Headers.TryGetValue(HttpTenancyTestHarness.TenantHeader, out var tenantValues))
+        {
+            claims.Add(new Claim(UserClaimTypes.TenantId, tenantValues.ToString()));
+        }
+
+        if (Request.Headers.TryGetValue(HttpTenancyTestHarness.CustomTenantHeader, out var customTenantValues))
+        {
+            claims.Add(new Claim(HttpTenancyTestHarness.CustomTenantClaimType, customTenantValues.ToString()));
+        }
+
+        var identity = new ClaimsIdentity(claims, authenticationType: isUnauthenticated ? null : Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Headless.Api.Tests.Integration/SkipTenantResolutionTests.cs
+++ b/tests/Headless.Api.Tests.Integration/SkipTenantResolutionTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Json;
-using System.Security.Claims;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using Headless.Abstractions;
 using Headless.Api;
@@ -13,30 +10,24 @@ using Headless.Api.MultiTenancy;
 using Headless.Constants;
 using Headless.MultiTenancy;
 using Headless.Testing.Tests;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Tests.Helpers;
 
 namespace Tests;
 
 public sealed class SkipTenantResolutionTests : TestBase
 {
-    private const string _Scheme = "Test";
-    private const string _UserHeader = "X-Test-User";
-    private const string _TenantHeader = "X-Test-Tenant";
-
     [Fact]
     public async Task should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_claim_present()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/skip-minimal", user: "alice", tenantId: "TENANT-1");
 
@@ -48,7 +39,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_not_mutate_current_tenant_when_route_group_marked_skip_resolution_and_claim_present()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/skip-group/child", user: "alice", tenantId: "TENANT-1");
 
@@ -60,7 +51,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_not_mutate_current_tenant_when_mvc_controller_marked_skip_resolution_and_claim_present()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/skip-mvc-class/action", user: "alice", tenantId: "TENANT-1");
 
@@ -72,7 +63,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_not_mutate_current_tenant_when_mvc_action_marked_skip_resolution_and_claim_present()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/skip-mvc-action/skip", user: "alice", tenantId: "TENANT-1");
 
@@ -84,7 +75,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_unauthenticated()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/skip-minimal");
 
@@ -95,13 +86,14 @@ public sealed class SkipTenantResolutionTests : TestBase
     [Fact]
     public async Task should_not_emit_middleware_ordering_warning_when_endpoint_marked_skip_resolution_and_unauthenticated()
     {
-        _ResetOrderingWarning();
+        TenantResolutionMiddleware.ResetOrderingWarningForTesting();
         var loggerProvider = new CapturingLoggerProvider();
-        await using var app = await _CreateAppAsync(
-            applyTenantMiddlewareBeforeAuthentication: true,
-            loggerProvider: loggerProvider
-        );
-        using var client = _CreateClient(app);
+        await using var app = await _CreateAppAsync(options =>
+        {
+            options.ApplyTenantMiddlewareBeforeAuthentication = true;
+            options.LoggerProvider = loggerProvider;
+        });
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         // Unauthenticated request to a skipped endpoint — middleware exits before the ordering-warning branch.
         await _GetTenantAsync(client, "/skip-minimal");
@@ -115,7 +107,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_mutate_current_tenant_for_unmarked_endpoint_when_claim_present()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/unmarked", user: "alice", tenantId: "TENANT-1");
 
@@ -127,7 +119,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_mutate_current_tenant_for_unmarked_endpoint_in_route_group_that_does_not_skip()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/unmarked-group/child", user: "alice", tenantId: "TENANT-1");
 
@@ -138,8 +130,8 @@ public sealed class SkipTenantResolutionTests : TestBase
     [Fact]
     public async Task should_compose_skip_resolution_with_allow_missing_tenant_independently()
     {
-        await using var app = await _CreateAppWithAuthorizationAsync();
-        using var client = _CreateClient(app);
+        await using var app = await _CreateAppAsync(options => options.RequireTenancyAuthorization = true);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         // SkipTenantResolution bypasses claim extraction; AllowMissingTenant satisfies TenantRequirement.
         // Send a tenant claim so the skip marker's claim-blocking is observable — the endpoint must reach the handler
@@ -156,7 +148,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     public async Task should_set_tenancy_resolution_applied_feature_when_endpoint_marked_skip_resolution()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetFeatureCheckAsync(client, "/skip-feature-check", user: "alice", tenantId: "TENANT-1");
 
@@ -170,8 +162,8 @@ public sealed class SkipTenantResolutionTests : TestBase
     {
         // SkipTenantResolution alone bypasses claim extraction but does NOT satisfy TenantRequirement.
         // Under a FallbackPolicy that requires a tenant, the request must fail authorization with 403.
-        await using var app = await _CreateAppWithAuthorizationAsync();
-        using var client = _CreateClient(app);
+        await using var app = await _CreateAppAsync(options => options.RequireTenancyAuthorization = true);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/skip-only", user: "alice", tenantId: "TENANT-1");
 
@@ -186,7 +178,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     {
         // [AttributeUsage(Inherited = false)] — derived controllers must NOT inherit SkipTenantResolution.
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/derived-skip/action", user: "alice", tenantId: "TENANT-1");
 
@@ -199,7 +191,7 @@ public sealed class SkipTenantResolutionTests : TestBase
     {
         // Method-level SkipTenantResolution must NOT bleed across sibling actions on the same controller.
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var result = await _GetTenantAsync(client, "/skip-mvc-action/no-skip", user: "alice", tenantId: "TENANT-1");
 
@@ -207,151 +199,143 @@ public sealed class SkipTenantResolutionTests : TestBase
         result.IsAvailable.Should().BeTrue();
     }
 
-    // --- app factories ---
+    // --- app factory ---
 
-    private async Task<WebApplication> _CreateAppAsync(
-        bool applyTenantMiddlewareBeforeAuthentication = false,
-        ILoggerProvider? loggerProvider = null
-    )
+    private sealed class TestAppOptions
     {
+        /// <summary>
+        /// When true, registers HeadlessTenancy with claim-based HTTP resolution and a FallbackPolicy requiring a tenant.
+        /// When false, the app wires authentication, raw <c>UseTenantResolution()</c>, and plain <c>AddAuthorization()</c>.
+        /// </summary>
+        public bool RequireTenancyAuthorization { get; set; }
+
+        /// <summary>
+        /// When true (and authorization is not enforced), the tenant middleware runs before authentication —
+        /// used to exercise the ordering-warning branch.
+        /// </summary>
+        public bool ApplyTenantMiddlewareBeforeAuthentication { get; set; }
+
+        public ILoggerProvider? LoggerProvider { get; set; }
+    }
+
+    private async Task<WebApplication> _CreateAppAsync(Action<TestAppOptions>? configure = null)
+    {
+        var options = new TestAppOptions();
+        configure?.Invoke(options);
+
         var builder = WebApplication.CreateBuilder(
             new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }
         );
         builder.WebHost.UseUrls("http://127.0.0.1:0");
-        _AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
+        HttpTenancyTestHarness.AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
 
-        if (loggerProvider is not null)
+        if (options.LoggerProvider is not null)
         {
             builder.Logging.ClearProviders();
-            builder.Logging.AddProvider(loggerProvider);
+            builder.Logging.AddProvider(options.LoggerProvider);
         }
 
-        builder.AddHeadless(configureServices: options =>
+        builder.AddHeadless(configureServices: hl =>
         {
-            options.Validation.ValidateServiceProviderOnStartup = false;
-            options.Validation.RequireUseHeadless = false;
-            options.Validation.RequireMapHeadlessEndpoints = false;
-            options.OpenTelemetry.Enabled = false;
-            options.OpenApi.Enabled = false;
+            hl.Validation.ValidateServiceProviderOnStartup = false;
+            hl.Validation.RequireUseHeadless = false;
+            hl.Validation.RequireMapHeadlessEndpoints = false;
+            hl.OpenTelemetry.Enabled = false;
+            hl.OpenApi.Enabled = false;
         });
 
-        builder
-            .Services.AddAuthentication(options =>
+        if (options.RequireTenancyAuthorization)
+        {
+            builder.AddHeadlessTenancy(tenancy =>
+                tenancy.Http(http => http.ResolveFromClaims()).Authorization(auth => auth.RequireTenant())
+            );
+        }
+
+        builder.Services.AddTestAuthentication(registerForbidScheme: options.RequireTenancyAuthorization);
+
+        if (options.RequireTenancyAuthorization)
+        {
+            builder.Services.AddAuthorization(authz =>
             {
-                options.DefaultAuthenticateScheme = _Scheme;
-                options.DefaultChallengeScheme = _Scheme;
-            })
-            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(_Scheme, _ => { });
-        builder.Services.AddAuthorization();
+                authz.FallbackPolicy = new AuthorizationPolicyBuilder(HttpTenancyTestHarness.Scheme)
+                    .RequireAuthenticatedUser()
+                    .AddRequirements(new TenantRequirement())
+                    .Build();
+            });
+        }
+        else
+        {
+            builder.Services.AddAuthorization();
+        }
+
         builder.Services.AddControllers().AddApplicationPart(typeof(SkipResolutionClassController).Assembly);
 
         var app = builder.Build();
 
-        if (applyTenantMiddlewareBeforeAuthentication)
+        if (options.RequireTenancyAuthorization)
         {
-            app.UseTenantResolution();
+            app.UseAuthentication();
+            app.UseHeadlessTenancy();
+            app.UseAuthorization();
+
+            app.MapGet(
+                    "/skip-and-allow-missing",
+                    (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable))
+                )
+                .SkipTenantResolution()
+                .AllowMissingTenant();
+
+            // Same shape as /skip-and-allow-missing but missing AllowMissingTenant — must hit TenantRequirement
+            // and produce 403 g:tenant_required when no tenant context is established.
+            app.MapGet("/skip-only", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))
+                .SkipTenantResolution();
         }
-
-        app.UseAuthentication();
-
-        if (!applyTenantMiddlewareBeforeAuthentication)
+        else
         {
-            app.UseTenantResolution();
-        }
-
-        app.UseAuthorization();
-
-        app.MapGet("/skip-minimal", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))
-            .SkipTenantResolution();
-
-        var skipGroup = app.MapGroup("/skip-group").SkipTenantResolution();
-        skipGroup.MapGet("/child", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
-
-        app.MapGet("/unmarked", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
-
-        var unmarkedGroup = app.MapGroup("/unmarked-group");
-        unmarkedGroup.MapGet("/child", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
-
-        // Probes that HeadlessTenancyResolutionApplied is set even when the skip path is taken.
-        app.MapGet(
-                "/skip-feature-check",
-                (HttpContext ctx, ICurrentTenant t) =>
-                {
-                    var applied = ctx.Features.Get<HeadlessTenancyResolutionApplied>() is not null;
-                    return Results.Json(new FeatureCheckResponse(t.Id, t.IsAvailable, applied));
-                }
-            )
-            .SkipTenantResolution();
-
-        app.MapControllers();
-
-        await app.StartAsync(AbortToken);
-        return app;
-    }
-
-    private async Task<WebApplication> _CreateAppWithAuthorizationAsync()
-    {
-        var builder = WebApplication.CreateBuilder(
-            new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }
-        );
-        builder.WebHost.UseUrls("http://127.0.0.1:0");
-        _AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
-
-        builder.AddHeadless(configureServices: options =>
-        {
-            options.Validation.ValidateServiceProviderOnStartup = false;
-            options.Validation.RequireUseHeadless = false;
-            options.Validation.RequireMapHeadlessEndpoints = false;
-            options.OpenTelemetry.Enabled = false;
-            options.OpenApi.Enabled = false;
-        });
-        builder.AddHeadlessTenancy(tenancy =>
-            tenancy.Http(http => http.ResolveFromClaims()).Authorization(auth => auth.RequireTenant())
-        );
-
-        builder
-            .Services.AddAuthentication(options =>
+            if (options.ApplyTenantMiddlewareBeforeAuthentication)
             {
-                options.DefaultAuthenticateScheme = _Scheme;
-                options.DefaultChallengeScheme = _Scheme;
-                options.DefaultForbidScheme = _Scheme;
-            })
-            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(_Scheme, _ => { });
-        builder.Services.AddAuthorization(options =>
-        {
-            options.FallbackPolicy = new AuthorizationPolicyBuilder(_Scheme)
-                .RequireAuthenticatedUser()
-                .AddRequirements(new TenantRequirement())
-                .Build();
-        });
+                app.UseTenantResolution();
+            }
 
-        var app = builder.Build();
-        app.UseAuthentication();
-        app.UseHeadlessTenancy();
-        app.UseAuthorization();
+            app.UseAuthentication();
 
-        app.MapGet(
-                "/skip-and-allow-missing",
-                (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable))
-            )
-            .SkipTenantResolution()
-            .AllowMissingTenant();
+            if (!options.ApplyTenantMiddlewareBeforeAuthentication)
+            {
+                app.UseTenantResolution();
+            }
 
-        // Same shape as /skip-and-allow-missing but missing AllowMissingTenant — must hit TenantRequirement
-        // and produce 403 g:tenant_required when no tenant context is established.
-        app.MapGet("/skip-only", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))
-            .SkipTenantResolution();
+            app.UseAuthorization();
+
+            app.MapGet("/skip-minimal", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))
+                .SkipTenantResolution();
+
+            var skipGroup = app.MapGroup("/skip-group").SkipTenantResolution();
+            skipGroup.MapGet("/child", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
+
+            app.MapGet("/unmarked", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
+
+            var unmarkedGroup = app.MapGroup("/unmarked-group");
+            unmarkedGroup.MapGet("/child", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
+
+            // Probes that HeadlessTenancyResolutionApplied is set even when the skip path is taken.
+            app.MapGet(
+                    "/skip-feature-check",
+                    (HttpContext ctx, ICurrentTenant t) =>
+                    {
+                        var applied = ctx.Features.Get<HeadlessTenancyResolutionApplied>() is not null;
+                        return Results.Json(new FeatureCheckResponse(t.Id, t.IsAvailable, applied));
+                    }
+                )
+                .SkipTenantResolution();
+
+            app.MapControllers();
+        }
 
         await app.StartAsync(AbortToken);
         return app;
     }
 
     // --- helpers ---
-
-    private HttpClient _CreateClient(WebApplication app)
-    {
-        return new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
-    }
 
     private async Task<TenantResponse> _GetTenantAsync(
         HttpClient client,
@@ -384,106 +368,11 @@ public sealed class SkipTenantResolutionTests : TestBase
         string? tenantId = null
     )
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, path);
-
-        if (user is not null)
-        {
-            request.Headers.Add(_UserHeader, user);
-        }
-
-        if (tenantId is not null)
-        {
-            request.Headers.Add(_TenantHeader, tenantId);
-        }
-
+        using var request = HttpTenancyTestHarness.CreateRequest(HttpMethod.Get, path, user, tenantId);
         return await client.SendAsync(request, AbortToken);
     }
 
-    private static void _ResetOrderingWarning()
-    {
-        TenantResolutionMiddleware.ResetOrderingWarningForTesting();
-    }
-
-    private static void _AddDefaultHeadlessSecurityConfiguration(IConfigurationBuilder configuration)
-    {
-        configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultPassPhrase", "TestPassPhrase123456"),
-            new KeyValuePair<string, string?>("Headless:StringEncryption:InitVectorBytes", "VGVzdElWMDEyMzQ1Njc4OQ=="),
-            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultSalt", "VGVzdFNhbHQ="),
-            new KeyValuePair<string, string?>("Headless:StringHash:DefaultSalt", "TestSalt"),
-        ]);
-    }
-
     private sealed record FeatureCheckResponse(string? Id, bool IsAvailable, bool ResolutionApplied);
-
-    private sealed record LogEntry(string Category, LogLevel Level, EventId EventId, string Message);
-
-    private sealed class CapturingLoggerProvider : ILoggerProvider
-    {
-        private readonly ConcurrentQueue<LogEntry> _entries = new();
-
-        public IReadOnlyCollection<LogEntry> Entries => _entries.ToArray();
-
-        public ILogger CreateLogger(string categoryName)
-        {
-            return new CapturingLogger(categoryName, _entries);
-        }
-
-        public void Dispose() { }
-    }
-
-    private sealed class CapturingLogger(string categoryName, ConcurrentQueue<LogEntry> entries) : ILogger
-    {
-        public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull
-        {
-            return null;
-        }
-
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            return true;
-        }
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter
-        )
-        {
-            entries.Enqueue(new LogEntry(categoryName, logLevel, eventId, formatter(state, exception)));
-        }
-    }
-
-    private sealed class TestAuthenticationHandler(
-        IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger,
-        UrlEncoder encoder
-    ) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
-    {
-        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
-        {
-            if (!Request.Headers.TryGetValue(_UserHeader, out var userValues))
-            {
-                return Task.FromResult(AuthenticateResult.NoResult());
-            }
-
-            var claims = new List<Claim> { new(UserClaimTypes.Name, userValues.ToString()) };
-
-            if (Request.Headers.TryGetValue(_TenantHeader, out var tenantValues))
-            {
-                claims.Add(new Claim(UserClaimTypes.TenantId, tenantValues.ToString()));
-            }
-
-            var identity = new ClaimsIdentity(claims, authenticationType: Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-
-            return Task.FromResult(AuthenticateResult.Success(ticket));
-        }
-    }
 }
 
 internal sealed record TenantResponse(string? Id, bool IsAvailable);

--- a/tests/Headless.Api.Tests.Integration/SkipTenantResolutionTests.cs
+++ b/tests/Headless.Api.Tests.Integration/SkipTenantResolutionTests.cs
@@ -3,9 +3,9 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Json;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using Headless.Abstractions;
 using Headless.Api;
 using Headless.Api.Middlewares;
@@ -31,7 +31,6 @@ public sealed class SkipTenantResolutionTests : TestBase
     private const string _Scheme = "Test";
     private const string _UserHeader = "X-Test-User";
     private const string _TenantHeader = "X-Test-Tenant";
-    private const string _UnauthenticatedHeader = "X-Test-Unauthenticated";
 
     [Fact]
     public async Task should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_claim_present()
@@ -143,8 +142,9 @@ public sealed class SkipTenantResolutionTests : TestBase
         using var client = _CreateClient(app);
 
         // SkipTenantResolution bypasses claim extraction; AllowMissingTenant satisfies TenantRequirement.
-        // Authenticated user with no tenant claim must reach the endpoint and observe a null tenant.
-        using var response = await _SendAsync(client, "/skip-and-allow-missing", user: "alice");
+        // Send a tenant claim so the skip marker's claim-blocking is observable — the endpoint must reach the handler
+        // and observe a null tenant despite the principal carrying TENANT-1.
+        using var response = await _SendAsync(client, "/skip-and-allow-missing", user: "alice", tenantId: "TENANT-1");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await response.Content.ReadFromJsonAsync<TenantResponse>(cancellationToken: AbortToken);
@@ -163,6 +163,48 @@ public sealed class SkipTenantResolutionTests : TestBase
         result.ResolutionApplied.Should().BeTrue();
         result.Id.Should().BeNull();
         result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_return_403_when_skip_resolution_without_allow_missing_tenant_under_tenant_required_policy()
+    {
+        // SkipTenantResolution alone bypasses claim extraction but does NOT satisfy TenantRequirement.
+        // Under a FallbackPolicy that requires a tenant, the request must fail authorization with 403.
+        await using var app = await _CreateAppWithAuthorizationAsync();
+        using var client = _CreateClient(app);
+
+        using var response = await _SendAsync(client, "/skip-only", user: "alice", tenantId: "TENANT-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var json = await response.Content.ReadAsStringAsync(AbortToken);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("g:tenant_required");
+    }
+
+    [Fact]
+    public async Task should_mutate_current_tenant_for_derived_mvc_controller_when_base_has_skip_marker_and_claim_present()
+    {
+        // [AttributeUsage(Inherited = false)] — derived controllers must NOT inherit SkipTenantResolution.
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/derived-skip/action", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().Be("TENANT-1");
+        result.IsAvailable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_mutate_current_tenant_for_unmarked_action_on_same_controller_when_claim_present()
+    {
+        // Method-level SkipTenantResolution must NOT bleed across sibling actions on the same controller.
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/skip-mvc-action/no-skip", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().Be("TENANT-1");
+        result.IsAvailable.Should().BeTrue();
     }
 
     // --- app factories ---
@@ -295,6 +337,11 @@ public sealed class SkipTenantResolutionTests : TestBase
             .SkipTenantResolution()
             .AllowMissingTenant();
 
+        // Same shape as /skip-and-allow-missing but missing AllowMissingTenant — must hit TenantRequirement
+        // and produce 403 g:tenant_required when no tenant context is established.
+        app.MapGet("/skip-only", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))
+            .SkipTenantResolution();
+
         await app.StartAsync(AbortToken);
         return app;
     }
@@ -354,12 +401,7 @@ public sealed class SkipTenantResolutionTests : TestBase
 
     private static void _ResetOrderingWarning()
     {
-        var field = typeof(TenantResolutionMiddleware).GetField(
-            "_orderingWarningEmitted",
-            BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly
-        );
-        field.Should().NotBeNull();
-        field!.SetValue(null, 0);
+        TenantResolutionMiddleware.ResetOrderingWarningForTesting();
     }
 
     private static void _AddDefaultHeadlessSecurityConfiguration(IConfigurationBuilder configuration)
@@ -371,8 +413,6 @@ public sealed class SkipTenantResolutionTests : TestBase
             new KeyValuePair<string, string?>("Headless:StringHash:DefaultSalt", "TestSalt"),
         ]);
     }
-
-    private sealed record TenantResponse(string? Id, bool IsAvailable);
 
     private sealed record FeatureCheckResponse(string? Id, bool IsAvailable, bool ResolutionApplied);
 
@@ -430,7 +470,6 @@ public sealed class SkipTenantResolutionTests : TestBase
                 return Task.FromResult(AuthenticateResult.NoResult());
             }
 
-            var isUnauthenticated = Request.Headers.ContainsKey(_UnauthenticatedHeader);
             var claims = new List<Claim> { new(UserClaimTypes.Name, userValues.ToString()) };
 
             if (Request.Headers.TryGetValue(_TenantHeader, out var tenantValues))
@@ -438,7 +477,7 @@ public sealed class SkipTenantResolutionTests : TestBase
                 claims.Add(new Claim(UserClaimTypes.TenantId, tenantValues.ToString()));
             }
 
-            var identity = new ClaimsIdentity(claims, authenticationType: isUnauthenticated ? null : Scheme.Name);
+            var identity = new ClaimsIdentity(claims, authenticationType: Scheme.Name);
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
@@ -446,6 +485,8 @@ public sealed class SkipTenantResolutionTests : TestBase
         }
     }
 }
+
+internal sealed record TenantResponse(string? Id, bool IsAvailable);
 
 [ApiController]
 [SkipTenantResolution]
@@ -455,7 +496,23 @@ public sealed class SkipResolutionClassController : ControllerBase
     [HttpGet("action")]
     public IActionResult GetTenant([FromServices] ICurrentTenant currentTenant)
     {
-        return Ok(new { currentTenant.Id, currentTenant.IsAvailable });
+        return Ok(new TenantResponse(currentTenant.Id, currentTenant.IsAvailable));
+    }
+}
+
+[ApiController]
+[SkipTenantResolution]
+public abstract class SkipResolutionBaseController : ControllerBase;
+
+// Derived controller — [AttributeUsage(Inherited = false)] means the SkipTenantResolution attribute on
+// SkipResolutionBaseController must NOT propagate to this derived type.
+[Route("derived-skip")]
+public sealed class SkipResolutionDerivedController : SkipResolutionBaseController
+{
+    [HttpGet("action")]
+    public IActionResult GetTenant([FromServices] ICurrentTenant currentTenant)
+    {
+        return Ok(new TenantResponse(currentTenant.Id, currentTenant.IsAvailable));
     }
 }
 
@@ -467,6 +524,14 @@ public sealed class SkipResolutionActionController : ControllerBase
     [SkipTenantResolution]
     public IActionResult Skip([FromServices] ICurrentTenant currentTenant)
     {
-        return Ok(new { currentTenant.Id, currentTenant.IsAvailable });
+        return Ok(new TenantResponse(currentTenant.Id, currentTenant.IsAvailable));
+    }
+
+    // Sibling action (no SkipTenantResolution marker) — regression check that the [Method-level] marker
+    // does not bleed across actions on the same controller.
+    [HttpGet("no-skip")]
+    public IActionResult NoSkip([FromServices] ICurrentTenant currentTenant)
+    {
+        return Ok(new TenantResponse(currentTenant.Id, currentTenant.IsAvailable));
     }
 }

--- a/tests/Headless.Api.Tests.Integration/SkipTenantResolutionTests.cs
+++ b/tests/Headless.Api.Tests.Integration/SkipTenantResolutionTests.cs
@@ -1,0 +1,472 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Headless.Abstractions;
+using Headless.Api;
+using Headless.Api.Middlewares;
+using Headless.Api.MultiTenancy;
+using Headless.Constants;
+using Headless.MultiTenancy;
+using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+public sealed class SkipTenantResolutionTests : TestBase
+{
+    private const string _Scheme = "Test";
+    private const string _UserHeader = "X-Test-User";
+    private const string _TenantHeader = "X-Test-Tenant";
+    private const string _UnauthenticatedHeader = "X-Test-Unauthenticated";
+
+    [Fact]
+    public async Task should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_claim_present()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/skip-minimal", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_mutate_current_tenant_when_route_group_marked_skip_resolution_and_claim_present()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/skip-group/child", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_mutate_current_tenant_when_mvc_controller_marked_skip_resolution_and_claim_present()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/skip-mvc-class/action", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_mutate_current_tenant_when_mvc_action_marked_skip_resolution_and_claim_present()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/skip-mvc-action/skip", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_mutate_current_tenant_when_endpoint_marked_skip_resolution_and_unauthenticated()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/skip-minimal");
+
+        result.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_emit_middleware_ordering_warning_when_endpoint_marked_skip_resolution_and_unauthenticated()
+    {
+        _ResetOrderingWarning();
+        var loggerProvider = new CapturingLoggerProvider();
+        await using var app = await _CreateAppAsync(
+            applyTenantMiddlewareBeforeAuthentication: true,
+            loggerProvider: loggerProvider
+        );
+        using var client = _CreateClient(app);
+
+        // Unauthenticated request to a skipped endpoint — middleware exits before the ordering-warning branch.
+        await _GetTenantAsync(client, "/skip-minimal");
+
+        loggerProvider
+            .Entries.Should()
+            .NotContain(entry => entry.EventId.Name == "HEADLESS_TENANCY_MIDDLEWARE_ORDERING");
+    }
+
+    [Fact]
+    public async Task should_mutate_current_tenant_for_unmarked_endpoint_when_claim_present()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/unmarked", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().Be("TENANT-1");
+        result.IsAvailable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_mutate_current_tenant_for_unmarked_endpoint_in_route_group_that_does_not_skip()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetTenantAsync(client, "/unmarked-group/child", user: "alice", tenantId: "TENANT-1");
+
+        result.Id.Should().Be("TENANT-1");
+        result.IsAvailable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_compose_skip_resolution_with_allow_missing_tenant_independently()
+    {
+        await using var app = await _CreateAppWithAuthorizationAsync();
+        using var client = _CreateClient(app);
+
+        // SkipTenantResolution bypasses claim extraction; AllowMissingTenant satisfies TenantRequirement.
+        // Authenticated user with no tenant claim must reach the endpoint and observe a null tenant.
+        using var response = await _SendAsync(client, "/skip-and-allow-missing", user: "alice");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<TenantResponse>(cancellationToken: AbortToken);
+        result!.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_set_tenancy_resolution_applied_feature_when_endpoint_marked_skip_resolution()
+    {
+        await using var app = await _CreateAppAsync();
+        using var client = _CreateClient(app);
+
+        var result = await _GetFeatureCheckAsync(client, "/skip-feature-check", user: "alice", tenantId: "TENANT-1");
+
+        result.ResolutionApplied.Should().BeTrue();
+        result.Id.Should().BeNull();
+        result.IsAvailable.Should().BeFalse();
+    }
+
+    // --- app factories ---
+
+    private async Task<WebApplication> _CreateAppAsync(
+        bool applyTenantMiddlewareBeforeAuthentication = false,
+        ILoggerProvider? loggerProvider = null
+    )
+    {
+        var builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }
+        );
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        _AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
+
+        if (loggerProvider is not null)
+        {
+            builder.Logging.ClearProviders();
+            builder.Logging.AddProvider(loggerProvider);
+        }
+
+        builder.AddHeadless(configureServices: options =>
+        {
+            options.Validation.ValidateServiceProviderOnStartup = false;
+            options.Validation.RequireUseHeadless = false;
+            options.Validation.RequireMapHeadlessEndpoints = false;
+            options.OpenTelemetry.Enabled = false;
+            options.OpenApi.Enabled = false;
+        });
+
+        builder
+            .Services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = _Scheme;
+                options.DefaultChallengeScheme = _Scheme;
+            })
+            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(_Scheme, _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddControllers().AddApplicationPart(typeof(SkipResolutionClassController).Assembly);
+
+        var app = builder.Build();
+
+        if (applyTenantMiddlewareBeforeAuthentication)
+        {
+            app.UseTenantResolution();
+        }
+
+        app.UseAuthentication();
+
+        if (!applyTenantMiddlewareBeforeAuthentication)
+        {
+            app.UseTenantResolution();
+        }
+
+        app.UseAuthorization();
+
+        app.MapGet("/skip-minimal", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)))
+            .SkipTenantResolution();
+
+        var skipGroup = app.MapGroup("/skip-group").SkipTenantResolution();
+        skipGroup.MapGet("/child", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
+
+        app.MapGet("/unmarked", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
+
+        var unmarkedGroup = app.MapGroup("/unmarked-group");
+        unmarkedGroup.MapGet("/child", (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable)));
+
+        // Probes that HeadlessTenancyResolutionApplied is set even when the skip path is taken.
+        app.MapGet(
+                "/skip-feature-check",
+                (HttpContext ctx, ICurrentTenant t) =>
+                {
+                    var applied = ctx.Features.Get<HeadlessTenancyResolutionApplied>() is not null;
+                    return Results.Json(new FeatureCheckResponse(t.Id, t.IsAvailable, applied));
+                }
+            )
+            .SkipTenantResolution();
+
+        app.MapControllers();
+
+        await app.StartAsync(AbortToken);
+        return app;
+    }
+
+    private async Task<WebApplication> _CreateAppWithAuthorizationAsync()
+    {
+        var builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }
+        );
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        _AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
+
+        builder.AddHeadless(configureServices: options =>
+        {
+            options.Validation.ValidateServiceProviderOnStartup = false;
+            options.Validation.RequireUseHeadless = false;
+            options.Validation.RequireMapHeadlessEndpoints = false;
+            options.OpenTelemetry.Enabled = false;
+            options.OpenApi.Enabled = false;
+        });
+        builder.AddHeadlessTenancy(tenancy =>
+            tenancy.Http(http => http.ResolveFromClaims()).Authorization(auth => auth.RequireTenant())
+        );
+
+        builder
+            .Services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = _Scheme;
+                options.DefaultChallengeScheme = _Scheme;
+                options.DefaultForbidScheme = _Scheme;
+            })
+            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(_Scheme, _ => { });
+        builder.Services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new AuthorizationPolicyBuilder(_Scheme)
+                .RequireAuthenticatedUser()
+                .AddRequirements(new TenantRequirement())
+                .Build();
+        });
+
+        var app = builder.Build();
+        app.UseAuthentication();
+        app.UseHeadlessTenancy();
+        app.UseAuthorization();
+
+        app.MapGet(
+                "/skip-and-allow-missing",
+                (ICurrentTenant t) => Results.Json(new TenantResponse(t.Id, t.IsAvailable))
+            )
+            .SkipTenantResolution()
+            .AllowMissingTenant();
+
+        await app.StartAsync(AbortToken);
+        return app;
+    }
+
+    // --- helpers ---
+
+    private HttpClient _CreateClient(WebApplication app)
+    {
+        return new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
+    }
+
+    private async Task<TenantResponse> _GetTenantAsync(
+        HttpClient client,
+        string path,
+        string? user = null,
+        string? tenantId = null
+    )
+    {
+        using var response = await _SendAsync(client, path, user, tenantId);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<TenantResponse>(cancellationToken: AbortToken))!;
+    }
+
+    private async Task<FeatureCheckResponse> _GetFeatureCheckAsync(
+        HttpClient client,
+        string path,
+        string? user = null,
+        string? tenantId = null
+    )
+    {
+        using var response = await _SendAsync(client, path, user, tenantId);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<FeatureCheckResponse>(cancellationToken: AbortToken))!;
+    }
+
+    private async Task<HttpResponseMessage> _SendAsync(
+        HttpClient client,
+        string path,
+        string? user = null,
+        string? tenantId = null
+    )
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, path);
+
+        if (user is not null)
+        {
+            request.Headers.Add(_UserHeader, user);
+        }
+
+        if (tenantId is not null)
+        {
+            request.Headers.Add(_TenantHeader, tenantId);
+        }
+
+        return await client.SendAsync(request, AbortToken);
+    }
+
+    private static void _ResetOrderingWarning()
+    {
+        var field = typeof(TenantResolutionMiddleware).GetField(
+            "_orderingWarningEmitted",
+            BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly
+        );
+        field.Should().NotBeNull();
+        field!.SetValue(null, 0);
+    }
+
+    private static void _AddDefaultHeadlessSecurityConfiguration(IConfigurationBuilder configuration)
+    {
+        configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultPassPhrase", "TestPassPhrase123456"),
+            new KeyValuePair<string, string?>("Headless:StringEncryption:InitVectorBytes", "VGVzdElWMDEyMzQ1Njc4OQ=="),
+            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultSalt", "VGVzdFNhbHQ="),
+            new KeyValuePair<string, string?>("Headless:StringHash:DefaultSalt", "TestSalt"),
+        ]);
+    }
+
+    private sealed record TenantResponse(string? Id, bool IsAvailable);
+
+    private sealed record FeatureCheckResponse(string? Id, bool IsAvailable, bool ResolutionApplied);
+
+    private sealed record LogEntry(string Category, LogLevel Level, EventId EventId, string Message);
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<LogEntry> _entries = new();
+
+        public IReadOnlyCollection<LogEntry> Entries => _entries.ToArray();
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new CapturingLogger(categoryName, _entries);
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(string categoryName, ConcurrentQueue<LogEntry> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            entries.Enqueue(new LogEntry(categoryName, logLevel, eventId, formatter(state, exception)));
+        }
+    }
+
+    private sealed class TestAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder
+    ) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(_UserHeader, out var userValues))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var isUnauthenticated = Request.Headers.ContainsKey(_UnauthenticatedHeader);
+            var claims = new List<Claim> { new(UserClaimTypes.Name, userValues.ToString()) };
+
+            if (Request.Headers.TryGetValue(_TenantHeader, out var tenantValues))
+            {
+                claims.Add(new Claim(UserClaimTypes.TenantId, tenantValues.ToString()));
+            }
+
+            var identity = new ClaimsIdentity(claims, authenticationType: isUnauthenticated ? null : Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}
+
+[ApiController]
+[SkipTenantResolution]
+[Route("skip-mvc-class")]
+public sealed class SkipResolutionClassController : ControllerBase
+{
+    [HttpGet("action")]
+    public IActionResult GetTenant([FromServices] ICurrentTenant currentTenant)
+    {
+        return Ok(new { currentTenant.Id, currentTenant.IsAvailable });
+    }
+}
+
+[ApiController]
+[Route("skip-mvc-action")]
+public sealed class SkipResolutionActionController : ControllerBase
+{
+    [HttpGet("skip")]
+    [SkipTenantResolution]
+    public IActionResult Skip([FromServices] ICurrentTenant currentTenant)
+    {
+        return Ok(new { currentTenant.Id, currentTenant.IsAvailable });
+    }
+}

--- a/tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs
+++ b/tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs
@@ -2,43 +2,34 @@
 
 using System.Net;
 using System.Net.Http.Json;
-using System.Security.Claims;
-using System.Text.Encodings.Web;
 using Headless.Abstractions;
 using Headless.Api;
 using Headless.Api.MultiTenancy;
 using Headless.Constants;
 using Headless.MultiTenancy;
 using Headless.Testing.Tests;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Tests.Helpers;
 
 namespace Tests;
 
 public sealed class TenantRequirementTests : TestBase
 {
-    private const string _Scheme = "Test";
-    private const string _UserHeader = "X-Test-User";
-    private const string _TenantHeader = "X-Test-Tenant";
-
     [Fact]
     public async Task should_allow_authenticated_request_with_tenant_claim()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-required", user: "alice", tenantId: "tenant-a");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var body = await response.Content.ReadFromJsonAsync<TenantResponse>(cancellationToken: AbortToken);
+        var body = await response.Content.ReadFromJsonAsync<TenantRequiredResponse>(cancellationToken: AbortToken);
         body!.TenantId.Should().Be("tenant-a");
     }
 
@@ -46,7 +37,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_return_tenant_problem_details_when_authenticated_request_has_no_tenant_claim()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-required", user: "alice");
 
@@ -58,7 +49,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_allow_minimal_api_endpoint_that_allows_missing_tenant()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/minimal-allow-missing", user: "alice");
 
@@ -69,7 +60,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_require_tenant_when_minimal_api_endpoint_overrides_group_allow_missing()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-requirement-group/require-tenant", user: "alice");
 
@@ -81,7 +72,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_allow_mvc_action_that_allows_missing_tenant()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-requirement-mvc/allow-missing", user: "alice");
 
@@ -92,7 +83,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_allow_mvc_controller_that_allows_missing_tenant()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-requirement-public/class-allow-missing", user: "alice");
 
@@ -103,7 +94,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_require_tenant_when_mvc_action_overrides_controller_allow_missing()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-requirement-public/action-require", user: "alice");
 
@@ -115,7 +106,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_map_missing_tenant_context_exception_to_tenant_problem_details()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/throw-missing-tenant", user: "alice", tenantId: "tenant-a");
 
@@ -127,7 +118,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_return_401_for_unauthenticated_tenant_required_endpoint()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-required");
 
@@ -138,7 +129,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_return_tenant_problem_details_when_composed_policy_also_fails()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-and-denied", user: "alice");
 
@@ -150,7 +141,7 @@ public sealed class TenantRequirementTests : TestBase
     public async Task should_delegate_to_default_forbidden_when_composed_policy_tenant_passes()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-and-denied", user: "alice", tenantId: "tenant-a");
 
@@ -168,7 +159,7 @@ public sealed class TenantRequirementTests : TestBase
         await using var app = await _CreateAppAsync(configureProblemDetails: options =>
             options.CustomizeProblemDetails = context => context.ProblemDetails.Extensions["x-custom"] = "auth-marker"
         );
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/tenant-required", user: "alice");
 
@@ -190,7 +181,7 @@ public sealed class TenantRequirementTests : TestBase
             options.CustomizeProblemDetails = context =>
                 context.ProblemDetails.Extensions["x-custom"] = "exception-marker"
         );
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         using var response = await _SendAsync(client, "/throw-missing-tenant", user: "alice", tenantId: "tenant-a");
 
@@ -211,7 +202,7 @@ public sealed class TenantRequirementTests : TestBase
             new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }
         );
         builder.WebHost.UseUrls("http://127.0.0.1:0");
-        _AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
+        HttpTenancyTestHarness.AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
 
         builder.AddHeadless(configureServices: options =>
         {
@@ -229,18 +220,12 @@ public sealed class TenantRequirementTests : TestBase
         {
             builder.Services.Configure(configureProblemDetails);
         }
+
         builder.Services.AddSingleton<IAuthorizationHandler, AlwaysFailRequirementHandler>();
-        builder
-            .Services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = _Scheme;
-                options.DefaultChallengeScheme = _Scheme;
-                options.DefaultForbidScheme = _Scheme;
-            })
-            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(_Scheme, _ => { });
+        builder.Services.AddTestAuthentication(registerForbidScheme: true);
         builder.Services.AddAuthorization(options =>
         {
-            options.FallbackPolicy = new AuthorizationPolicyBuilder(_Scheme)
+            options.FallbackPolicy = new AuthorizationPolicyBuilder(HttpTenancyTestHarness.Scheme)
                 .RequireAuthenticatedUser()
                 .AddRequirements(new TenantRequirement())
                 .Build();
@@ -262,7 +247,7 @@ public sealed class TenantRequirementTests : TestBase
 
         app.MapGet(
             "/tenant-required",
-            (ICurrentTenant currentTenant) => Results.Json(new TenantResponse(currentTenant.Id))
+            (ICurrentTenant currentTenant) => Results.Json(new TenantRequiredResponse(currentTenant.Id))
         );
         app.MapGet("/minimal-allow-missing", () => Results.Ok()).AllowMissingTenant();
         var allowMissingGroup = app.MapGroup("/tenant-requirement-group").AllowMissingTenant();
@@ -275,11 +260,6 @@ public sealed class TenantRequirementTests : TestBase
         return app;
     }
 
-    private static HttpClient _CreateClient(WebApplication app)
-    {
-        return new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
-    }
-
     private async Task<HttpResponseMessage> _SendAsync(
         HttpClient client,
         string path,
@@ -287,18 +267,7 @@ public sealed class TenantRequirementTests : TestBase
         string? tenantId = null
     )
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, path);
-
-        if (user is not null)
-        {
-            request.Headers.Add(_UserHeader, user);
-        }
-
-        if (tenantId is not null)
-        {
-            request.Headers.Add(_TenantHeader, tenantId);
-        }
-
+        using var request = HttpTenancyTestHarness.CreateRequest(HttpMethod.Get, path, user, tenantId);
         return await client.SendAsync(request, AbortToken);
     }
 
@@ -322,17 +291,7 @@ public sealed class TenantRequirementTests : TestBase
             .Be(HeadlessProblemDetailsConstants.Errors.TenantContextRequired.Code);
     }
 
-    private static void _AddDefaultHeadlessSecurityConfiguration(IConfigurationBuilder configuration)
-    {
-        configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultPassPhrase", "TestPassPhrase123456"),
-            new KeyValuePair<string, string?>("Headless:StringEncryption:InitVectorBytes", "VGVzdElWMDEyMzQ1Njc4OQ=="),
-            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultSalt", "VGVzdFNhbHQ="),
-            new KeyValuePair<string, string?>("Headless:StringHash:DefaultSalt", "TestSalt"),
-        ]);
-    }
-
-    private sealed record TenantResponse(string? TenantId);
+    private sealed record TenantRequiredResponse(string? TenantId);
 
     private sealed class AlwaysFailRequirement : IAuthorizationRequirement;
 
@@ -346,34 +305,6 @@ public sealed class TenantRequirementTests : TestBase
             context.Fail(new AuthorizationFailureReason(this, "AlwaysFail"));
 
             return Task.CompletedTask;
-        }
-    }
-
-    private sealed class TestAuthenticationHandler(
-        IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger,
-        UrlEncoder encoder
-    ) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
-    {
-        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
-        {
-            if (!Request.Headers.TryGetValue(_UserHeader, out var userValues))
-            {
-                return Task.FromResult(AuthenticateResult.NoResult());
-            }
-
-            var claims = new List<Claim> { new(UserClaimTypes.Name, userValues.ToString()) };
-
-            if (Request.Headers.TryGetValue(_TenantHeader, out var tenantValues))
-            {
-                claims.Add(new Claim(UserClaimTypes.TenantId, tenantValues.ToString()));
-            }
-
-            var identity = new ClaimsIdentity(claims, authenticationType: Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-
-            return Task.FromResult(AuthenticateResult.Success(ticket));
         }
     }
 }

--- a/tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs
+++ b/tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs
@@ -205,9 +205,7 @@ public sealed class TenantRequirementTests : TestBase
             .Be(HeadlessProblemDetailsConstants.Errors.TenantContextRequired.Code);
     }
 
-    private async Task<WebApplication> _CreateAppAsync(
-        Action<Microsoft.AspNetCore.Http.ProblemDetailsOptions>? configureProblemDetails = null
-    )
+    private async Task<WebApplication> _CreateAppAsync(Action<ProblemDetailsOptions>? configureProblemDetails = null)
     {
         var builder = WebApplication.CreateBuilder(
             new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }

--- a/tests/Headless.Api.Tests.Integration/TenantResolutionMiddlewareTests.cs
+++ b/tests/Headless.Api.Tests.Integration/TenantResolutionMiddlewareTests.cs
@@ -1,40 +1,28 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Collections.Concurrent;
 using System.Net.Http.Json;
-using System.Reflection;
-using System.Security.Claims;
-using System.Text.Encodings.Web;
 using Headless.Abstractions;
 using Headless.Api;
 using Headless.Api.Middlewares;
 using Headless.Constants;
 using Headless.MultiTenancy;
 using Headless.Testing.Tests;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Tests.Helpers;
 
 namespace Tests;
 
 public sealed class TenantResolutionMiddlewareTests : TestBase
 {
-    private const string _Scheme = "Test";
-    private const string _UserHeader = "X-Test-User";
-    private const string _TenantHeader = "X-Test-Tenant";
-    private const string _CustomTenantHeader = "X-Test-Custom-Tenant";
-    private const string _UnauthenticatedHeader = "X-Test-Unauthenticated";
-
     [Fact]
     public async Task should_resolve_default_tenant_claim_and_not_bleed_between_requests()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var authenticated = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1");
         var unauthenticated = await _GetTenantAsync(client);
@@ -51,8 +39,10 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     [Fact]
     public async Task should_resolve_custom_tenant_claim_type_when_configured()
     {
-        await using var app = await _CreateAppAsync(options => options.ClaimType = "custom_tenant_id");
-        using var client = _CreateClient(app);
+        await using var app = await _CreateAppAsync(options =>
+            options.ClaimType = HttpTenancyTestHarness.CustomTenantClaimType
+        );
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", customTenantId: "TENANT-42");
 
@@ -64,7 +54,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     public async Task should_skip_resolution_for_unauthenticated_principal_even_when_tenant_claim_exists()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1", unauthenticated: true);
 
@@ -76,7 +66,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     public async Task should_skip_resolution_for_whitespace_tenant_claim()
     {
         await using var app = await _CreateAppAsync();
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "   ");
 
@@ -88,7 +78,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     public async Task should_fall_back_to_default_claim_type_when_custom_claim_type_is_blank()
     {
         await using var app = await _CreateAppAsync(options => options.ClaimType = " ");
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1");
 
@@ -100,7 +90,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     public async Task should_resolve_tenant_claim_through_use_headless_tenancy_when_http_tenancy_configured()
     {
         await using var app = await _CreateAppAsync(setup: TenancySetup.RootHttp);
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1");
 
@@ -118,7 +108,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
             useAuthentication: false,
             useAuthorization: false
         );
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1");
 
@@ -130,7 +120,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     public async Task should_noop_use_headless_tenancy_when_http_tenancy_is_not_configured()
     {
         await using var app = await _CreateAppAsync(setup: TenancySetup.RootNoHttp);
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1");
 
@@ -179,10 +169,10 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     [Fact]
     public async Task should_not_emit_ordering_warning_for_correctly_ordered_anonymous_request()
     {
-        _ResetOrderingWarning();
+        TenantResolutionMiddleware.ResetOrderingWarningForTesting();
         var loggerProvider = new CapturingLoggerProvider();
         await using var app = await _CreateAppAsync(loggerProvider: loggerProvider);
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         await _GetTenantAsync(client);
 
@@ -194,13 +184,13 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
     [Fact]
     public async Task should_emit_ordering_warning_when_tenant_resolution_runs_before_authentication()
     {
-        _ResetOrderingWarning();
+        TenantResolutionMiddleware.ResetOrderingWarningForTesting();
         var loggerProvider = new CapturingLoggerProvider();
         await using var app = await _CreateAppAsync(
             applyTenantMiddlewareBeforeAuthentication: true,
             loggerProvider: loggerProvider
         );
-        using var client = _CreateClient(app);
+        using var client = HttpTenancyTestHarness.CreateClient(app);
 
         var tenant = await _GetTenantAsync(client, user: "alice", tenantId: "TENANT-1");
 
@@ -230,7 +220,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
             new WebApplicationOptions { EnvironmentName = EnvironmentNames.Test }
         );
         builder.WebHost.UseUrls("http://127.0.0.1:0");
-        _AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
+        HttpTenancyTestHarness.AddDefaultHeadlessSecurityConfiguration(builder.Configuration);
 
         if (loggerProvider is not null)
         {
@@ -265,13 +255,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
 
         if (registerAuthentication)
         {
-            builder
-                .Services.AddAuthentication(options =>
-                {
-                    options.DefaultAuthenticateScheme = _Scheme;
-                    options.DefaultChallengeScheme = _Scheme;
-                })
-                .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(_Scheme, _ => { });
+            builder.Services.AddTestAuthentication();
         }
 
         if (useAuthorization)
@@ -315,11 +299,6 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
         return app;
     }
 
-    private HttpClient _CreateClient(WebApplication app)
-    {
-        return new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
-    }
-
     private async Task<TenantResponse> _GetTenantAsync(
         HttpClient client,
         string? user = null,
@@ -328,28 +307,14 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
         bool unauthenticated = false
     )
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, "/tenant");
-
-        if (user is not null)
-        {
-            request.Headers.Add(_UserHeader, user);
-        }
-
-        if (tenantId is not null)
-        {
-            request.Headers.Add(_TenantHeader, tenantId);
-        }
-
-        if (customTenantId is not null)
-        {
-            request.Headers.Add(_CustomTenantHeader, customTenantId);
-        }
-
-        if (unauthenticated)
-        {
-            request.Headers.Add(_UnauthenticatedHeader, "true");
-        }
-
+        using var request = HttpTenancyTestHarness.CreateRequest(
+            HttpMethod.Get,
+            "/tenant",
+            user,
+            tenantId,
+            customTenantId,
+            unauthenticated
+        );
         using var response = await client.SendAsync(request, AbortToken);
         response.EnsureSuccessStatusCode();
 
@@ -368,69 +333,6 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
         }
     }
 
-    private static void _ResetOrderingWarning()
-    {
-        var field = typeof(TenantResolutionMiddleware).GetField(
-            "_orderingWarningEmitted",
-            BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly
-        );
-        field.Should().NotBeNull();
-        field!.SetValue(null, 0);
-    }
-
-    private static void _AddDefaultHeadlessSecurityConfiguration(IConfigurationBuilder configuration)
-    {
-        configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultPassPhrase", "TestPassPhrase123456"),
-            new KeyValuePair<string, string?>("Headless:StringEncryption:InitVectorBytes", "VGVzdElWMDEyMzQ1Njc4OQ=="),
-            new KeyValuePair<string, string?>("Headless:StringEncryption:DefaultSalt", "VGVzdFNhbHQ="),
-            new KeyValuePair<string, string?>("Headless:StringHash:DefaultSalt", "TestSalt"),
-        ]);
-    }
-
-    private sealed record TenantResponse(string? Id, bool IsAvailable);
-
-    private sealed record LogEntry(string Category, LogLevel Level, EventId EventId, string Message);
-
-    private sealed class CapturingLoggerProvider : ILoggerProvider
-    {
-        private readonly ConcurrentQueue<LogEntry> _entries = new();
-
-        public IReadOnlyCollection<LogEntry> Entries => _entries.ToArray();
-
-        public ILogger CreateLogger(string categoryName)
-        {
-            return new CapturingLogger(categoryName, _entries);
-        }
-
-        public void Dispose() { }
-    }
-
-    private sealed class CapturingLogger(string categoryName, ConcurrentQueue<LogEntry> entries) : ILogger
-    {
-        public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull
-        {
-            return null;
-        }
-
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            return true;
-        }
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter
-        )
-        {
-            entries.Enqueue(new LogEntry(categoryName, logLevel, eventId, formatter(state, exception)));
-        }
-    }
-
     private enum TenancySetup
     {
         Direct,
@@ -438,37 +340,5 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
         RootNoHttp,
     }
 
-    private sealed class TestAuthenticationHandler(
-        IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger,
-        UrlEncoder encoder
-    ) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
-    {
-        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
-        {
-            if (!Request.Headers.TryGetValue(_UserHeader, out var userValues))
-            {
-                return Task.FromResult(AuthenticateResult.NoResult());
-            }
-
-            var isUnauthenticated = Request.Headers.ContainsKey(_UnauthenticatedHeader);
-            var claims = new List<Claim> { new(UserClaimTypes.Name, userValues.ToString()) };
-
-            if (Request.Headers.TryGetValue(_TenantHeader, out var tenantValues))
-            {
-                claims.Add(new Claim(UserClaimTypes.TenantId, tenantValues.ToString()));
-            }
-
-            if (Request.Headers.TryGetValue(_CustomTenantHeader, out var customTenantValues))
-            {
-                claims.Add(new Claim("custom_tenant_id", customTenantValues.ToString()));
-            }
-
-            var identity = new ClaimsIdentity(claims, authenticationType: isUnauthenticated ? null : Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-
-            return Task.FromResult(AuthenticateResult.Success(ticket));
-        }
-    }
+    private sealed record TenantResponse(string? Id, bool IsAvailable);
 }

--- a/tests/Headless.Api.Tests.Integration/TenantResolutionMiddlewareTests.cs
+++ b/tests/Headless.Api.Tests.Integration/TenantResolutionMiddlewareTests.cs
@@ -168,7 +168,7 @@ public sealed class TenantResolutionMiddlewareTests : TestBase
             start: false
         );
 
-        Func<Task> act = () => app.StartAsync(AbortToken);
+        var act = () => app.StartAsync(AbortToken);
 
         await act.Should()
             .ThrowAsync<InvalidOperationException>()

--- a/tests/Headless.Api.Tests.Unit/MultiTenancy/EndpointConventionBuilderExtensionsTests.cs
+++ b/tests/Headless.Api.Tests.Unit/MultiTenancy/EndpointConventionBuilderExtensionsTests.cs
@@ -37,6 +37,19 @@ public sealed class EndpointConventionBuilderExtensionsTests
     }
 
     [Fact]
+    public void should_define_skip_tenant_resolution_attribute_usage_for_classes_and_methods_only()
+    {
+        // when
+        var usage = _GetUsage<SkipTenantResolutionAttribute>();
+
+        // then
+        usage.ValidOn.Should().Be(AttributeTargets.Class | AttributeTargets.Method);
+        usage.Inherited.Should().BeFalse();
+        usage.AllowMultiple.Should().BeFalse();
+        typeof(SkipTenantResolutionAttribute).IsSealed.Should().BeTrue();
+    }
+
+    [Fact]
     public void should_attach_allow_missing_tenant_metadata_to_endpoint_builder()
     {
         // given
@@ -66,6 +79,22 @@ public sealed class EndpointConventionBuilderExtensionsTests
         // then
         result.Should().BeSameAs(conventionBuilder);
         endpointBuilder.Metadata.OfType<RequireTenantAttribute>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void should_attach_skip_tenant_resolution_metadata_to_endpoint_builder()
+    {
+        // given
+        var conventionBuilder = new CapturingEndpointConventionBuilder();
+        var endpointBuilder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+
+        // when
+        var result = conventionBuilder.SkipTenantResolution();
+        conventionBuilder.Apply(endpointBuilder);
+
+        // then
+        result.Should().BeSameAs(conventionBuilder);
+        endpointBuilder.Metadata.OfType<SkipTenantResolutionAttribute>().Should().ContainSingle();
     }
 
     private static AttributeUsageAttribute _GetUsage<TAttribute>()

--- a/tests/Headless.Blobs.Redis.Tests.Integration/RedisBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Redis.Tests.Integration/RedisBlobStorageTests.cs
@@ -219,7 +219,7 @@ public sealed class RedisBlobStorageTests(RedisBlobStorageFixture fixture) : Blo
         await using var stream = new MemoryStream(data);
 
         // when & then
-        Func<Task> act = async () => await storage.UploadAsync(["test-container"], "small-blob.bin", stream);
+        var act = async () => await storage.UploadAsync(["test-container"], "small-blob.bin", stream);
         await act.Should().NotThrowAsync();
     }
 

--- a/tests/Headless.Caching.Abstractions.Tests.Unit/GetOrAddAsyncTests.cs
+++ b/tests/Headless.Caching.Abstractions.Tests.Unit/GetOrAddAsyncTests.cs
@@ -320,7 +320,7 @@ public sealed class GetOrAddAsyncTests : TestBase
         // given
         using var cache = _CreateCache();
         using var cts = new CancellationTokenSource();
-        CancellationToken receivedToken = CancellationToken.None;
+        var receivedToken = CancellationToken.None;
 
         // when
         await cache.GetOrAddAsync<string>(

--- a/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCachePerformanceTests.cs
+++ b/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCachePerformanceTests.cs
@@ -26,7 +26,7 @@ public sealed class InMemoryCachePerformanceTests : TestBase
         using var cache = _CreateCache();
         var count = 100_000;
 
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
             await cache.UpsertAsync($"key{i}", "value", TimeSpan.FromHours(1), AbortToken);
         }
@@ -54,7 +54,7 @@ public sealed class InMemoryCachePerformanceTests : TestBase
         var timeWith100K = sw.ElapsedMilliseconds;
 
         // Add more items
-        for (int i = count; i < count * 2; i++)
+        for (var i = count; i < count * 2; i++)
         {
             await cache.UpsertAsync($"key{i}", "value", TimeSpan.FromHours(1), AbortToken);
         }

--- a/tests/Headless.Checks.Tests.Unit/EnsureTests.cs
+++ b/tests/Headless.Checks.Tests.Unit/EnsureTests.cs
@@ -80,7 +80,7 @@ public sealed class EnsureTests
         object? obj = null;
 
         // when
-        Action action = () => Ensure.NotDisposed(disposed, obj);
+        var action = () => Ensure.NotDisposed(disposed, obj);
 
         // then
         action.Should().ThrowExactly<ObjectDisposedException>().WithMessage("Cannot access a disposed object.*");
@@ -94,7 +94,7 @@ public sealed class EnsureTests
         object obj = "test string";
 
         // when
-        Action action = () => Ensure.NotDisposed(disposed, obj);
+        var action = () => Ensure.NotDisposed(disposed, obj);
 
         // then
         action
@@ -112,7 +112,7 @@ public sealed class EnsureTests
         const string customMessage = "Custom disposal message";
 
         // when
-        Action action = () => Ensure.NotDisposed(disposed, obj, customMessage);
+        var action = () => Ensure.NotDisposed(disposed, obj, customMessage);
 
         // then
         action.Should().ThrowExactly<ObjectDisposedException>().WithMessage($"*{customMessage}*");
@@ -126,7 +126,7 @@ public sealed class EnsureTests
         var obj = new TestDisposableObject();
 
         // when
-        Action action = () => Ensure.NotDisposed(disposed, obj);
+        var action = () => Ensure.NotDisposed(disposed, obj);
 
         // then
         action

--- a/tests/Headless.Checks.Tests.Unit/NullableOverloadTests.cs
+++ b/tests/Headless.Checks.Tests.Unit/NullableOverloadTests.cs
@@ -326,7 +326,7 @@ public sealed class NullableOverloadTests
     public void is_positive_with_datetime_creates_message_with_invariant_string()
     {
         // given
-        DateTime argument = DateTime.MinValue;
+        var argument = DateTime.MinValue;
 
         // when
         Action action = () => Argument.IsPositive(argument.Ticks);
@@ -339,7 +339,7 @@ public sealed class NullableOverloadTests
     public void is_positive_with_datetimeoffset_creates_message_with_invariant_string()
     {
         // given
-        DateTimeOffset argument = DateTimeOffset.MinValue;
+        var argument = DateTimeOffset.MinValue;
 
         // when
         Action action = () => Argument.IsPositive(argument.Ticks);

--- a/tests/Headless.Checks.Tests.Unit/NumericGenericOverloadsTests.cs
+++ b/tests/Headless.Checks.Tests.Unit/NumericGenericOverloadsTests.cs
@@ -197,7 +197,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_positive_half_with_positive_value_does_not_throw()
     {
         // given
-        Half value = (Half)5.5;
+        var value = (Half)5.5;
 
         // when & then
         Argument.IsPositive(value).Should().Be(value);
@@ -207,7 +207,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_positive_half_with_negative_value_throws()
     {
         // given
-        Half argument = (Half)(-5.5);
+        var argument = (Half)(-5.5);
 
         // when
         Action action = () => Argument.IsPositive(argument);
@@ -253,7 +253,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_positive_uint128_with_zero_throws()
     {
         // given
-        UInt128 argument = UInt128.Zero;
+        var argument = UInt128.Zero;
 
         // when
         Action action = () => Argument.IsPositive(argument);
@@ -337,7 +337,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_negative_half_with_negative_value_does_not_throw()
     {
         // given
-        Half value = (Half)(-5.5);
+        var value = (Half)(-5.5);
 
         // when & then
         Argument.IsNegative(value).Should().Be(value);
@@ -347,7 +347,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_negative_half_with_positive_value_throws()
     {
         // given
-        Half argument = (Half)5.5;
+        var argument = (Half)5.5;
 
         // when
         Action action = () => Argument.IsNegative(argument);
@@ -418,7 +418,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_positive_or_zero_half_with_zero_does_not_throw()
     {
         // given
-        Half value = Half.Zero;
+        var value = Half.Zero;
 
         // when & then
         Argument.IsPositiveOrZero(value).Should().Be(value);
@@ -463,7 +463,7 @@ public sealed class NumericGenericOverloadsTests
     public void is_negative_or_zero_half_with_zero_does_not_throw()
     {
         // given
-        Half value = Half.Zero;
+        var value = Half.Zero;
 
         // when & then
         Argument.IsNegativeOrZero(value).Should().Be(value);

--- a/tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisDistributedLockStorageTests.cs
+++ b/tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisDistributedLockStorageTests.cs
@@ -69,7 +69,7 @@ public sealed class RedisDistributedLockStorageTests(RedisTestFixture fixture) :
             new ParallelOptions { MaxDegreeOfParallelism = 50 },
             async (lockId, _) =>
             {
-                var result = await fixture.LockStorage.InsertAsync(key, lockId, TimeSpan.FromMinutes(5));
+                var result = await fixture.LockStorage.InsertAsync(key, lockId, TimeSpan.FromMinutes(5), AbortToken);
                 if (result)
                 {
                     Interlocked.Increment(ref successCount);
@@ -230,7 +230,7 @@ public sealed class RedisDistributedLockStorageTests(RedisTestFixture fixture) :
             new ParallelOptions { MaxDegreeOfParallelism = 20 },
             async (_, _) =>
             {
-                var result = await fixture.LockStorage.RemoveIfEqualAsync(key, lockId);
+                var result = await fixture.LockStorage.RemoveIfEqualAsync(key, lockId, AbortToken);
                 if (result)
                 {
                     Interlocked.Increment(ref removeCount);

--- a/tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisThrottlingDistributedLockStorageTests.cs
+++ b/tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisThrottlingDistributedLockStorageTests.cs
@@ -85,7 +85,7 @@ public sealed class RedisThrottlingDistributedLockStorageTests(RedisTestFixture 
         await Parallel.ForEachAsync(
             Enumerable.Range(0, concurrentIncrements),
             new ParallelOptions { MaxDegreeOfParallelism = 50 },
-            async (_, _) => await fixture.ThrottlingLockStorage.IncrementAsync(resource, ttl)
+            async (_, _) => await fixture.ThrottlingLockStorage.IncrementAsync(resource, ttl, AbortToken)
         );
 
         // then

--- a/tests/Headless.Extensions.Tests.Unit/Collections/EnumerableExtensionsTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/Collections/EnumerableExtensionsTests.cs
@@ -51,7 +51,7 @@ public sealed class EnumerableExtensionsTests
     public void as_icollection_should_materialize_enumerable()
     {
         // given
-        IEnumerable<int> source = Enumerable.Range(1, 3);
+        var source = Enumerable.Range(1, 3);
 
         // when
         var result = source.AsICollection();
@@ -79,7 +79,7 @@ public sealed class EnumerableExtensionsTests
     public void as_list_should_materialize_enumerable()
     {
         // given
-        IEnumerable<int> source = Enumerable.Range(1, 3);
+        var source = Enumerable.Range(1, 3);
 
         // when
         var result = source.AsList();
@@ -107,7 +107,7 @@ public sealed class EnumerableExtensionsTests
     public void as_ilist_should_materialize_enumerable()
     {
         // given
-        IEnumerable<int> source = Enumerable.Range(1, 3);
+        var source = Enumerable.Range(1, 3);
 
         // when
         var result = source.AsIList();
@@ -135,7 +135,7 @@ public sealed class EnumerableExtensionsTests
     public void as_array_should_materialize_enumerable()
     {
         // given
-        IEnumerable<int> source = Enumerable.Range(1, 3);
+        var source = Enumerable.Range(1, 3);
 
         // when
         var result = source.AsArray();
@@ -232,7 +232,7 @@ public sealed class EnumerableExtensionsTests
     public void as_ireadonlycollection_should_materialize_enumerable()
     {
         // given
-        IEnumerable<int> source = Enumerable.Range(1, 3);
+        var source = Enumerable.Range(1, 3);
 
         // when
         var result = source.AsIReadOnlyCollection();
@@ -260,7 +260,7 @@ public sealed class EnumerableExtensionsTests
     public void as_ireadonlylist_should_materialize_enumerable()
     {
         // given
-        IEnumerable<int> source = Enumerable.Range(1, 3);
+        var source = Enumerable.Range(1, 3);
 
         // when
         var result = source.AsIReadOnlyList();
@@ -471,7 +471,7 @@ public sealed class EnumerableExtensionsTests
     public async Task to_list_async_from_task_should_materialize_result()
     {
         // given
-        Task<IEnumerable<int>> task = Task.FromResult<IEnumerable<int>>([1, 2, 3]);
+        var task = Task.FromResult<IEnumerable<int>>([1, 2, 3]);
 
         // when
         var result = await task.ToListAsync();
@@ -487,7 +487,7 @@ public sealed class EnumerableExtensionsTests
     public async Task to_array_async_from_task_should_materialize_result()
     {
         // given
-        Task<IEnumerable<int>> task = Task.FromResult<IEnumerable<int>>([1, 2, 3]);
+        var task = Task.FromResult<IEnumerable<int>>([1, 2, 3]);
 
         // when
         var result = await task.ToArrayAsync();

--- a/tests/Headless.Extensions.Tests.Unit/Collections/TypeListTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/Collections/TypeListTests.cs
@@ -42,7 +42,7 @@ public sealed class TypeListTests
     public void add_should_throw_exception_for_invalid_type()
     {
         // when
-        Action act = () => _shapeTypeList.Add(typeof(string));
+        var act = () => _shapeTypeList.Add(typeof(string));
 
         // then
         act.Should().Throw<ArgumentException>().WithMessage("*should be instance of*IShape*");

--- a/tests/Headless.Extensions.Tests.Unit/Http/AuthenticationHeaderFactoryTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/Http/AuthenticationHeaderFactoryTests.cs
@@ -132,7 +132,7 @@ public sealed class AuthenticationHeaderFactoryTests
     public void CreateBasic_bytes_overload_should_return_basic_header()
     {
         // given
-        ReadOnlySpan<byte> value = "user:pass"u8;
+        var value = "user:pass"u8;
         var expectedParameter = Convert.ToBase64String("user:pass"u8);
 
         // when

--- a/tests/Headless.Extensions.Tests.Unit/IO/NestedStreamTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/IO/NestedStreamTests.cs
@@ -320,7 +320,7 @@ public sealed class NestedStreamTests : TestBase
     {
         var buffer = new byte[_underlyingStream.Length];
 
-        int bytesRead = await _stream.ReadAsync(buffer, 0, buffer.Length, TimeoutToken).WithCancellation(TimeoutToken);
+        var bytesRead = await _stream.ReadAsync(buffer, 0, buffer.Length, TimeoutToken).WithCancellation(TimeoutToken);
 
         Assert.Equal(_DefaultNestedLength, bytesRead);
 

--- a/tests/Headless.Extensions.Tests.Unit/Threading/KeyedAsyncLockTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/Threading/KeyedAsyncLockTests.cs
@@ -360,7 +360,7 @@ public sealed class KeyedAsyncLockTests : TestBase
         var holdingTask = Task.Run(
             async () =>
             {
-                using (await keyedLock.LockAsync("cancel-cleanup-key"))
+                using (await keyedLock.LockAsync("cancel-cleanup-key", AbortToken))
                 {
                     lockAcquired.SetResult();
                     await canRelease.Task;
@@ -431,7 +431,7 @@ public sealed class KeyedAsyncLockTests : TestBase
 
         // when - dispose twice
         releaser.Dispose();
-        var act = () => releaser.Dispose();
+        var act = releaser.Dispose;
 
         // then - should not throw
         act.Should().NotThrow();
@@ -520,16 +520,17 @@ public sealed class KeyedAsyncLockTests : TestBase
         releaser2.Dispose();
 
         // Acquire more and don't release - these will be cleaned up by Dispose
+        // ReSharper disable once NotDisposedResource
         var releaser3 = await keyedLock.LockAsync("key3", AbortToken);
 
         // when
-        var act = () => keyedLock.Dispose();
+        var act = keyedLock.Dispose;
 
         // then - should not throw
         act.Should().NotThrow();
 
         // Clean up the releaser (should be safe even after parent disposed)
-        var act2 = () => releaser3.Dispose();
+        var act2 = releaser3.Dispose;
         act2.Should().NotThrow();
     }
 }

--- a/tests/Headless.Features.Tests.Integration/FeatureManagerTests.cs
+++ b/tests/Headless.Features.Tests.Integration/FeatureManagerTests.cs
@@ -35,7 +35,7 @@ public sealed class FeatureManagerTests(FeaturesTestFixture fixture) : FeaturesT
         const string editionId = "AnyEditionId";
 
         // when
-        Func<Task<FeatureValue>> act = () => featureManager.GetForEditionAsync(featureName, editionId);
+        var act = () => featureManager.GetForEditionAsync(featureName, editionId);
 
         // then
         await act.Should()

--- a/tests/Headless.Features.Tests.Unit/Seeders/FeaturesInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Features.Tests.Unit/Seeders/FeaturesInitializationBackgroundServiceTests.cs
@@ -353,16 +353,16 @@ public sealed class FeaturesInitializationBackgroundServiceTests : TestBase
 
         // when - start with a cancellable token
         await sut.StartAsync(cts.Token);
-        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         await cts.CancelAsync();
 
-        var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5), AbortToken));
 
         // then
         cancelledTask.Should().Be(saveCancelled.Task, "cancellation token should cancel the background task");
 
-        await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+        await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1), AbortToken));
     }
 
     #endregion

--- a/tests/Headless.Jobs.Tests.Unit/RetryBehaviorTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/RetryBehaviorTests.cs
@@ -24,7 +24,7 @@ public sealed class RetryBehaviorTests
 
         // then - initial + 3 retries = 4 attempts
         attempts.Should().HaveCount(4);
-        for (int i = 0; i < 4; i++)
+        for (var i = 0; i < 4; i++)
             attempts[i].RetryCount.Should().Be(i);
 
         // Verify mapped retry intervals produced the expected spacing between attempts

--- a/tests/Headless.Messaging.AwsSqs.Tests.Integration/ConcurrencyTests.cs
+++ b/tests/Headless.Messaging.AwsSqs.Tests.Integration/ConcurrencyTests.cs
@@ -43,7 +43,7 @@ public sealed class ConcurrencyTests(LocalStackTestFixture fixture) : TestBase
                     Encoding.UTF8.GetBytes($"{{\"id\":{messageId}}}")
                 );
 
-                results[messageId] = await transport.SendAsync(message);
+                results[messageId] = await transport.SendAsync(message, AbortToken);
             }
         );
 
@@ -77,7 +77,7 @@ public sealed class ConcurrencyTests(LocalStackTestFixture fixture) : TestBase
                     "{\"data\":\"init-test\"}"u8.ToArray()
                 );
 
-                results[messageId] = await transport.SendAsync(message);
+                results[messageId] = await transport.SendAsync(message, AbortToken);
             }
         );
 
@@ -116,7 +116,7 @@ public sealed class ConcurrencyTests(LocalStackTestFixture fixture) : TestBase
                     Encoding.UTF8.GetBytes($"{{\"topic\":\"{topicName}\",\"index\":{messageId}}}")
                 );
 
-                results[messageId] = await transport.SendAsync(message);
+                results[messageId] = await transport.SendAsync(message, AbortToken);
             }
         );
 
@@ -149,7 +149,7 @@ public sealed class ConcurrencyTests(LocalStackTestFixture fixture) : TestBase
                     Encoding.UTF8.GetBytes($"{{\"index\":{messageId}}}")
                 );
 
-                results[messageId] = await transport.SendAsync(message);
+                results[messageId] = await transport.SendAsync(message, AbortToken);
             }
         );
 

--- a/tests/Headless.Messaging.AwsSqs.Tests.Unit/AmazonSqsConsumerClientTests.cs
+++ b/tests/Headless.Messaging.AwsSqs.Tests.Unit/AmazonSqsConsumerClientTests.cs
@@ -15,6 +15,7 @@ using SqsMessage = Amazon.SQS.Model.Message;
 
 namespace Tests;
 
+// ReSharper disable AccessToDisposedClosure
 public sealed class AmazonSqsConsumerClientTests : TestBase
 {
     private static IOptions<AmazonSqsOptions> _CreateOptions() =>
@@ -938,24 +939,27 @@ public sealed class AmazonSqsConsumerClientTests : TestBase
         await client.PauseAsync();
 
         using var cts = new CancellationTokenSource();
-        var listenTask = Task.Run(async () =>
-        {
-            try
+        var listenTask = Task.Run(
+            async () =>
             {
-                await client.ListeningAsync(TimeSpan.FromMilliseconds(50), cts.Token);
-            }
-            catch (OperationCanceledException) { }
-        });
+                try
+                {
+                    await client.ListeningAsync(TimeSpan.FromMilliseconds(50), cts.Token);
+                }
+                catch (OperationCanceledException) { }
+            },
+            AbortToken
+        );
 
-        await Task.Delay(300);
+        await Task.Delay(300, AbortToken);
         var countWhilePaused = receiveCount;
 
         // then — no messages polled while paused
         countWhilePaused.Should().Be(0);
 
         // cleanup
-        await client.ResumeAsync();
-        await Task.Delay(300);
+        await client.ResumeAsync(AbortToken);
+        await Task.Delay(300, AbortToken);
         await cts.CancelAsync();
         await listenTask;
 

--- a/tests/Headless.Messaging.Core.Tests.Harness/ConsumerClientTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/ConsumerClientTestsBase.cs
@@ -162,26 +162,29 @@ public abstract class ConsumerClientTestsBase : TestBase
 
         // Start listening in background
         using var cts = new CancellationTokenSource();
-        var listeningTask = Task.Run(async () =>
-        {
-            try
+        var listeningTask = Task.Run(
+            async () =>
             {
-                await consumer.ListeningAsync(TimeSpan.FromSeconds(1), cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected
-            }
-        });
+                try
+                {
+                    await consumer.ListeningAsync(TimeSpan.FromSeconds(1), cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected
+                }
+            },
+            AbortToken
+        );
 
         // Allow some time for listening to start
-        await Task.Delay(100);
+        await Task.Delay(100, AbortToken);
 
         // when
         await cts.CancelAsync();
 
         // then - should complete without hanging
-        var completed = await Task.WhenAny(listeningTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        var completed = await Task.WhenAny(listeningTask, Task.Delay(TimeSpan.FromSeconds(5), AbortToken));
         completed.Should().Be(listeningTask, "Consumer should shutdown gracefully within timeout");
     }
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/BootstrapperTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/BootstrapperTests.cs
@@ -109,30 +109,40 @@ public sealed class BootstrapperTests : TestBase
     public async Task should_log_warning_when_use_storage_lock_is_true_and_no_real_lock_provider_registered()
     {
         var captured = new List<(LogLevel Level, EventId EventId)>();
-        await using var provider = _CreateProvider(captureLog: captured, configureOptions: o => o.UseStorageLock = true);
+        await using var provider = _CreateProvider(
+            captureLog: captured,
+            configureOptions: o => o.UseStorageLock = true
+        );
         var bootstrapper = provider.GetRequiredService<IBootstrapper>();
 
         await bootstrapper.BootstrapAsync(AbortToken);
 
-        captured.Should().Contain(
-            e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
-            "UseStorageLockWithNoOpProvider warning must fire when only NoOpDistributedLockProvider is registered"
-        );
+        captured
+            .Should()
+            .Contain(
+                e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
+                "UseStorageLockWithNoOpProvider warning must fire when only NoOpDistributedLockProvider is registered"
+            );
     }
 
     [Fact]
     public async Task should_not_log_warning_when_use_storage_lock_is_false()
     {
         var captured = new List<(LogLevel Level, EventId EventId)>();
-        await using var provider = _CreateProvider(captureLog: captured, configureOptions: o => o.UseStorageLock = false);
+        await using var provider = _CreateProvider(
+            captureLog: captured,
+            configureOptions: o => o.UseStorageLock = false
+        );
         var bootstrapper = provider.GetRequiredService<IBootstrapper>();
 
         await bootstrapper.BootstrapAsync(AbortToken);
 
-        captured.Should().NotContain(
-            e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
-            "warning must be silent when UseStorageLock is false, even with NoOpDistributedLockProvider"
-        );
+        captured
+            .Should()
+            .NotContain(
+                e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
+                "warning must be silent when UseStorageLock is false, even with NoOpDistributedLockProvider"
+            );
     }
 
     [Fact]
@@ -154,14 +164,18 @@ public sealed class BootstrapperTests : TestBase
 
         await bootstrapper.BootstrapAsync(AbortToken);
 
-        captured.Should().Contain(
-            e => e.Level == LogLevel.Warning && e.EventId.Id == 78,
-            "EventId 78 must fire when a real un-keyed IDistributedLockProvider exists but UseDistributedLock(...) was not called"
-        );
-        captured.Should().NotContain(
-            e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
-            "EventId 77 (the no-provider-at-all case) must NOT fire when an un-keyed real provider exists"
-        );
+        captured
+            .Should()
+            .Contain(
+                e => e.Level == LogLevel.Warning && e.EventId.Id == 78,
+                "EventId 78 must fire when a real un-keyed IDistributedLockProvider exists but UseDistributedLock(...) was not called"
+            );
+        captured
+            .Should()
+            .NotContain(
+                e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
+                "EventId 77 (the no-provider-at-all case) must NOT fire when an un-keyed real provider exists"
+            );
     }
 
     [Fact]
@@ -177,10 +191,12 @@ public sealed class BootstrapperTests : TestBase
 
         await bootstrapper.BootstrapAsync(AbortToken);
 
-        captured.Should().NotContain(
-            e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
-            "warning must be silent when a real IDistributedLockProvider is registered"
-        );
+        captured
+            .Should()
+            .NotContain(
+                e => e.Level == LogLevel.Warning && e.EventId.Id == 77,
+                "warning must be silent when a real IDistributedLockProvider is registered"
+            );
     }
 
     [Fact]
@@ -192,7 +208,7 @@ public sealed class BootstrapperTests : TestBase
 
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddSingleton<IDistributedLockProvider>(appLevelProvider);
+        services.AddSingleton(appLevelProvider);
 
         var messagingBuilder = services.AddHeadlessMessaging(setup =>
         {
@@ -217,7 +233,12 @@ public sealed class BootstrapperTests : TestBase
         // Exposed via internal helper (InternalsVisibleTo) instead of reflection so the test stays
         // resilient to private-field renames.
         var injected = processor.LockProvider;
-        injected.Should().BeSameAs(messagingProvider, "the processor must receive the messaging-keyed provider, not the un-keyed app-level one");
+        injected
+            .Should()
+            .BeSameAs(
+                messagingProvider,
+                "the processor must receive the messaging-keyed provider, not the un-keyed app-level one"
+            );
         injected.Should().NotBeSameAs(appLevelProvider);
     }
 
@@ -262,7 +283,7 @@ public sealed class BootstrapperTests : TestBase
 
         if (configureOptions is not null)
         {
-            services.Configure<MessagingOptions>(configureOptions);
+            services.Configure(configureOptions);
         }
 
         extraSetup?.Invoke(services);
@@ -339,7 +360,8 @@ public sealed class BootstrapperTests : TestBase
 
         private sealed class CapturingLogger(List<(LogLevel Level, EventId EventId)> log) : ILogger
         {
-            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
 
             public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
@@ -23,7 +23,7 @@ public sealed class ConsumerRegisterTests : TestBase
         using var hostCts = new CancellationTokenSource();
 
         await register.StartAsync(hostCts.Token);
-        await register.ReStartAsync(force: true);
+        await register.ReStartAsync(force: true, AbortToken);
 
         await hostCts.CancelAsync();
 
@@ -123,7 +123,7 @@ public sealed class ConsumerRegisterTests : TestBase
             .SetValue(register, factorySub);
 
         // Act — ReStartAsync should propagate the exception from ExecuteAsync.
-        var act = async () => await register.ReStartAsync(force: true);
+        var act = async () => await register.ReStartAsync(force: true, AbortToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/ContextTypes/ConsumeContextHierarchyTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ContextTypes/ConsumeContextHierarchyTests.cs
@@ -73,7 +73,7 @@ public sealed class ConsumeContextHierarchyTests : TestBase
 
         // then
         context.Should().BeAssignableTo<ConsumeContext<OrderPlaced>>();
-        ((ConsumeContext)context).MessageType.Should().Be<OrderPlaced>();
+        context.MessageType.Should().Be<OrderPlaced>();
     }
 
     private static ConsumeContext<OrderPlaced> _CreateContext(OrderPlaced message)

--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -143,16 +143,14 @@ public sealed class DispatcherTests : TestBase
         // when
         await dispatcher.StartAsync(cts.Token);
         var dateTime = DateTime.UtcNow.AddSeconds(1);
+
         await Parallel.ForEachAsync(
             messages,
-            CancellationToken.None,
-            async (m, _) =>
-            {
-                await dispatcher.EnqueueToScheduler(m, dateTime);
-            }
+            AbortToken,
+            async (m, ct) => await dispatcher.EnqueueToScheduler(m, dateTime, null, ct)
         );
 
-        await sender.WaitForCountAsync(10000, TimeSpan.FromSeconds(10));
+        await sender.WaitForCountAsync(10000, TimeSpan.FromSeconds(10), AbortToken);
 
         await cts.CancelAsync();
 
@@ -279,14 +277,11 @@ public sealed class DispatcherTests : TestBase
 
         await Parallel.ForEachAsync(
             messages,
-            CancellationToken.None,
-            async (m, _) =>
-            {
-                await dispatcher.EnqueueToScheduler(m, dateTime);
-            }
+            AbortToken,
+            async (m, ct) => await dispatcher.EnqueueToScheduler(m, dateTime, null, ct)
         );
 
-        await sender.WaitForCountAsync(10000, TimeSpan.FromSeconds(10));
+        await sender.WaitForCountAsync(10000, TimeSpan.FromSeconds(10), AbortToken);
 
         await cts.CancelAsync();
 
@@ -426,7 +421,7 @@ public sealed class DispatcherTests : TestBase
             await dispatcher.EnqueueToPublish(message, AbortToken);
         }
 
-        await sender.WaitForCountAsync(100, TimeSpan.FromSeconds(5));
+        await sender.WaitForCountAsync(100, TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // then - verify all messages sent successfully
@@ -463,7 +458,7 @@ public sealed class DispatcherTests : TestBase
             await dispatcher.EnqueueToPublish(message, AbortToken);
         }
 
-        await sender.WaitForCountAsync(500, TimeSpan.FromSeconds(5));
+        await sender.WaitForCountAsync(500, TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // then - verify all messages sent successfully

--- a/tests/Headless.Messaging.Core.Tests.Unit/Helpers/TestBootstrapService.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Helpers/TestBootstrapService.cs
@@ -7,7 +7,7 @@ public sealed class TestBootstrapService(IBootstrapper bootstrapper) : IHostedSe
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        await bootstrapper.BootstrapAsync();
+        await bootstrapper.BootstrapAsync(cancellationToken);
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/tests/Headless.Messaging.Core.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Retry/RetryHelperTests.cs
@@ -21,7 +21,9 @@ public sealed class RetryHelperTests : TestBase
 
         var decision = RetryHelper.RecordAttemptAndComputeDecision(
             message,
-            new ArgumentException("permanent", "param"),
+#pragma warning disable MA0015 // ReSharper disable once NotResolvedInText
+            new ArgumentException(@"permanent", "param"),
+#pragma warning restore MA0015
             new RetryPolicyOptions(),
             inlineRetries: 0
         );
@@ -457,11 +459,10 @@ public sealed class RetryHelperTests : TestBase
         // executor's gating logic). Loop until the helper returns a terminal decision.
         var message = _CreateMessage();
         var inlineInFlightObservations = new List<bool>();
-        RetryDecision lastDecision = RetryDecision.Stop;
 
         for (var pickup = 0; pickup <= maxPersistedRetries + 1; pickup++)
         {
-            lastDecision = RetryHelper.RecordAttemptAndComputeDecision(
+            var lastDecision = RetryHelper.RecordAttemptAndComputeDecision(
                 message,
                 new TimeoutException(),
                 policy,
@@ -663,7 +664,7 @@ public sealed class RetryHelperTests : TestBase
         );
 
         // The callback's CT should have been cancelled by the OCE branch's CancelAsync call.
-        var cancelled = await callbackCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var cancelled = await callbackCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
         cancelled.Should().BeTrue();
         observedCallbackCt.IsCancellationRequested.Should().BeTrue();
     }

--- a/tests/Headless.Messaging.InMemoryQueue.Tests.Unit/InMemoryConsumerClientTests.cs
+++ b/tests/Headless.Messaging.InMemoryQueue.Tests.Unit/InMemoryConsumerClientTests.cs
@@ -477,7 +477,7 @@ public sealed class InMemoryConsumerClientTests : TestBase
         await Task.Delay(50, AbortToken);
 
         // when — pause then send
-        await _client.PauseAsync();
+        await _client.PauseAsync(AbortToken);
         _queue.Send(_CreateTestMessage("paused-msg", "test-topic"));
         await Task.Delay(200, AbortToken);
 
@@ -485,7 +485,7 @@ public sealed class InMemoryConsumerClientTests : TestBase
         receivedCount.Should().Be(0);
 
         // cleanup — resume and cancel
-        await _client.ResumeAsync();
+        await _client.ResumeAsync(AbortToken);
         await Task.Delay(200, AbortToken);
         await cts.CancelAsync();
 

--- a/tests/Headless.Messaging.InMemoryQueue.Tests.Unit/InMemoryQueueTransportTests.cs
+++ b/tests/Headless.Messaging.InMemoryQueue.Tests.Unit/InMemoryQueueTransportTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Tests;
 
+// ReSharper disable AccessToDisposedClosure
 public sealed class InMemoryQueueTransportTests : TestBase
 {
     private readonly InMemoryQueueTransport _transport;
@@ -72,7 +73,7 @@ public sealed class InMemoryQueueTransportTests : TestBase
         var message = _CreateTestMessage("msg-1", "test-topic");
 
         // when
-        var result = await _transport.SendAsync(message);
+        var result = await _transport.SendAsync(message, AbortToken);
 
         await Task.Delay(100, AbortToken);
         await cts.CancelAsync();
@@ -152,7 +153,7 @@ public sealed class InMemoryQueueTransportTests : TestBase
         var message = new TransportMessage(headers, ReadOnlyMemory<byte>.Empty);
 
         // when
-        await _transport.SendAsync(message);
+        await _transport.SendAsync(message, AbortToken);
 
         await Task.Delay(100, AbortToken);
         await cts.CancelAsync();
@@ -177,7 +178,8 @@ public sealed class InMemoryQueueTransportTests : TestBase
         };
 
         using var cts = new CancellationTokenSource();
-        var listenTask = Task.Run(
+
+        _ = Task.Run(
             async () =>
             {
                 try
@@ -200,7 +202,7 @@ public sealed class InMemoryQueueTransportTests : TestBase
         var message = new TransportMessage(headers, bodyContent);
 
         // when
-        await _transport.SendAsync(message);
+        await _transport.SendAsync(message, AbortToken);
 
         await Task.Delay(100, AbortToken);
         await cts.CancelAsync();
@@ -271,7 +273,7 @@ public sealed class InMemoryQueueTransportTests : TestBase
         // when - send messages concurrently via transport
         var sendTasks = Enumerable
             .Range(0, messageCount)
-            .Select(i => _transport.SendAsync(_CreateTestMessage($"msg-{i}", "concurrent-topic")));
+            .Select(i => _transport.SendAsync(_CreateTestMessage($"msg-{i}", "concurrent-topic"), AbortToken));
 
         var results = await Task.WhenAll(sendTasks);
 

--- a/tests/Headless.Messaging.Kafka.Tests.Unit/KafkaConsumerClientTests.cs
+++ b/tests/Headless.Messaging.Kafka.Tests.Unit/KafkaConsumerClientTests.cs
@@ -10,17 +10,13 @@ using Microsoft.Extensions.Options;
 
 namespace Tests;
 
+// ReSharper disable AccessToDisposedClosure
 public sealed class KafkaConsumerClientTests : TestBase
 {
     private readonly IOptions<MessagingKafkaOptions> _options = Options.Create(
         new MessagingKafkaOptions { Servers = "localhost:9092" }
     );
-    private readonly IServiceProvider _serviceProvider;
-
-    public KafkaConsumerClientTests()
-    {
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-    }
+    private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
 
     [Fact]
     public async Task should_have_correct_broker_address()
@@ -511,7 +507,7 @@ public sealed class KafkaConsumerClientTests : TestBase
             // Observe the faulted task to prevent unobserved exception
             try
             {
-                await listeningTask.WaitAsync(TimeSpan.FromSeconds(1));
+                await listeningTask.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
             }
             catch
             {

--- a/tests/Headless.Messaging.Nats.Tests.Integration/NatsConnectionTest.cs
+++ b/tests/Headless.Messaging.Nats.Tests.Integration/NatsConnectionTest.cs
@@ -19,6 +19,6 @@ public sealed class NatsConnectionTest(NatsFixture fixture)
         await using var conn = new NatsConnection(opts);
         var rtt = await conn.PingAsync();
 
-        rtt.TotalMilliseconds.Should().BeGreaterThan(0);
+        rtt.TotalMilliseconds.Should().BePositive();
     }
 }

--- a/tests/Headless.Messaging.Nats.Tests.Integration/NatsConsumerClientTests.cs
+++ b/tests/Headless.Messaging.Nats.Tests.Integration/NatsConsumerClientTests.cs
@@ -3,6 +3,7 @@
 using Headless.Messaging.Exceptions;
 using Headless.Messaging.Messages;
 using Headless.Messaging.Nats;
+using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NATS.Client.Core;
@@ -13,7 +14,7 @@ using MessagingHeaders = Headless.Messaging.Headers;
 namespace Tests;
 
 [Collection("Nats")]
-public sealed class NatsConsumerClientTests(NatsFixture fixture)
+public sealed class NatsConsumerClientTests(NatsFixture fixture) : TestBase
 {
     private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
 
@@ -48,7 +49,7 @@ public sealed class NatsConsumerClientTests(NatsFixture fixture)
         var listeningTask = client.ListeningAsync(TimeSpan.FromSeconds(1), cts.Token).AsTask();
         try
         {
-            await Task.Delay(500);
+            await Task.Delay(500, AbortToken);
 
             var body = "hello-commit"u8.ToArray();
             await _PublishAsync(subject, body);
@@ -97,7 +98,7 @@ public sealed class NatsConsumerClientTests(NatsFixture fixture)
         var listeningTask = client.ListeningAsync(TimeSpan.FromSeconds(1), cts.Token).AsTask();
         try
         {
-            await Task.Delay(500);
+            await Task.Delay(500, AbortToken);
             await _PublishAsync(subject, "hello-reject"u8.ToArray());
 
             var natsMsg = await received.Task.WaitAsync(cts.Token);
@@ -195,7 +196,7 @@ public sealed class NatsConsumerClientTests(NatsFixture fixture)
         var listeningTask = client.ListeningAsync(TimeSpan.FromSeconds(1), cts.Token).AsTask();
         try
         {
-            await Task.Delay(500);
+            await Task.Delay(500, AbortToken);
 
             var conn = await fixture.GetConnectionAsync();
             var js = new NatsJSContext(conn);
@@ -204,7 +205,8 @@ public sealed class NatsConsumerClientTests(NatsFixture fixture)
                 subject,
                 "body"u8.ToArray(),
                 serializer: NatsRawSerializer<ReadOnlyMemory<byte>>.Default,
-                headers: headers
+                headers: headers,
+                cancellationToken: AbortToken
             );
 
             var transportMsg = await received.Task.WaitAsync(cts.Token);
@@ -269,23 +271,23 @@ public sealed class NatsConsumerClientTests(NatsFixture fixture)
         var listeningTask = client.ListeningAsync(TimeSpan.FromSeconds(1), cts.Token).AsTask();
         try
         {
-            await Task.Delay(500); // let consumer start and create durable consumer
+            await Task.Delay(500, AbortToken); // let consumer start and create durable consumer
 
-            await client.PauseAsync();
+            await client.PauseAsync(AbortToken);
             await _PublishAsync(subject, "paused-msg"u8.ToArray());
-            await Task.Delay(1000);
+            await Task.Delay(1000, AbortToken);
 
             var countWhilePaused = Volatile.Read(ref messageCount);
 
             // resume and wait for delivery via signal
-            await client.ResumeAsync();
-            await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await client.ResumeAsync(AbortToken);
+            await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(10), AbortToken);
 
             var countAfterResume = Volatile.Read(ref messageCount);
 
             // then
             countWhilePaused.Should().Be(0);
-            countAfterResume.Should().BeGreaterThan(0);
+            countAfterResume.Should().BePositive();
         }
         finally
         {

--- a/tests/Headless.Messaging.Nats.Tests.Unit/NatsConsumerClientTests.cs
+++ b/tests/Headless.Messaging.Nats.Tests.Unit/NatsConsumerClientTests.cs
@@ -10,16 +10,13 @@ using MsOptions = Microsoft.Extensions.Options;
 
 namespace Tests;
 
+// ReSharper disable AccessToDisposedClosure
 public sealed class NatsConsumerClientTests : TestBase
 {
-    private readonly MsOptions.IOptions<MessagingNatsOptions> _options;
-    private readonly IServiceProvider _serviceProvider;
-
-    public NatsConsumerClientTests()
-    {
-        _options = MsOptions.Options.Create(new MessagingNatsOptions { Servers = "nats://localhost:4222" });
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-    }
+    private readonly MsOptions.IOptions<MessagingNatsOptions> _options = MsOptions.Options.Create(
+        new MessagingNatsOptions { Servers = "nats://localhost:4222" }
+    );
+    private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
 
     [Fact]
     public async Task should_have_correct_broker_address()
@@ -498,8 +495,8 @@ public sealed class NatsConsumerClientTests : TestBase
             // then
             nextCallCount.Should().Be(0);
 
-            await client.ResumeAsync();
-            await WaitUntilAsync(() => Volatile.Read(ref nextCallCount) > 0, TimeSpan.FromSeconds(1));
+            await client.ResumeAsync(AbortToken);
+            await _WaitUntilAsync(() => Volatile.Read(ref nextCallCount) > 0, TimeSpan.FromSeconds(1));
         }
         finally
         {
@@ -553,7 +550,7 @@ public sealed class NatsConsumerClientTests : TestBase
         try
         {
             await nextStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
-            await client.PauseAsync();
+            await client.PauseAsync(AbortToken);
 
             // then
             await fetchCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
@@ -634,12 +631,12 @@ public sealed class NatsConsumerClientTests : TestBase
         try
         {
             await startedSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
-            await client.PauseAsync();
+            await client.PauseAsync(AbortToken);
             await canceledSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
 
-            await client.ResumeAsync();
+            await client.ResumeAsync(AbortToken);
             await startedSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
-            await client.PauseAsync();
+            await client.PauseAsync(AbortToken);
             await canceledSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
 
             // then
@@ -657,7 +654,7 @@ public sealed class NatsConsumerClientTests : TestBase
         return new NatsConsumerClient(groupName, groupConcurrent, _options, _serviceProvider);
     }
 
-    private async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    private static async Task _WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(AbortToken);
         cts.CancelAfter(timeout);

--- a/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/DiagnosticListenerTests.cs
+++ b/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/DiagnosticListenerTests.cs
@@ -54,7 +54,7 @@ public sealed class DiagnosticListenerTests : TestBase
         var listener = new DiagnosticListener([]);
 
         // when/then
-        var act = () => listener.OnCompleted();
+        var act = listener.OnCompleted;
         act.Should().NotThrow();
     }
 
@@ -338,9 +338,9 @@ public sealed class DiagnosticListenerTests : TestBase
             // fire-and-forget async-tail observer path. We cannot mark this method `async`
             // (the `in` parameter forbids it), so we wrap an async local in a Task and return
             // a non-completed ValueTask.
-            return new ValueTask(_ThrowAfterYieldAsync());
+            return new ValueTask(throwAfterYieldAsync());
 
-            static async Task _ThrowAfterYieldAsync()
+            static async Task throwAfterYieldAsync()
             {
                 await Task.Yield();
                 throw new InvalidOperationException("async enricher failure");
@@ -536,8 +536,9 @@ public sealed class DiagnosticListenerTests : TestBase
     {
         var listener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == DiagnosticListener.SourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ShouldListenTo = source =>
+                string.Equals(source.Name, DiagnosticListener.SourceName, StringComparison.Ordinal),
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
         };
         ActivitySource.AddActivityListener(listener);
         return listener;

--- a/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/RetryCountTagEnricherTests.cs
+++ b/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/RetryCountTagEnricherTests.cs
@@ -71,6 +71,9 @@ public sealed class RetryCountTagEnricherTests : TestBase
     private static Activity _CreateActivity()
     {
         using var source = new ActivitySource("test");
+#pragma warning disable CA2000  // Dispose objects before losing scope
+        // ReSharper disable once ExplicitCallerInfoArgument
         return source.StartActivity("test") ?? new Activity("test").Start();
+#pragma warning restore CA2000
     }
 }

--- a/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/SetupTests.cs
+++ b/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/SetupTests.cs
@@ -66,7 +66,7 @@ public sealed class SetupTests : TestBase
     public void should_accept_custom_enricher()
     {
         // given - register a custom enricher alongside the built-in defaults
-        var customEnricher = NSubstitute.Substitute.For<IActivityTagEnricher>();
+        var customEnricher = Substitute.For<IActivityTagEnricher>();
         var options = new MessagingInstrumentationOptions();
         options.AddEnricher(customEnricher);
 

--- a/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/TenantIdTagEnricherTests.cs
+++ b/tests/Headless.Messaging.OpenTelemetry.Tests.Unit/TenantIdTagEnricherTests.cs
@@ -73,6 +73,9 @@ public sealed class TenantIdTagEnricherTests : TestBase
     private static Activity _CreateActivity()
     {
         using var source = new ActivitySource("test");
+#pragma warning disable CA2000  // Dispose objects before losing scope
+        // ReSharper disable once ExplicitCallerInfoArgument
         return source.StartActivity("test") ?? new Activity("test").Start();
+#pragma warning restore CA2000
     }
 }

--- a/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlCrudTest.cs
+++ b/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlCrudTest.cs
@@ -178,18 +178,22 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         var expiredTime = DateTime.UtcNow.AddDays(-1);
         var id = _longIdGenerator.Create();
         var messageId = $"msg-{id}";
+
         await connection.ExecuteAsync(
-            """
-            INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","StatusName","MessageId")
-            VALUES (@Id,'v1','test.topic','{}',0,@Added,@ExpiresAt,'Succeeded',@MessageId)
-            """,
-            new
-            {
-                Id = id,
-                Added = expiredTime,
-                ExpiresAt = expiredTime,
-                MessageId = messageId,
-            }
+            new CommandDefinition(
+                """
+                INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","StatusName","MessageId")
+                VALUES (@Id,'v1','test.topic','{}',0,@Added,@ExpiresAt,'Succeeded',@MessageId)
+                """,
+                new
+                {
+                    Id = id,
+                    Added = expiredTime,
+                    ExpiresAt = expiredTime,
+                    MessageId = messageId,
+                },
+                cancellationToken: AbortToken
+            )
         );
 
         // when
@@ -242,23 +246,27 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         var id = _longIdGenerator.Create();
         var messageId = $"msg-{id}";
         var content = "{\"Headers\":{\"headless-msg-id\":\"" + messageId + "\"},\"Value\":null}";
+
         await connection.ExecuteAsync(
-            """
-            INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
-            VALUES (@Id,'v1','test.topic',@Content,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
-            """,
-            new
-            {
-                Id = id,
-                Content = content,
-                Added = addedTime,
-                NextRetryAt = DateTime.UtcNow.AddSeconds(-1),
-                MessageId = messageId,
-            }
+            new CommandDefinition(
+                """
+                INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
+                VALUES (@Id,'v1','test.topic',@Content,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
+                """,
+                new
+                {
+                    Id = id,
+                    Content = content,
+                    Added = addedTime,
+                    NextRetryAt = DateTime.UtcNow.AddSeconds(-1),
+                    MessageId = messageId,
+                },
+                cancellationToken: AbortToken
+            )
         );
 
         // when
-        var messages = await _storage.GetPublishedMessagesOfNeedRetryAsync(AbortToken);
+        var messages = (await _storage.GetPublishedMessagesOfNeedRetryAsync(AbortToken)).ToList();
 
         // then
         messages.Should().NotBeEmpty();
@@ -277,22 +285,25 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         var msgId = _longIdGenerator.Create().ToString(CultureInfo.InvariantCulture);
         var content = "{\"Headers\":{\"headless-msg-id\":\"" + msgId + "\"},\"Value\":null}";
         await connection.ExecuteAsync(
-            """
-            INSERT INTO messaging.received ("Id","Version","Name","Group","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
-            VALUES (@Id,'v1','test.topic','test.group',@Content,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
-            """,
-            new
-            {
-                Id = id,
-                Content = content,
-                Added = addedTime,
-                NextRetryAt = DateTime.UtcNow.AddSeconds(-1),
-                MessageId = msgId,
-            }
+            new CommandDefinition(
+                """
+                INSERT INTO messaging.received ("Id","Version","Name","Group","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
+                VALUES (@Id,'v1','test.topic','test.group',@Content,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
+                """,
+                new
+                {
+                    Id = id,
+                    Content = content,
+                    Added = addedTime,
+                    NextRetryAt = DateTime.UtcNow.AddSeconds(-1),
+                    MessageId = msgId,
+                },
+                cancellationToken: AbortToken
+            )
         );
 
         // when
-        var messages = await _storage.GetReceivedMessagesOfNeedRetryAsync(AbortToken);
+        var messages = (await _storage.GetReceivedMessagesOfNeedRetryAsync(AbortToken)).ToList();
 
         // then
         messages.Should().NotBeEmpty();
@@ -350,10 +361,15 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         // then
         await using var connection = new NpgsqlConnection(fixture.ConnectionString);
         await connection.OpenAsync(AbortToken);
+
         var status = await connection.QueryFirstOrDefaultAsync<string>(
-            "SELECT \"StatusName\" FROM messaging.received WHERE \"MessageId\"=@MessageId",
-            new { MessageId = msgId }
+            new CommandDefinition(
+                "SELECT \"StatusName\" FROM messaging.received WHERE \"MessageId\"=@MessageId",
+                new { MessageId = msgId },
+                cancellationToken: AbortToken
+            )
         );
+
         status.Should().Be(nameof(StatusName.Failed));
     }
 

--- a/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
+++ b/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
@@ -98,10 +98,13 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
             await using var connection = new NpgsqlConnection(fixture.ConnectionString);
             await connection.OpenAsync();
             await connection.ExecuteAsync(
-                """
-                TRUNCATE TABLE messaging.published;
-                TRUNCATE TABLE messaging.received;
-                """
+                new CommandDefinition(
+                    """
+                    TRUNCATE TABLE messaging.published;
+                    TRUNCATE TABLE messaging.received;
+                    """,
+                    cancellationToken: AbortToken
+                )
             );
         }
         catch (PostgresException)

--- a/tests/Headless.Messaging.RabbitMq.Tests.Unit/RabbitMqBasicConsumerTests.cs
+++ b/tests/Headless.Messaging.RabbitMq.Tests.Unit/RabbitMqBasicConsumerTests.cs
@@ -702,7 +702,7 @@ public sealed class RabbitMqBasicConsumerTests : TestBase
         consumer.Dispose();
 
         // then - should not throw on second dispose
-        var act = () => consumer.Dispose();
+        var act = consumer.Dispose;
         act.Should().NotThrow();
     }
 

--- a/tests/Headless.Messaging.RabbitMq.Tests.Unit/RabbitMqConsumerClientTests.cs
+++ b/tests/Headless.Messaging.RabbitMq.Tests.Unit/RabbitMqConsumerClientTests.cs
@@ -492,22 +492,24 @@ public sealed class RabbitMqConsumerClientTests : TestBase
         _channel.IsClosed.Returns(false);
 
         using var cts = new CancellationTokenSource();
-        await client.PauseAsync();
+        await client.PauseAsync(AbortToken);
 
         // when
         var listeningTask = client.ListeningAsync(TimeSpan.FromMilliseconds(10), cts.Token).AsTask();
         try
         {
             // then - startup remains gated while paused
-            await Task.Delay(100);
+            await Task.Delay(100, AbortToken);
+
             _channel
                 .ReceivedCalls()
                 .Should()
                 .NotContain(c => c.GetMethodInfo().Name == nameof(IChannel.BasicConsumeAsync));
 
-            await client.ResumeAsync();
+            await client.ResumeAsync(AbortToken);
 
-            await Task.Delay(100);
+            await Task.Delay(100, AbortToken);
+
             _channel
                 .ReceivedCalls()
                 .Should()

--- a/tests/Headless.Messaging.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
+++ b/tests/Headless.Messaging.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
@@ -25,16 +25,24 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
 
         // then
         await using var connection = new SqlConnection(fixture.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(AbortToken);
+
         var schemaExists = await connection.QueryFirstOrDefaultAsync<int>(
-            "SELECT 1 FROM sys.schemas WHERE name = @Schema",
-            new { Schema = customSchema }
+            new CommandDefinition(
+                "SELECT 1 FROM sys.schemas WHERE name = @Schema",
+                new { Schema = customSchema },
+                cancellationToken: AbortToken
+            )
         );
+
         schemaExists.Should().Be(1);
 
         // cleanup
         await connection.ExecuteAsync(
-            $"DROP TABLE IF EXISTS [{customSchema}].Published; DROP TABLE IF EXISTS [{customSchema}].Received; DROP SCHEMA IF EXISTS [{customSchema}]"
+            new CommandDefinition(
+                $"DROP TABLE IF EXISTS [{customSchema}].Published; DROP TABLE IF EXISTS [{customSchema}].Received; DROP SCHEMA IF EXISTS [{customSchema}]",
+                cancellationToken: AbortToken
+            )
         );
     }
 
@@ -66,7 +74,10 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
 
         // cleanup
         await connection.ExecuteAsync(
-            $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP SCHEMA IF EXISTS [{schema}]"
+            new CommandDefinition(
+                $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP SCHEMA IF EXISTS [{schema}]",
+                cancellationToken: AbortToken
+            )
         );
     }
 
@@ -109,7 +120,10 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
 
         // cleanup
         await connection.ExecuteAsync(
-            $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP SCHEMA IF EXISTS [{schema}]"
+            new CommandDefinition(
+                $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP SCHEMA IF EXISTS [{schema}]",
+                cancellationToken: AbortToken
+            )
         );
     }
 
@@ -172,25 +186,28 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
 
         var keyColumns = (
             await connection.QueryAsync<string>(
-                """
-                SELECT c.name
-                FROM sys.indexes i
-                INNER JOIN sys.tables t ON i.object_id = t.object_id
-                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
-                INNER JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
-                INNER JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
-                WHERE s.name = @Schema
-                  AND t.name = @Table
-                  AND i.name = @IndexName
-                  AND ic.is_included_column = 0
-                ORDER BY ic.key_ordinal
-                """,
-                new
-                {
-                    Schema = schema,
-                    Table = table,
-                    IndexName = indexName,
-                }
+                new CommandDefinition(
+                    """
+                    SELECT c.name
+                    FROM sys.indexes i
+                    INNER JOIN sys.tables t ON i.object_id = t.object_id
+                    INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                    INNER JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                    INNER JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+                    WHERE s.name = @Schema
+                      AND t.name = @Table
+                      AND i.name = @IndexName
+                      AND ic.is_included_column = 0
+                    ORDER BY ic.key_ordinal
+                    """,
+                    new
+                    {
+                        Schema = schema,
+                        Table = table,
+                        IndexName = indexName,
+                    },
+                    cancellationToken: AbortToken
+                )
             )
         ).ToList();
 
@@ -199,25 +216,32 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
         // Filtered predicate must be `[NextRetryAt] IS NOT NULL` so terminal rows are physically
         // excluded — keeps the index small even under high failed-message volume.
         var filter = await connection.QueryFirstOrDefaultAsync<string>(
-            """
-            SELECT i.filter_definition
-            FROM sys.indexes i
-            INNER JOIN sys.tables t ON i.object_id = t.object_id
-            INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
-            WHERE s.name = @Schema AND t.name = @Table AND i.name = @IndexName
-            """,
-            new
-            {
-                Schema = schema,
-                Table = table,
-                IndexName = indexName,
-            }
+            new CommandDefinition(
+                """
+                SELECT i.filter_definition
+                FROM sys.indexes i
+                INNER JOIN sys.tables t ON i.object_id = t.object_id
+                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = @Schema AND t.name = @Table AND i.name = @IndexName
+                """,
+                new
+                {
+                    Schema = schema,
+                    Table = table,
+                    IndexName = indexName,
+                },
+                cancellationToken: AbortToken
+            )
         );
+
         filter.Should().NotBeNull().And.Contain("NextRetryAt").And.Contain("IS NOT NULL");
 
         // cleanup
         await connection.ExecuteAsync(
-            $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP SCHEMA IF EXISTS [{schema}]"
+            new CommandDefinition(
+                $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP SCHEMA IF EXISTS [{schema}]",
+                cancellationToken: AbortToken
+            )
         );
     }
 
@@ -278,11 +302,14 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
 
         // then - should return early without error
         await using var connection = new SqlConnection(fixture.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(AbortToken);
 
         var schemaExists = await connection.QueryFirstOrDefaultAsync<int?>(
-            "SELECT 1 FROM sys.schemas WHERE name = @Schema",
-            new { Schema = schema }
+            new CommandDefinition(
+                "SELECT 1 FROM sys.schemas WHERE name = @Schema",
+                new { Schema = schema },
+                cancellationToken: AbortToken
+            )
         );
 
         schemaExists.Should().BeNull();

--- a/tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs
+++ b/tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs
@@ -69,7 +69,7 @@ public sealed class SetupHeadlessTenancyTests
                 .Single(service => service.GetType().Name == "HeadlessTenancyStartupValidator");
 
         // when — validation runs in StartingAsync so it fires before any other hosted service's StartAsync.
-        Func<Task> act = () => hostedService.StartingAsync(CancellationToken.None);
+        var act = () => hostedService.StartingAsync(CancellationToken.None);
 
         // then
         await act.Should()
@@ -98,7 +98,7 @@ public sealed class SetupHeadlessTenancyTests
                 .Single(service => service.GetType().Name == "HeadlessTenancyStartupValidator");
 
         // when
-        Func<Task> act = () => hostedService.StartingAsync(CancellationToken.None);
+        var act = () => hostedService.StartingAsync(CancellationToken.None);
 
         // then
         await act.Should()

--- a/tests/Headless.Permissions.Tests.Unit/Services/PermissionsInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Permissions.Tests.Unit/Services/PermissionsInitializationBackgroundServiceTests.cs
@@ -400,19 +400,19 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
         // when - start with a cancellable token
         await sut.StartAsync(cts.Token);
-        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         // Cancel the token
         await cts.CancelAsync();
 
         // Wait for cancellation to be observed
-        var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5), AbortToken));
 
         // then - the save operation should have been cancelled
         cancelledTask.Should().Be(saveCancelled.Task, "cancellation token should cancel the background task");
 
         // Wait for task completion before dispose
-        await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+        await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1), AbortToken));
     }
 
     #endregion
@@ -437,7 +437,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
 
         // then - should not throw on dispose (proper cleanup)
         // Calling dispose again should also not throw (idempotent)
-        var action = () => sut.Dispose();
+        var action = sut.Dispose;
         action.Should().NotThrow();
     }
 

--- a/tests/Headless.Settings.Tests.Unit/Seeders/SettingsInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Settings.Tests.Unit/Seeders/SettingsInitializationBackgroundServiceTests.cs
@@ -353,16 +353,16 @@ public sealed class SettingsInitializationBackgroundServiceTests : TestBase
 
         // when - start with a cancellable token
         await sut.StartAsync(cts.Token);
-        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         await cts.CancelAsync();
 
-        var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        var cancelledTask = await Task.WhenAny(saveCancelled.Task, Task.Delay(TimeSpan.FromSeconds(5), AbortToken));
 
         // then
         cancelledTask.Should().Be(saveCancelled.Task, "cancellation token should cancel the background task");
 
-        await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+        await Task.WhenAny(taskCompleted.Task, Task.Delay(TimeSpan.FromSeconds(1), AbortToken));
     }
 
     #endregion
@@ -386,7 +386,7 @@ public sealed class SettingsInitializationBackgroundServiceTests : TestBase
         sut.Dispose();
 
         // then - should not throw on dispose (proper cleanup)
-        var action = () => sut.Dispose();
+        var action = sut.Dispose;
         action.Should().NotThrow();
     }
 

--- a/tests/Headless.Sql.Tests.Unit/DefaultSqlCurrentConnectionTests.cs
+++ b/tests/Headless.Sql.Tests.Unit/DefaultSqlCurrentConnectionTests.cs
@@ -220,7 +220,7 @@ public sealed class DefaultSqlCurrentConnectionTests
         connection.State.Returns(ConnectionState.Closed);
 
         // when/then - should not throw
-        Func<Task> act = async () => await sut.DisposeAsync();
+        var act = async () => await sut.DisposeAsync();
         await act.Should().NotThrowAsync();
         await connection.DidNotReceive().DisposeAsync();
     }
@@ -244,7 +244,7 @@ public sealed class DefaultSqlCurrentConnectionTests
         // Connection state is now effectively null after first dispose
         connection.State.Returns(ConnectionState.Closed);
 
-        Func<Task> act = async () => await sut.DisposeAsync();
+        var act = async () => await sut.DisposeAsync();
 
         // then - should not throw
         await act.Should().NotThrowAsync();

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerDatabaseResetTests.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerDatabaseResetTests.cs
@@ -26,7 +26,7 @@ public sealed class HeadlessTestServerDatabaseResetTests : IAsyncLifetime
         _server = new HeadlessTestServer<Program>();
         await _server.InitializeAsync();
 
-        Func<Task> act = async () => await _server.ResetDatabaseAsync();
+        var act = async () => await _server.ResetDatabaseAsync();
 
         await act.Should().ThrowExactlyAsync<InvalidOperationException>().WithMessage("*not configured*");
     }
@@ -38,7 +38,7 @@ public sealed class HeadlessTestServerDatabaseResetTests : IAsyncLifetime
         _server.ConfigureDatabaseReset(_ => { });
         await _server.InitializeAsync();
 
-        Func<Task> act = async () => await _server.ResetDatabaseAsync();
+        var act = async () => await _server.ResetDatabaseAsync();
 
         await act.Should()
             .ThrowExactlyAsync<InvalidOperationException>()
@@ -53,7 +53,7 @@ public sealed class HeadlessTestServerDatabaseResetTests : IAsyncLifetime
         await _server.InitializeAsync();
         await _server.DisposeAsync();
 
-        Func<Task> act = async () => await _server.ResetDatabaseAsync();
+        var act = async () => await _server.ResetDatabaseAsync();
 
         await act.Should().ThrowExactlyAsync<ObjectDisposedException>();
     }

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerTests.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerTests.cs
@@ -5,23 +5,24 @@ using Headless.Abstractions;
 using Headless.Hosting.Initialization;
 using Headless.Testing.AspNetCore;
 using Headless.Testing.Helpers;
+using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Tests;
 
-public sealed class HeadlessTestServerTests : IAsyncLifetime
+public sealed class HeadlessTestServerTests : TestBase
 {
     private HeadlessTestServer<Program>? _server;
 
-    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
-
-    public async ValueTask DisposeAsync()
+    protected override async ValueTask DisposeAsyncCore()
     {
         if (_server is not null)
         {
             await _server.DisposeAsync();
         }
+
+        await base.DisposeAsyncCore();
     }
 
     [Fact]
@@ -206,7 +207,7 @@ public sealed class HeadlessTestServerTests : IAsyncLifetime
         _server = new HeadlessTestServer<Program>();
         _server.WaitForReadiness(_ => Task.Delay(TimeSpan.FromSeconds(30)), timeout: TimeSpan.FromMilliseconds(50));
 
-        Func<Task> act = async () => await _server.InitializeAsync();
+        var act = async () => await _server.InitializeAsync();
 
         await act.Should().ThrowExactlyAsync<TimeoutException>();
     }
@@ -225,9 +226,13 @@ public sealed class HeadlessTestServerTests : IAsyncLifetime
     public async Task should_cleanup_factory_on_init_failure()
     {
         _server = new HeadlessTestServer<Program>();
-        _server.WaitForReadiness(_ => Task.Delay(TimeSpan.FromSeconds(30)), timeout: TimeSpan.FromMilliseconds(50));
 
-        Func<Task> act = async () => await _server.InitializeAsync();
+        _server.WaitForReadiness(
+            _ => Task.Delay(TimeSpan.FromSeconds(30), AbortToken),
+            timeout: TimeSpan.FromMilliseconds(50)
+        );
+
+        var act = async () => await _server.InitializeAsync();
         await act.Should().ThrowExactlyAsync<TimeoutException>();
 
         // After init failure, dispose should be safe (factory already cleaned up)
@@ -284,7 +289,7 @@ public sealed class HeadlessTestServerTests : IAsyncLifetime
             initializerTimeout: TimeSpan.FromMilliseconds(100)
         );
 
-        Func<Task> act = async () => await _server.InitializeAsync();
+        var act = async () => await _server.InitializeAsync();
 
         await act.Should().ThrowExactlyAsync<TimeoutException>().WithMessage("*NeverCompletesInitializer*");
     }
@@ -296,7 +301,7 @@ public sealed class HeadlessTestServerTests : IAsyncLifetime
             services.AddSingleton<IInitializer>(new FaultingInitializer())
         );
 
-        Func<Task> act = async () => await _server.InitializeAsync();
+        var act = async () => await _server.InitializeAsync();
 
         await act.Should().ThrowExactlyAsync<InvalidOperationException>().WithMessage("*FaultingInitializer*faulted*");
     }
@@ -307,15 +312,19 @@ public sealed class HeadlessTestServerTests : IAsyncLifetime
     {
         public bool IsInitialized => false;
 
-        public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
-            Task.Delay(Timeout.Infinite, cancellationToken);
+        public Task WaitForInitializationAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.Delay(Timeout.Infinite, cancellationToken);
+        }
     }
 
     private sealed class FaultingInitializer : IInitializer
     {
         public bool IsInitialized => false;
 
-        public Task WaitForInitializationAsync(CancellationToken cancellationToken = default) =>
-            Task.FromException(new InvalidOperationException("Initializer exploded"));
+        public Task WaitForInitializationAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromException(new InvalidOperationException("Initializer exploded"));
+        }
     }
 }

--- a/tests/Headless.Tus.Tests.Unit/Azure/TusAzureMetadataTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/Azure/TusAzureMetadataTests.cs
@@ -270,7 +270,7 @@ public sealed class TusAzureMetadataTests : TestBase
         var metadata = TusAzureMetadata.FromAzure(dict);
 
         // when
-        Dictionary<string, Metadata> tus = metadata.ToTus();
+        var tus = metadata.ToTus();
 
         // then
         tus.Should().ContainKey("filename");

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
@@ -34,7 +34,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
         var sut = new DistributedLockTusLockProvider(_distributedLockProvider);
 
         // when
-        ITusFileLock fileLock = await sut.AquireLock(fileId);
+        var fileLock = await sut.AquireLock(fileId);
         await fileLock.Lock();
 
         // then
@@ -66,7 +66,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
         var sut = new DistributedLockTusLockProvider(_distributedLockProvider);
 
         // when
-        ITusFileLock fileLock = await sut.AquireLock(fileId);
+        var fileLock = await sut.AquireLock(fileId);
         var lockResult = await fileLock.Lock();
 
         // then


### PR DESCRIPTION
## Summary

- Adds `[SkipTenantResolution]` attribute and `.SkipTenantResolution()` fluent extension to opt individual endpoints, route groups, or MVC controllers/actions out of HTTP claims-based tenant resolution — without touching the global middleware
- `TenantResolutionMiddleware` checks for the marker after setting `HeadlessTenancyResolutionApplied` (so the exception handler stays coherent) but before auth/claim extraction, then passes through immediately
- Composable with `.AllowMissingTenant()` when the endpoint also lives under a tenant-required authorization policy

## Test plan

- [ ] 10 new integration tests in `SkipTenantResolutionTests` cover: minimal API endpoint, route group, MVC class attribute, MVC action attribute, unauthenticated request, ordering-warning suppression on skipped+unauthenticated, control group (unmarked endpoint still resolves), control group (unmarked group still resolves), compose with `AllowMissingTenant`, `HeadlessTenancyResolutionApplied` feature flag set even on skip path
- [ ] `make test-class CLASS='*SkipTenantResolutionTests'` → 10/10 passed
- [ ] `dotnet build tests/Headless.Api.Tests.Integration --no-incremental` → 0 errors 0 warnings