### PR TITLE
feat(messaging): persist bus queue intent

### DIFF
--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -256,6 +256,7 @@ Core provides the transactional outbox pattern (automatic retries, delayed deliv
 - **Runtime handlers are first-class**: Use `IRuntimeSubscriber` for ephemeral broker-attached delegates. They share scoped DI, middleware, diagnostics, retry, and correlation semantics with class handlers.
 - **Two publisher modes**: Use `IOutboxPublisher` for reliable at-least-once delivery (transactional outbox). Use `IDirectPublisher` for fire-and-forget low-latency scenarios (metrics, cache invalidation).
 - **One publish shape**: `IDirectPublisher` and `IOutboxPublisher` both use `PublishAsync(message, options, cancellationToken)`. Prefer mappings or conventions for topics, and use `PublishOptions` only for explicit overrides.
+- **Outbox intent is durable**: Storage rows carry `IntentType`; retry drainers dispatch bus rows through `IBusTransport` and queue rows through `IQueueTransport`. A persisted row whose intent has no registered transport is terminally failed and the drainer continues.
 - **Do NOT use raw transport client libraries** (e.g., `RabbitMQ.Client`, `Confluent.Kafka`) directly -- always use the `Headless.Messaging` abstraction layer.
 - **Ordering depends on transport**: Kafka orders by partition key. Azure Service Bus orders by session. RabbitMQ has no ordering with multiple consumers. Set `ConsumerThreadCount = 1` for strict ordering.
 - **RabbitMQ credentials**: The framework rejects default `guest`/`guest` credentials. Always configure explicit username/password.
@@ -495,7 +496,7 @@ Provides the foundational runtime for reliable distributed messaging with transa
 
 - **Outbox Publisher**: Transactional message publishing with database consistency
 - **Consumer Management**: Automatic registration, invocation, and per-dispatch lifecycle handling
-- **Message Processing**: Retry processor, delayed message scheduler, transport health checks
+- **Message Processing**: Retry processor, delayed message scheduler, transport health checks, and intent-aware drainer dispatch
 - **Type-Safe Dispatch**: Reflection-free consumer invocation via compile-time generated code
 - **Extension System**: Pluggable storage and transport providers
 - **Bootstrapper**: Hosted service for startup and shutdown coordination
@@ -569,6 +570,7 @@ Use `IOutboxPublisher` for messages that must not be lost:
 - **At-least-once**: Automatic retries with configurable backoff
 - **Delayed delivery**: Schedule messages for future delivery
 - **Ordering**: Preserves publish order within transactions
+- **Durable intent**: Stored rows preserve bus/queue intent; retry pickup routes to the matching transport instead of relying on the current publisher facade.
 
 ### IDirectPublisher (Fire-and-Forget)
 
@@ -2061,7 +2063,8 @@ Provides durable, transactional message storage using PostgreSQL with schema ini
 ## Key Features
 
 - **Transactional Outbox**: ACID-compliant message publishing with database changes
-- **Schema Initialization**: Tables created via `CREATE TABLE IF NOT EXISTS` on startup. Does NOT add columns or indexes to pre-existing tables.
+- **Schema Initialization**: Tables created via `CREATE TABLE IF NOT EXISTS` on startup, with idempotent updates for durable bus/queue intent columns and received-message identity indexes.
+- **Intent-Aware Identity**: Received-message de-duplication includes version, message ID, group, and bus/queue intent.
 - **Archival**: Automatic cleanup of old messages
 - **Performance**: Optimized indexes and queries for high throughput
 - **Monitoring**: Built-in dashboard data queries
@@ -2111,6 +2114,7 @@ options.UsePostgreSql(config =>
     - `{prefix}_published` - Published messages
     - `{prefix}_received` - Received messages
 - Creates indexes for message queries
+- Stores `IntentType` on published and received rows without a database default; runtime writes must provide the intent explicitly
 - Periodically cleans up expired messages
 
 ---
@@ -2126,7 +2130,8 @@ Provides durable, transactional message storage using SQL Server with schema ini
 ## Key Features
 
 - **Transactional Outbox**: ACID-compliant message publishing with database changes
-- **Schema Initialization**: Tables created via `CREATE TABLE IF NOT EXISTS` on startup. Does NOT add columns or indexes to pre-existing tables.
+- **Schema Initialization**: Tables created via `CREATE TABLE IF NOT EXISTS` on startup, with idempotent updates for durable bus/queue intent columns and received-message identity indexes.
+- **Intent-Aware Identity**: Received-message de-duplication includes version, message ID, group, and bus/queue intent.
 - **Archival**: Automatic cleanup of old messages
 - **Performance**: Optimized indexes and queries for SQL Server
 - **Monitoring**: Built-in dashboard data queries
@@ -2176,6 +2181,7 @@ options.UseSqlServer(config =>
     - `{prefix}_published` - Published messages
     - `{prefix}_received` - Received messages
 - Creates indexes for message queries
+- Stores `IntentType` on published and received rows without a database default; runtime writes must provide the intent explicitly
 - Periodically cleans up expired messages
 
 ---
@@ -2194,6 +2200,7 @@ Provides ephemeral message storage without database dependencies for local devel
 - **Fast**: In-memory operations
 - **Testing**: Deterministic behavior for tests
 - **Full API**: Complete outbox storage implementation
+- **Intent-Aware Identity**: Mirrors durable providers by storing bus/queue intent and including it in received-message de-duplication
 - **Monitoring**: In-memory dashboard data
 
 ## Installation

--- a/docs/plans/2026-05-21-003-feat-messaging-intent-persistence-drainer-plan.md
+++ b/docs/plans/2026-05-21-003-feat-messaging-intent-persistence-drainer-plan.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-05-21
 type: feat
-status: active
+status: completed
 depth: deep
 origin: docs/plans/2026-05-21-001-feat-messaging-bus-queue-split-plan.md
 part_of: messaging-bus-queue-split

--- a/src/Headless.Messaging.Core/Internal/IMessagePublishRequestFactory.cs
+++ b/src/Headless.Messaging.Core/Internal/IMessagePublishRequestFactory.cs
@@ -11,7 +11,12 @@ namespace Headless.Messaging.Internal;
 
 internal interface IMessagePublishRequestFactory
 {
-    PreparedPublishMessage Create<T>(T? contentObj, PublishOptions? options = null, TimeSpan? delayTime = null);
+    PreparedPublishMessage Create<T>(
+        T? contentObj,
+        PublishOptions? options = null,
+        TimeSpan? delayTime = null,
+        IntentType intentType = IntentType.Bus
+    );
 }
 
 internal sealed class MessagePublishRequestFactory(
@@ -39,7 +44,12 @@ internal sealed class MessagePublishRequestFactory(
     private readonly TimeProvider _timeProvider = timeProvider;
     private readonly ICurrentTenant _currentTenant = currentTenant;
 
-    public PreparedPublishMessage Create<T>(T? contentObj, PublishOptions? options = null, TimeSpan? delayTime = null)
+    public PreparedPublishMessage Create<T>(
+        T? contentObj,
+        PublishOptions? options = null,
+        TimeSpan? delayTime = null,
+        IntentType intentType = IntentType.Bus
+    )
     {
         if (delayTime is { } requestedDelay)
         {
@@ -62,6 +72,7 @@ internal sealed class MessagePublishRequestFactory(
             Topic = topicName,
             PublishAt = publishAt.UtcDateTime,
             Message = new Message(headers, contentObj),
+            IntentType = intentType,
         };
     }
 
@@ -283,4 +294,6 @@ internal sealed class PreparedPublishMessage
     public required DateTime PublishAt { get; init; }
 
     public required Message Message { get; init; }
+
+    public required IntentType IntentType { get; init; }
 }

--- a/src/Headless.Messaging.Core/Internal/IMessageSender.cs
+++ b/src/Headless.Messaging.Core/Internal/IMessageSender.cs
@@ -46,7 +46,8 @@ internal sealed class MessageSender : IMessageSender
     private readonly ILogger _logger;
     private readonly MessagingOptions _options;
     private readonly ISerializer _serializer;
-    private readonly ITransport _transport;
+    private readonly IBusTransport? _busTransport;
+    private readonly IQueueTransport? _queueTransport;
     private readonly TimeProvider _timeProvider;
     private readonly RetryPolicyOptions _retryPolicy;
     private readonly CancellationToken _shutdownToken;
@@ -57,7 +58,8 @@ internal sealed class MessageSender : IMessageSender
         _logger = logger;
         _dataStorage = serviceProvider.GetRequiredService<IDataStorage>();
         _serializer = serviceProvider.GetRequiredService<ISerializer>();
-        _transport = serviceProvider.GetRequiredService<ITransport>();
+        _busTransport = serviceProvider.GetService<IBusTransport>();
+        _queueTransport = serviceProvider.GetService<IQueueTransport>();
         _timeProvider = serviceProvider.GetRequiredService<TimeProvider>();
         var opts = serviceProvider.GetRequiredService<IOptions<MessagingOptions>>().Value;
         _options = opts;
@@ -104,23 +106,29 @@ internal sealed class MessageSender : IMessageSender
         }
 
         var transportMsg = await _serializer.SerializeToTransportMessageAsync(message.Origin).ConfigureAwait(false);
+        var selected = await _ResolveTransportAsync(message).ConfigureAwait(false);
+        if (selected.Result is { } failure)
+        {
+            return (RetryDecision.Stop, failure);
+        }
 
-        var tracingTimestamp = _TracingBefore(transportMsg, _transport.BrokerAddress, cancellationToken);
+        var transport = selected.Transport.GetValueOrDefault();
+        var tracingTimestamp = _TracingBefore(transportMsg, transport.BrokerAddress, cancellationToken);
 
         using var publishCts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken);
         publishCts.CancelAfter(_options.TransportPublishTimeout);
-        var result = await _transport.SendAsync(transportMsg, publishCts.Token).ConfigureAwait(false);
+        var result = await transport.SendAsync(transportMsg, publishCts.Token).ConfigureAwait(false);
 
         if (result.Succeeded)
         {
             await _SetSuccessfulState(message, CancellationToken.None).ConfigureAwait(false);
 
-            _TracingAfter(tracingTimestamp, transportMsg, _transport.BrokerAddress, cancellationToken);
+            _TracingAfter(tracingTimestamp, transportMsg, transport.BrokerAddress, cancellationToken);
 
             return (RetryDecision.Stop, OperateResult.Success);
         }
 
-        _TracingError(tracingTimestamp, transportMsg, _transport.BrokerAddress, result, cancellationToken);
+        _TracingError(tracingTimestamp, transportMsg, transport.BrokerAddress, result, cancellationToken);
 
         var decision = await _SetFailedState(
                 message,
@@ -132,6 +140,59 @@ internal sealed class MessageSender : IMessageSender
             .ConfigureAwait(false);
 
         return (decision, OperateResult.Failed(result.Exception!));
+    }
+
+    private async Task<(DispatchTransport? Transport, OperateResult? Result)> _ResolveTransportAsync(MediumMessage message)
+    {
+        if (!Enum.IsDefined(message.IntentType))
+        {
+            var ex = new InvalidOperationException(
+                $"Stored message {message.StorageId} has unsupported IntentType value '{(short)message.IntentType}'."
+            );
+            await _MarkUnsupportedIntentFailedAsync(message, ex).ConfigureAwait(false);
+            return (null, OperateResult.Failed(ex));
+        }
+
+        return message.IntentType switch
+        {
+            IntentType.Bus when _busTransport is not null => (DispatchTransport.ForBus(_busTransport), null),
+            IntentType.Queue when _queueTransport is not null => (DispatchTransport.ForQueue(_queueTransport), null),
+            IntentType.Bus => await _MissingTransportAsync(message, nameof(IBusTransport)).ConfigureAwait(false),
+            IntentType.Queue => await _MissingTransportAsync(message, nameof(IQueueTransport)).ConfigureAwait(false),
+            _ => throw new UnreachableException(),
+        };
+    }
+
+    private async Task<(DispatchTransport? Transport, OperateResult? Result)> _MissingTransportAsync(
+        MediumMessage message,
+        string transportType
+    )
+    {
+        var ex = new InvalidOperationException(
+            $"Stored message {message.StorageId} requires {transportType}, but no matching transport is registered."
+        );
+        await _MarkUnsupportedIntentFailedAsync(message, ex).ConfigureAwait(false);
+        return (null, OperateResult.Failed(ex));
+    }
+
+    private async Task _MarkUnsupportedIntentFailedAsync(MediumMessage message, Exception ex)
+    {
+        message.ExpiresAt = _timeProvider.GetUtcNow().UtcDateTime.AddSeconds(_options.FailedMessageExpiredAfter);
+        message.NextRetryAt = null;
+        message.LockedUntil = null;
+
+        await _dataStorage
+            .ChangePublishStateAsync(
+                message,
+                StatusName.Failed,
+                nextRetryAt: null,
+                lockedUntil: null,
+                originalRetries: message.Retries,
+                cancellationToken: CancellationToken.None
+            )
+            .ConfigureAwait(false);
+
+        _logger.StoredMessageUnsupportedIntent(ex, message.StorageId, message.IntentType.ToString("D"));
     }
 
     private async Task _SetSuccessfulState(MediumMessage message, CancellationToken cancellationToken)
@@ -381,4 +442,14 @@ internal sealed class MessageSender : IMessageSender
     }
 
     #endregion
+}
+
+internal readonly record struct DispatchTransport(
+    BrokerAddress BrokerAddress,
+    Func<TransportMessage, CancellationToken, Task<OperateResult>> SendAsync
+)
+{
+    public static DispatchTransport ForBus(IBusTransport transport) => new(transport.BrokerAddress, transport.SendAsync);
+
+    public static DispatchTransport ForQueue(IQueueTransport transport) => new(transport.BrokerAddress, transport.SendAsync);
 }

--- a/src/Headless.Messaging.Core/Internal/LoggerExtensions.cs
+++ b/src/Headless.Messaging.Core/Internal/LoggerExtensions.cs
@@ -659,4 +659,17 @@ internal static partial class LoggerExtensions
         Exception ex,
         int consecutiveFailures
     );
+
+    [LoggerMessage(
+        EventId = 85,
+        EventName = "StoredMessageUnsupportedIntent",
+        Level = LogLevel.Error,
+        Message = "Stored published message {StorageId} cannot be dispatched because its intent '{IntentType}' has no supported transport. Marked terminal Failed."
+    )]
+    public static partial void StoredMessageUnsupportedIntent(
+        this ILogger logger,
+        Exception exception,
+        long storageId,
+        string intentType
+    );
 }

--- a/src/Headless.Messaging.Core/Internal/OutboxBus.cs
+++ b/src/Headless.Messaging.Core/Internal/OutboxBus.cs
@@ -2,7 +2,7 @@
 
 namespace Headless.Messaging.Internal;
 
-internal sealed class OutboxBus(IOutboxPublisher publisher, IScheduledPublisher scheduledPublisher) : IOutboxBus
+internal sealed class OutboxBus(OutboxPublisher publisher) : IOutboxBus
 {
     public Task PublishAsync<T>(
         T? contentObj,
@@ -11,7 +11,7 @@ internal sealed class OutboxBus(IOutboxPublisher publisher, IScheduledPublisher 
     )
     {
         return options?.Delay is { } delay
-            ? scheduledPublisher.PublishDelayAsync(delay, contentObj, options, cancellationToken)
-            : publisher.PublishAsync(contentObj, options, cancellationToken);
+            ? publisher.PublishDelayAsync(delay, contentObj, options, IntentType.Bus, cancellationToken)
+            : publisher.PublishAsync(contentObj, options, IntentType.Bus, cancellationToken);
     }
 }

--- a/src/Headless.Messaging.Core/Internal/OutboxPublisher.cs
+++ b/src/Headless.Messaging.Core/Internal/OutboxPublisher.cs
@@ -26,6 +26,13 @@ internal sealed class OutboxPublisher(
         T? contentObj,
         PublishOptions? options = null,
         CancellationToken cancellationToken = default
+    ) => PublishAsync(contentObj, options, IntentType.Bus, cancellationToken);
+
+    internal Task PublishAsync<T>(
+        T? contentObj,
+        PublishOptions? options,
+        IntentType intentType,
+        CancellationToken cancellationToken
     )
     {
         // Pre-decide whether this publish lands on the non-AutoCommit transactional branch so the
@@ -38,7 +45,7 @@ internal sealed class OutboxPublisher(
             delayTime: null,
             // DelayTime is undefined for the immediate publish path; ignored.
             innerPublish: (middlewareOptions, _, ct) =>
-                _PublishInternalAsync(publishRequestFactory.Create(contentObj, middlewareOptions), ct),
+                _PublishInternalAsync(publishRequestFactory.Create(contentObj, middlewareOptions, intentType: intentType), ct),
             isTransactional,
             cancellationToken
         );
@@ -49,6 +56,14 @@ internal sealed class OutboxPublisher(
         T? contentObj,
         PublishOptions? options = null,
         CancellationToken cancellationToken = default
+    ) => PublishDelayAsync(delayTime, contentObj, options, IntentType.Bus, cancellationToken);
+
+    internal Task PublishDelayAsync<T>(
+        TimeSpan delayTime,
+        T? contentObj,
+        PublishOptions? options,
+        IntentType intentType,
+        CancellationToken cancellationToken
     )
     {
         var isTransactional = _IsNonAutoCommitTransactional();
@@ -62,8 +77,8 @@ internal sealed class OutboxPublisher(
                 // Middleware mutated DelayTime to null -> drop to immediate-publish path; otherwise use the
                 // middleware-mutated value, falling back to the caller-supplied delay if middleware left it untouched.
                 var request = middlewareDelay.HasValue
-                    ? publishRequestFactory.Create(contentObj, middlewareOptions, middlewareDelay.Value)
-                    : publishRequestFactory.Create(contentObj, middlewareOptions);
+                    ? publishRequestFactory.Create(contentObj, middlewareOptions, middlewareDelay.Value, intentType)
+                    : publishRequestFactory.Create(contentObj, middlewareOptions, intentType: intentType);
                 return _PublishInternalAsync(request, ct);
             },
             isTransactional,
@@ -89,7 +104,12 @@ internal sealed class OutboxPublisher(
             if (currentTransaction?.DbTransaction == null)
             {
                 var mediumMessage = await storage
-                    .StoreMessageAsync(publishRequest.Topic, publishRequest.Message, null, CancellationToken.None)
+                    .StoreMessageAsync(
+                        publishRequest.Topic,
+                        _CreateStorageEnvelope(publishRequest),
+                        null,
+                        CancellationToken.None
+                    )
                     .ConfigureAwait(false);
 
                 _TracingAfter(tracingTimestamp, publishRequest.Message, cancellationToken);
@@ -118,7 +138,7 @@ internal sealed class OutboxPublisher(
                 var mediumMessage = await storage
                     .StoreMessageAsync(
                         publishRequest.Topic,
-                        publishRequest.Message,
+                        _CreateStorageEnvelope(publishRequest),
                         currentTransaction.DbTransaction,
                         cancellationToken
                     )
@@ -141,6 +161,15 @@ internal sealed class OutboxPublisher(
             throw;
         }
     }
+
+    private static MediumMessage _CreateStorageEnvelope(PreparedPublishMessage publishRequest) =>
+        new()
+        {
+            StorageId = 0,
+            Origin = publishRequest.Message,
+            Content = string.Empty,
+            IntentType = publishRequest.IntentType,
+        };
 
     #region Tracing
 

--- a/src/Headless.Messaging.Core/Internal/OutboxQueue.cs
+++ b/src/Headless.Messaging.Core/Internal/OutboxQueue.cs
@@ -2,7 +2,7 @@
 
 namespace Headless.Messaging.Internal;
 
-internal sealed class OutboxQueue(IOutboxPublisher publisher, IScheduledPublisher scheduledPublisher) : IOutboxQueue
+internal sealed class OutboxQueue(OutboxPublisher publisher) : IOutboxQueue
 {
     public Task EnqueueAsync<T>(
         T? contentObj,
@@ -13,7 +13,7 @@ internal sealed class OutboxQueue(IOutboxPublisher publisher, IScheduledPublishe
         var publishOptions = PublishOptionsAdapter.ToPublishOptions(options);
 
         return publishOptions?.Delay is { } delay
-            ? scheduledPublisher.PublishDelayAsync(delay, contentObj, publishOptions, cancellationToken)
-            : publisher.PublishAsync(contentObj, publishOptions, cancellationToken);
+            ? publisher.PublishDelayAsync(delay, contentObj, publishOptions, IntentType.Queue, cancellationToken)
+            : publisher.PublishAsync(contentObj, publishOptions, IntentType.Queue, cancellationToken);
     }
 }

--- a/src/Headless.Messaging.Core/Messages/MediumMessage.cs
+++ b/src/Headless.Messaging.Core/Messages/MediumMessage.cs
@@ -11,6 +11,8 @@ public class MediumMessage
 
     public required string Content { get; set; }
 
+    public required IntentType IntentType { get; set; }
+
     public DateTime Added { get; set; }
 
     public DateTime? ExpiresAt { get; set; }

--- a/src/Headless.Messaging.Core/Monitoring/MessageQuery.cs
+++ b/src/Headless.Messaging.Core/Monitoring/MessageQuery.cs
@@ -16,6 +16,8 @@ public class MessageQuery
 
     public string? StatusName { get; set; }
 
+    public IntentType? IntentType { get; set; }
+
     public int CurrentPage { get; set; }
 
     public int PageSize { get; set; }

--- a/src/Headless.Messaging.Core/Monitoring/MessageView.cs
+++ b/src/Headless.Messaging.Core/Monitoring/MessageView.cs
@@ -15,6 +15,8 @@ public class MessageView
 
     public required string Name { get; set; }
 
+    public IntentType IntentType { get; set; }
+
     public string? Content { get; set; }
 
     public DateTime Added { get; set; }

--- a/src/Headless.Messaging.Core/Persistence/IDataStorage.cs
+++ b/src/Headless.Messaging.Core/Persistence/IDataStorage.cs
@@ -134,15 +134,44 @@ public interface IDataStorage
 
     ValueTask<MediumMessage> StoreMessageAsync(
         string name,
-        Message content,
+        MediumMessage message,
         object? transaction = null,
         CancellationToken cancellationToken = default
     );
 
+    ValueTask<MediumMessage> StoreMessageAsync(
+        string name,
+        Message content,
+        object? transaction = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return StoreMessageAsync(
+            name,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = content,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            transaction,
+            cancellationToken
+        );
+    }
+
     /// <summary>
     /// Stores a failed received message using serialized <see cref="Message"/> JSON so providers can persist message headers.
     /// </summary>
-    /// <param name="content">Serialized <see cref="Message"/> payload, including headers.</param>
+    /// <param name="message">The failed received message envelope, including serialized content and delivery intent.</param>
+    ValueTask<bool> StoreReceivedExceptionMessageAsync(
+        string name,
+        string group,
+        MediumMessage message,
+        string? exceptionInfo = null,
+        CancellationToken cancellationToken = default
+    );
+
     ValueTask<bool> StoreReceivedExceptionMessageAsync(
         string name,
         string group,
@@ -154,9 +183,30 @@ public interface IDataStorage
     ValueTask<MediumMessage> StoreReceivedMessageAsync(
         string name,
         string group,
-        Message content,
+        MediumMessage message,
         CancellationToken cancellationToken = default
     );
+
+    ValueTask<MediumMessage> StoreReceivedMessageAsync(
+        string name,
+        string group,
+        Message content,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return StoreReceivedMessageAsync(
+            name,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = content,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            cancellationToken
+        );
+    }
 
     ValueTask<int> DeleteExpiresAsync(
         string table,

--- a/src/Headless.Messaging.Core/README.md
+++ b/src/Headless.Messaging.Core/README.md
@@ -14,6 +14,7 @@ Provides the foundational runtime for reliable distributed messaging with transa
 - **Consumer Management**: `AddHeadlessMessaging(...)`, `Subscribe*()`, `AddBusConsumer(...)`, `AddQueueConsumer(...)`, invocation, and per-dispatch lifecycle handling
 - **Runtime Delegate Support**: Broker-attached function handlers with scoped DI and the same consume pipeline as class handlers
 - **Message Processing**: Retry processor, delayed message scheduler, transport health checks
+- **Durable Intent Dispatch**: Outbox rows carry bus/queue intent so retry drainers use the matching transport
 - **Type-Safe Dispatch**: Reflection-free consumer invocation via compile-time generated code
 - **Extension System**: Pluggable storage and transport providers
 - **Bootstrapper**: Hosted service for startup and shutdown coordination
@@ -88,6 +89,8 @@ public sealed class MetricsService(IDirectPublisher publisher)
 - `SubscribeFromAssemblyContaining<T>()` and `Subscribe<T>()` are the primary registration APIs.
 - `AddBusConsumer<TConsumer, TMessage>(topic)` and `AddQueueConsumer<TConsumer, TMessage>(topic)` are the library-author registration APIs when a package wants to contribute consumers through DI with explicit delivery intent.
 - topic and group defaults are deterministic; duplicate registrations fail fast by default.
+- persisted published and received rows store `IntentType`; retry pickup and dashboard projections preserve that value. Received-message identity is `(Version, MessageId, Group, IntentType)`, so bus and queue deliveries with the same logical message ID do not collapse into one row.
+- a persisted row whose `IntentType` has no registered transport is marked terminal `Failed` with no next retry; the drainer logs the unsupported intent and continues processing later rows.
 - direct publish, outbox publish, and runtime delegates preserve the existing diagnostic listener and metric names used by dashboards.
 - runtime delegates execute through the same scoped consume pipeline as class handlers, so diagnostics, middleware, and correlation behavior stay aligned.
 - `IConsumerLifecycle` hooks run per delivery on the scoped consumer instance, not once for application startup or shutdown.

--- a/src/Headless.Messaging.InMemoryStorage/InMemoryDataStorage.cs
+++ b/src/Headless.Messaging.InMemoryStorage/InMemoryDataStorage.cs
@@ -23,14 +23,14 @@ internal sealed class InMemoryDataStorage(
 
     public ConcurrentDictionary<long, MemoryMessage> ReceivedMessages { get; } = new();
 
-    // Secondary index keyed on the SQL-providers' upsert identity (Version, MessageId, Group?).
+    // Secondary index keyed on the SQL-providers' upsert identity (Version, MessageId, Group?, IntentType).
     // Maps to the primary row id in <see cref="ReceivedMessages"/>. The lookup that backs
     // StoreReceivedExceptionMessageAsync is then O(1) via TryGetValue instead of an O(N) scan
     // over the whole received-message map. Updated in lockstep with every code path that inserts
     // into or removes from ReceivedMessages. ValueTuple's default equality uses ordinal string
     // equality for each component, matching the SQL providers' BINARY-collation key semantics.
     private readonly ConcurrentDictionary<
-        (string Version, string MessageId, string? Group),
+        (string Version, string MessageId, string? Group, IntentType IntentType),
         long
     > _receivedIdentityIndex = new();
 
@@ -171,7 +171,7 @@ internal sealed class InMemoryDataStorage(
 
     public ValueTask<MediumMessage> StoreMessageAsync(
         string name,
-        Message content,
+        MediumMessage message,
         object? dbTransaction = null,
         CancellationToken cancellationToken = default
     )
@@ -179,11 +179,12 @@ internal sealed class InMemoryDataStorage(
         cancellationToken.ThrowIfCancellationRequested();
 
         var added = timeProvider.GetUtcNow().UtcDateTime;
-        var message = new MediumMessage
+        var stored = new MediumMessage
         {
             StorageId = longIdGenerator.Create(),
-            Origin = content,
-            Content = serializer.Serialize(content),
+            Origin = message.Origin,
+            Content = serializer.Serialize(message.Origin),
+            IntentType = message.IntentType,
             Added = added,
             ExpiresAt = null,
             NextRetryAt = added.Add(messagingOptions.Value.RetryPolicy.InitialDispatchGrace),
@@ -191,23 +192,43 @@ internal sealed class InMemoryDataStorage(
             Retries = 0,
         };
 
-        PublishedMessages[message.StorageId] = new MemoryMessage
+        PublishedMessages[stored.StorageId] = new MemoryMessage
         {
-            StorageId = message.StorageId,
+            StorageId = stored.StorageId,
             Name = name,
-            Origin = message.Origin,
-            Content = message.Content,
-            Retries = message.Retries,
-            Added = message.Added,
-            ExpiresAt = message.ExpiresAt,
-            NextRetryAt = message.NextRetryAt,
-            LockedUntil = message.LockedUntil,
+            Origin = stored.Origin,
+            Content = stored.Content,
+            IntentType = stored.IntentType,
+            Retries = stored.Retries,
+            Added = stored.Added,
+            ExpiresAt = stored.ExpiresAt,
+            NextRetryAt = stored.NextRetryAt,
+            LockedUntil = stored.LockedUntil,
             StatusName = StatusName.Scheduled,
             Version = messagingOptions.Value.Version,
         };
 
-        return ValueTask.FromResult(message);
+        return ValueTask.FromResult(stored);
     }
+
+    public ValueTask<MediumMessage> StoreMessageAsync(
+        string name,
+        Message content,
+        object? dbTransaction = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        StoreMessageAsync(
+            name,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = content,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            dbTransaction,
+            cancellationToken
+        );
 
     public ValueTask<bool> StoreReceivedExceptionMessageAsync(
         string name,
@@ -217,18 +238,42 @@ internal sealed class InMemoryDataStorage(
         CancellationToken cancellationToken = default
     )
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
         var origin =
             serializer.Deserialize(content)
             ?? throw new InvalidOperationException("Failed to deserialize received exception message content.");
 
-        var messageId = origin.GetId();
+        return StoreReceivedExceptionMessageAsync(
+            name,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = origin,
+                Content = content,
+                IntentType = IntentType.Bus,
+            },
+            exceptionInfo,
+            cancellationToken
+        );
+    }
+
+    public ValueTask<bool> StoreReceivedExceptionMessageAsync(
+        string name,
+        string group,
+        MediumMessage message,
+        string? exceptionInfo = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var content = string.IsNullOrEmpty(message.Content) ? serializer.Serialize(message.Origin) : message.Content;
+        var messageId = message.Origin.GetId();
         var version = messagingOptions.Value.Version;
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var expiresAt = now.AddSeconds(messagingOptions.Value.FailedMessageExpiredAfter);
         var retries = messagingOptions.Value.RetryPolicy.MaxPersistedRetries;
-        var indexKey = (version, messageId, (string?)group);
+        var indexKey = (version, messageId, (string?)group, message.IntentType);
 
         // Upsert on (Version, MessageId, Group) — mirrors the SQL providers' MERGE / ON CONFLICT
         // semantics so broker redelivery doesn't accumulate duplicate rows. The terminal-row guard
@@ -290,9 +335,10 @@ internal sealed class InMemoryDataStorage(
             {
                 StorageId = id,
                 Group = group,
-                Origin = origin,
+                Origin = message.Origin,
                 Name = name,
                 Content = content,
+                IntentType = message.IntentType,
                 Retries = retries,
                 Added = now,
                 ExpiresAt = expiresAt,
@@ -311,7 +357,7 @@ internal sealed class InMemoryDataStorage(
     public ValueTask<MediumMessage> StoreReceivedMessageAsync(
         string name,
         string group,
-        Message message,
+        MediumMessage message,
         CancellationToken cancellationToken = default
     )
     {
@@ -319,13 +365,14 @@ internal sealed class InMemoryDataStorage(
         var version = messagingOptions.Value.Version;
         var added = timeProvider.GetUtcNow().UtcDateTime;
         var initialNextRetryAt = added.Add(messagingOptions.Value.RetryPolicy.InitialDispatchGrace);
-        var serialized = serializer.Serialize(message);
+        var origin = message.Origin;
+        var serialized = serializer.Serialize(origin);
 
         // Tolerate missing MessageId header (degenerate test inputs / synthetic payloads): without
         // a MessageId there's no upsert identity to share, so concurrent calls degrade to plain
         // inserts. This matches the SQL providers' MERGE/ON CONFLICT semantics — the constraint
         // is on MessageId, so a NULL MessageId effectively opts out of dedupe.
-        var hasMessageId = message.Headers.TryGetValue(Headers.MessageId, out var messageId) && messageId is not null;
+        var hasMessageId = origin.Headers.TryGetValue(Headers.MessageId, out var messageId) && messageId is not null;
 
         if (!hasMessageId)
         {
@@ -333,7 +380,7 @@ internal sealed class InMemoryDataStorage(
             return ValueTask.FromResult(inserted);
         }
 
-        var indexKey = (version, messageId!, (string?)group);
+        var indexKey = (version, messageId!, (string?)group, message.IntentType);
 
         // R3 — extend the same lock + check-then-insert/update pattern from
         // StoreReceivedExceptionMessageAsync to the non-exception path. Before R3 two concurrent
@@ -376,6 +423,7 @@ internal sealed class InMemoryDataStorage(
                             StorageId = existing.StorageId,
                             Origin = existing.Origin,
                             Content = existing.Content,
+                            IntentType = existing.IntentType,
                             Added = existing.Added,
                             ExpiresAt = existing.ExpiresAt,
                             NextRetryAt = existing.NextRetryAt,
@@ -404,8 +452,9 @@ internal sealed class InMemoryDataStorage(
                 var leaseActive = existing.LockedUntil is not null && existing.LockedUntil > nowUtc;
                 if (!leaseActive)
                 {
-                    existing.Origin = message;
+                    existing.Origin = message.Origin;
                     existing.Content = serialized;
+                    existing.IntentType = message.IntentType;
                     existing.Retries = 0;
                     existing.Added = added;
                     existing.ExpiresAt = null;
@@ -421,6 +470,7 @@ internal sealed class InMemoryDataStorage(
                         StorageId = existing.StorageId,
                         Origin = existing.Origin,
                         Content = existing.Content,
+                        IntentType = existing.IntentType,
                         Added = existing.Added,
                         ExpiresAt = existing.ExpiresAt,
                         NextRetryAt = existing.NextRetryAt,
@@ -436,10 +486,29 @@ internal sealed class InMemoryDataStorage(
         }
     }
 
-    private MediumMessage _InsertNewReceivedRow(
+    public ValueTask<MediumMessage> StoreReceivedMessageAsync(
         string name,
         string group,
         Message message,
+        CancellationToken cancellationToken = default
+    ) =>
+        StoreReceivedMessageAsync(
+            name,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = message,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            cancellationToken
+        );
+
+    private MediumMessage _InsertNewReceivedRow(
+        string name,
+        string group,
+        MediumMessage message,
         string serialized,
         DateTime added,
         DateTime initialNextRetryAt,
@@ -449,8 +518,9 @@ internal sealed class InMemoryDataStorage(
         var mdMessage = new MediumMessage
         {
             StorageId = longIdGenerator.Create(),
-            Origin = message,
+            Origin = message.Origin,
             Content = serialized,
+            IntentType = message.IntentType,
             Added = added,
             ExpiresAt = null,
             NextRetryAt = initialNextRetryAt,
@@ -462,6 +532,7 @@ internal sealed class InMemoryDataStorage(
         {
             StorageId = mdMessage.StorageId,
             Origin = mdMessage.Origin,
+            IntentType = mdMessage.IntentType,
             Group = group,
             Name = name,
             Content = mdMessage.Content,
@@ -616,6 +687,7 @@ internal sealed class InMemoryDataStorage(
             LockedUntil = m.LockedUntil,
             Retries = m.Retries,
             ExceptionInfo = m.ExceptionInfo,
+            IntentType = m.IntentType,
         };
 
     private static ValueTask<bool> _LeaseAsync(
@@ -676,7 +748,7 @@ internal sealed class InMemoryDataStorage(
         // shutdown cleanup of degenerate test inputs.
         if (removed.Origin.Headers.TryGetValue(Headers.MessageId, out var messageId) && messageId is not null)
         {
-            _receivedIdentityIndex.TryRemove((removed.Version, messageId, removed.Group), out _);
+            _receivedIdentityIndex.TryRemove((removed.Version, messageId, removed.Group, removed.IntentType), out _);
         }
     }
 

--- a/src/Headless.Messaging.InMemoryStorage/InMemoryMonitoringApi.cs
+++ b/src/Headless.Messaging.InMemoryStorage/InMemoryMonitoringApi.cs
@@ -89,6 +89,11 @@ internal sealed class InMemoryMonitoringApi(InMemoryDataStorage storage, TimePro
                 expression = expression.Where(x => x.Content.Contains(query.Content, StringComparison.Ordinal));
             }
 
+            if (query.IntentType is { } intentType)
+            {
+                expression = expression.Where(x => x.IntentType == intentType);
+            }
+
             var offset = query.CurrentPage * query.PageSize;
             var size = query.PageSize;
 
@@ -100,6 +105,7 @@ internal sealed class InMemoryMonitoringApi(InMemoryDataStorage storage, TimePro
                     MessageId = x.Origin.GetId(),
                     Version = "N/A",
                     Content = x.Content,
+                    IntentType = x.IntentType,
                     ExpiresAt = x.ExpiresAt,
                     Name = x.Name,
                     Retries = x.Retries,
@@ -146,6 +152,11 @@ internal sealed class InMemoryMonitoringApi(InMemoryDataStorage storage, TimePro
                 expression = expression.Where(x => x.Content.Contains(query.Content, StringComparison.Ordinal));
             }
 
+            if (query.IntentType is { } intentType)
+            {
+                expression = expression.Where(x => x.IntentType == intentType);
+            }
+
             var offset = query.CurrentPage * query.PageSize;
             var size = query.PageSize;
 
@@ -158,6 +169,7 @@ internal sealed class InMemoryMonitoringApi(InMemoryDataStorage storage, TimePro
                     MessageId = x.Origin.GetId(),
                     Version = "N/A",
                     Content = x.Content,
+                    IntentType = x.IntentType,
                     ExpiresAt = x.ExpiresAt,
                     Name = x.Name,
                     Retries = x.Retries,

--- a/src/Headless.Messaging.InMemoryStorage/README.md
+++ b/src/Headless.Messaging.InMemoryStorage/README.md
@@ -12,6 +12,7 @@ Provides ephemeral message storage without database dependencies for local devel
 - **Fast**: In-memory operations
 - **Testing**: Deterministic behavior for tests
 - **Full API**: Complete outbox storage implementation
+- **Intent-Aware Identity**: Mirrors durable providers by storing bus/queue intent and including it in received-message de-duplication
 - **Monitoring**: In-memory dashboard data
 
 ## Installation

--- a/src/Headless.Messaging.PostgreSql/PostgreSqlDataStorage.cs
+++ b/src/Headless.Messaging.PostgreSql/PostgreSqlDataStorage.cs
@@ -189,21 +189,22 @@ public sealed class PostgreSqlDataStorage(
 
     public async ValueTask<MediumMessage> StoreMessageAsync(
         string name,
-        Message content,
+        MediumMessage message,
         object? transaction = null,
         CancellationToken cancellationToken = default
     )
     {
         var sql =
-            $"INSERT INTO {_publishedTable} (\"Id\",\"Version\",\"Name\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\",\"NextRetryAt\",\"LockedUntil\",\"StatusName\",\"MessageId\")"
-            + $"VALUES(@Id,'{messagingOptions.Value.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId);";
+            $"INSERT INTO {_publishedTable} (\"Id\",\"Version\",\"Name\",\"Content\",\"IntentType\",\"Retries\",\"Added\",\"ExpiresAt\",\"NextRetryAt\",\"LockedUntil\",\"StatusName\",\"MessageId\")"
+            + $"VALUES(@Id,'{messagingOptions.Value.Version}',@Name,@Content,@IntentType,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId);";
 
         var added = timeProvider.GetUtcNow().UtcDateTime;
-        var message = new MediumMessage
+        var stored = new MediumMessage
         {
             StorageId = longIdGenerator.Create(),
-            Origin = content,
-            Content = serializer.Serialize(content),
+            Origin = message.Origin,
+            Content = serializer.Serialize(message.Origin),
+            IntentType = message.IntentType,
             Added = added,
             ExpiresAt = null,
             NextRetryAt = added.Add(messagingOptions.Value.RetryPolicy.InitialDispatchGrace),
@@ -213,16 +214,17 @@ public sealed class PostgreSqlDataStorage(
 
         object[] sqlParams =
         [
-            new NpgsqlParameter("@Id", message.StorageId),
+            new NpgsqlParameter("@Id", stored.StorageId),
             new NpgsqlParameter("@Name", name),
-            new NpgsqlParameter("@Content", message.Content),
-            new NpgsqlParameter("@Retries", message.Retries),
-            new NpgsqlParameter("@Added", message.Added),
-            new NpgsqlParameter("@ExpiresAt", message.ExpiresAt.HasValue ? message.ExpiresAt.Value : DBNull.Value),
-            new NpgsqlParameter("@NextRetryAt", message.NextRetryAt.ToUtcParameterValue()),
-            new NpgsqlParameter("@LockedUntil", message.LockedUntil.ToUtcParameterValue()),
+            new NpgsqlParameter("@Content", stored.Content),
+            new NpgsqlParameter("@IntentType", (short)stored.IntentType),
+            new NpgsqlParameter("@Retries", stored.Retries),
+            new NpgsqlParameter("@Added", stored.Added),
+            new NpgsqlParameter("@ExpiresAt", stored.ExpiresAt.HasValue ? stored.ExpiresAt.Value : DBNull.Value),
+            new NpgsqlParameter("@NextRetryAt", stored.NextRetryAt.ToUtcParameterValue()),
+            new NpgsqlParameter("@LockedUntil", stored.LockedUntil.ToUtcParameterValue()),
             new NpgsqlParameter("@StatusName", nameof(StatusName.Scheduled)),
-            new NpgsqlParameter("@MessageId", content.GetId()),
+            new NpgsqlParameter("@MessageId", message.Origin.GetId()),
         ];
 
         if (transaction == null)
@@ -263,8 +265,27 @@ public sealed class PostgreSqlDataStorage(
                 .ConfigureAwait(false);
         }
 
-        return message;
+        return stored;
     }
+
+    public ValueTask<MediumMessage> StoreMessageAsync(
+        string name,
+        Message content,
+        object? transaction = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        StoreMessageAsync(
+            name,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = content,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            transaction,
+            cancellationToken
+        );
 
     public async ValueTask<bool> StoreReceivedExceptionMessageAsync(
         string name,
@@ -274,12 +295,38 @@ public sealed class PostgreSqlDataStorage(
         CancellationToken cancellationToken = default
     )
     {
+        var origin = serializer.Deserialize(content)!;
+        return await StoreReceivedExceptionMessageAsync(
+                name,
+                group,
+                new MediumMessage
+                {
+                    StorageId = 0,
+                    Origin = origin,
+                    Content = content,
+                    IntentType = IntentType.Bus,
+                },
+                exceptionInfo,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask<bool> StoreReceivedExceptionMessageAsync(
+        string name,
+        string group,
+        MediumMessage message,
+        string? exceptionInfo = null,
+        CancellationToken cancellationToken = default
+    )
+    {
         object[] sqlParams =
         [
             new NpgsqlParameter("@Id", longIdGenerator.Create()),
             new NpgsqlParameter("@Name", name),
             new NpgsqlParameter("@Group", NpgsqlDbType.Varchar) { Value = (object?)group ?? DBNull.Value },
-            new NpgsqlParameter("@Content", content),
+            new NpgsqlParameter("@Content", string.IsNullOrEmpty(message.Content) ? serializer.Serialize(message.Origin) : message.Content),
+            new NpgsqlParameter("@IntentType", (short)message.IntentType),
             new NpgsqlParameter("@Retries", messagingOptions.Value.RetryPolicy.MaxPersistedRetries),
             new NpgsqlParameter("@Added", timeProvider.GetUtcNow().UtcDateTime),
             new NpgsqlParameter(
@@ -289,7 +336,7 @@ public sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@NextRetryAt", DBNull.Value),
             new NpgsqlParameter("@LockedUntil", DBNull.Value),
             new NpgsqlParameter("@StatusName", nameof(StatusName.Failed)),
-            new NpgsqlParameter("@MessageId", serializer.Deserialize(content)!.GetId()),
+            new NpgsqlParameter("@MessageId", message.Origin.GetId()),
             new NpgsqlParameter("@ExceptionInfo", exceptionInfo ?? (object)DBNull.Value),
         ];
 
@@ -299,7 +346,7 @@ public sealed class PostgreSqlDataStorage(
     public async ValueTask<MediumMessage> StoreReceivedMessageAsync(
         string name,
         string group,
-        Message message,
+        MediumMessage message,
         CancellationToken cancellationToken = default
     )
     {
@@ -307,8 +354,9 @@ public sealed class PostgreSqlDataStorage(
         var mediumMessage = new MediumMessage
         {
             StorageId = longIdGenerator.Create(),
-            Origin = message,
-            Content = serializer.Serialize(message),
+            Origin = message.Origin,
+            Content = serializer.Serialize(message.Origin),
+            IntentType = message.IntentType,
             Added = added,
             ExpiresAt = null,
             NextRetryAt = added.Add(messagingOptions.Value.RetryPolicy.InitialDispatchGrace),
@@ -322,6 +370,7 @@ public sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@Name", name),
             new NpgsqlParameter("@Group", NpgsqlDbType.Varchar) { Value = (object?)group ?? DBNull.Value },
             new NpgsqlParameter("@Content", mediumMessage.Content),
+            new NpgsqlParameter("@IntentType", (short)mediumMessage.IntentType),
             new NpgsqlParameter("@Retries", mediumMessage.Retries),
             new NpgsqlParameter("@Added", mediumMessage.Added),
             new NpgsqlParameter(
@@ -331,7 +380,7 @@ public sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@NextRetryAt", mediumMessage.NextRetryAt.ToUtcParameterValue()),
             new NpgsqlParameter("@LockedUntil", mediumMessage.LockedUntil.ToUtcParameterValue()),
             new NpgsqlParameter("@StatusName", nameof(StatusName.Scheduled)),
-            new NpgsqlParameter("@MessageId", message.GetId()),
+            new NpgsqlParameter("@MessageId", message.Origin.GetId()),
             new NpgsqlParameter("@ExceptionInfo", DBNull.Value),
         ];
 
@@ -339,6 +388,25 @@ public sealed class PostgreSqlDataStorage(
 
         return mediumMessage;
     }
+
+    public ValueTask<MediumMessage> StoreReceivedMessageAsync(
+        string name,
+        string group,
+        Message message,
+        CancellationToken cancellationToken = default
+    ) =>
+        StoreReceivedMessageAsync(
+            name,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = message,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            cancellationToken
+        );
 
     public async ValueTask<int> DeleteExpiresAsync(
         string table,
@@ -424,7 +492,7 @@ public sealed class PostgreSqlDataStorage(
     )
     {
         var sql =
-            $"SELECT \"Id\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\" FROM {_publishedTable} WHERE \"Version\"=@Version "
+            $"SELECT \"Id\",\"Content\",\"IntentType\",\"Retries\",\"Added\",\"ExpiresAt\" FROM {_publishedTable} WHERE \"Version\"=@Version "
             + $"AND ((\"ExpiresAt\"< @TwoMinutesLater AND \"StatusName\" = '{nameof(StatusName.Delayed)}') OR (\"ExpiresAt\"< @OneMinutesAgo AND \"StatusName\" = '{nameof(StatusName.Queued)}')) FOR UPDATE SKIP LOCKED LIMIT @BatchSize;";
 
         var sqlParams = new object[]
@@ -457,9 +525,10 @@ public sealed class PostgreSqlDataStorage(
                             StorageId = reader.GetInt64(0),
                             Origin = serializer.Deserialize(content)!,
                             Content = content,
-                            Retries = reader.GetInt32(2),
-                            Added = reader.GetDateTime(3),
-                            ExpiresAt = reader.GetDateTime(4),
+                            IntentType = (IntentType)reader.GetInt16(2),
+                            Retries = reader.GetInt32(3),
+                            Added = reader.GetDateTime(4),
+                            ExpiresAt = reader.GetDateTime(5),
                         };
 
                         messages.Add(mediumMessage);
@@ -579,7 +648,7 @@ public sealed class PostgreSqlDataStorage(
         //   no row             → ON CONFLICT matched but the WHERE filter blocked the update
         //                        (terminal-row guard hit). We treat as "not modified" → return false.
         // Use the inference form `ON CONFLICT (col, expression)` so the planner matches the
-        // partial unique index `uq_received_MessageId_GroupCoalesced` by structure rather than
+        // unique expression index by structure rather than
         // requiring a named constraint (a `CREATE UNIQUE INDEX` is an index, not a constraint;
         // `ON CONFLICT ON CONSTRAINT` would error out against it).
         // #3 — additionally skip rows whose lease is still active (LockedUntil in the future). A
@@ -588,9 +657,9 @@ public sealed class PostgreSqlDataStorage(
         // mid-attempt and letting the retry processor re-pick the row while the inline retry loop
         // is still in flight. Mirrors the matching guard in SqlServerDataStorage._StoreReceivedMessage.
         var sql = $"""
-            INSERT INTO {_receivedTable}("Id","Version","Name","Group","Content","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId","ExceptionInfo")
-            VALUES(@Id,'{messagingOptions.Value.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId,@ExceptionInfo)
-            ON CONFLICT ("MessageId", (COALESCE("Group", ''))) DO UPDATE SET
+            INSERT INTO {_receivedTable}("Id","Version","Name","Group","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId","ExceptionInfo")
+            VALUES(@Id,'{messagingOptions.Value.Version}',@Name,@Group,@Content,@IntentType,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId,@ExceptionInfo)
+            ON CONFLICT ("Version", "MessageId", (COALESCE("Group", '')), "IntentType") DO UPDATE SET
                 "StatusName"=EXCLUDED."StatusName",
                 "Retries"=EXCLUDED."Retries",
                 "ExpiresAt"=EXCLUDED."ExpiresAt",
@@ -688,7 +757,7 @@ public sealed class PostgreSqlDataStorage(
                 LIMIT {_RetryBatchSize}
                 FOR UPDATE SKIP LOCKED
             )
-            RETURNING "Id","Content","Retries","Added","NextRetryAt","LockedUntil";
+            RETURNING "Id","Content","IntentType","Retries","Added","NextRetryAt","LockedUntil";
             """;
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
@@ -719,14 +788,15 @@ public sealed class PostgreSqlDataStorage(
                             StorageId = reader.GetInt64(0),
                             Origin = serializer.Deserialize(content)!,
                             Content = content,
-                            Retries = reader.GetInt32(2),
-                            Added = reader.GetDateTime(3),
-                            NextRetryAt = await reader.IsDBNullAsync(4, token).ConfigureAwait(false)
-                                ? null
-                                : reader.GetDateTime(4),
-                            LockedUntil = await reader.IsDBNullAsync(5, token).ConfigureAwait(false)
+                            IntentType = (IntentType)reader.GetInt16(2),
+                            Retries = reader.GetInt32(3),
+                            Added = reader.GetDateTime(4),
+                            NextRetryAt = await reader.IsDBNullAsync(5, token).ConfigureAwait(false)
                                 ? null
                                 : reader.GetDateTime(5),
+                            LockedUntil = await reader.IsDBNullAsync(6, token).ConfigureAwait(false)
+                                ? null
+                                : reader.GetDateTime(6),
                         };
 
                         messages.Add(mediumMessage);

--- a/src/Headless.Messaging.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Headless.Messaging.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -111,8 +111,8 @@ public sealed class PostgreSqlMonitoringApi(
         var tableName = query.MessageType == MessageType.Publish ? _publishedTable : _receivedTable;
         var selectColumns =
             query.MessageType == MessageType.Publish
-                ? @"""Id"",""MessageId"",""Version"",""Name"",CAST(NULL AS VARCHAR(200)) AS ""Group"",""Content"",""Retries"",""Added"",""ExpiresAt"",""StatusName"",""NextRetryAt"",""LockedUntil"""
-                : @"""Id"",""MessageId"",""Version"",""Name"",""Group"",""Content"",""Retries"",""Added"",""ExpiresAt"",""StatusName"",""NextRetryAt"",""LockedUntil""";
+                ? @"""Id"",""MessageId"",""Version"",""Name"",CAST(NULL AS VARCHAR(200)) AS ""Group"",""Content"",""IntentType"",""Retries"",""Added"",""ExpiresAt"",""StatusName"",""NextRetryAt"",""LockedUntil"""
+                : @"""Id"",""MessageId"",""Version"",""Name"",""Group"",""Content"",""IntentType"",""Retries"",""Added"",""ExpiresAt"",""StatusName"",""NextRetryAt"",""LockedUntil""";
         var where = string.Empty;
 
         if (!string.IsNullOrEmpty(query.StatusName))
@@ -135,6 +135,11 @@ public sealed class PostgreSqlMonitoringApi(
             where += " AND \"Content\" ILike @Content";
         }
 
+        if (query.IntentType is { })
+        {
+            where += " AND \"IntentType\" = @IntentType";
+        }
+
         // Keep the total count in a separate query: COUNT(*) OVER() returns no count row when OFFSET/LIMIT yields
         // an empty later page, which breaks pagination metadata even though matching rows still exist.
         var countQuery = $"SELECT COUNT(\"Id\") FROM {tableName} WHERE 1=1 {where}";
@@ -150,6 +155,7 @@ public sealed class PostgreSqlMonitoringApi(
             new NpgsqlParameter("@Group", query.Group ?? string.Empty),
             new NpgsqlParameter("@Name", query.Name ?? string.Empty),
             new NpgsqlParameter("@Content", $"%{query.Content}%"),
+            new NpgsqlParameter("@IntentType", (short?)query.IntentType ?? 0),
             new NpgsqlParameter("@Offset", query.CurrentPage * query.PageSize),
             new NpgsqlParameter("@Limit", query.PageSize),
         ];
@@ -191,6 +197,7 @@ public sealed class PostgreSqlMonitoringApi(
                                 Content = await reader.IsDBNullAsync(index++, token).ConfigureAwait(false)
                                     ? null
                                     : reader.GetString(index - 1),
+                                IntentType = (IntentType)reader.GetInt16(index++),
                                 Retries = reader.GetInt32(index++),
                                 Added = reader.GetDateTime(index++),
                                 ExpiresAt = await reader.IsDBNullAsync(index++, token).ConfigureAwait(false)
@@ -372,7 +379,7 @@ public sealed class PostgreSqlMonitoringApi(
             ? @"""ExceptionInfo"""
             : "NULL AS \"ExceptionInfo\"";
         var sql =
-            $@"SELECT ""Id"" AS ""StorageId"", ""Content"", ""Added"", ""ExpiresAt"", ""Retries"", {exceptionInfoSql}, ""NextRetryAt"", ""LockedUntil"" FROM {tableName} WHERE ""Id""=@Id";
+            $@"SELECT ""Id"" AS ""StorageId"", ""Content"", ""IntentType"", ""Added"", ""ExpiresAt"", ""Retries"", {exceptionInfoSql}, ""NextRetryAt"", ""LockedUntil"" FROM {tableName} WHERE ""Id""=@Id";
 
         await using var connection = _options.CreateConnection();
 
@@ -390,20 +397,21 @@ public sealed class PostgreSqlMonitoringApi(
                             StorageId = reader.GetInt64(0),
                             Origin = serializer.Deserialize(reader.GetString(1))!,
                             Content = reader.GetString(1),
-                            Added = reader.GetDateTime(2),
-                            ExpiresAt = await reader.IsDBNullAsync(3, token).ConfigureAwait(false)
+                            IntentType = (IntentType)reader.GetInt16(2),
+                            Added = reader.GetDateTime(3),
+                            ExpiresAt = await reader.IsDBNullAsync(4, token).ConfigureAwait(false)
                                 ? null
-                                : reader.GetDateTime(3),
-                            Retries = reader.GetInt32(4),
-                            ExceptionInfo = await reader.IsDBNullAsync(5, token).ConfigureAwait(false)
+                                : reader.GetDateTime(4),
+                            Retries = reader.GetInt32(5),
+                            ExceptionInfo = await reader.IsDBNullAsync(6, token).ConfigureAwait(false)
                                 ? null
-                                : reader.GetString(5),
-                            NextRetryAt = await reader.IsDBNullAsync(6, token).ConfigureAwait(false)
-                                ? null
-                                : reader.GetDateTime(6),
-                            LockedUntil = await reader.IsDBNullAsync(7, token).ConfigureAwait(false)
+                                : reader.GetString(6),
+                            NextRetryAt = await reader.IsDBNullAsync(7, token).ConfigureAwait(false)
                                 ? null
                                 : reader.GetDateTime(7),
+                            LockedUntil = await reader.IsDBNullAsync(8, token).ConfigureAwait(false)
+                                ? null
+                                : reader.GetDateTime(8),
                         };
                     }
 

--- a/src/Headless.Messaging.PostgreSql/PostgreSqlStorageInitializer.cs
+++ b/src/Headless.Messaging.PostgreSql/PostgreSqlStorageInitializer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Messaging;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Persistence;
 using Microsoft.Extensions.Logging;
@@ -168,6 +169,7 @@ public sealed class PostgreSqlStorageInitializer(
             	"Name" VARCHAR(200) NOT NULL,
             	"Group" VARCHAR(200) NULL,
             	"Content" TEXT NULL,
+                "IntentType" SMALLINT NOT NULL,
             	"Retries" INT NOT NULL,
             	"Added" TIMESTAMPTZ NOT NULL,
                 "ExpiresAt" TIMESTAMPTZ NULL,
@@ -190,7 +192,11 @@ public sealed class PostgreSqlStorageInitializer(
             -- on a violation is non-deterministic. The plain index would fire first for non-null
             -- groups and produce a raw 23505 that bypasses the ON CONFLICT target, breaking
             -- concurrent-insert convergence under load.
-            CREATE UNIQUE INDEX IF NOT EXISTS "uq_received_MessageId_GroupCoalesced" ON {GetReceivedTableName()} ("MessageId", (COALESCE("Group", '')));
+            ALTER TABLE {GetReceivedTableName()} ADD COLUMN IF NOT EXISTS "IntentType" SMALLINT;
+            UPDATE {GetReceivedTableName()} SET "IntentType" = {(short)IntentType.Bus} WHERE "IntentType" IS NULL;
+            ALTER TABLE {GetReceivedTableName()} ALTER COLUMN "IntentType" SET NOT NULL;
+            DROP INDEX IF EXISTS "{schema}"."uq_received_MessageId_GroupCoalesced";
+            CREATE UNIQUE INDEX IF NOT EXISTS "uq_received_Version_MessageId_GroupCoalesced_IntentType" ON {GetReceivedTableName()} ("Version", "MessageId", (COALESCE("Group", '')), "IntentType");
             CREATE INDEX IF NOT EXISTS "idx_received_ExpiresAt_StatusName" ON {GetReceivedTableName()} ("ExpiresAt","StatusName");
             CREATE INDEX IF NOT EXISTS "idx_received_Version_ExpiresAt_StatusName" ON {GetReceivedTableName()} ("Version","ExpiresAt","StatusName");
             -- #8 — The partial retry-pickup index (idx_received_Version_NextRetryAt) is created
@@ -205,6 +211,7 @@ public sealed class PostgreSqlStorageInitializer(
                 "Version" VARCHAR(20) NOT NULL,
             	"Name" VARCHAR(200) NOT NULL,
             	"Content" TEXT NULL,
+                "IntentType" SMALLINT NOT NULL,
             	"Retries" INT NOT NULL,
             	"Added" TIMESTAMPTZ NOT NULL,
                 "ExpiresAt" TIMESTAMPTZ NULL,
@@ -220,6 +227,10 @@ public sealed class PostgreSqlStorageInitializer(
             -- retry-pickup index for published is also created post-transaction via
             -- _EnsureRetryPickupIndexConcurrentlyAsync.
             CREATE INDEX IF NOT EXISTS "idx_published_delayed" ON {GetPublishedTableName()} ("StatusName","ExpiresAt") WHERE "StatusName" = 'Delayed';
+
+            ALTER TABLE {GetPublishedTableName()} ADD COLUMN IF NOT EXISTS "IntentType" SMALLINT;
+            UPDATE {GetPublishedTableName()} SET "IntentType" = {(short)IntentType.Bus} WHERE "IntentType" IS NULL;
+            ALTER TABLE {GetPublishedTableName()} ALTER COLUMN "IntentType" SET NOT NULL;
             """;
 
         return batchSql;

--- a/src/Headless.Messaging.PostgreSql/README.md
+++ b/src/Headless.Messaging.PostgreSql/README.md
@@ -9,7 +9,8 @@ Provides durable, transactional message storage using PostgreSQL with automatic 
 ## Key Features
 
 - **Transactional Outbox**: ACID-compliant message publishing with database changes
-- **Auto-Migration**: Automatic table creation and schema updates
+- **Auto-Migration**: Automatic table creation and schema updates, including durable bus/queue intent columns
+- **Intent-Aware Identity**: Received-message de-duplication includes version, message ID, group, and bus/queue intent
 - **Archival**: Automatic cleanup of old messages
 - **Performance**: Optimized indexes and queries for high throughput
 - **Monitoring**: Built-in dashboard data queries
@@ -59,4 +60,5 @@ options.UsePostgreSql(config =>
   - `{schema}.received` - Received messages
   - `{schema}.lock` - Distributed lock table
 - Creates indexes for message queries
+- Stores `IntentType` on published and received rows without a database default; runtime writes must provide the intent explicitly
 - Periodically cleans up expired messages

--- a/src/Headless.Messaging.SqlServer/README.md
+++ b/src/Headless.Messaging.SqlServer/README.md
@@ -9,7 +9,8 @@ Provides durable, transactional message storage using SQL Server with automatic 
 ## Key Features
 
 - **Transactional Outbox**: ACID-compliant message publishing with database changes
-- **Auto-Migration**: Automatic table creation and schema updates
+- **Auto-Migration**: Automatic table creation and schema updates, including durable bus/queue intent columns
+- **Intent-Aware Identity**: Received-message de-duplication includes version, message ID, group, and bus/queue intent
 - **Archival**: Automatic cleanup of old messages
 - **Performance**: Optimized indexes and queries for SQL Server
 - **Monitoring**: Built-in dashboard data queries
@@ -59,4 +60,5 @@ options.UseSqlServer(config =>
   - `{schema}.Received` - Received messages
   - `{schema}.Lock` - Distributed lock table
 - Creates indexes for message queries
+- Stores `IntentType` on published and received rows without a database default; runtime writes must provide the intent explicitly
 - Periodically cleans up expired messages

--- a/src/Headless.Messaging.SqlServer/SqlServerDataStorage.cs
+++ b/src/Headless.Messaging.SqlServer/SqlServerDataStorage.cs
@@ -185,21 +185,22 @@ public sealed class SqlServerDataStorage(
 
     public async ValueTask<MediumMessage> StoreMessageAsync(
         string name,
-        Message content,
+        MediumMessage message,
         object? transaction = null,
         CancellationToken cancellationToken = default
     )
     {
         var sql =
-            $"INSERT INTO {_publishedTable} ([Id],[Version],[Name],[Content],[Retries],[Added],[ExpiresAt],[NextRetryAt],[LockedUntil],[StatusName],[MessageId])"
-            + $"VALUES(@Id,'{messagingOptions.Value.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId);";
+            $"INSERT INTO {_publishedTable} ([Id],[Version],[Name],[Content],[IntentType],[Retries],[Added],[ExpiresAt],[NextRetryAt],[LockedUntil],[StatusName],[MessageId])"
+            + $"VALUES(@Id,'{messagingOptions.Value.Version}',@Name,@Content,@IntentType,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId);";
 
         var added = timeProvider.GetUtcNow().UtcDateTime;
-        var message = new MediumMessage
+        var stored = new MediumMessage
         {
             StorageId = longIdGenerator.Create(),
-            Origin = content,
-            Content = serializer.Serialize(content),
+            Origin = message.Origin,
+            Content = serializer.Serialize(message.Origin),
+            IntentType = message.IntentType,
             Added = added,
             ExpiresAt = null,
             NextRetryAt = added.Add(messagingOptions.Value.RetryPolicy.InitialDispatchGrace),
@@ -209,19 +210,20 @@ public sealed class SqlServerDataStorage(
 
         object[] sqlParams =
         [
-            new SqlParameter("@Id", message.StorageId),
+            new SqlParameter("@Id", stored.StorageId),
             new SqlParameter("@Name", name),
-            new SqlParameter("@Content", message.Content),
-            new SqlParameter("@Retries", message.Retries),
-            new SqlParameter("@Added", message.Added),
+            new SqlParameter("@Content", stored.Content),
+            new SqlParameter("@IntentType", SqlDbType.SmallInt) { Value = (short)stored.IntentType },
+            new SqlParameter("@Retries", stored.Retries),
+            new SqlParameter("@Added", stored.Added),
             new SqlParameter("@ExpiresAt", SqlDbType.DateTime2)
             {
-                Value = message.ExpiresAt.HasValue ? message.ExpiresAt.Value : DBNull.Value,
+                Value = stored.ExpiresAt.HasValue ? stored.ExpiresAt.Value : DBNull.Value,
             },
-            new SqlParameter("@NextRetryAt", SqlDbType.DateTime2) { Value = message.NextRetryAt.ToUtcParameterValue() },
-            new SqlParameter("@LockedUntil", SqlDbType.DateTime2) { Value = message.LockedUntil.ToUtcParameterValue() },
+            new SqlParameter("@NextRetryAt", SqlDbType.DateTime2) { Value = stored.NextRetryAt.ToUtcParameterValue() },
+            new SqlParameter("@LockedUntil", SqlDbType.DateTime2) { Value = stored.LockedUntil.ToUtcParameterValue() },
             new SqlParameter("@StatusName", nameof(StatusName.Scheduled)),
-            new SqlParameter("@MessageId", content.GetId()),
+            new SqlParameter("@MessageId", message.Origin.GetId()),
         ];
 
         if (transaction == null)
@@ -262,8 +264,27 @@ public sealed class SqlServerDataStorage(
                 .ConfigureAwait(false);
         }
 
-        return message;
+        return stored;
     }
+
+    public ValueTask<MediumMessage> StoreMessageAsync(
+        string name,
+        Message content,
+        object? transaction = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        StoreMessageAsync(
+            name,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = content,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            transaction,
+            cancellationToken
+        );
 
     public async ValueTask<bool> StoreReceivedExceptionMessageAsync(
         string name,
@@ -273,12 +294,38 @@ public sealed class SqlServerDataStorage(
         CancellationToken cancellationToken = default
     )
     {
+        var origin = serializer.Deserialize(content)!;
+        return await StoreReceivedExceptionMessageAsync(
+                name,
+                group,
+                new MediumMessage
+                {
+                    StorageId = 0,
+                    Origin = origin,
+                    Content = content,
+                    IntentType = IntentType.Bus,
+                },
+                exceptionInfo,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask<bool> StoreReceivedExceptionMessageAsync(
+        string name,
+        string group,
+        MediumMessage message,
+        string? exceptionInfo = null,
+        CancellationToken cancellationToken = default
+    )
+    {
         object[] sqlParams =
         [
             new SqlParameter("@Id", longIdGenerator.Create()),
             new SqlParameter("@Name", name),
             new SqlParameter("@Group", SqlDbType.NVarChar, 200) { Value = (object?)group ?? DBNull.Value },
-            new SqlParameter("@Content", content),
+            new SqlParameter("@Content", string.IsNullOrEmpty(message.Content) ? serializer.Serialize(message.Origin) : message.Content),
+            new SqlParameter("@IntentType", SqlDbType.SmallInt) { Value = (short)message.IntentType },
             new SqlParameter("@Retries", messagingOptions.Value.RetryPolicy.MaxPersistedRetries),
             new SqlParameter("@Added", timeProvider.GetUtcNow().UtcDateTime),
             new SqlParameter("@ExpiresAt", SqlDbType.DateTime2)
@@ -290,7 +337,7 @@ public sealed class SqlServerDataStorage(
             new SqlParameter("@NextRetryAt", SqlDbType.DateTime2) { Value = DBNull.Value },
             new SqlParameter("@LockedUntil", SqlDbType.DateTime2) { Value = DBNull.Value },
             new SqlParameter("@StatusName", nameof(StatusName.Failed)),
-            new SqlParameter("@MessageId", serializer.Deserialize(content)!.GetId()),
+            new SqlParameter("@MessageId", message.Origin.GetId()),
             new SqlParameter("@Version", messagingOptions.Value.Version),
             new SqlParameter("@ExceptionInfo", exceptionInfo ?? (object)DBNull.Value),
         ];
@@ -301,7 +348,7 @@ public sealed class SqlServerDataStorage(
     public async ValueTask<MediumMessage> StoreReceivedMessageAsync(
         string name,
         string group,
-        Message message,
+        MediumMessage message,
         CancellationToken cancellationToken = default
     )
     {
@@ -309,8 +356,9 @@ public sealed class SqlServerDataStorage(
         var mediumMessage = new MediumMessage
         {
             StorageId = longIdGenerator.Create(),
-            Origin = message,
-            Content = serializer.Serialize(message),
+            Origin = message.Origin,
+            Content = serializer.Serialize(message.Origin),
+            IntentType = message.IntentType,
             Added = added,
             ExpiresAt = null,
             NextRetryAt = added.Add(messagingOptions.Value.RetryPolicy.InitialDispatchGrace),
@@ -324,6 +372,7 @@ public sealed class SqlServerDataStorage(
             new SqlParameter("@Name", name),
             new SqlParameter("@Group", SqlDbType.NVarChar, 200) { Value = (object?)group ?? DBNull.Value },
             new SqlParameter("@Content", mediumMessage.Content),
+            new SqlParameter("@IntentType", SqlDbType.SmallInt) { Value = (short)mediumMessage.IntentType },
             new SqlParameter("@Retries", mediumMessage.Retries),
             new SqlParameter("@Added", mediumMessage.Added),
             new SqlParameter("@ExpiresAt", SqlDbType.DateTime2)
@@ -339,7 +388,7 @@ public sealed class SqlServerDataStorage(
                 Value = mediumMessage.LockedUntil.ToUtcParameterValue(),
             },
             new SqlParameter("@StatusName", nameof(StatusName.Scheduled)),
-            new SqlParameter("@MessageId", message.GetId()),
+            new SqlParameter("@MessageId", message.Origin.GetId()),
             new SqlParameter("@Version", messagingOptions.Value.Version),
             new SqlParameter("@ExceptionInfo", DBNull.Value),
         ];
@@ -348,6 +397,25 @@ public sealed class SqlServerDataStorage(
 
         return mediumMessage;
     }
+
+    public ValueTask<MediumMessage> StoreReceivedMessageAsync(
+        string name,
+        string group,
+        Message message,
+        CancellationToken cancellationToken = default
+    ) =>
+        StoreReceivedMessageAsync(
+            name,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = message,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            cancellationToken
+        );
 
     public async ValueTask<int> DeleteExpiresAsync(
         string table,
@@ -434,10 +502,10 @@ public sealed class SqlServerDataStorage(
     )
     {
         var sql = $"""
-            SELECT TOP (@BatchSize) Id, Content, Retries, Added, ExpiresAt FROM {_publishedTable} WITH (UPDLOCK, READPAST)
+            SELECT TOP (@BatchSize) Id, Content, IntentType, Retries, Added, ExpiresAt FROM {_publishedTable} WITH (UPDLOCK, READPAST)
             WHERE Version = @Version AND StatusName = '{nameof(StatusName.Delayed)}' AND ExpiresAt < @TwoMinutesLater
             UNION ALL
-            SELECT TOP (@BatchSize) Id, Content, Retries, Added, ExpiresAt FROM {_publishedTable} WITH (UPDLOCK, READPAST)
+            SELECT TOP (@BatchSize) Id, Content, IntentType, Retries, Added, ExpiresAt FROM {_publishedTable} WITH (UPDLOCK, READPAST)
             WHERE Version = @Version AND StatusName = '{nameof(StatusName.Queued)}' AND ExpiresAt < @OneMinutesAgo;
             """;
 
@@ -468,9 +536,10 @@ public sealed class SqlServerDataStorage(
                                 StorageId = reader.GetInt64(0),
                                 Origin = serializer.Deserialize(content)!,
                                 Content = content,
-                                Retries = reader.GetInt32(2),
-                                Added = reader.GetDateTime(3),
-                                ExpiresAt = reader.GetDateTime(4),
+                                IntentType = (IntentType)reader.GetInt16(2),
+                                Retries = reader.GetInt32(3),
+                                Added = reader.GetDateTime(4),
+                                ExpiresAt = reader.GetDateTime(5),
                             }
                         );
                     }
@@ -587,8 +656,8 @@ public sealed class SqlServerDataStorage(
         // re-pick the row while the inline retry loop is still in flight.
         var sql = $"""
             MERGE {_receivedTable} WITH (HOLDLOCK) AS target
-            USING (SELECT @MessageId AS MessageId, @Group AS [Group]) AS source
-            ON target.MessageId = source.MessageId AND (target.[Group] = source.[Group] OR (target.[Group] IS NULL AND source.[Group] IS NULL))
+            USING (SELECT @Version AS Version, @MessageId AS MessageId, @Group AS [Group], @IntentType AS IntentType) AS source
+            ON target.Version = source.Version AND target.MessageId = source.MessageId AND (target.[Group] = source.[Group] OR (target.[Group] IS NULL AND source.[Group] IS NULL)) AND target.IntentType = source.IntentType
             WHEN MATCHED
                 AND NOT (target.StatusName IN ('{nameof(StatusName.Succeeded)}','{nameof(
                     StatusName.Failed
@@ -597,8 +666,8 @@ public sealed class SqlServerDataStorage(
             THEN
                 UPDATE SET StatusName = @StatusName, Retries = @Retries, ExpiresAt = @ExpiresAt, NextRetryAt = @NextRetryAt, LockedUntil = @LockedUntil, Content = @Content, ExceptionInfo = @ExceptionInfo
             WHEN NOT MATCHED THEN
-                INSERT ([Id],[Version],[Name],[Group],[Content],[Retries],[Added],[ExpiresAt],[NextRetryAt],[LockedUntil],[StatusName],[MessageId],[ExceptionInfo])
-                VALUES (@Id,@Version,@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId,@ExceptionInfo);
+                INSERT ([Id],[Version],[Name],[Group],[Content],[IntentType],[Retries],[Added],[ExpiresAt],[NextRetryAt],[LockedUntil],[StatusName],[MessageId],[ExceptionInfo])
+                VALUES (@Id,@Version,@Name,@Group,@Content,@IntentType,@Retries,@Added,@ExpiresAt,@NextRetryAt,@LockedUntil,@StatusName,@MessageId,@ExceptionInfo);
             """;
 
         await using var connection = new SqlConnection(options.Value.ConnectionString);
@@ -682,7 +751,7 @@ public sealed class SqlServerDataStorage(
         var sql = $"""
             UPDATE TOP (@BatchSize) {tableName} WITH (UPDLOCK, READPAST, ROWLOCK)
             SET LockedUntil = @NewLease
-            OUTPUT inserted.Id, inserted.Content, inserted.Retries, inserted.Added, inserted.NextRetryAt, inserted.LockedUntil
+            OUTPUT inserted.Id, inserted.Content, inserted.IntentType, inserted.Retries, inserted.Added, inserted.NextRetryAt, inserted.LockedUntil
             WHERE Retries <= @Retries
               AND Version = @Version
               AND NextRetryAt IS NOT NULL AND NextRetryAt <= @Now
@@ -720,14 +789,15 @@ public sealed class SqlServerDataStorage(
                                 StorageId = reader.GetInt64(0),
                                 Origin = serializer.Deserialize(content)!,
                                 Content = content,
-                                Retries = reader.GetInt32(2),
-                                Added = reader.GetDateTime(3),
-                                NextRetryAt = await reader.IsDBNullAsync(4, ct).ConfigureAwait(false)
-                                    ? null
-                                    : reader.GetDateTime(4),
-                                LockedUntil = await reader.IsDBNullAsync(5, ct).ConfigureAwait(false)
+                                IntentType = (IntentType)reader.GetInt16(2),
+                                Retries = reader.GetInt32(3),
+                                Added = reader.GetDateTime(4),
+                                NextRetryAt = await reader.IsDBNullAsync(5, ct).ConfigureAwait(false)
                                     ? null
                                     : reader.GetDateTime(5),
+                                LockedUntil = await reader.IsDBNullAsync(6, ct).ConfigureAwait(false)
+                                    ? null
+                                    : reader.GetDateTime(6),
                             }
                         );
                     }

--- a/src/Headless.Messaging.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Headless.Messaging.SqlServer/SqlServerMonitoringApi.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Data;
 using Headless.Checks;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Internal;
@@ -101,8 +102,8 @@ public sealed class SqlServerMonitoringApi(
         var tableName = query.MessageType == MessageType.Publish ? _publishedTable : _receivedTable;
         var selectColumns =
             query.MessageType == MessageType.Publish
-                ? "[Id],[MessageId],[Version],[Name],CAST(NULL AS nvarchar(200)) AS [Group],[Content],[Retries],[Added],[ExpiresAt],[StatusName],[NextRetryAt],[LockedUntil]"
-                : "[Id],[MessageId],[Version],[Name],[Group],[Content],[Retries],[Added],[ExpiresAt],[StatusName],[NextRetryAt],[LockedUntil]";
+                ? "[Id],[MessageId],[Version],[Name],CAST(NULL AS nvarchar(200)) AS [Group],[Content],[IntentType],[Retries],[Added],[ExpiresAt],[StatusName],[NextRetryAt],[LockedUntil]"
+                : "[Id],[MessageId],[Version],[Name],[Group],[Content],[IntentType],[Retries],[Added],[ExpiresAt],[StatusName],[NextRetryAt],[LockedUntil]";
         var where = string.Empty;
         if (!string.IsNullOrEmpty(query.StatusName))
         {
@@ -124,6 +125,11 @@ public sealed class SqlServerMonitoringApi(
             where += " AND [Content] LIKE @Content";
         }
 
+        if (query.IntentType is { })
+        {
+            where += " AND [IntentType]=@IntentType";
+        }
+
         // Keep the total count in a separate query: COUNT(*) OVER() returns no count row when OFFSET/FETCH yields
         // an empty later page, which breaks pagination metadata even though matching rows still exist.
         var countQuery = $"SELECT COUNT_BIG(Id) FROM {tableName} WHERE 1=1 {where}";
@@ -137,6 +143,7 @@ public sealed class SqlServerMonitoringApi(
             new SqlParameter("@Group", query.Group ?? string.Empty),
             new SqlParameter("@Name", query.Name ?? string.Empty),
             new SqlParameter("@Content", $"%{query.Content}%"),
+            new SqlParameter("@IntentType", SqlDbType.SmallInt) { Value = (short?)query.IntentType ?? 0 },
         ];
 
         object[] pageSqlParams =
@@ -145,6 +152,7 @@ public sealed class SqlServerMonitoringApi(
             new SqlParameter("@Group", query.Group ?? string.Empty),
             new SqlParameter("@Name", query.Name ?? string.Empty),
             new SqlParameter("@Content", $"%{query.Content}%"),
+            new SqlParameter("@IntentType", SqlDbType.SmallInt) { Value = (short?)query.IntentType ?? 0 },
             new SqlParameter("@Offset", query.CurrentPage * query.PageSize),
             new SqlParameter("@Limit", query.PageSize),
         ];
@@ -188,6 +196,7 @@ public sealed class SqlServerMonitoringApi(
                                 Content = await reader.IsDBNullAsync(index++, ct).ConfigureAwait(false)
                                     ? null
                                     : reader.GetString(index - 1),
+                                IntentType = (IntentType)reader.GetInt16(index++),
                                 Retries = reader.GetInt32(index++),
                                 Added = reader.GetDateTime(index++),
                                 ExpiresAt = await reader.IsDBNullAsync(index++, ct).ConfigureAwait(false)
@@ -366,7 +375,7 @@ public sealed class SqlServerMonitoringApi(
             ? "ExceptionInfo"
             : "CAST(NULL AS nvarchar(max)) AS ExceptionInfo";
         var sql =
-            $"SELECT TOP(1) Id, Content, Added, ExpiresAt, Retries, {exceptionInfoSql}, NextRetryAt, LockedUntil FROM {tableName} WITH (READPAST) WHERE Id=@Id";
+            $"SELECT TOP(1) Id, Content, IntentType, Added, ExpiresAt, Retries, {exceptionInfoSql}, NextRetryAt, LockedUntil FROM {tableName} WITH (READPAST) WHERE Id=@Id";
 
         await using var connection = new SqlConnection(_options.ConnectionString);
 
@@ -379,24 +388,25 @@ public sealed class SqlServerMonitoringApi(
 
                     while (await reader.ReadAsync(ct).ConfigureAwait(false))
                     {
-                        var expiresAtIsNull = await reader.IsDBNullAsync(3, ct).ConfigureAwait(false);
+                        var expiresAtIsNull = await reader.IsDBNullAsync(4, ct).ConfigureAwait(false);
                         message = new MediumMessage
                         {
                             StorageId = reader.GetInt64(0),
                             Origin = serializer.Deserialize(reader.GetString(1))!,
                             Content = reader.GetString(1),
-                            Added = reader.GetDateTime(2),
-                            ExpiresAt = expiresAtIsNull ? null : reader.GetDateTime(3),
-                            Retries = reader.GetInt32(4),
-                            ExceptionInfo = await reader.IsDBNullAsync(5, ct).ConfigureAwait(false)
+                            IntentType = (IntentType)reader.GetInt16(2),
+                            Added = reader.GetDateTime(3),
+                            ExpiresAt = expiresAtIsNull ? null : reader.GetDateTime(4),
+                            Retries = reader.GetInt32(5),
+                            ExceptionInfo = await reader.IsDBNullAsync(6, ct).ConfigureAwait(false)
                                 ? null
-                                : reader.GetString(5),
-                            NextRetryAt = await reader.IsDBNullAsync(6, ct).ConfigureAwait(false)
-                                ? null
-                                : reader.GetDateTime(6),
-                            LockedUntil = await reader.IsDBNullAsync(7, ct).ConfigureAwait(false)
+                                : reader.GetString(6),
+                            NextRetryAt = await reader.IsDBNullAsync(7, ct).ConfigureAwait(false)
                                 ? null
                                 : reader.GetDateTime(7),
+                            LockedUntil = await reader.IsDBNullAsync(8, ct).ConfigureAwait(false)
+                                ? null
+                                : reader.GetDateTime(8),
                         };
                     }
 

--- a/src/Headless.Messaging.SqlServer/SqlServerStorageInitializer.cs
+++ b/src/Headless.Messaging.SqlServer/SqlServerStorageInitializer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Messaging;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Persistence;
 using Microsoft.Data.SqlClient;
@@ -92,6 +93,7 @@ public sealed class SqlServerStorageInitializer(
                         [Name] [nvarchar](200) NOT NULL,
                         [Group] [nvarchar](200) NULL,
                         [Content] [nvarchar](max) NULL,
+                        [IntentType] [smallint] NOT NULL,
                         [Retries] [int] NOT NULL,
                         [Added] [datetime2](7) NOT NULL,
                         [ExpiresAt] [datetime2](7) NULL,
@@ -103,7 +105,7 @@ public sealed class SqlServerStorageInitializer(
                         CONSTRAINT [PK_{receivedPrefix}] PRIMARY KEY CLUSTERED ([Id] ASC)
                     );
 
-                    CREATE UNIQUE NONCLUSTERED INDEX [IX_{receivedPrefix}_MessageId_Group] ON {GetReceivedTableName()} ([MessageId] ASC, [Group] ASC);
+                    CREATE UNIQUE NONCLUSTERED INDEX [IX_{receivedPrefix}_Version_MessageId_Group_IntentType] ON {GetReceivedTableName()} ([Version] ASC, [MessageId] ASC, [Group] ASC, [IntentType] ASC);
                     CREATE NONCLUSTERED INDEX [IX_{receivedPrefix}_Version_ExpiresAt_StatusName] ON {GetReceivedTableName()} ([Version] ASC,[ExpiresAt] ASC,[StatusName] ASC);
                     CREATE NONCLUSTERED INDEX [IX_{receivedPrefix}_ExpiresAt_StatusName] ON {GetReceivedTableName()} ([ExpiresAt] ASC,[StatusName] ASC);
                     -- Filtered index for retry pickup. Keyed on (Version, NextRetryAt) so Version
@@ -125,6 +127,7 @@ public sealed class SqlServerStorageInitializer(
                         [Version] [nvarchar](20) NOT NULL,
                         [Name] [nvarchar](200) NOT NULL,
                         [Content] [nvarchar](max) NULL,
+                        [IntentType] [smallint] NOT NULL,
                         [Retries] [int] NOT NULL,
                         [Added] [datetime2](7) NOT NULL,
                         [ExpiresAt] [datetime2](7) NULL,
@@ -175,6 +178,31 @@ public sealed class SqlServerStorageInitializer(
             --   3701 — index does not exist (idempotency under TOCTOU race)
             DECLARE @engineEdition INT = CAST(SERVERPROPERTY('EngineEdition') AS INT);
             DECLARE @supportsOnline BIT = CASE WHEN @engineEdition IN (3, 5, 8) THEN 1 ELSE 0 END;
+
+            BEGIN TRY
+                IF COL_LENGTH(N'{GetReceivedTableName()}', N'IntentType') IS NULL
+                BEGIN
+                    ALTER TABLE {GetReceivedTableName()} ADD [IntentType] [smallint] NULL;
+                    UPDATE {GetReceivedTableName()} SET [IntentType] = {(short)IntentType.Bus} WHERE [IntentType] IS NULL;
+                    ALTER TABLE {GetReceivedTableName()} ALTER COLUMN [IntentType] [smallint] NOT NULL;
+                END;
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_MessageId_Group' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))
+                    DROP INDEX [IX_{receivedPrefix}_MessageId_Group] ON {GetReceivedTableName()};
+
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_Version_MessageId_Group_IntentType' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))
+                    CREATE UNIQUE NONCLUSTERED INDEX [IX_{receivedPrefix}_Version_MessageId_Group_IntentType] ON {GetReceivedTableName()} ([Version] ASC, [MessageId] ASC, [Group] ASC, [IntentType] ASC);
+
+                IF COL_LENGTH(N'{GetPublishedTableName()}', N'IntentType') IS NULL
+                BEGIN
+                    ALTER TABLE {GetPublishedTableName()} ADD [IntentType] [smallint] NULL;
+                    UPDATE {GetPublishedTableName()} SET [IntentType] = {(short)IntentType.Bus} WHERE [IntentType] IS NULL;
+                    ALTER TABLE {GetPublishedTableName()} ALTER COLUMN [IntentType] [smallint] NOT NULL;
+                END;
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() <> 1913 THROW;
+            END CATCH;
 
             BEGIN TRY
                 IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_Version_NextRetryAt' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))

--- a/tests/Headless.Messaging.Core.Tests.Harness/DataStorageTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/DataStorageTestsBase.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Collections.Concurrent;
+using Headless.Messaging;
 using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
+using Headless.Messaging.Monitoring;
 using Headless.Messaging.Persistence;
 using Headless.Messaging.Serialization;
 using Headless.Testing.Tests;
@@ -134,6 +136,85 @@ public abstract class DataStorageTestsBase : TestBase
         result.Origin.GetId().Should().Be("non-numeric-id");
     }
 
+    public virtual async Task should_store_published_message_with_intent_type()
+    {
+        // given
+        if (!Capabilities.SupportsMonitoringApi)
+        {
+            Assert.Skip("Storage does not support monitoring roundtrip");
+        }
+
+        var storage = GetStorage();
+        var message = CreateMessage();
+        var envelope = new MediumMessage
+        {
+            StorageId = 0,
+            Origin = message,
+            Content = string.Empty,
+            IntentType = IntentType.Queue,
+        };
+
+        // when
+        var result = await storage.StoreMessageAsync("test-published-message", envelope, cancellationToken: AbortToken);
+
+        // then
+        result.IntentType.Should().Be(IntentType.Queue);
+        var roundTripped = await storage.GetMonitoringApi().GetPublishedMessageAsync(result.StorageId, AbortToken);
+        roundTripped.Should().NotBeNull();
+        roundTripped!.IntentType.Should().Be(IntentType.Queue);
+    }
+
+    public virtual async Task should_filter_monitoring_messages_by_intent_type()
+    {
+        // given
+        if (!Capabilities.SupportsMonitoringApi)
+        {
+            Assert.Skip("Storage does not support monitoring roundtrip");
+        }
+
+        var storage = GetStorage();
+        await storage.StoreMessageAsync(
+            "intent-filter",
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = CreateMessage(),
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            cancellationToken: AbortToken
+        );
+        await storage.StoreMessageAsync(
+            "intent-filter",
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = CreateMessage(),
+                Content = string.Empty,
+                IntentType = IntentType.Queue,
+            },
+            cancellationToken: AbortToken
+        );
+
+        // when
+        var page = await storage
+            .GetMonitoringApi()
+            .GetMessagesAsync(
+                new MessageQuery
+                {
+                    MessageType = MessageType.Publish,
+                    Name = "intent-filter",
+                    IntentType = IntentType.Queue,
+                    PageSize = 20,
+                },
+                AbortToken
+            );
+
+        // then
+        page.Items.Should().OnlyContain(message => message.IntentType == IntentType.Queue);
+        page.Items.Should().ContainSingle();
+    }
+
     public virtual async Task should_store_received_message()
     {
         // given
@@ -149,6 +230,47 @@ public abstract class DataStorageTestsBase : TestBase
         result.Should().NotBeNull();
         result.StorageId.Should().BeGreaterThan(0);
         result.Origin.Should().BeSameAs(message);
+    }
+
+    public virtual async Task should_store_received_bus_and_queue_rows_with_same_identity()
+    {
+        // given
+        var storage = GetStorage();
+        var messageId = $"same-identity-{Guid.NewGuid():N}";
+        var bus = CreateMessage(messageId);
+        var queue = CreateMessage(messageId);
+        const string messageName = "test-received-message";
+        const string group = "test-group";
+
+        // when
+        await storage.StoreReceivedMessageAsync(
+            messageName,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = bus,
+                Content = string.Empty,
+                IntentType = IntentType.Bus,
+            },
+            AbortToken
+        );
+        await storage.StoreReceivedMessageAsync(
+            messageName,
+            group,
+            new MediumMessage
+            {
+                StorageId = 0,
+                Origin = queue,
+                Content = string.Empty,
+                IntentType = IntentType.Queue,
+            },
+            AbortToken
+        );
+
+        // then
+        var rowCount = await CountReceivedMessagesByIdentityAsync(messageId, group, AbortToken);
+        rowCount.Should().Be(2);
     }
 
     public virtual async Task should_store_received_exception_message()
@@ -685,6 +807,7 @@ public abstract class DataStorageTestsBase : TestBase
                             StorageId = storedMessage.StorageId,
                             Origin = storedMessage.Origin,
                             Content = storedMessage.Content,
+            IntentType = IntentType.Bus,
                             Retries = 1,
                         };
                         var ok = await storage.ChangeReceiveStateAsync(

--- a/tests/Headless.Messaging.Core.Tests.Unit/CircuitBreaker/CircuitBreakerIntegrationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/CircuitBreaker/CircuitBreakerIntegrationTests.cs
@@ -73,6 +73,7 @@ public sealed class CircuitBreakerIntegrationTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, null),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
     }
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/CircuitBreaker/SubscribeExecutorCircuitBreakerTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/CircuitBreaker/SubscribeExecutorCircuitBreakerTests.cs
@@ -43,6 +43,7 @@ public sealed class SubscribeExecutorCircuitBreakerTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, "{}"),
             Content = "{}",
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
         };
     }

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerContextTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerContextTests.cs
@@ -113,6 +113,7 @@ public sealed class ConsumerContextTests : TestBase
             StorageId = 1L,
             Origin = message,
             Content = "{}",
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
         };
     }

--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Headless.Messaging;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
@@ -662,6 +663,7 @@ public sealed class DispatcherTests : TestBase
             StorageId = storageId,
             Origin = message,
             Content = JsonSerializer.Serialize(message),
+            IntentType = IntentType.Bus,
         };
     }
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/ConsumeMiddlewarePipelineMigratedTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/ConsumeMiddlewarePipelineMigratedTests.cs
@@ -296,6 +296,7 @@ public sealed class ConsumeMiddlewarePipelineMigratedTests : TestBase
                 StorageId = 10,
                 Origin = new Message(headers, new MigratedConsumeMessage("stored")),
                 Content = "{}",
+            IntentType = IntentType.Bus,
                 Added = DateTime.UtcNow,
             }
         );

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/ConsumeMiddlewarePipelineTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/ConsumeMiddlewarePipelineTests.cs
@@ -170,6 +170,7 @@ public sealed class ConsumeMiddlewarePipelineTests : TestBase
                 StorageId = 1,
                 Origin = origin,
                 Content = "{}",
+            IntentType = IntentType.Bus,
                 Added = DateTime.UtcNow,
             }
         );

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/IsTransactionalPropagationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/IsTransactionalPropagationTests.cs
@@ -148,6 +148,7 @@ public sealed class IsTransactionalPropagationTests : TestBase
                         StorageId = 1L,
                         Origin = content,
                         Content = "{}",
+            IntentType = IntentType.Bus,
                         Added = DateTime.UtcNow,
                     }
                 );

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
@@ -106,6 +106,7 @@ public sealed class ScheduledMediumMessageQueueTests
                 null
             ),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
     }
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/MediumMessageTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/MediumMessageTests.cs
@@ -28,6 +28,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = storageId,
             Origin = message,
             Content = content,
+            IntentType = IntentType.Bus,
         };
 
         // then
@@ -45,6 +46,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
 
         // then
@@ -63,6 +65,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
             Added = addedTime,
         };
 
@@ -79,6 +82,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
 
         // then
@@ -97,6 +101,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
             ExpiresAt = expiresAt,
         };
 
@@ -113,6 +118,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
 
         // then
@@ -128,6 +134,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
             Retries = 5,
         };
 
@@ -144,6 +151,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
             Retries = 0,
         };
 
@@ -163,6 +171,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
         var newAddedTime = DateTime.UtcNow;
 
@@ -182,6 +191,7 @@ public sealed class MediumMessageTests : TestBase
             StorageId = 1L,
             Origin = new Message(),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
         var expiresAt = DateTime.UtcNow.AddHours(1);
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/MessageSenderTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/MessageSenderTests.cs
@@ -22,6 +22,11 @@ public sealed class MessageSenderTests : TestBase
 {
     private static MediumMessage _CreateMediumMessage()
     {
+        return _CreateMediumMessage(IntentType.Bus);
+    }
+
+    private static MediumMessage _CreateMediumMessage(IntentType intentType)
+    {
         var headers = new Dictionary<string, string?>(StringComparer.Ordinal)
         {
             [Headers.MessageId] = Guid.NewGuid().ToString(),
@@ -33,6 +38,7 @@ public sealed class MessageSenderTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, "{}"),
             Content = "{}",
+            IntentType = intentType,
             Added = DateTime.UtcNow,
         };
     }
@@ -54,11 +60,46 @@ public sealed class MessageSenderTests : TestBase
         services.AddSingleton(storage);
         services.AddSingleton(serializer);
         services.AddSingleton(transport);
+        services.AddSingleton<IBusTransport>(new LegacyBusTransportAdapter(transport));
+        services.AddSingleton<IQueueTransport>(new LegacyQueueTransportAdapter(transport));
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton(Options.Create(options));
         if (lifetime is not null)
         {
             services.AddSingleton(lifetime);
+        }
+
+        var provider = services.BuildServiceProvider();
+        return new MessageSender(provider.GetRequiredService<ILogger<MessageSender>>(), provider);
+    }
+
+    private static MessageSender _CreateSenderWithTransports(
+        IDataStorage storage,
+        ISerializer serializer,
+        MessagingOptions options,
+        IBusTransport? busTransport = null,
+        IQueueTransport? queueTransport = null
+    )
+    {
+        storage
+            .LeasePublishAsync(Arg.Any<MediumMessage>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(true));
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(storage);
+        services.AddSingleton(serializer);
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(Options.Create(options));
+
+        if (busTransport is not null)
+        {
+            services.AddSingleton(busTransport);
+        }
+
+        if (queueTransport is not null)
+        {
+            services.AddSingleton(queueTransport);
         }
 
         var provider = services.BuildServiceProvider();
@@ -595,6 +636,202 @@ public sealed class MessageSenderTests : TestBase
         transport.ReceivedCalls().Should().BeEmpty();
         serializer.ReceivedCalls().Should().BeEmpty();
         storage.ReceivedCalls().Select(c => c.GetMethodInfo().Name).Should().NotContain("ChangePublishStateAsync");
+    }
+
+    [Fact]
+    public async Task should_dispatch_bus_message_through_bus_transport_only()
+    {
+        // given
+        var storage = Substitute.For<IDataStorage>();
+        storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ValueTask.FromResult(true));
+
+        var transportMessage = new TransportMessage(
+            new Dictionary<string, string?>(StringComparer.Ordinal),
+            ReadOnlyMemory<byte>.Empty
+        );
+        var serializer = Substitute.For<ISerializer>();
+        serializer.SerializeToTransportMessageAsync(Arg.Any<Message>()).Returns(ValueTask.FromResult(transportMessage));
+
+        var busTransport = Substitute.For<IBusTransport>();
+        busTransport.BrokerAddress.Returns(new BrokerAddress("bus", "localhost"));
+        busTransport.SendAsync(transportMessage, Arg.Any<CancellationToken>()).Returns(OperateResult.Success);
+
+        var queueTransport = Substitute.For<IQueueTransport>();
+        queueTransport.BrokerAddress.Returns(new BrokerAddress("queue", "localhost"));
+
+        var sender = _CreateSenderWithTransports(storage, serializer, new MessagingOptions(), busTransport, queueTransport);
+
+        // when
+        var result = await sender.SendAsync(_CreateMediumMessage(IntentType.Bus));
+
+        // then
+        result.Succeeded.Should().BeTrue();
+        busTransport.ReceivedCalls().Count(call => call.GetMethodInfo().Name == nameof(IBusTransport.SendAsync)).Should().Be(1);
+        queueTransport
+            .ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(IQueueTransport.SendAsync))
+            .Should()
+            .Be(0);
+    }
+
+    [Fact]
+    public async Task should_dispatch_queue_message_through_queue_transport_only()
+    {
+        // given
+        var storage = Substitute.For<IDataStorage>();
+        storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ValueTask.FromResult(true));
+
+        var transportMessage = new TransportMessage(
+            new Dictionary<string, string?>(StringComparer.Ordinal),
+            ReadOnlyMemory<byte>.Empty
+        );
+        var serializer = Substitute.For<ISerializer>();
+        serializer.SerializeToTransportMessageAsync(Arg.Any<Message>()).Returns(ValueTask.FromResult(transportMessage));
+
+        var busTransport = Substitute.For<IBusTransport>();
+        busTransport.BrokerAddress.Returns(new BrokerAddress("bus", "localhost"));
+
+        var queueTransport = Substitute.For<IQueueTransport>();
+        queueTransport.BrokerAddress.Returns(new BrokerAddress("queue", "localhost"));
+        queueTransport.SendAsync(transportMessage, Arg.Any<CancellationToken>()).Returns(OperateResult.Success);
+
+        var sender = _CreateSenderWithTransports(storage, serializer, new MessagingOptions(), busTransport, queueTransport);
+
+        // when
+        var result = await sender.SendAsync(_CreateMediumMessage(IntentType.Queue));
+
+        // then
+        result.Succeeded.Should().BeTrue();
+        queueTransport
+            .ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(IQueueTransport.SendAsync))
+            .Should()
+            .Be(1);
+        busTransport.ReceivedCalls().Count(call => call.GetMethodInfo().Name == nameof(IBusTransport.SendAsync)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_mark_row_terminal_failed_when_stored_intent_is_invalid()
+    {
+        // given
+        var storage = Substitute.For<IDataStorage>();
+        storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ValueTask.FromResult(true));
+
+        var serializer = Substitute.For<ISerializer>();
+        serializer
+            .SerializeToTransportMessageAsync(Arg.Any<Message>())
+            .Returns(
+                ValueTask.FromResult(
+                    new TransportMessage(
+                        new Dictionary<string, string?>(StringComparer.Ordinal),
+                        ReadOnlyMemory<byte>.Empty
+                    )
+                )
+            );
+
+        var sender = _CreateSenderWithTransports(storage, serializer, new MessagingOptions());
+        var message = _CreateMediumMessage((IntentType)42);
+
+        // when
+        var result = await sender.SendAsync(message);
+
+        // then
+        result.Succeeded.Should().BeFalse();
+        await storage
+            .Received(1)
+            .ChangePublishStateAsync(
+                message,
+                StatusName.Failed,
+                Arg.Any<object?>(),
+                null,
+                null,
+                message.Retries,
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task should_mark_row_terminal_failed_when_queue_transport_is_missing()
+    {
+        // given
+        var storage = Substitute.For<IDataStorage>();
+        storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ValueTask.FromResult(true));
+
+        var serializer = Substitute.For<ISerializer>();
+        serializer
+            .SerializeToTransportMessageAsync(Arg.Any<Message>())
+            .Returns(
+                ValueTask.FromResult(
+                    new TransportMessage(
+                        new Dictionary<string, string?>(StringComparer.Ordinal),
+                        ReadOnlyMemory<byte>.Empty
+                    )
+                )
+            );
+
+        var busTransport = Substitute.For<IBusTransport>();
+        busTransport.BrokerAddress.Returns(new BrokerAddress("bus", "localhost"));
+
+        var sender = _CreateSenderWithTransports(storage, serializer, new MessagingOptions(), busTransport);
+        var message = _CreateMediumMessage(IntentType.Queue);
+
+        // when
+        var result = await sender.SendAsync(message);
+
+        // then
+        result.Succeeded.Should().BeFalse();
+        await storage
+            .Received(1)
+            .ChangePublishStateAsync(
+                message,
+                StatusName.Failed,
+                Arg.Any<object?>(),
+                null,
+                null,
+                message.Retries,
+                Arg.Any<CancellationToken>()
+            );
+        busTransport.ReceivedCalls().Count(call => call.GetMethodInfo().Name == nameof(IBusTransport.SendAsync)).Should().Be(0);
     }
 
     private sealed class ScopedMarker;

--- a/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
@@ -43,6 +43,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, null),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
     }
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Retry/RetryHelperTests.cs
@@ -251,6 +251,7 @@ public sealed class RetryHelperTests : TestBase
             StorageId = 1,
             Origin = new Message(new Dictionary<string, string?>(StringComparer.Ordinal), null),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
 
     private sealed class AlwaysRetryStrategy(TimeSpan delay) : IRetryBackoffStrategy

--- a/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorCancellationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorCancellationTests.cs
@@ -37,6 +37,7 @@ public sealed class SubscribeExecutorCancellationTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, "{}"),
             Content = "{}",
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
         };
     }

--- a/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorRetryTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorRetryTests.cs
@@ -34,6 +34,7 @@ public sealed class SubscribeExecutorRetryTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, "{}"),
             Content = "{}",
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
         };
     }

--- a/tests/Headless.Messaging.Core.Tests.Unit/SubscribeInvokerTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/SubscribeInvokerTests.cs
@@ -126,6 +126,7 @@ public sealed class SubscribeInvokerTests : TestBase
                 null
             ), // null value
             Content = string.Empty,
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
         };
 
@@ -434,6 +435,7 @@ public sealed class SubscribeInvokerTests : TestBase
             StorageId = 1L,
             Origin = new Message(headers, json),
             Content = json,
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
         };
     }

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/PublishedMessageEndpointTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/PublishedMessageEndpointTests.cs
@@ -32,6 +32,7 @@ public sealed class PublishedMessageEndpointTests : TestBase
         {
             StorageId = messageId,
             Content = "{\"key\":\"value\"}",
+            IntentType = IntentType.Bus,
             Origin = new Message(
                 new Dictionary<string, string?>(StringComparer.Ordinal)
                 {

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/ReceivedMessageEndpointTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/ReceivedMessageEndpointTests.cs
@@ -32,6 +32,7 @@ public sealed class ReceivedMessageEndpointTests : TestBase
         {
             StorageId = messageId,
             Content = "{\"received\":\"data\"}",
+            IntentType = IntentType.Bus,
             Origin = new Message(
                 new Dictionary<string, string?>(StringComparer.Ordinal)
                 {

--- a/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlCrudTest.cs
+++ b/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlCrudTest.cs
@@ -182,8 +182,8 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         await connection.ExecuteAsync(
             new CommandDefinition(
                 """
-                INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","StatusName","MessageId")
-                VALUES (@Id,'v1','test.topic','{}',0,@Added,@ExpiresAt,'Succeeded',@MessageId)
+                INSERT INTO messaging.published ("Id","Version","Name","Content","IntentType","Retries","Added","ExpiresAt","StatusName","MessageId")
+                VALUES (@Id,'v1','test.topic','{}',0,0,@Added,@ExpiresAt,'Succeeded',@MessageId)
                 """,
                 new
                 {
@@ -250,8 +250,8 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         await connection.ExecuteAsync(
             new CommandDefinition(
                 """
-                INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
-                VALUES (@Id,'v1','test.topic',@Content,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
+                INSERT INTO messaging.published ("Id","Version","Name","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
+                VALUES (@Id,'v1','test.topic',@Content,0,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
                 """,
                 new
                 {
@@ -287,8 +287,8 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         await connection.ExecuteAsync(
             new CommandDefinition(
                 """
-                INSERT INTO messaging.received ("Id","Version","Name","Group","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
-                VALUES (@Id,'v1','test.topic','test.group',@Content,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
+                INSERT INTO messaging.received ("Id","Version","Name","Group","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
+                VALUES (@Id,'v1','test.topic','test.group',@Content,0,0,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
                 """,
                 new
                 {
@@ -323,8 +323,8 @@ public sealed class PostgreSqlCrudTest(PostgreSqlTestFixture fixture) : TestBase
         var content = "{\"Headers\":{\"headless-msg-id\":\"" + messageId + "\"},\"Value\":null}";
         await connection.ExecuteAsync(
             """
-            INSERT INTO messaging.published ("Id","Version","Name","Content","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
-            VALUES (@Id,'v1','test.topic',@Content,10,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
+            INSERT INTO messaging.published ("Id","Version","Name","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","StatusName","MessageId")
+            VALUES (@Id,'v1','test.topic',@Content,0,10,@Added,NULL,@NextRetryAt,'Failed',@MessageId)
             """,
             new
             {

--- a/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
+++ b/tests/Headless.Messaging.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
@@ -425,16 +425,16 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
         var seedSql = tableSuffix switch
         {
             "received" => $$"""
-                INSERT INTO {{qualifiedTable}} ("Id","Version","Name","Group","Content","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId")
-                SELECT g, 'v1', 'plan-test', NULL, '{}', 0, now(), NULL,
+                INSERT INTO {{qualifiedTable}} ("Id","Version","Name","Group","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId")
+                SELECT g, 'v1', 'plan-test', NULL, '{}', 0, 0, now(), NULL,
                        CASE WHEN g % 2 = 0 THEN now() - interval '1 minute' ELSE NULL END,
                        NULL, 'Failed', 'plan-' || g
                 FROM generate_series(1000, 1000 + {{seedRows - 1}}) g
                 ON CONFLICT DO NOTHING;
                 """,
             "published" => $$"""
-                INSERT INTO {{qualifiedTable}} ("Id","Version","Name","Content","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId")
-                SELECT g, 'v1', 'plan-test', '{}', 0, now(), NULL,
+                INSERT INTO {{qualifiedTable}} ("Id","Version","Name","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId")
+                SELECT g, 'v1', 'plan-test', '{}', 0, 0, now(), NULL,
                        CASE WHEN g % 2 = 0 THEN now() - interval '1 minute' ELSE NULL END,
                        NULL, 'Failed', 'plan-' || g
                 FROM generate_series(1000, 1000 + {{seedRows - 1}}) g
@@ -457,7 +457,7 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
         var explainSql = $"""
             SET LOCAL enable_seqscan = off;
             EXPLAIN (ANALYZE, FORMAT JSON)
-            SELECT "Id","Content","Retries","Added","NextRetryAt" FROM {qualifiedTable}
+            SELECT "Id","Content","IntentType","Retries","Added","NextRetryAt" FROM {qualifiedTable}
             WHERE "Retries" <= @Retries
               AND "Version" = @Version
               AND "NextRetryAt" IS NOT NULL

--- a/tests/Headless.Messaging.PostgreSql.Tests.Unit/PostgreSqlOutboxTransactionTests.cs
+++ b/tests/Headless.Messaging.PostgreSql.Tests.Unit/PostgreSqlOutboxTransactionTests.cs
@@ -84,6 +84,7 @@ public sealed class PostgreSqlOutboxTransactionTests : TestBase
                 null
             ),
             Content = "{}",
+            IntentType = IntentType.Bus,
         };
     }
 

--- a/tests/Headless.Messaging.Testing.Tests.Unit/RecordingInfrastructureTests.cs
+++ b/tests/Headless.Messaging.Testing.Tests.Unit/RecordingInfrastructureTests.cs
@@ -52,6 +52,7 @@ public sealed class RecordingInfrastructureTests : TestBase
         {
             StorageId = 1,
             Content = "{}",
+            IntentType = IntentType.Bus,
             Added = DateTime.UtcNow,
             Origin = new Message(_BaseHeaders(id, name, correlationId), value: null),
         };


### PR DESCRIPTION
## Summary
- persist `IntentType` on published and received storage rows across in-memory, PostgreSQL, and SQL Server providers
- route outbox retry draining through `IBusTransport` or `IQueueTransport` based on the stored intent, with terminal failure for unsupported persisted intent
- add monitoring filters/projections, schema migration handling, docs, and focused storage/sender coverage

## Validation
- `make build`
- `dotnet csharpier format $(git diff --name-only -- '*.cs')` (0 files changed)
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.InMemoryStorage.Tests.Unit/Headless.Messaging.InMemoryStorage.Tests.Unit.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.PostgreSql.Tests.Unit/Headless.Messaging.PostgreSql.Tests.Unit.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.SqlServer.Tests.Unit/Headless.Messaging.SqlServer.Tests.Unit.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.PostgreSql.Tests.Integration/Headless.Messaging.PostgreSql.Tests.Integration.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.SqlServer.Tests.Integration/Headless.Messaging.SqlServer.Tests.Integration.csproj`
