### PR TITLE
docs(orm): document HeadlessDbContext is intentionally not poolable

### DIFF
--- a/docs/llms/orm.md
+++ b/docs/llms/orm.md
@@ -17,6 +17,7 @@ packages: Orm.EntityFramework, Orm.Couchbase, MultiTenancy
     - [Key Features](#key-features)
     - [Installation](#installation)
     - [Quick Start](#quick-start)
+    - [Pooling](#pooling)
     - [Transaction Pattern](#transaction-pattern)
     - [Configuration](#configuration)
     - [Dependencies](#dependencies)
@@ -126,6 +127,19 @@ builder.Services.AddHeadlessDbContext<AppDbContext>(options =>
 // otherwise SaveChanges will throw via ThrowHeadlessMessageDispatcher.
 builder.Services.AddHeadlessMessageDispatcher<AppHeadlessMessageDispatcher>();
 ```
+
+## Pooling
+
+`HeadlessDbContext` is intentionally **not poolable**. Do not register subclasses with `AddDbContextPool` or `AddPooledDbContextFactory`.
+
+Why:
+
+- The context holds a private `HeadlessDbContextRuntime` field that captures the request-scoped outbox dispatcher (`IHeadlessMessageDispatcher`) and audit persistence (`IHeadlessAuditPersistence`). Pooled instances would reuse a prior request's unit of work — EF only resets state it knows about, and the save pipeline is opaque to EF.
+- The constructor signature is `(HeadlessDbContextServices services, DbContextOptions options)`. `AddDbContextPool` only supports a single-`DbContextOptions` constructor.
+
+`ICurrentTenant` (AsyncLocal-backed) and `IClock` (singleton) are **not** the blocker — they resolve fresh per request even from a long-lived instance.
+
+For read-heavy hot paths that don't need the Headless write machinery, use a plain `DbContext` with `AddDbContextPool` alongside the write-side `HeadlessDbContext`. Writes don't benefit from pooling, so the split (heavy scoped write context + plain poolable storage contexts) is deliberate.
 
 ## Transaction Pattern
 

--- a/src/Headless.Orm.EntityFramework/Contexts/HeadlessDbContext.cs
+++ b/src/Headless.Orm.EntityFramework/Contexts/HeadlessDbContext.cs
@@ -14,6 +14,40 @@ public interface IHeadlessDbContext
     string? TenantId { get; }
 }
 
+/// <summary>
+/// Base <see cref="DbContext"/> with the framework's save pipeline, multi-tenancy filter,
+/// auditing, soft-delete, and domain-event dispatch wired in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Not poolable.</b> Do not register subclasses with <c>AddDbContextPool</c> or
+/// <c>AddPooledDbContextFactory</c>. Two independent reasons:
+/// </para>
+/// <list type="number">
+/// <item>
+/// <description>
+/// The instance holds a private <c>HeadlessDbContextRuntime</c> field that captures the
+/// scoped save pipeline (outbox dispatcher, audit persistence). Pooled instances would
+/// reuse a prior request's unit of work — a captive-dependency correctness bug. EF's own
+/// guidance: avoid pooling when the context maintains private state, since EF only resets
+/// state it is aware of.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// The constructor takes a second non-<see cref="DbContextOptions"/> parameter
+/// (<see cref="HeadlessDbContextServices"/>); the pooling path resolves contexts through a
+/// single-<see cref="DbContextOptions"/> constructor and does not support this shape.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// <c>ICurrentTenant</c> (AsyncLocal-backed) and <c>IClock</c> are not the blocker — only
+/// the save/outbox/audit pipeline is request-bound. Use a plain <see cref="DbContext"/>
+/// with <c>AddDbContextPool</c> for read-heavy hot paths that do not need the Headless
+/// write machinery.
+/// </para>
+/// </remarks>
 public abstract class HeadlessDbContext : DbContext, IHeadlessDbContext
 {
     private readonly HeadlessDbContextRuntime _runtime;

--- a/src/Headless.Orm.EntityFramework/README.md
+++ b/src/Headless.Orm.EntityFramework/README.md
@@ -53,6 +53,17 @@ builder.Services.AddHeadlessDbContext<AppDbContext>(options =>
 );
 ```
 
+## Pooling
+
+`HeadlessDbContext` is intentionally **not poolable**. Do not register subclasses with `AddDbContextPool` or `AddPooledDbContextFactory`. Two independent reasons:
+
+1. **Private per-instance state holds a scoped save pipeline.** The constructor builds a private `HeadlessDbContextRuntime` field that captures the request-scoped outbox dispatcher (`IHeadlessMessageDispatcher`, enlisted in the EF transaction) and audit persistence (`IHeadlessAuditPersistence`, capturing this request's entries). EF's own guidance is to avoid pooling when the context maintains private state — EF only resets the state it knows about, so a pooled instance would reuse a prior request's outbox / audit unit of work. That is a captive-dependency correctness bug, not a perf trade-off.
+2. **Two-argument constructor.** Pooling resolves contexts through a single-`DbContextOptions` constructor; the second `HeadlessDbContextServices` parameter is not supported by `AddDbContextPool`. EF's "managing state in pooled contexts" guidance exists precisely because per-request state cannot be constructor-injected into pooled contexts — it requires a custom lease-time factory.
+
+`ICurrentTenant` (AsyncLocal-backed singleton) and `IClock` (singleton) are **not** the problem — both resolve fresh per request even from a long-lived instance. Only the save / outbox / audit pipeline is request-bound.
+
+For read-heavy hot paths that don't need the Headless write machinery (settings, features, permissions, lookup tables), use a plain `DbContext` with `AddDbContextPool` alongside the write-side `HeadlessDbContext`. Writes don't benefit from pooling, so the current split — heavy scoped write context + plain poolable storage contexts — is deliberate.
+
 ## Configuration
 
 ### Value Converters


### PR DESCRIPTION
Closes #324.

## Summary

- Add XML doc on `HeadlessDbContext` capturing the two independent reasons it is intentionally not poolable: the private `HeadlessDbContextRuntime` field that captures the scoped save/outbox/audit pipeline, and the two-arg constructor that `AddDbContextPool` does not support.
- Mirror the rationale in `src/Headless.Orm.EntityFramework/README.md` with a new "Pooling" section between Quick Start and Configuration, and in `docs/llms/orm.md` with a matching TOC entry and section.
- Clarify that `ICurrentTenant` (AsyncLocal-backed singleton) and `IClock` (singleton) are not the blocker, and that read-heavy hot paths should use a plain pooled `DbContext` alongside the write-side `HeadlessDbContext`.

The stretch goal from #324 (opt-in poolable read-only `HeadlessDbContext` variant) is intentionally deferred — no concrete workload yet justifies the carrying cost. Easy to add later under a new type without touching the write context.

## Test plan

- [x] `dotnet build src/Headless.Orm.EntityFramework/Headless.Orm.EntityFramework.csproj --no-incremental` — 0 warnings, 0 errors (XML doc references resolve).
- [ ] CI green.
