### PR TITLE
fix(caching-memory): align InMemoryCache set key-type predicate

### DIFF
--- a/src/Headless.Caching.Memory/InMemoryCache.cs
+++ b/src/Headless.Caching.Memory/InMemoryCache.cs
@@ -943,12 +943,23 @@ public sealed class InMemoryCache : IInMemoryCache, IDisposable
         var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
         var expiresAt = expiration.HasValue ? utcNow.Add(expiration.Value) : (DateTime?)null;
 
-        if (value is string stringValue)
+        if (typeof(T) == typeof(string))
         {
-            var newItems = new Dictionary<string, DateTime?>(StringComparer.OrdinalIgnoreCase)
+            var newItems = new Dictionary<string, DateTime?>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var v in value)
             {
-                { stringValue, expiresAt },
-            };
+                if (v is not null)
+                {
+                    newItems[(string)(object)v] = expiresAt;
+                }
+            }
+
+            if (newItems.Count is 0)
+            {
+                return 0;
+            }
+
             var entrySize = _CalculateEntrySize(newItems);
             var entry = new CacheEntry(
                 newItems,
@@ -978,7 +989,11 @@ public sealed class InMemoryCache : IInMemoryCache, IDisposable
 
                     var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
                     var currentMax = _ExpireAndGetMaxExpiration(updatedDict);
-                    updatedDict[stringValue] = expiresAt;
+
+                    foreach (var kvp in newItems)
+                    {
+                        updatedDict[kvp.Key] = kvp.Value;
+                    }
 
                     var newExpiresAt =
                         (expiresAt is null || currentMax is null) ? (DateTime?)null
@@ -1412,8 +1427,15 @@ public sealed class InMemoryCache : IInMemoryCache, IDisposable
 
         key = _GetKey(key);
 
-        if (value is string stringValue)
+        if (typeof(T) == typeof(string))
         {
+            var stringsToRemove = value.Where(v => v is not null).Select(v => (string)(object)v!).ToList();
+
+            if (stringsToRemove.Count is 0)
+            {
+                return new ValueTask<long>(0L);
+            }
+
             long removed = 0;
             long sizeDelta = 0;
 
@@ -1428,7 +1450,16 @@ public sealed class InMemoryCache : IInMemoryCache, IDisposable
                     }
 
                     var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
-                    var localRemoved = updatedDict.Remove(stringValue) ? 1L : 0L;
+                    long localRemoved = 0;
+
+                    foreach (var v in stringsToRemove)
+                    {
+                        if (updatedDict.Remove(v))
+                        {
+                            localRemoved++;
+                        }
+                    }
+
                     removed = localRemoved;
 
                     var newExpiresAt = _ExpireAndGetMaxExpiration(updatedDict);

--- a/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheTests.cs
+++ b/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheTests.cs
@@ -709,13 +709,47 @@ public sealed class InMemoryCacheTests : TestBase
         // given
         using var cache = _CreateCache();
         var key = Faker.Random.AlphaNumeric(10);
-        const string value = "test-value";
 
         // when
-        var result = await cache.SetAddAsync(key, value, TimeSpan.FromMinutes(5), AbortToken);
+        var result = await cache.SetAddAsync(key, new[] { "test-value" }, TimeSpan.FromMinutes(5), AbortToken);
 
         // then
         result.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_roundtrip_string_set_through_get_set()
+    {
+        // Regression: SetAddAsync<string> previously stored Dictionary<object, DateTime?>
+        // while GetSetAsync<string> read Dictionary<string, DateTime?>, causing InvalidCastException.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await cache.SetAddAsync(key, new[] { "a", "b" }, expiration: null, AbortToken);
+        var result = await cache.GetSetAsync<string>(key, cancellationToken: AbortToken);
+
+        // then
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(["a", "b"]);
+    }
+
+    [Fact]
+    public async Task should_merge_strings_into_existing_set()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.SetAddAsync(key, new[] { "a", "b" }, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        await cache.SetAddAsync(key, new[] { "c", "d" }, TimeSpan.FromMinutes(5), AbortToken);
+        var result = await cache.GetSetAsync<string>(key, cancellationToken: AbortToken);
+
+        // then
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(["a", "b", "c", "d"]);
     }
 
     [Fact]
@@ -811,14 +845,33 @@ public sealed class InMemoryCacheTests : TestBase
         // given
         using var cache = _CreateCache();
         var key = Faker.Random.AlphaNumeric(10);
-        await cache.SetAddAsync(key, "item1", TimeSpan.FromMinutes(5), AbortToken);
-        await cache.SetAddAsync(key, "item2", TimeSpan.FromMinutes(5), AbortToken);
+        await cache.SetAddAsync(key, new[] { "item1", "item2" }, TimeSpan.FromMinutes(5), AbortToken);
 
         // when
-        var result = await cache.SetRemoveAsync(key, "item1", null, AbortToken);
+        var result = await cache.SetRemoveAsync(key, new[] { "item1" }, null, AbortToken);
 
         // then
         result.Should().Be(1);
+        var remaining = await cache.GetSetAsync<string>(key, cancellationToken: AbortToken);
+        remaining.Value.Should().BeEquivalentTo(["item2"]);
+    }
+
+    [Fact]
+    public async Task should_roundtrip_guid_set_through_get_set()
+    {
+        // Regression: non-string T must still use the object-keyed branch end-to-end.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+        // when
+        await cache.SetAddAsync(key, ids, TimeSpan.FromMinutes(5), AbortToken);
+        var result = await cache.GetSetAsync<Guid>(key, cancellationToken: AbortToken);
+
+        // then
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(ids);
     }
 
     [Fact]
@@ -833,6 +886,90 @@ public sealed class InMemoryCacheTests : TestBase
 
         // then
         result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_return_zero_when_removing_strings_from_nonexistent_set()
+    {
+        // Regression: string-branch must hit the TryUpdate no-op path without throwing.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        // when
+        var result = await cache.SetRemoveAsync(key, new[] { "missing" }, null, AbortToken);
+
+        // then
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_roundtrip_add_then_remove_for_string_set()
+    {
+        // Regression: explicit add->remove->get path for T=string from the bug report.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.SetAddAsync(key, new[] { "a", "b", "c" }, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var removed = await cache.SetRemoveAsync(key, new[] { "a", "c" }, null, AbortToken);
+        var remaining = await cache.GetSetAsync<string>(key, cancellationToken: AbortToken);
+
+        // then
+        removed.Should().Be(2);
+        remaining.HasValue.Should().BeTrue();
+        remaining.Value.Should().BeEquivalentTo(["b"]);
+    }
+
+    [Fact]
+    public async Task should_return_zero_when_adding_only_null_strings_to_set()
+    {
+        // Regression: previously the buggy string branch would silently count nulls as 1.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var items = new string?[] { null, null };
+
+        // when
+        var result = await cache.SetAddAsync(key, items!, TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_deduplicate_string_set_case_insensitively()
+    {
+        // The string branch uses StringComparer.OrdinalIgnoreCase; the last value wins for the key bucket.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await cache.SetAddAsync(key, new[] { "Hello", "HELLO", "world" }, TimeSpan.FromMinutes(5), AbortToken);
+        var result = await cache.GetSetAsync<string>(key, cancellationToken: AbortToken);
+
+        // then
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task should_page_string_set_items()
+    {
+        // The string-keyed read branch must honor pageIndex/pageSize like the object-keyed branch.
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.SetAddAsync(key, new[] { "a", "b", "c", "d", "e" }, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var page = await cache.GetSetAsync<string>(key, pageIndex: 1, pageSize: 2, cancellationToken: AbortToken);
+
+        // then
+        page.HasValue.Should().BeTrue();
+        page.Value.Should().HaveCount(2);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

`InMemoryCache.GetSetAsync<string>` threw `InvalidCastException` on every string-set round-trip because the store and read paths chose the dictionary key type with **different predicates**.

- `SetAddAsync<T>` / `SetRemoveAsync<T>` branched on `value is string` — the runtime type of the `IEnumerable<T>` argument. For the normal `SetAddAsync<string>(key, ["a","b"], …)` call, `value` is `string[]`, **not** a `string`, so the code fell into the object-keyed `else` branch and stored `Dictionary<object, DateTime?>`. The "string" branch only ever fired when a bare `string` was passed as `IEnumerable<char>` (junk for set usage), and additionally only stored a single key from the enumerable.
- `GetSetAsync<T>` branched on `typeof(T) == typeof(string)` (the correct predicate), tried to read `IDictionary<string, DateTime?>`, and threw.

Result: any consumer doing the natural `SetAddAsync<string>` → `GetSetAsync<string>` round-trip crashed at read time. Surfaced in `CacheCommunicationHubConnectionStore` (SignalR connection tracking).

### Fix

- Align both write methods on `typeof(T) == typeof(string)`, matching the read path.
- Rewrite the string branches to iterate the enumerable and mirror the object branch's structure exactly (same `AddOrUpdate` / `TryUpdate` shape, same `_ExpireAndGetMaxExpiration` ordering, same null-filter and early-exit).

`src/Headless.Caching.Memory/InMemoryCache.cs` — `SetAddAsync<T>` (~L946) and `SetRemoveAsync<T>` (~L1415).

### Behavior change worth flagging

`cache.SetAddAsync(key, "test-value", …)` — passing a bare string, which the compiler infers as `IEnumerable<char>` (T=char) — used to be silently rescued by the broken predicate. With the corrected predicate it falls into the char branch as the signature implies. Consumers must pass `new[] { "test-value" }`, which is what `ICache.SetAddAsync<T>(string, IEnumerable<T>, …)` has always asked for. No public API or contract changed; two unit tests that codified the buggy shape were updated to the real pattern.

### Performance

The new string branch is allocation-equivalent to the existing object branch and avoids per-element boxing — strictly cheaper for `T=string` workloads.

## Test plan

- [x] `should_roundtrip_string_set_through_get_set` — exact failing path from the report
- [x] `should_merge_strings_into_existing_set` — second-add merge
- [x] `should_roundtrip_add_then_remove_for_string_set` — `SetRemoveAsync<string>` round-trip
- [x] `should_return_zero_when_removing_strings_from_nonexistent_set` — `TryUpdate` no-op path
- [x] `should_return_zero_when_adding_only_null_strings_to_set` — null filtering
- [x] `should_deduplicate_string_set_case_insensitively` — preserves `OrdinalIgnoreCase`
- [x] `should_page_string_set_items` — pagination on the string-keyed read branch
- [x] `should_roundtrip_guid_set_through_get_set` — object branch unaffected
- [x] Updated `should_add_string_to_set` / `should_remove_string_from_set` to the real array shape
- [x] `make test-project TEST_PROJECT=tests/Headless.Caching.Memory.Tests.Unit` — 123/123 pass on a fresh `origin/main` base