### PR TITLE
feat(distributed-locks): add lease monitoring

### DIFF
--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -64,6 +64,8 @@ Use `IDistributedLockProvider` when only one worker should own a named resource 
 - Per-call configuration is bundled into `DistributedLockAcquireOptions` (`TimeUntilExpires`, `AcquireTimeout`, `ReleaseOnDispose`, `Monitoring`). Omit the argument to use defaults; use `with` expressions to derive variants.
 - Always `await using` the returned lock when `ReleaseOnDispose` is `true` (the default); set `ReleaseOnDispose = false` only when ownership is deliberately transferred and the caller will release explicitly.
 - Set `Monitoring = LockMonitoringMode.Monitor` when work should observe lease loss through `IDistributedLock.HandleLostToken`; set `Monitoring = LockMonitoringMode.AutoExtend` only when long work should renew its own lease in the background (it implies `Monitor`).
+- Use `GetLockIdAsync(resource)` for operational inspection only; it reads the current lock id and does not renew the lease. If you already hold a monitored handle, observe `HandleLostToken` instead of polling `GetLockIdAsync`.
+- Synchronous `TryUsingAsync(..., Action ...)` overloads force `LockMonitoringMode.None` because synchronous delegates cannot observe a lease-lost cancellation token.
 - Do not use distributed locks as rate limiters. Use `Microsoft.AspNetCore.RateLimiting` (in-process) or `Polly.RateLimiting` + community Redis (distributed) — the framework does not ship a rate-limiting package.
 - Before choosing a backend, classify the use case as efficiency or correctness. Redis and cache locks are efficiency locks, not transaction-coupled correctness locks.
 - Default lock expiration is 20 minutes and default acquire timeout is 30 seconds. Override them per call via `DistributedLockAcquireOptions`; `DistributedLockOptions` configures key prefix and waiter/resource limits.
@@ -90,7 +92,7 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 Lock monitoring is opt-in per acquire call via `DistributedLockAcquireOptions.Monitoring` (a `LockMonitoringMode` enum). `Monitoring = LockMonitoringMode.Monitor` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. With `LockMonitoringMode.None` (default), `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
 
-Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 30`, name `LeaseMonitorStateChanged`) for programmatic log filtering. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
+Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 30`, name `LeaseMonitorStateChanged`) for programmatic log filtering. The structured fields are `Resource`, `LockId`, `PreviousState`, and `NextState`. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
 
 Combining `LockMonitoringMode.Monitor` or `LockMonitoringMode.AutoExtend` with `Timeout.InfiniteTimeSpan` for `TimeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
 
@@ -125,7 +127,7 @@ Lets application and domain code depend on lock interfaces without referencing a
 - `IDistributedLock` handle with `LockId`, `HandleLostToken`, `IsMonitored`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
 - `TryUsingAsync(resource, work, ...)` convenience that acquires, executes work, and releases — prefer this over manual try/finally for simple guarded execution.
 - `LockAcquisitionTimeoutException`, `LockHandleLostException`, and `DistributedLockException` for lock-specific failures.
-- `GetLockIdAsync(resource)`, `GetLockInfoAsync(resource)`, `ListActiveLocksAsync()`, `GetActiveLocksCountAsync()`, `GetExpirationAsync(resource)` for operational inspection and monitoring.
+- `GetLockIdAsync(resource)`, `GetLockInfoAsync(resource)`, `ListActiveLocksAsync()`, `GetActiveLocksCountAsync()`, `GetExpirationAsync(resource)` for operational inspection and monitoring. `GetLockIdAsync` does not renew a lease; monitored holders should use `HandleLostToken` for lease-loss observation.
 
 ### Design Notes
 
@@ -133,6 +135,7 @@ Lets application and domain code depend on lock interfaces without referencing a
 - Per-call configuration (`TimeUntilExpires`, `AcquireTimeout`, `ReleaseOnDispose`, `Monitoring`) is bundled into `DistributedLockAcquireOptions`. Omit the argument to use defaults; use `with` expressions to derive variants.
 - `ReleaseOnDispose = false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
 - `HandleLostToken` is an observability signal. Consumer code decides whether to stop, compensate, or throw `LockHandleLostException`.
+- `TimeUntilExpires = null` uses the provider default. Built-in providers use a finite 20-minute default, so `null` is valid with `LockMonitoringMode.AutoExtend`; `Timeout.InfiniteTimeSpan` is not.
 
 ### Installation
 
@@ -240,6 +243,20 @@ await lockProvider.AcquireAsync(
         TimeUntilExpires = TimeSpan.FromMinutes(5),
         AcquireTimeout = TimeSpan.FromSeconds(10),
         Monitoring = LockMonitoringMode.Monitor,
+    },
+    ct
+);
+```
+
+Use `AutoExtend` when the protected work can exceed the initial TTL and should keep the lease alive while the process is healthy:
+
+```csharp
+await using var lease = await lockProvider.AcquireAsync(
+    "orders:123",
+    new DistributedLockAcquireOptions
+    {
+        TimeUntilExpires = TimeSpan.FromMinutes(5),
+        Monitoring = LockMonitoringMode.AutoExtend,
     },
     ct
 );

--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -13,6 +13,7 @@ packages: DistributedLocks.Abstractions, DistributedLocks.Core, DistributedLocks
     - [Efficiency Locks](#efficiency-locks)
     - [Correctness Locks](#correctness-locks)
     - [Weak Fencing With LockId](#weak-fencing-with-lockid)
+    - [Lease Lifecycle Monitoring](#lease-lifecycle-monitoring)
     - [Messaging Wake-ups](#messaging-wake-ups)
 - [Choosing a Provider](#choosing-a-provider)
 - [Headless.DistributedLocks.Abstractions](#headlessdistributedlocksabstractions)
@@ -61,6 +62,7 @@ Use `IDistributedLockProvider` when only one worker should own a named resource 
 - Code against `IDistributedLockProvider` from `Headless.DistributedLocks.Abstractions`; do not inject Redis or cache storage types into application services.
 - Use `TryAcquireAsync(...)` when timeout is an expected branch; use `AcquireAsync(...)` when timeout should fail the workflow.
 - Always `await using` the returned lock when `releaseOnDispose` is `true`; use `releaseOnDispose: false` only when ownership is deliberately transferred and the caller will release explicitly.
+- Pass `monitorLease: true` when work should observe lease loss through `IDistributedLock.HandleLostToken`; pass `autoExtend: true` only when long work should renew its own lease in the background.
 - Do not use distributed locks as rate limiters. Use `Microsoft.AspNetCore.RateLimiting` (in-process) or `Polly.RateLimiting` + community Redis (distributed) — the framework does not ship a rate-limiting package.
 - Before choosing a backend, classify the use case as efficiency or correctness. Redis and cache locks are efficiency locks, not transaction-coupled correctness locks.
 - Default lock expiration is 20 minutes and default acquire timeout is 30 seconds. Override them per `AcquireAsync(...)` or `TryAcquireAsync(...)` call; `DistributedLockOptions` configures key prefix and waiter/resource limits.
@@ -83,9 +85,15 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 `IDistributedLock.LockId` is a Snowflake-style `long` and can be passed to a protected write path as a weak fencing token. The target resource must store the last accepted fence and reject older values. This is consumer-enforced and does not turn Redis locks into transaction-coupled locks.
 
+### Lease Lifecycle Monitoring
+
+Lock monitoring is opt-in per acquire call. `monitorLease: true` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. Without monitoring, `HandleLostToken` is `CancellationToken.None`.
+
+`autoExtend: true` implies monitoring and renews at `DistributedLockOptions.AutoExtensionCadenceFraction` of the TTL. Monitoring without auto-extension validates at `PollingCadenceFraction` and never renews the lease. These signals narrow stale-work windows; they do not upgrade Redis or cache locks into correctness locks. Fence protected writes with `LockId` when stale owners can corrupt state.
+
 ### Messaging Wake-ups
 
-`DistributedLockProvider` can publish `DistributedLockReleased` through `IOutboxPublisher` so waiters wake quickly. Messaging is optional: when no publisher is registered, lock acquisition retries through polling backoff. This keeps distributed locks usable without forcing `Headless.Messaging`.
+`DistributedLockProvider` can publish `DistributedLockReleased` through `IOutboxPublisher` so waiters wake quickly. The same message also nudges active lease monitors for that resource so loss validation can happen before the next polling cadence. Messaging is optional: when no publisher is registered, lock acquisition and lease monitoring fall back to polling. This keeps distributed locks usable without forcing `Headless.Messaging`.
 
 ## Choosing a Provider
 
@@ -109,15 +117,16 @@ Lets application and domain code depend on lock interfaces without referencing a
 ### Key Features
 
 - `IDistributedLockProvider` with `TryAcquireAsync(...)` and `AcquireAsync(...)`.
-- `IDistributedLock` handle with `LockId`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
+- `IDistributedLock` handle with `LockId`, `HandleLostToken`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
 - `TryUsingAsync(resource, work, ...)` convenience that acquires, executes work, and releases — prefer this over manual try/finally for simple guarded execution.
-- `LockAcquisitionTimeoutException` and `DistributedLockException` for lock-specific failures.
-- `GetLockInfoAsync(resource)`, `ListActiveLocksAsync()`, `GetActiveLocksCountAsync()`, `GetExpirationAsync(resource)` for operational inspection and monitoring.
+- `LockAcquisitionTimeoutException`, `LockHandleLostException`, and `DistributedLockException` for lock-specific failures.
+- `GetLockIdAsync(resource)`, `GetLockInfoAsync(resource)`, `ListActiveLocksAsync()`, `GetActiveLocksCountAsync()`, `GetExpirationAsync(resource)` for operational inspection and monitoring.
 
 ### Design Notes
 
 - `AcquireAsync(...)` is a throwing convenience over `TryAcquireAsync(...)`. It does not provide stronger safety guarantees.
 - `releaseOnDispose: false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
+- `HandleLostToken` is an observability signal. Consumer code decides whether to stop, compensate, or throw `LockHandleLostException`.
 
 ### Installation
 
@@ -136,9 +145,11 @@ public sealed class OrderWorker(IDistributedLockProvider lockProvider)
             $"order:{orderId}",
             timeUntilExpires: TimeSpan.FromMinutes(5),
             acquireTimeout: TimeSpan.FromSeconds(10),
+            monitorLease: true,
             cancellationToken: ct
         );
 
+        using var lostRegistration = lease.HandleLostToken.Register(() => { /* stop work */ });
         // process the order while the lease is held
     }
 }
@@ -171,13 +182,14 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 
 - `DistributedLockProvider` implements `IDistributedLockProvider`.
 - `DisposableDistributedLock` releases on dispose by default.
-- `DistributedLockOptions` configures default expiration, acquire timeout, renewal interval, resource name length, and retry behavior.
+- `DistributedLockOptions` configures key prefix, resource name length, waiter limits, and lease-monitor cadence fractions.
 - `AddDistributedLock(...)` overloads wire storage, options, time provider, ID generator, and optional release consumers.
 
 ### Design Notes
 
 - `IOutboxPublisher` is optional. Without it, release notifications fall back to polling backoff and a warning is logged once when the provider is constructed.
 - `TryAcquireAsync(..., acquireTimeout: TimeSpan.Zero)` performs a single storage attempt with an internal safety deadline.
+- Lease monitors drain before dispose-time release, so monitoring does not add release retry latency during shutdown.
 
 ### Installation
 
@@ -205,6 +217,8 @@ options.KeyPrefix = "distributed-lock:";
 options.MaxResourceNameLength = 512;
 options.MaxConcurrentWaitingResources = 10_000;
 options.MaxWaitersPerResource = 1_000;
+options.PollingCadenceFraction = 0.5;
+options.AutoExtensionCadenceFraction = 1.0 / 3.0;
 ```
 
 Use method arguments to override per-call expiration and acquire timeout:
@@ -214,6 +228,8 @@ await lockProvider.AcquireAsync(
     "orders:123",
     timeUntilExpires: TimeSpan.FromMinutes(5),
     acquireTimeout: TimeSpan.FromSeconds(10),
+    monitorLease: true,
+    autoExtend: false,
     cancellationToken: ct
 );
 ```

--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -62,7 +62,7 @@ Use `IDistributedLockProvider` when only one worker should own a named resource 
 - Code against `IDistributedLockProvider` from `Headless.DistributedLocks.Abstractions`; do not inject Redis or cache storage types into application services.
 - Use `TryAcquireAsync(...)` when timeout is an expected branch; use `AcquireAsync(...)` when timeout should fail the workflow.
 - Always `await using` the returned lock when `releaseOnDispose` is `true`; use `releaseOnDispose: false` only when ownership is deliberately transferred and the caller will release explicitly.
-- Pass `monitorLease: true` when work should observe lease loss through `IDistributedLock.HandleLostToken`; pass `autoExtend: true` only when long work should renew its own lease in the background.
+- Pass `monitoring: LockMonitoringMode.Monitor` when work should observe lease loss through `IDistributedLock.HandleLostToken`; pass `monitoring: LockMonitoringMode.AutoExtend` only when long work should renew its own lease in the background (it implies `Monitor`).
 - Do not use distributed locks as rate limiters. Use `Microsoft.AspNetCore.RateLimiting` (in-process) or `Polly.RateLimiting` + community Redis (distributed) — the framework does not ship a rate-limiting package.
 - Before choosing a backend, classify the use case as efficiency or correctness. Redis and cache locks are efficiency locks, not transaction-coupled correctness locks.
 - Default lock expiration is 20 minutes and default acquire timeout is 30 seconds. Override them per `AcquireAsync(...)` or `TryAcquireAsync(...)` call; `DistributedLockOptions` configures key prefix and waiter/resource limits.
@@ -87,13 +87,13 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 ### Lease Lifecycle Monitoring
 
-Lock monitoring is opt-in per acquire call. `monitorLease: true` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. Without monitoring, `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
+Lock monitoring is opt-in per acquire call via the `LockMonitoringMode` enum. `monitoring: LockMonitoringMode.Monitor` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. With `LockMonitoringMode.None` (default), `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
 
 Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 1`, name `LeaseMonitorStateChanged`) for programmatic log filtering. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
 
-Combining `monitorLease: true` or `autoExtend: true` with `Timeout.InfiniteTimeSpan` for `timeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
+Combining `LockMonitoringMode.Monitor` or `LockMonitoringMode.AutoExtend` with `Timeout.InfiniteTimeSpan` for `timeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
 
-`autoExtend: true` implies monitoring and renews at `DistributedLockOptions.AutoExtensionCadenceFraction` of the TTL. Monitoring without auto-extension validates at `PollingCadenceFraction` and never renews the lease. These signals narrow stale-work windows; they do not upgrade Redis or cache locks into correctness locks. Fence protected writes with `LockId` when stale owners can corrupt state.
+`LockMonitoringMode.AutoExtend` implies monitoring and renews at `DistributedLockOptions.AutoExtensionCadenceFraction` of the TTL. `LockMonitoringMode.Monitor` (validate only) validates at `PollingCadenceFraction` and never renews the lease. These signals narrow stale-work windows; they do not upgrade Redis or cache locks into correctness locks. Fence protected writes with `LockId` when stale owners can corrupt state.
 
 ### Messaging Wake-ups
 
@@ -149,7 +149,7 @@ public sealed class OrderWorker(IDistributedLockProvider lockProvider)
             $"order:{orderId}",
             timeUntilExpires: TimeSpan.FromMinutes(5),
             acquireTimeout: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: ct
         );
 
@@ -232,8 +232,7 @@ await lockProvider.AcquireAsync(
     "orders:123",
     timeUntilExpires: TimeSpan.FromMinutes(5),
     acquireTimeout: TimeSpan.FromSeconds(10),
-    monitorLease: true,
-    autoExtend: false,
+    monitoring: LockMonitoringMode.Monitor,
     cancellationToken: ct
 );
 ```

--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -61,11 +61,12 @@ Use `IDistributedLockProvider` when only one worker should own a named resource 
 
 - Code against `IDistributedLockProvider` from `Headless.DistributedLocks.Abstractions`; do not inject Redis or cache storage types into application services.
 - Use `TryAcquireAsync(...)` when timeout is an expected branch; use `AcquireAsync(...)` when timeout should fail the workflow.
-- Always `await using` the returned lock when `releaseOnDispose` is `true`; use `releaseOnDispose: false` only when ownership is deliberately transferred and the caller will release explicitly.
-- Pass `monitoring: LockMonitoringMode.Monitor` when work should observe lease loss through `IDistributedLock.HandleLostToken`; pass `monitoring: LockMonitoringMode.AutoExtend` only when long work should renew its own lease in the background (it implies `Monitor`).
+- Per-call configuration is bundled into `DistributedLockAcquireOptions` (`TimeUntilExpires`, `AcquireTimeout`, `ReleaseOnDispose`, `Monitoring`). Omit the argument to use defaults; use `with` expressions to derive variants.
+- Always `await using` the returned lock when `ReleaseOnDispose` is `true` (the default); set `ReleaseOnDispose = false` only when ownership is deliberately transferred and the caller will release explicitly.
+- Set `Monitoring = LockMonitoringMode.Monitor` when work should observe lease loss through `IDistributedLock.HandleLostToken`; set `Monitoring = LockMonitoringMode.AutoExtend` only when long work should renew its own lease in the background (it implies `Monitor`).
 - Do not use distributed locks as rate limiters. Use `Microsoft.AspNetCore.RateLimiting` (in-process) or `Polly.RateLimiting` + community Redis (distributed) — the framework does not ship a rate-limiting package.
 - Before choosing a backend, classify the use case as efficiency or correctness. Redis and cache locks are efficiency locks, not transaction-coupled correctness locks.
-- Default lock expiration is 20 minutes and default acquire timeout is 30 seconds. Override them per `AcquireAsync(...)` or `TryAcquireAsync(...)` call; `DistributedLockOptions` configures key prefix and waiter/resource limits.
+- Default lock expiration is 20 minutes and default acquire timeout is 30 seconds. Override them per call via `DistributedLockAcquireOptions`; `DistributedLockOptions` configures key prefix and waiter/resource limits.
 - If `Headless.Messaging` is registered, lock release wake-ups are push-based. If no `IOutboxPublisher` is registered, the provider still works and falls back to polling backoff with a one-time warning.
 - `Headless.Messaging.Core` uses a keyed `IDistributedLockProvider` registration under `"headless.messaging"`; an un-keyed app lock provider is not automatically used by message retry processors.
 
@@ -87,11 +88,11 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 ### Lease Lifecycle Monitoring
 
-Lock monitoring is opt-in per acquire call via the `LockMonitoringMode` enum. `monitoring: LockMonitoringMode.Monitor` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. With `LockMonitoringMode.None` (default), `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
+Lock monitoring is opt-in per acquire call via `DistributedLockAcquireOptions.Monitoring` (a `LockMonitoringMode` enum). `Monitoring = LockMonitoringMode.Monitor` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. With `LockMonitoringMode.None` (default), `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
 
 Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 1`, name `LeaseMonitorStateChanged`) for programmatic log filtering. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
 
-Combining `LockMonitoringMode.Monitor` or `LockMonitoringMode.AutoExtend` with `Timeout.InfiniteTimeSpan` for `timeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
+Combining `LockMonitoringMode.Monitor` or `LockMonitoringMode.AutoExtend` with `Timeout.InfiniteTimeSpan` for `TimeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
 
 `LockMonitoringMode.AutoExtend` implies monitoring and renews at `DistributedLockOptions.AutoExtensionCadenceFraction` of the TTL. `LockMonitoringMode.Monitor` (validate only) validates at `PollingCadenceFraction` and never renews the lease. These signals narrow stale-work windows; they do not upgrade Redis or cache locks into correctness locks. Fence protected writes with `LockId` when stale owners can corrupt state.
 
@@ -129,7 +130,8 @@ Lets application and domain code depend on lock interfaces without referencing a
 ### Design Notes
 
 - `AcquireAsync(...)` is a throwing convenience over `TryAcquireAsync(...)`. It does not provide stronger safety guarantees.
-- `releaseOnDispose: false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
+- Per-call configuration (`TimeUntilExpires`, `AcquireTimeout`, `ReleaseOnDispose`, `Monitoring`) is bundled into `DistributedLockAcquireOptions`. Omit the argument to use defaults; use `with` expressions to derive variants.
+- `ReleaseOnDispose = false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
 - `HandleLostToken` is an observability signal. Consumer code decides whether to stop, compensate, or throw `LockHandleLostException`.
 
 ### Installation
@@ -147,10 +149,13 @@ public sealed class OrderWorker(IDistributedLockProvider lockProvider)
     {
         await using var lease = await lockProvider.AcquireAsync(
             $"order:{orderId}",
-            timeUntilExpires: TimeSpan.FromMinutes(5),
-            acquireTimeout: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: ct
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromMinutes(5),
+                AcquireTimeout = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            ct
         );
 
         using var lostRegistration = lease.HandleLostToken.Register(() => { /* stop work */ });
@@ -192,7 +197,7 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 ### Design Notes
 
 - `IOutboxPublisher` is optional. Without it, release notifications fall back to polling backoff and a warning is logged once when the provider is constructed.
-- `TryAcquireAsync(..., acquireTimeout: TimeSpan.Zero)` performs a single storage attempt with an internal safety deadline.
+- `TryAcquireAsync(..., new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero })` performs a single storage attempt with an internal safety deadline.
 - Lease monitors drain before dispose-time release, so monitoring does not add release retry latency during shutdown.
 
 ### Installation
@@ -225,15 +230,18 @@ options.PollingCadenceFraction = 0.5;
 options.AutoExtensionCadenceFraction = 1.0 / 3.0;
 ```
 
-Use method arguments to override per-call expiration and acquire timeout:
+Use `DistributedLockAcquireOptions` to override per-call expiration, acquire timeout, monitoring, and dispose behavior:
 
 ```csharp
 await lockProvider.AcquireAsync(
     "orders:123",
-    timeUntilExpires: TimeSpan.FromMinutes(5),
-    acquireTimeout: TimeSpan.FromSeconds(10),
-    monitoring: LockMonitoringMode.Monitor,
-    cancellationToken: ct
+    new DistributedLockAcquireOptions
+    {
+        TimeUntilExpires = TimeSpan.FromMinutes(5),
+        AcquireTimeout = TimeSpan.FromSeconds(10),
+        Monitoring = LockMonitoringMode.Monitor,
+    },
+    ct
 );
 ```
 

--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -90,7 +90,7 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 Lock monitoring is opt-in per acquire call via `DistributedLockAcquireOptions.Monitoring` (a `LockMonitoringMode` enum). `Monitoring = LockMonitoringMode.Monitor` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. With `LockMonitoringMode.None` (default), `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
 
-Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 1`, name `LeaseMonitorStateChanged`) for programmatic log filtering. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
+Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 30`, name `LeaseMonitorStateChanged`) for programmatic log filtering. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
 
 Combining `LockMonitoringMode.Monitor` or `LockMonitoringMode.AutoExtend` with `Timeout.InfiniteTimeSpan` for `TimeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
 
@@ -106,7 +106,7 @@ Choose based on the storage you already operate and the safety category.
 
 | Provider | Use when | Avoid when | Trade-off |
 | --- | --- | --- | --- |
-| `Headless.DistributedLocks.Cache` | You already use `ICache` and the cache is distributed for multi-instance apps. | The app cache is in-memory and you need cross-instance coordination. | Reuses cache infrastructure but inherits that cache provider's consistency and availability behavior. |
+| `Headless.DistributedLocks.Cache` | You already use `ICache` and the cache is distributed for multi-instance apps. | The app cache is in-memory, or the cache provider serves stale local reads such as `HybridCache` and you need lease monitoring or auto-extension. | Reuses cache infrastructure but inherits that cache provider's consistency and availability behavior. |
 | `Headless.DistributedLocks.Redis` | You want direct Redis-backed efficiency locks with atomic acquire/release scripts. | You need correctness locks for protected state mutations. | Requires `IConnectionMultiplexer` and Redis script loading, but avoids routing lock operations through a generic cache abstraction. |
 
 ---
@@ -273,7 +273,8 @@ Stores lock records through `ICache` so applications can reuse an existing cache
 
 - `CacheDistributedLockStorage` implements `IDistributedLockStorage`.
 - Uses cache TTL for lock expiration.
-- Works with memory, Redis, hybrid, or custom cache providers through `ICache`.
+- Works with memory, Redis, or custom cache providers through `ICache`.
+- Do not use `HybridCache` for monitored or auto-extending leases; local L1 reads can outlive the distributed lock TTL and hide lease loss.
 
 ### Installation
 
@@ -295,6 +296,8 @@ builder.Services.AddDistributedLock<CacheDistributedLockStorage>(options =>
 ### Configuration
 
 No storage-specific configuration. Configure the selected `ICache` provider and `DistributedLockOptions`.
+
+Avoid `HybridCache` for `LockMonitoringMode.Monitor` and `LockMonitoringMode.AutoExtend`. Lease validation reads the current lock id through `ICache`; `HybridCache` may satisfy that read from its local L1 cache even after the distributed TTL has expired. Use `Headless.DistributedLocks.Redis` for monitored Redis-backed locks, or use a cache provider whose reads are distributed and TTL-accurate.
 
 ### Dependencies
 

--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -87,7 +87,11 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 ### Lease Lifecycle Monitoring
 
-Lock monitoring is opt-in per acquire call. `monitorLease: true` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. Without monitoring, `HandleLostToken` is `CancellationToken.None`.
+Lock monitoring is opt-in per acquire call. `monitorLease: true` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. Without monitoring, `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
+
+Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 1`, name `LeaseMonitorStateChanged`) for programmatic log filtering. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
+
+Combining `monitorLease: true` or `autoExtend: true` with `Timeout.InfiniteTimeSpan` for `timeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.
 
 `autoExtend: true` implies monitoring and renews at `DistributedLockOptions.AutoExtensionCadenceFraction` of the TTL. Monitoring without auto-extension validates at `PollingCadenceFraction` and never renews the lease. These signals narrow stale-work windows; they do not upgrade Redis or cache locks into correctness locks. Fence protected writes with `LockId` when stale owners can corrupt state.
 
@@ -117,7 +121,7 @@ Lets application and domain code depend on lock interfaces without referencing a
 ### Key Features
 
 - `IDistributedLockProvider` with `TryAcquireAsync(...)` and `AcquireAsync(...)`.
-- `IDistributedLock` handle with `LockId`, `HandleLostToken`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
+- `IDistributedLock` handle with `LockId`, `HandleLostToken`, `IsMonitored`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
 - `TryUsingAsync(resource, work, ...)` convenience that acquires, executes work, and releases — prefer this over manual try/finally for simple guarded execution.
 - `LockAcquisitionTimeoutException`, `LockHandleLostException`, and `DistributedLockException` for lock-specific failures.
 - `GetLockIdAsync(resource)`, `GetLockInfoAsync(resource)`, `ListActiveLocksAsync()`, `GetActiveLocksCountAsync()`, `GetExpirationAsync(resource)` for operational inspection and monitoring.

--- a/docs/llms/distributed-locks.md
+++ b/docs/llms/distributed-locks.md
@@ -92,6 +92,8 @@ Correctness locks protect invariants where a stale owner could corrupt data. TTL
 
 Lock monitoring is opt-in per acquire call via `DistributedLockAcquireOptions.Monitoring` (a `LockMonitoringMode` enum). `Monitoring = LockMonitoringMode.Monitor` starts a background lease monitor and makes `IDistributedLock.HandleLostToken` cancel when validation detects the stored lock id changed, disappeared, or the lease lifetime exceeds the requested TTL after repeated unknown validation results. With `LockMonitoringMode.None` (default), `HandleLostToken` is `CancellationToken.None` and `IDistributedLock.IsMonitored` is `false`.
 
+If the monitor loop faults, `HandleLostToken` is also cancelled as a fail-safe so a silently dead monitor cannot keep appearing healthy.
+
 Intermediate monitor states (`Held`, `Renewed`, `Lost`, `Unknown`) are not exposed as a public API; they are visible through the `LeaseMonitorStateChanged` log event (`EventId = 30`, name `LeaseMonitorStateChanged`) for programmatic log filtering. The structured fields are `Resource`, `LockId`, `PreviousState`, and `NextState`. `GetActiveMonitorCount` on the provider is `internal` and intended for test/diagnostic use only.
 
 Combining `LockMonitoringMode.Monitor` or `LockMonitoringMode.AutoExtend` with `Timeout.InfiniteTimeSpan` for `TimeUntilExpires` throws `ArgumentException` (`ParamName = "timeUntilExpires"`): lease monitoring requires a finite lease window.

--- a/docs/plans/2026-05-21-001-feat-distributed-locks-phase-2-lease-monitor-plan.md
+++ b/docs/plans/2026-05-21-001-feat-distributed-locks-phase-2-lease-monitor-plan.md
@@ -80,17 +80,17 @@ Origin: GitHub issue #289 (treated as the requirements document for this plan).
 stateDiagram-v2
     [*] --> Held : monitor constructed
     Held --> Renewed : RenewOrValidateLeaseAsync = Renewed (lifetime reset)
-    Held --> Held : RenewOrValidateLeaseAsync = Held
+    Held --> Held : RenewOrValidateLeaseAsync = Held (lifetime reset)
     Held --> Unknown : transient exception
     Held --> Lost : RenewOrValidateLeaseAsync = Lost
     Renewed --> Held : continue polling
-    Unknown --> Held : next iteration ok
-    Unknown --> Lost : lifetime > LeaseDuration (self-loss)
-    Unknown --> Renewed : transient cleared
+    Unknown --> Held : next iteration ok (lifetime reset)
+    Unknown --> Lost : lifetime > LeaseDuration AND state == Unknown (self-loss)
+    Unknown --> Renewed : transient cleared (lifetime reset)
     Lost --> [*] : HandleLostToken cancelled, loop exits
 ```
 
-Key invariant: `Lost` is terminal. Only `Renewed` resets `leaseLifetime`. `Unknown` does not reset — repeated `Unknown` accumulates lifetime and eventually self-promotes to `Lost` when `leaseLifetime > LeaseDuration`. This is what makes partition behavior correct (AC1).
+Key invariant: `Lost` is terminal. Both `Renewed` and `Held` reset `leaseLifetime` — both are positive ownership confirmations from storage and the polling-only mode (`autoExtend: false`) never sees `Renewed`, so resetting only on `Renewed` would accumulate lifetime drift across long `Held` streaks. `Unknown` does NOT reset — repeated `Unknown` accumulates lifetime. The self-loss promotion fires only when `leaseLifetime > LeaseDuration` AND the prior probe was `Unknown`; a confirmed `Held` or `Renewed` cannot trip the safety net (defense in depth alongside the lifetime reset). This is what makes partition behavior correct (AC1) without producing false-positive Lost in polling mode.
 
 ### Acquire-to-monitor-to-dispose sequence
 

--- a/docs/plans/2026-05-21-001-feat-distributed-locks-phase-2-lease-monitor-plan.md
+++ b/docs/plans/2026-05-21-001-feat-distributed-locks-phase-2-lease-monitor-plan.md
@@ -1,0 +1,697 @@
+---
+title: "feat: distributed-locks Phase 2 — LeaseMonitor + HandleLostToken + opt-in auto-extension"
+type: feat
+date: 2026-05-21
+status: completed
+depth: deep
+issue: "#289"
+related_issues: ["#287", "#288", "#283"]
+target_repo: headless-framework
+---
+
+# feat: distributed-locks Phase 2 — LeaseMonitor + HandleLostToken + opt-in auto-extension
+
+## Summary
+
+Add lease-lifecycle correctness to `Headless.DistributedLocks.*`. Introduce an internal `LeaseMonitor` with a 4-state machine (`Held` / `Renewed` / `Lost` / `Unknown`) that runs a background polling loop holding only a `WeakReference<LeaseMonitor>` to itself, so abandoned `DisposableDistributedLock` handles can be GC'd and the loop exits naturally. Expose loss detection through a new `IDistributedLock.HandleLostToken` (breaking) so consumer code can short-circuit work the moment the lease is lost. Wire a hybrid wake-up: the existing outbox `DistributedLockReleased` consumer nudges every active monitor for that resource for fast-path validation (target latency < 100ms); the ½-TTL poll is the backstop when outbox is absent or messages drop. Add opt-in background auto-extension via `autoExtend: bool` on acquire (default `false`), with monitor cadence at 1/3 TTL when auto-extending. Disposal of the lock awaits monitor disposal first, which is what closes #283 — the monitor honors its own disposal token without 15-retry hangs.
+
+Greenfield posture per `CLAUDE.md` — interface change ships clean, no shims. Docs sync (agent-facing `docs/llms/distributed-locks.md` + package READMEs) is part of the phase.
+
+---
+
+## Problem Frame
+
+Today's `DisposableDistributedLock` is fire-and-acquire: once a handle returns, the consumer has no signal that the lease was lost (storage eviction, network partition, clock skew, GC pause exceeding TTL). The consumer keeps doing work past the point where another process can legally acquire the same resource. The lock stays in the "efficiency lock" safety category (see `docs/solutions/tooling-decisions/redlock-multi-instance-not-adopted-2026-05-19.md`) — the framework cannot promise correctness through clock skew — but it can narrow the window where work continues against a lost lease, which is what Phase 2 ships.
+
+Phase 1 (#288, landed) added `releaseOnDispose: false`, the optional-`IOutboxPublisher` path, and `LockAcquisitionTimeoutException` under a new `DistributedLockException` base. Phase 2 sits on that foundation and adds the lease-lifecycle layer the rest of the four-phase track (#287) builds against — Phase 3's RW lock, semaphore, and composite primitives all consume `HandleLostToken`.
+
+`IDistributedLock` is consumed framework-internally today by `Headless.Messaging` (per `docs/llms/distributed-locks.md`) and is the next-target dependency for `Headless.Jobs`. Both are in this monorepo, so the breaking change is single-commit reachable. No external NuGet consumers exist yet.
+
+---
+
+## Requirements Traceability
+
+Origin: GitHub issue #289 (treated as the requirements document for this plan).
+
+| Origin ID | Description | Implementation Units |
+|---|---|---|
+| R2.1 | `HandleLostToken` on `IDistributedLock`; returns `None` when monitor not enabled | U3, U6 |
+| R2.2 | `LeaseMonitor` 4-state machine with `leaseLifetime > LeaseDuration` self-loss | U2 |
+| R2.3 | `WeakReference<LeaseMonitor>` capture in monitoring loop; abandoned handles GC | U2 |
+| R2.4 | Outbox fast-path: `DistributedLockReleased` → `TriggerImmediateValidation` | U6 |
+| R2.5 | Polling cadence default ½ TTL; `PollingCadenceFraction` option | U4 |
+| R2.6 | `autoExtend: bool` parameter on acquire; renew vs. validate routing | U5, U7 |
+| R2.7 | Auto-extension cadence 1/3 TTL; `AutoExtensionCadenceFraction` option | U4 |
+| R2.8 | Disposal: monitor disposes first, then release — closes #283 | U5 |
+| AC1 | Partition: repeated `Unknown` fires loss only at `leaseLifetime > LeaseDuration` | U2 / U8 |
+| AC2 | Transient: single `Unknown` followed by `Renewed` resets lifetime; no loss fired | U2 / U8 |
+| AC3 | Outbox fast-path: `DistributedLockReleased` → validation < 100ms | U6 / U9 |
+| AC4 | `autoExtend: true`: work past TTL succeeds; storage shows renewals | U5 / U9 |
+| AC5 | `autoExtend: false`: work past TTL fires `HandleLostToken`; no renewals | U5 / U9 |
+| AC6 | Abandonment: drop strong ref, force GC, loop exits within one cadence | U2 / U8 |
+| AC7 | Shutdown disposal: under 100ms CT, returns ≤ 100ms; closes #283 | U5 / U9 |
+| AC8 | Works without `IOutboxPublisher`: falls back to polling-only | U6 / U9 |
+
+---
+
+## Key Technical Decisions
+
+- **Two opt-in parameters on acquire, not one.** `monitorLease: bool` (default `false`) controls whether the monitor and `HandleLostToken` are wired; `autoExtend: bool` (default `false`) controls whether the monitor calls `RenewAsync` (extend) or `GetAsync` (validate only). `autoExtend: true` implies `monitorLease: true` — auto-promote silently rather than throw, since `autoExtend` without monitoring is non-sensical. `monitorLease: false` keeps the current cost profile: no background task, no registry entry, `HandleLostToken == CancellationToken.None`. Rationale: every monitor is a background polling task; high-churn workloads with thousands of throwaway acquires should not pay for monitoring they don't read.
+- **`IDistributedLock.ReleaseAsync()` stays parameterless.** Issue #283 is closed by disposal *ordering* (drain monitor first; monitor honors its own disposal CT), not by adding a `CancellationToken` to the public `ReleaseAsync()` surface. Consumers needing a hard shutdown bound use Phase 1's `releaseOnDispose: false` + `IDistributedLockProvider.ReleaseAsync(resource, lockId, ct)` which already takes a token. Keeps the breaking-change footprint of Phase 2 to a single `IDistributedLock` member.
+- **Active-monitor registry on the provider, not the handle — and holds `WeakReference<LeaseMonitor>`.** Shape: `ConcurrentDictionary<string, ConcurrentDictionary<string, WeakReference<LeaseMonitor>>>` keyed by resource → lockId → weak-ref-to-monitor. The registry must NOT be a GC root for the monitor; otherwise the loop's own `WeakReference<LeaseMonitor>` self-reference is defeated and abandoned handles leak both the handle and the background monitoring task. Registration happens at construction time inside `TryAcquireAsync` / `_TryAcquireOnceAsync` when `monitorLease: true`; deregistration happens in `LeaseMonitor.DisposeAsync` (always called by `DisposableDistributedLock.DisposeAsync`). The provider owns the registry because `OnLockReleased` is invoked on the provider and needs to dispatch the nudge synchronously. Dispatch resolves the weak-ref via `TryGetTarget`; dead entries are skipped on read and lazily evicted by `OnLockReleased` sweeps (cheap because the inner dict is small).
+
+  Reference graph: handle → strong → monitor; monitor → strong → handle (as `ILeaseHandle`, scoped to monitor lifetime); registry → weak → monitor; loop closure → weak → monitor. When the consumer drops the handle (no external root), the handle ↔ monitor strong cycle is unreachable, GC reclaims both, the loop's `TryGetTarget` returns false on the next iteration, the loop exits, and the registry entry becomes dead-and-evictable. This satisfies AC6 (abandonment GC).
+- **`OnLockReleased` stays synchronous.** Contract in `src/Headless.DistributedLocks.Core/RegularLocks/ICanReceiveLockReleased.cs` requires non-blocking dispatch. The monitor nudge is a single `AsyncAutoResetEvent.Set()` per matching monitor — the same primitive already used for waiter wake-up.
+- **`TimeProvider.CreateCancellationTokenSource(cadence)` over `CreateTimer`.** No `CreateTimer` precedent exists in the DistributedLocks codebase; the loop + linked-CTS + `AsyncAutoResetEvent.SafeWaitAsync` pattern matches existing acquire loop conventions. Avoid introducing a new timing primitive.
+- **State category framing.** The monitor adds observability + recovery. It does NOT upgrade these locks to correctness locks. Public framing on `HandleLostToken` doc-comments and in `docs/llms/distributed-locks.md` must align with `redlock-multi-instance-not-adopted-2026-05-19.md`: consumers needing correctness still need to fence the protected resource with `LockId`.
+- **Apply circuit-breaker thread-safety checklist verbatim** per `docs/solutions/concurrency/circuit-breaker-transport-thread-safety-patterns.md`. Specifically: timer-generation guard before any state transition; dispose-race lock; fire-and-forget continuation observer on the monitor's `_monitoringTask`.
+- **`LockHandleLostException` is a consumer-throw type, not framework-throw.** The framework signals lease loss via `HandleLostToken` cancellation. Consumers wrap their work cancellation in `try/catch` and throw `LockHandleLostException` when they need an exception-shape signal. The type ships in `Headless.DistributedLocks.Abstractions/Exceptions/` — already named in `LockAcquisitionTimeoutException`'s doc-comment as a sibling under `DistributedLockException`.
+- **No new Setup overload.** `monitorLease` and `autoExtend` are per-call parameters on existing `AcquireAsync` / `TryAcquireAsync`. The Setup contract in `src/Headless.DistributedLocks.Core/Setup.cs` (`AddDistributedLockExtensions`) is untouched. Options-level globals (cadence fractions) bind through the existing `services.Configure<DistributedLockOptions, DistributedLockOptionsValidator>(...)` pipeline.
+
+---
+
+## High-Level Technical Design
+
+*The diagrams below illustrate the intended approach and are directional guidance for review, not implementation specification. The implementing agent should treat them as context, not code to reproduce.*
+
+### State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Held : monitor constructed
+    Held --> Renewed : RenewOrValidateLeaseAsync = Renewed (lifetime reset)
+    Held --> Held : RenewOrValidateLeaseAsync = Held
+    Held --> Unknown : transient exception
+    Held --> Lost : RenewOrValidateLeaseAsync = Lost
+    Renewed --> Held : continue polling
+    Unknown --> Held : next iteration ok
+    Unknown --> Lost : lifetime > LeaseDuration (self-loss)
+    Unknown --> Renewed : transient cleared
+    Lost --> [*] : HandleLostToken cancelled, loop exits
+```
+
+Key invariant: `Lost` is terminal. Only `Renewed` resets `leaseLifetime`. `Unknown` does not reset — repeated `Unknown` accumulates lifetime and eventually self-promotes to `Lost` when `leaseLifetime > LeaseDuration`. This is what makes partition behavior correct (AC1).
+
+### Acquire-to-monitor-to-dispose sequence
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Provider as DistributedLockProvider
+    participant Handle as DisposableDistributedLock
+    participant Monitor as LeaseMonitor
+    participant Storage as IDistributedLockStorage
+    participant Outbox as LockReleasedConsumer
+
+    Caller->>Provider: TryAcquireAsync(monitorLease: true, autoExtend: false)
+    Provider->>Storage: InsertAsync
+    Storage-->>Provider: ok
+    Provider->>Handle: new(monitor: null)
+    Provider->>Monitor: new(handle as ILeaseHandle, timeProvider)
+    Monitor->>Monitor: Task.Run(_MonitoringLoopAsync, weakRef)
+    Provider->>Provider: _activeMonitors[resource][lockId] = monitor
+    Provider->>Handle: AttachMonitor(monitor)
+    Provider-->>Caller: handle
+
+    Note over Monitor: loop: SafeWaitAsync(cadence) or nudge
+
+    Outbox->>Provider: OnLockReleased(message)
+    Provider->>Monitor: TriggerImmediateValidation (Set nudge signal)
+    Monitor->>Storage: GetAsync(resource)
+    Storage-->>Monitor: lockId or other
+    Monitor->>Monitor: state transition
+
+    Caller->>Handle: DisposeAsync
+    Handle->>Monitor: DisposeAsync (cancel _disposalSource, await loop)
+    Monitor-->>Handle: drained
+    Handle->>Provider: ReleaseAsync (CancellationToken.None)
+    Provider->>Provider: _activeMonitors[resource].Remove(lockId)
+```
+
+The drain step (`await _monitor.DisposeAsync()` before `ReleaseAsync()`) is what closes #283. Monitor disposal honors its own `_disposalSource` token; it does not retry storage; it exits within one cadence tick. Consumers needing a hard time bound on the *release* path use `releaseOnDispose: false` from Phase 1.
+
+---
+
+## Implementation Units
+
+### U2. Implement `LeaseMonitor` with 4-state machine, weak-ref loop, nudge signal
+
+*Note: this unit also defines the `LeaseState` enum and `LeaseMonitor.ILeaseHandle` nested interface inside the same `LeaseMonitor.cs` file (formerly described as U1 — folded here since U1 had no separate file output of its own; U-IDs U3+ keep their original numbering per the U-ID stability rule).*
+
+**Nested types defined here:**
+- `LeaseState` — nested public enum on `LeaseMonitor`: `Held`, `Renewed`, `Lost`, `Unknown`. Nested-on-internal keeps it invisible to consumers.
+- `LeaseMonitor.ILeaseHandle` — nested interface: `TimeSpan LeaseDuration { get; }`, `TimeSpan MonitoringCadence { get; }`, `Task<LeaseState> RenewOrValidateLeaseAsync(CancellationToken)`. `DisposableDistributedLock` implements it in U5.
+- `MonitoringCadence` is computed by the handle, not the monitor — the handle owns the cadence-fraction lookup since it holds the options reference. Monitor stays storage-agnostic.
+
+Nested types on internal classes match the existing `LockReleasedConsumer` nested under `DistributedLockProvider` (`src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs:791`).
+
+**Goal:** Land the monitor primitive that drives lease lifecycle. Background polling loop with `WeakReference<LeaseMonitor>` self-reference, `AsyncAutoResetEvent`-based nudge for fast-path validation, terminal `HandleLostToken` cancellation on lost state.
+
+**Requirements:** R2.2, R2.3, AC1, AC2, AC6
+
+**Dependencies:** none
+
+**Files:**
+- `src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs` (created)
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs` (created)
+- `tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeLeaseHandle.cs` (created) — test double implementing `LeaseMonitor.ILeaseHandle`
+
+**Approach:**
+- `internal sealed class LeaseMonitor : IAsyncDisposable`. Two `CancellationTokenSource` fields: `_disposalSource` (loop exit), `_handleLostSource` (the externally-observed token).
+- Constructor takes `ILeaseHandle` + `TimeProvider`. Validates `LeaseDuration >= MonitoringCadence` via `Argument.IsGreaterThanOrEqualTo`. Starts loop via `Task.Run`, passing only `WeakReference<LeaseMonitor>(this)` plus value-typed copies (cadence, time provider, disposal token) — the loop never closes over `this`. The weak-ref is load-bearing for abandonment GC and only works if no other strong root holds the monitor; U6 keeps the registry weak-only to honor this.
+- Loop pattern (mirrors `DistributedLockProvider`'s acquire backoff loop): linked CTS over (cadence-CTS, disposal-CT) → `_nudgeSignal.SafeWaitAsync(linkedCts.Token)` (catches `OperationCanceledException`) → check disposal → resolve weak ref → `_RunIterationAsync(monitor, leaseLifetime)`.
+- `_RunIterationAsync` checks `leaseLifetime > _leaseHandle.LeaseDuration` first (self-loss); else calls `_leaseHandle.RenewOrValidateLeaseAsync(_disposalSource.Token)` inside `try/catch` mapping non-cancellation exceptions to `Unknown`; then state-machine switch.
+- On `Lost`, cancel `_handleLostSource` on a background thread via `Task.Run(() => _handleLostSource.Cancel())` to avoid running waiter continuations under the loop's effective lock. Stash the resulting `Task` for `DisposeAsync` to dispose the CTS after continuations drain.
+- `TriggerImmediateValidation()` is a synchronous public method — calls `_nudgeSignal.Set()`. No `async` boundary.
+- `DisposeAsync`: cancel `_disposalSource` (if not already), `await _monitoringTask` in `try/finally`, dispose CTS in `finally` (handling the deferred dispose of `_handleLostSource` if `_cancellationTask` is non-null).
+- Apply circuit-breaker thread-safety checklist from `docs/solutions/concurrency/circuit-breaker-transport-thread-safety-patterns.md`: no `volatile bool` gates, no sync-over-async in `DisposeAsync`, idempotent double-dispose, observer on the `Task.Run` continuation (`ContinueWith(OnlyOnFaulted)` to log fault — silent wedge prevention).
+
+**Technical design** (directional):
+```text
+LeaseMonitor
+├── ctor(ILeaseHandle, TimeProvider)
+│   ├── validates LeaseDuration >= MonitoringCadence
+│   └── starts Task.Run(_MonitoringLoopAsync, weakRef = new WeakReference<LeaseMonitor>(this))
+├── HandleLostToken => _handleLostSource.Token
+├── TriggerImmediateValidation() => _nudgeSignal.Set()
+└── DisposeAsync()
+    ├── _disposalSource.Cancel()
+    ├── await _monitoringTask
+    └── dispose CTS (defer _handleLostSource dispose if _cancellationTask is non-null)
+```
+
+This illustrates the intended shape and is directional guidance for review, not implementation specification.
+
+**Patterns to follow:**
+- `AsyncAutoResetEvent.SafeWaitAsync(ct)` extension already exists at `src/Headless.Extensions/Threading/AsyncExExtensions.cs:30` — reuse, do not duplicate.
+- `timeProvider.CreateCancellationTokenSource(cadence)` matches `src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs:225`.
+- Source-gen `[LoggerMessage]` partial class at the bottom of the file (per memory note `feedback_logger_class_placement.md`). Event IDs start at 1 for the new `LeaseMonitorLog` class.
+- `Argument.IsGreaterThanOrEqualTo` / `Argument.IsNotNull` from `Headless.Checks`.
+- Circuit-breaker patterns from `docs/solutions/concurrency/circuit-breaker-transport-thread-safety-patterns.md`.
+
+**Execution note:** Implement the state-machine test cases first (RED) against `FakeLeaseHandle` before wiring up the production loop. Weak-ref / GC-abandonment test in particular tends to mis-spec without an empirical loop.
+
+**Test suite design:** All tests are unit tests under `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/`. Use `FakeTimeProvider` (already imported throughout existing unit tests) + `FakeLeaseHandle` (new). Reuse the `_DrainContinuationsAsync` idiom established at `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs:559` for advancing virtual time across the monitor's `Task.Run` continuations.
+
+**Test scenarios:**
+- *Happy path — `Renewed` transitions reset lifetime.* `FakeLeaseHandle` returns `Renewed` on every call; advance time past one cadence; `HandleLostToken` never fires; `leaseLifetime` (visible via fake-injected stopwatch peek or assert via repeated cadences without loss) is reset after each `Renewed`. Covers AC2.
+- *Happy path — `Held` continues polling.* `FakeLeaseHandle` returns `Held`; advance multiple cadences within `LeaseDuration`; no loss fired; loop alive.
+- *Self-loss when `leaseLifetime > LeaseDuration`.* `FakeLeaseHandle` returns `Unknown` forever; advance past `LeaseDuration`; `HandleLostToken` cancels exactly once; loop exits within one cadence after loss. Covers AC1.
+- *Transient `Unknown` followed by `Renewed` does not fire loss.* Sequence: `Unknown` → `Renewed`; advance to `1.5 × LeaseDuration` total, but the `Renewed` happens before `LeaseDuration` elapses; `HandleLostToken` never fires. Covers AC2.
+- *Explicit `Lost` from handle fires immediately.* `FakeLeaseHandle` returns `Lost` on first iteration; `HandleLostToken` cancels within one cadence regardless of `leaseLifetime`.
+- *Edge case — nudge wakes the loop before cadence elapses.* `TriggerImmediateValidation` is called while `SafeWaitAsync` is pending; verify iteration runs within a small tolerance (assert via fake-clock elapsed at iteration time, not wall-clock).
+- *Edge case — exception during `RenewOrValidateLeaseAsync` maps to `Unknown`.* `FakeLeaseHandle` throws `InvalidOperationException`; one iteration returns `Unknown` state internally; loop continues; cumulative `Unknown` eventually self-promotes to `Lost` per the `Unknown`-forever case.
+- *Edge case — exception when disposal already requested is suppressed.* Trigger disposal during iteration; `RenewOrValidateLeaseAsync` throws `OperationCanceledException`; loop exits cleanly, `HandleLostToken` does not fire.
+- *Abandonment — drop strong ref + GC → loop exits.* Construct monitor, drop the local strong reference, call `GC.Collect()` + `GC.WaitForPendingFinalizers()`; advance one cadence; verify the monitoring task completes (use a fake-handle invocation counter to observe loop termination indirectly — direct assertion on `_monitoringTask.IsCompleted` via internal test hook acceptable since `LeaseMonitor` is internal). Covers AC6.
+- *Disposal — idempotent double-dispose.* Call `DisposeAsync` twice; second call is no-op; no exceptions.
+- *Disposal — drain awaits in-flight iteration.* Hold a TCS inside the fake handle; trigger disposal; `DisposeAsync` does not complete until the fake handle releases.
+- *Constructor — validates `LeaseDuration >= MonitoringCadence`.* Throw `ArgumentException` when cadence > duration.
+
+**Verification:** All listed test scenarios implemented and passing under `make test-project-fast TEST_PROJECT=tests/Headless.DistributedLocks.Tests.Unit`. Line coverage on `LeaseMonitor` ≥ 85%, branch ≥ 80% per `CLAUDE.md`. `make format-check` clean. No new analyzer warnings introduced.
+
+---
+
+### U3. Add `HandleLostToken` to `IDistributedLock` + introduce `LockHandleLostException`
+
+**Goal:** Land the breaking interface change and the consumer-facing exception type.
+
+**Requirements:** R2.1
+
+**Dependencies:** none (independent of U2 — interface lives in `Abstractions`)
+
+**Files:**
+- `src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLock.cs` (modified)
+- `src/Headless.DistributedLocks.Abstractions/Exceptions/LockHandleLostException.cs` (created)
+- `src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs` (modified — null lock returns `CancellationToken.None`)
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LockHandleLostExceptionTests.cs` (created)
+
+**Approach:**
+- Add `CancellationToken HandleLostToken { get; }` to `IDistributedLock`. XML doc must explicitly state: returns `CancellationToken.None` when `monitorLease: false` was passed at acquire time; otherwise cancels when the lease is detected lost or self-lost via `leaseLifetime > LeaseDuration`. Doc must include the safety-category framing: *"This is an observability signal. Consumers needing correctness must validate `LockId` at the protected resource — see `docs/llms/distributed-locks.md` for fencing guidance."*
+- `LockHandleLostException` mirrors `LockAcquisitionTimeoutException` shape exactly: `sealed`, inherits `DistributedLockException`, three public ctors (`(string resource, string lockId)`, `(string, string, string?)`, `(string, string, string?, Exception?)`), all chain through `Argument.IsNotNullOrWhiteSpace` on both `resource` and `lockId`. Exposes `Resource` and `LockId` properties. `[PublicAPI]`.
+- Update `LockAcquisitionTimeoutException`'s doc-comment that anticipates `LockHandleLostException` (currently lines 11-17 of `LockAcquisitionTimeoutException.cs`) — point to the new sibling type.
+- `NullDistributedLockProvider`'s `IDistributedLock` implementation returns `CancellationToken.None` for `HandleLostToken`.
+
+**Patterns to follow:**
+- `LockAcquisitionTimeoutException` at `src/Headless.DistributedLocks.Abstractions/Exceptions/LockAcquisitionTimeoutException.cs` is the exact template — chained ctor validation, `Argument.IsNotNullOrWhiteSpace`, `[PublicAPI]`, `sealed`.
+- XML doc style on `IDistributedLock` members.
+
+**Test suite design:** Unit tests for the exception type land in `Headless.DistributedLocks.Tests.Unit`. Interface contract is exercised via integration tests in U9 (against `NullDistributedLockProvider` and real provider).
+
+**Test scenarios:**
+- *`LockHandleLostException` ctors validate `resource` and `lockId`.* `Argument.IsNotNullOrWhiteSpace` throws on null/empty/whitespace for both params, across all three ctors.
+- *`LockHandleLostException` exposes `Resource` and `LockId`.* Construct with sentinel values; assert getters.
+- *`LockHandleLostException` inherits `DistributedLockException`.* Type-check assertion.
+- *`NullDistributedLockProvider`'s lock returns `CancellationToken.None` for `HandleLostToken`.* Acquire, read property, assert default.
+
+**Verification:** Interface change compiles across all referencing projects in the solution (including `Headless.Messaging.Core` which is the explicit current consumer). `make build` clean. Listed exception tests pass. `NullDistributedLockProvider` test for `HandleLostToken == CancellationToken.None` passes.
+
+---
+
+### U4. Extend `DistributedLockOptions` with cadence-fraction fields + validator
+
+**Goal:** Surface the two new tunables (`PollingCadenceFraction`, `AutoExtensionCadenceFraction`) on the existing options class with FluentValidation `InclusiveBetween(0.1, 0.5)` rules colocated in the same file.
+
+**Requirements:** R2.5, R2.7
+
+**Dependencies:** none
+
+**Files:**
+- `src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs` (modified)
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockOptionsValidatorTests.cs` (modified or created — check if exists)
+
+**Approach:**
+- Add two `public double` properties on `DistributedLockOptions` with defaults `PollingCadenceFraction = 0.5` and `AutoExtensionCadenceFraction = 1.0 / 3.0`.
+- Add two `RuleFor(...).InclusiveBetween(0.1, 0.5)` rules to the existing `DistributedLockOptionsValidator` (already colocated below the options class).
+- Independent ranges — both fractions clamp the same `[0.1, 0.5]` range to avoid pathological cadences (too aggressive starves storage; too slow misses partition recovery within reasonable TTLs).
+
+**Patterns to follow:**
+- Colocated validator at the bottom of the options file per `CLAUDE.md` options pattern; existing structure at `src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs:24` is the template.
+- No new options class — extend the existing one to avoid expanding the configuration surface.
+
+**Test scenarios:**
+- *Defaults validate clean.* Construct `DistributedLockOptions` with no overrides; validator returns valid.
+- *Boundary — `0.1` validates clean for both fractions.*
+- *Boundary — `0.5` validates clean for both fractions.*
+- *Below boundary — `0.09` fails validation for both fractions.*
+- *Above boundary — `0.51` fails validation for both fractions.*
+
+**Verification:** Validator tests pass; `services.Configure<DistributedLockOptions, DistributedLockOptionsValidator>(...)` registration at startup catches out-of-band fractions via `ValidateOnStart()` (covered by integration tests in U9 indirectly via DI bootstrap).
+
+---
+
+### U5. Wire `LeaseMonitor` into `DisposableDistributedLock`
+
+**Goal:** Make the handle implement `LeaseMonitor.ILeaseHandle`, accept an optional monitor reference, expose `HandleLostToken`, and reorder `DisposeAsync` to drain the monitor before issuing release — closing #283.
+
+**Requirements:** R2.1, R2.6, R2.8, AC4, AC5, AC7
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- `src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs` (modified)
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs` (modified)
+
+**Approach:**
+- `DisposableDistributedLock` constructor gains a nullable `LeaseMonitor?` parameter and the `autoExtend` and options refs needed to compute `MonitoringCadence`. Add `DistributedLockOptions` to the ctor (`DistributedLockProvider` already holds it; pass through).
+- `DisposableDistributedLock` implements `LeaseMonitor.ILeaseHandle` explicitly:
+  - `LeaseDuration` returns `_timeUntilExpires` (need to thread this through the ctor — currently not on the handle; comes from the acquire-call path, must be plumbed).
+  - `MonitoringCadence` returns `_timeUntilExpires * (autoExtend ? options.AutoExtensionCadenceFraction : options.PollingCadenceFraction)`.
+  - `RenewOrValidateLeaseAsync(ct)` routes by `autoExtend`: `true` → `lockProvider.RenewAsync(Resource, LockId, _timeUntilExpires, ct)` → `Renewed`/`Lost`; `false` → `lockProvider.GetLockIdAsync(Resource, ct)` (need to add this to `IDistributedLockProvider` — see below) → compare with `LockId` → `Held`/`Lost`.
+- Add `Task<string?> GetLockIdAsync(string resource, CancellationToken)` to `IDistributedLockProvider` and implement on `DistributedLockProvider` (route through `_queryPipeline` to `_storage.GetAsync(resource, ct)`). This is the validate-without-renew primitive the monitor needs. Cleaner than exposing `IDistributedLockStorage` to the handle.
+- `HandleLostToken` property: `_monitor?.HandleLostToken ?? CancellationToken.None`.
+- `DisposeAsync` reorder:
+  1. Trace log: disposing
+  2. **If `_monitor` is non-null: `await _monitor.DisposeAsync()` first.** This is the drain that closes #283.
+  3. `if (releaseOnDispose) await ReleaseAsync()` (existing logic; release still passes `CancellationToken.None` per Key Technical Decisions).
+  4. Trace log: disposed
+- Catch + log on monitor dispose failure does NOT short-circuit the release — release still runs.
+
+**Technical design** (directional):
+```text
+DisposeAsync:
+  trace("disposing")
+  if monitor is not null:
+    await monitor.DisposeAsync()    // drains _disposalSource, awaits loop
+  if releaseOnDispose:
+    await ReleaseAsync()             // existing, CT.None
+  trace("disposed")
+```
+
+This illustrates the drain-then-release ordering and is directional guidance for review.
+
+**Patterns to follow:**
+- Source-gen logger partial class at the bottom of the file (existing `DisposableDistributedLockLog` at line 120) — append new event IDs 8+ for monitor lifecycle traces.
+- `Argument.IsNotNull` for the new ctor params that are non-nullable.
+- `[Pure]` / `[MustDisposeResource]` annotations where applicable per `JetBrains.Annotations` discipline.
+
+**Execution note:** Add the failing AC7 shutdown-disposal test first against the current code — confirm the 15-retry hang reproduces — then implement the drain-order fix. Characterizes the bug before fixing.
+
+**Test suite design:** Unit tests for the handle live in the existing `DisposableDistributedLockTests.cs`. Integration tests for AC4, AC5, AC7 land on the harness (U9).
+
+**Test scenarios:**
+- *`HandleLostToken` is `None` when monitor is null.* Construct handle without monitor; read property; assert default.
+- *`HandleLostToken` forwards monitor's token.* Construct with a monitor whose `_handleLostSource` is fresh; assert tokens equal-via-source (use `WaitHandle`-equivalent identity check or fire monitor's loss and observe handle's token cancel).
+- *`DisposeAsync` awaits monitor before release.* Inject a fake monitor whose `DisposeAsync` holds a TCS; assert `lockProvider.ReleaseAsync` not called until the TCS completes.
+- *`DisposeAsync` swallows monitor-disposal exceptions and still releases.* Fake monitor throws on dispose; release still runs; handle is marked released.
+- *`DisposeAsync` honors `releaseOnDispose: false` regardless of monitor.* `releaseOnDispose: false` + monitor non-null; dispose still drains monitor but does NOT call release.
+- *`ILeaseHandle.RenewOrValidateLeaseAsync` routes by `autoExtend`.* `autoExtend: true` → calls `RenewAsync`, maps `true → Renewed`, `false → Lost`. `autoExtend: false` → calls `GetLockIdAsync`, maps matching lockId → `Held`, mismatched → `Lost`, null → `Lost`.
+- *`ILeaseHandle.MonitoringCadence` reflects fraction.* With `autoExtend: false` and `PollingCadenceFraction = 0.5`, cadence = `_timeUntilExpires / 2`. With `autoExtend: true` and `AutoExtensionCadenceFraction = 1/3`, cadence = `_timeUntilExpires / 3`.
+
+**Verification:** Existing `DisposableDistributedLockTests` continue to pass; new scenarios pass. `IDistributedLockProvider` gains `GetLockIdAsync`; `DistributedLockProvider` implements it; `NullDistributedLockProvider` returns `null`.
+
+---
+
+### U6. Wire active-monitor registry on `DistributedLockProvider`; extend `OnLockReleased` to nudge
+
+**Goal:** Add the per-resource active-monitor registry on the provider; register monitors at acquire time; deregister at monitor disposal time; extend the existing `OnLockReleased` to nudge every active monitor for the released resource.
+
+**Requirements:** R2.1, R2.4, AC3, AC8
+
+**Dependencies:** U2, U3, U5
+
+**Files:**
+- `src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs` (modified)
+- `src/Headless.DistributedLocks.Core/RegularLocks/LoggerExtensions.cs` (modified — new EventIds for monitor register/unregister/nudge traces)
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs` (modified — add registry + nudge tests)
+
+**Approach:**
+- New field on `DistributedLockProvider`: `ConcurrentDictionary<string, ConcurrentDictionary<string, WeakReference<LeaseMonitor>>> _activeMonitors` keyed by resource → lockId → weak-ref-to-monitor. Both levels use `StringComparer.Ordinal` (matches `_autoResetEvents`). The weak-ref is load-bearing — see Key Technical Decisions for the reference-graph rationale.
+- New internal methods: `_RegisterMonitor(string resource, string lockId, LeaseMonitor monitor)` (wraps in a fresh `WeakReference<>`) and `_DeregisterMonitor(string resource, string lockId)`. Inner-dict removal cleans up when empty. Both methods are non-blocking dictionary ops.
+- Extend `ICanReceiveLockReleased.OnLockReleased`:
+  ```text
+  void OnLockReleased(DistributedLockReleased message):
+      logger.LogGotLockReleasedMessage(...)
+      // existing: pulse the waiter reset event
+      if _autoResetEvents.TryGetValue(message.Resource, out var ev): ev.Target.Set()
+      // new: nudge active monitors for this resource; lazy-evict dead weak-refs
+      if _activeMonitors.TryGetValue(message.Resource, out var monitors):
+          foreach (var (lockId, weakRef) in monitors):
+              if weakRef.TryGetTarget(out var monitor): monitor.TriggerImmediateValidation()
+              else: monitors.TryRemove(KeyValuePair.Create(lockId, weakRef))  // lazy GC sweep
+          if monitors.IsEmpty: _activeMonitors.TryRemove(KeyValuePair.Create(message.Resource, monitors))
+  ```
+- The release dispatch contract stays synchronous; `TriggerImmediateValidation` is `_nudgeSignal.Set()` (synchronous).
+- Monitor disposal calls back to `_DeregisterMonitor`. Two viable shapes: (a) pass an `Action<string, string>` to the monitor ctor; (b) wire `DisposableDistributedLock.DisposeAsync` to call the deregister method after the monitor drains. Lean: **(b)** — keeps `LeaseMonitor` provider-agnostic (testable in isolation against `FakeLeaseHandle`); the handle already knows the provider. When monitor + handle are GC'd without explicit disposal, the `OnLockReleased` sweep above evicts the dead entry; cleanup is eventually-consistent, not synchronous.
+
+**Patterns to follow:**
+- `ConcurrentDictionary` usage matches existing `_autoResetEvents` at `src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs:36`.
+- `OnLockReleased` synchronous contract per `src/Headless.DistributedLocks.Core/RegularLocks/ICanReceiveLockReleased.cs`.
+- `[LoggerMessage]` in `LoggerExtensions.cs` (this file uses sibling-file logger pattern, not bottom-of-file). EventIds continue from current max — implementer must audit `RegularLockLoggerExtensions` for the actual current max immediately before adding new ones rather than trusting any number stated here (snapshot risk).
+
+**Test suite design:** Unit tests for registry + nudge against the in-memory storage in `DistributedLockProviderTests`. Integration test for outbox fast-path latency (AC3) and no-outbox fallback (AC8) lives in U9 on the harness.
+
+**Test scenarios:**
+- *`_RegisterMonitor` inserts a weak-ref into nested dict.* Register two monitors for same resource with different lockIds; assert dict shape; assert each inner entry is a `WeakReference<LeaseMonitor>` (not strong).
+- *`_DeregisterMonitor` removes inner entry; outer entry removed when empty.* Register one, deregister; outer dict no longer contains the resource.
+- *`OnLockReleased` nudges every active monitor for the resource.* Register two monitors (fake monitors with counting `TriggerImmediateValidation`); call `OnLockReleased(resource, anyLockId)`; both monitors' nudge counts == 1. Note: the nudge dispatches by resource, not lockId — a released message wakes all active monitors for that resource (a stale monitor holding a different lockId will see its `GetAsync` return null or someone-else's-lockId and transition to `Lost` correctly).
+- *`OnLockReleased` does not call into a deregistered monitor.* Register, deregister, send `OnLockReleased`; monitor's nudge count == 0.
+- *`OnLockReleased` evicts dead weak-refs lazily.* Register a monitor, drop the strong ref + force GC so the weak-ref dies; call `OnLockReleased`; assert no exception, no nudge, and the dead entry is removed from the inner dict after the sweep.
+- *Registry weak-ref does not pin the monitor.* Register a monitor inside a helper method (no caller-side strong ref); `GC.Collect()` + `GC.WaitForPendingFinalizers()`; assert `TryGetTarget` on the registry entry returns `false`. Regression guard for the load-bearing weak-ref decision.
+- *`OnLockReleased` keeps existing waiter wake-up working.* Register a waiter (force `_IncrementResetEvent`); call `OnLockReleased`; assert the auto-reset event was pulsed — regression guard for the existing contract.
+- *Concurrent register/deregister/dispatch — no exception.* Spin two tasks: one repeatedly registers/deregisters; one fires `OnLockReleased` in a tight loop. Assert no exception over N iterations (smoke-test for `ConcurrentDictionary` boundary cases).
+- *Provider with null `IOutboxPublisher` still registers + nudges via in-process call.* Construct provider with `outboxPublisher: null` (Phase 1 path); manually invoke `((ICanReceiveLockReleased)provider).OnLockReleased(...)`; nudge fires. Covers AC8 at unit level.
+
+**Verification:** Listed unit tests pass. Existing waiter-wake-up tests in `DistributedLockProviderTests` continue to pass (regression guard for the contract this unit extends).
+
+---
+
+### U7. Add `monitorLease` and `autoExtend` parameters to acquire APIs; create + register monitors at acquire time
+
+**Goal:** Surface the two new acquire-time parameters on `IDistributedLockProvider`, plumb through `DistributedLockProvider.TryAcquireAsync` and `_TryAcquireOnceAsync`, and wire monitor construction + registry insertion + handle attachment at both acquire success sites.
+
+**Requirements:** R2.1, R2.6, R2.7
+
+**Dependencies:** U2, U4, U5, U6
+
+**Files:**
+- `src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs` (modified)
+- `src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs` (modified — accept new params; ignore)
+- `src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs` (modified if overloads need to be added there)
+- `src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs` (modified — both `TryAcquireAsync` and `_TryAcquireOnceAsync` paths)
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs` (modified — add parameter-routing tests)
+
+**Approach:**
+- Add `bool monitorLease = false` and `bool autoExtend = false` parameters to both `AcquireAsync` and `TryAcquireAsync` on `IDistributedLockProvider`. Place them between `releaseOnDispose` and `cancellationToken` to keep the cancellation-token-last convention.
+- Update XML docs: `monitorLease` enables `HandleLostToken` and background lease polling; `autoExtend` controls renew-vs-validate inside the monitor and auto-promotes `monitorLease` to `true` if not already set.
+- In `TryAcquireAsync` and `_TryAcquireOnceAsync`, after a successful acquire and before constructing `DisposableDistributedLock`:
+  - Compute `effectiveMonitorLease = monitorLease || autoExtend`.
+  - If `effectiveMonitorLease`: construct `DisposableDistributedLock` first (passing `monitor: null` initially, plus the `autoExtend`, `_options` refs and the resolved `_timeUntilExpires`), then construct `LeaseMonitor` passing the handle as `ILeaseHandle`, then `_RegisterMonitor(resource, lockId, monitor)`, then attach via `handle.AttachMonitor(monitor)` (add an internal `AttachMonitor` method to the handle since the monitor must reference the handle).
+  - Else: construct `DisposableDistributedLock` with `monitor: null`.
+- Resolution of `effectiveMonitorLease` and the construction order are critical: handle exists first (so `ILeaseHandle` is implementable), monitor wraps handle, registry holds monitor, handle exposes monitor via `HandleLostToken`. The "attach" step is small but necessary because `DisposableDistributedLock` cannot reference an instance that doesn't exist yet.
+- Both acquire paths (`TryAcquireAsync` main loop and `_TryAcquireOnceAsync` zero-timeout fast path) get the same monitor-attachment block — keep them parallel.
+- `AcquireAsync` (which currently delegates to `TryAcquireAsync` then throws on null) needs no extra logic — params plumb through to `TryAcquireAsync`.
+- `NullDistributedLockProvider` accepts the new params and ignores them — its handle continues to return `CancellationToken.None`.
+
+**Patterns to follow:**
+- Existing parameter pattern in `TryAcquireAsync` (line 109 of `DistributedLockProvider.cs`) — extend, don't rewrite.
+- `Argument.*` validation: no new validation needed for two booleans.
+- Keep both construction sites in lockstep — they are the dispatch fork for the Zero-timeout fast path; any change to one needs the mirror in the other.
+
+**Test scenarios:**
+- *Default params produce no monitor.* `TryAcquireAsync(resource)` with no `monitorLease`/`autoExtend`; resulting handle's `HandleLostToken` is `CancellationToken.None`; registry empty for the resource.
+- *`monitorLease: true` creates monitor and registers.* Acquire; assert registry contains the resource→lockId mapping; assert `HandleLostToken` is non-`None` and not yet cancelled.
+- *`autoExtend: true` auto-promotes `monitorLease: false`.* Acquire with `autoExtend: true, monitorLease: false`; monitor created; registry populated; `HandleLostToken` live.
+- *`autoExtend: true` configures monitor with 1/3 cadence.* Acquire; inspect `MonitoringCadence` on handle (via internal test hook on `DisposableDistributedLock`); equals `_timeUntilExpires / 3`.
+- *`monitorLease: true` + `autoExtend: false` configures monitor with ½ cadence.* Inspect cadence; equals `_timeUntilExpires / 2`.
+- *Dispose deregisters monitor from registry.* Acquire with `monitorLease: true`; dispose handle; assert registry no longer contains the lockId.
+- *Acquire failure does not register.* Force `TryAcquireAsync` to return null (storage rejects); registry empty.
+- *Zero-timeout fast path also creates + registers monitor.* `acquireTimeout: TimeSpan.Zero, monitorLease: true`; monitor created and registered (mirror behavior with main loop).
+- *Failed cancellation cleanup deregisters cleanly.* Cancel during acquire; if monitor was registered (only possible after handle construction), deregistration runs. If acquire never reached handle construction, no entry exists.
+- *Concurrent acquires same resource (different lockIds, only one wins) — only winner registers monitor.* Race two `TryAcquireAsync` calls with `monitorLease: true`; one returns handle (registered), one returns null (no registry entry for its lockId).
+
+**Verification:** Listed unit tests pass. Both `TryAcquireAsync` and `_TryAcquireOnceAsync` paths exercised by tests that pass `acquireTimeout: TimeSpan.Zero` and non-zero. `make build` clean across all `IDistributedLockProvider` consumers in the solution (`Headless.Messaging.Core` notably — must not break).
+
+---
+
+### U8. Cross-cutting unit tests for `LeaseMonitor` × `DisposableDistributedLock` interaction
+
+**Goal:** Validate the monitor↔handle↔provider three-way wiring works end-to-end at the unit-test level (no Testcontainers). Covers behaviors that span all three components but don't need a real storage backend.
+
+**Requirements:** AC1, AC2, AC6 (unit-level)
+
+**Dependencies:** U2, U5, U6, U7
+
+**Files:**
+- `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs` (created — naming reflects "unit-level integration of components", lives in unit project)
+
+**Approach:**
+- Compose `DistributedLockProvider` + `FakeDistributedLockStorage` + `FakeTimeProvider` (existing patterns from `DistributedLockProviderTests.cs`). Acquire with `monitorLease: true`; force storage state changes; observe `HandleLostToken` behavior on the returned handle.
+- Reuse `_DrainContinuationsAsync` helper from `DistributedLockProviderTests.cs:559`.
+
+**Test scenarios:**
+- *Acquire + monitor + outbox-style nudge.* Acquire with `monitorLease: true`; manually invoke `((ICanReceiveLockReleased)provider).OnLockReleased(...)` for the resource; storage state shows the lock still exists (simulating a stale release message); monitor validates, sees lockId match, stays `Held`; `HandleLostToken` does not fire.
+- *Acquire + monitor + foreign release.* Acquire with `monitorLease: true`; tamper with storage to replace the lockId with a different value; advance one cadence; monitor's next validation returns `Lost`; `HandleLostToken` fires.
+- *Acquire + monitor + storage deletion.* Acquire with `monitorLease: true`; remove the entry from storage (simulating TTL expiry); advance one cadence; monitor's next validation gets `null` → `Lost`; `HandleLostToken` fires.
+- *Acquire + auto-extend renews at cadence.* Acquire with `autoExtend: true, timeUntilExpires: 6s`; storage's `ReplaceIfEqualAsync` increments a renewal counter; advance time `1s + 2s + 2s + 2s` (3 cadences at 2s = 1/3 of 6s); renewal counter ≥ 3.
+- *Disposed handle deregisters and stops monitor.* Acquire with `monitorLease: true`; dispose; assert registry empty for the resource; monitor's `_monitoringTask` is `IsCompleted`.
+
+**Verification:** Listed scenarios pass. Coverage delta on `DistributedLockProvider`'s monitor wiring ≥ 85% line.
+
+---
+
+### U9. Cross-storage integration tests on harness — partition, fast-path, abandonment, shutdown, no-outbox
+
+**Goal:** Exercise the eight ACs on the three integration storage backends (Redis, InMemory, Cache) through `DistributedLockProviderTestsBase`.
+
+**Requirements:** AC1, AC3, AC4, AC5, AC6, AC7, AC8
+
+**Dependencies:** U7
+
+**Files:**
+- `tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs` (modified — add virtual lease-monitor methods)
+- `tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisDistributedLockProviderTests.cs` (modified — override + storage-specific partition simulation)
+- `tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryDistributedLockProviderTests.cs` (modified — override standard cases)
+- `tests/Headless.DistributedLocks.Cache.Tests.Integration/CacheDistributedLockProviderTests.cs` (modified — override standard cases; check file name in repo)
+
+**Approach:**
+- Add virtual test methods on `DistributedLockProviderTestsBase` for each AC that doesn't require storage-specific chaos. The Redis-only partition-simulation test goes in `Headless.DistributedLocks.Redis.Tests.Integration` directly because it requires Testcontainers chaos hooks (network pause on the Redis container) that aren't expressible in InMemory or Cache backends.
+- Use `RedisTestFixture` per `tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisTestFixture.cs:11` for Redis tests. Use `TestBase.AbortToken` everywhere.
+- For AC3 (outbox fast-path latency), inject a real outbox setup via the existing harness setup and measure stopwatch time from `OnLockReleased` invocation to monitor's next `RenewOrValidateLeaseAsync` call (via a wrapping handle that timestamps the call). Assert < 100ms.
+- For AC6 (abandonment GC), allocate the lock in a separate method (so the local ref doesn't pin), call `GC.Collect()` + `WaitForPendingFinalizers()`, advance time one cadence (with FakeTimeProvider where possible, wall-clock where required — Redis path may need real time advance via `await Task.Delay(cadence + tolerance, AbortToken)`). Assert the monitor task is completed by querying the provider's `_activeMonitors` count (expose via internal test hook).
+- For AC7 (shutdown disposal), construct provider with FakeTimeProvider AND a storage decorator that delays `RemoveIfEqualAsync` (simulating degraded storage); acquire with `monitorLease: true, releaseOnDispose: false` — this is the AC7-relevant shape because `releaseOnDispose: true` would still pay the underlying `_releasePipeline` 15-retry budget on `ReleaseAsync`. Start `DisposeAsync` and assert it completes within 100ms (FakeTimeProvider step + tolerance). The point of AC7 is that the *monitor* does not add to shutdown latency; the release path stays best-effort, and consumers needing a hard release bound under shutdown use `releaseOnDispose: false` per Phase 1's design.
+- For AC8 (no-outbox), construct provider with `outboxPublisher: null`; acquire with `monitorLease: true`; foreign-replace the storage entry; advance ½ TTL; assert `HandleLostToken` fires (polling-only backstop works).
+- For AC4/AC5 (auto-extend vs polling-only TTL behavior), use the existing `RenewAsync` mock-or-real path; assert renewal counts via storage observability.
+
+**Test suite design:**
+- Cross-storage behavior → harness (`DistributedLockProviderTestsBase`).
+- Storage-specific chaos → Redis integration project.
+- Unit-level state machine + weak-ref / disposal → U2 and U8 (already covered).
+
+**Test scenarios** (harness-level, each becomes a virtual method override in each integration project):
+- *Covers AC1. Network-partition simulation (Redis-only override site): pause the Redis container's network; monitor returns `Unknown` repeatedly; `HandleLostToken` fires only after `leaseLifetime > _timeUntilExpires`.* InMemory and Cache override this with a fake-storage-fault injection or skip per fixture capability.
+- *Covers AC2. Transient error then recovery: storage decorator returns one `Exception` then succeeds; `Unknown` once → `Renewed`; `HandleLostToken` does not fire even after `leaseLifetime` would have exceeded `_timeUntilExpires` minus the recovery.* Harness method using a decorator on the storage; works against all backends.
+- *Covers AC3. Outbox fast-path latency.* Acquire with `monitorLease: true`; another producer releases the lock; measure dispatch latency from `OnLockReleased` to next monitor validation < 100ms. Harness-level; runs on all backends that have outbox wired.
+- *Covers AC4. `autoExtend: true` work past TTL.* Acquire with `autoExtend: true, timeUntilExpires: 3s`; sleep 6s; verify lock still held (`IsLockedAsync(resource) == true` and lockId matches); cleanup via dispose.
+- *Covers AC5. `autoExtend: false` work past TTL fires `HandleLostToken`.* Acquire with `monitorLease: true, autoExtend: false, timeUntilExpires: 3s`; sleep 6s; assert `HandleLostToken.IsCancellationRequested == true`; storage shows no renewal calls.
+- *Covers AC6. Abandonment GC.* Acquire inside a helper method that doesn't return the handle; `GC.Collect` + `WaitForPendingFinalizers`; advance one cadence; assert `_activeMonitors` is empty for the resource within bounded wait.
+- *Covers AC7. Shutdown disposal under 100ms with degraded storage.* Construct degraded-storage scenario (decorator that delays `RemoveIfEqualAsync` by 30s); acquire with `monitorLease: true, releaseOnDispose: false` (the AC7-relevant shape per Key Technical Decisions); start `DisposeAsync`; assert `DisposeAsync` returns within 100ms. AC7 closure of #283 is scoped to monitor drain not adding to shutdown latency; the underlying `_releasePipeline` retry budget on `ReleaseAsync` is a separate concern tracked in Deferred to Follow-Up Work. A secondary regression-style scenario asserts `DisposeAsync` with `releaseOnDispose: true` against the same degraded storage takes substantially longer than 100ms (confirming the test is exercising the intended boundary).
+- *Covers AC8. Works without `IOutboxPublisher`.* Setup provider with `IOutboxPublisher` not registered; acquire with `monitorLease: true`; ½-TTL poll detects a tampered storage entry; `HandleLostToken` fires; no monitor failures logged.
+
+**Verification:** All eight AC scenarios pass on all three integration backends (where applicable; Redis-only chaos tests pass only on Redis). Coverage targets met per `CLAUDE.md`. Integration suite runs clean under `make test-integration`.
+
+---
+
+### U10. Documentation sync — `docs/llms/distributed-locks.md` + package READMEs
+
+**Goal:** Update agent-facing and consumer-facing docs in lockstep with the API change, per `docs/authoring/AUTHORING.md` and the `CLAUDE.md` sync trigger ("public API surface changes" + "consumer-visible behavior changes").
+
+**Requirements:** R2.1 (doc surface), R2.5, R2.6, R2.7
+
+**Dependencies:** U3, U7
+
+**Files:**
+- `docs/llms/distributed-locks.md` (modified)
+- `src/Headless.DistributedLocks.Abstractions/README.md` (modified)
+- `src/Headless.DistributedLocks.Core/README.md` (modified)
+- `src/Headless.DistributedLocks.Redis/README.md` (modified — note Phase 2 is storage-agnostic)
+- `src/Headless.DistributedLocks.Cache/README.md` (modified — same)
+
+**Approach:**
+- Add a "Lease lifecycle and `HandleLostToken`" section to `docs/llms/distributed-locks.md` covering: what `monitorLease: true` does, the 4-state machine in plain prose, fast-path nudge vs. polling backstop, auto-extension cadence, and the safety-category framing (still efficiency locks; fence with `LockId` for correctness).
+- Update the existing "Messaging Wake-ups" section to mention that `OnLockReleased` now also nudges active monitors, not just waiters.
+- Add new options (`PollingCadenceFraction`, `AutoExtensionCadenceFraction`) to the options reference table.
+- Add the `LockHandleLostException` to the exception list.
+- READMEs: update the public API examples to show the new acquire parameters; note that `HandleLostToken` is part of `IDistributedLock`.
+- Cross-link the safety-category doc (`docs/solutions/tooling-decisions/redlock-multi-instance-not-adopted-2026-05-19.md`).
+- Apply the drift checks in `docs/authoring/AUTHORING.md` before considering this unit complete.
+
+**Patterns to follow:**
+- Existing structure of `docs/llms/distributed-locks.md` (Phase 1's "Messaging Wake-ups" section is the closest template).
+- README style across `src/Headless.DistributedLocks.*/README.md`.
+
+**Test expectation:** none — documentation. Verification is via the doc drift checks in `docs/authoring/AUTHORING.md` and manual review.
+
+**Verification:** Docs build / link-check clean (if such tooling exists). Manual review confirms the safety-category framing is preserved. The Phase 2 API surface is discoverable from `docs/llms/distributed-locks.md`.
+
+---
+
+## Test Suite Design (Cross-Unit)
+
+| Layer | Project | Owns |
+|---|---|---|
+| Pure state-machine / weak-ref / disposal | `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs` | U2 |
+| Handle ↔ monitor wiring + dispose ordering | `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs` | U5 |
+| Provider registry + `OnLockReleased` nudge | `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs` | U6 |
+| Three-way provider + handle + monitor integration on fake storage | `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs` | U8 |
+| Cross-storage behavior (eight ACs) | `tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs` + each integration project's override | U9 |
+| Redis-specific chaos (partition) | `tests/Headless.DistributedLocks.Redis.Tests.Integration/` | U9 |
+
+**Shared test infrastructure to reuse:**
+- `FakeTimeProvider` (Microsoft.Extensions.Time.Testing).
+- `FakeDistributedLockStorage` at `tests/Headless.DistributedLocks.Tests.Unit/Fakes/` (existing).
+- `_DrainContinuationsAsync` helper at `tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs:559`.
+- `RedisTestFixture` at `tests/Headless.DistributedLocks.Redis.Tests.Integration/RedisTestFixture.cs:11`.
+- `TestBase.AbortToken` / `TestContext.Current.CancellationToken` everywhere — no `CancellationToken.None` in tests.
+- `Bogus` for varied input data on non-asserted fields.
+
+**New test infrastructure required:**
+- `FakeLeaseHandle` test double for `LeaseMonitor.ILeaseHandle` (lands in U2).
+- A storage decorator that injects partition / transient failures (lands in U9; consider placing in `Tests.Harness` if shared, else in `Tests.Unit` or `Redis.Tests.Integration`).
+- An internal test hook exposing `_activeMonitors` snapshot count for AC6 abandonment assertion (lands in U6 or U9; consider an `internal` property with `[InternalsVisibleTo("Headless.DistributedLocks.Tests.Unit")]` if not already configured).
+
+---
+
+## Scope Boundaries
+
+**In scope (this plan):**
+- `LeaseMonitor` with 4-state machine, weak-ref loop, nudge signal.
+- `IDistributedLock.HandleLostToken` (breaking).
+- `LockHandleLostException` (consumer-throw type).
+- `PollingCadenceFraction` and `AutoExtensionCadenceFraction` options + validators.
+- `monitorLease` and `autoExtend` parameters on `AcquireAsync` / `TryAcquireAsync`.
+- Active-monitor registry on `DistributedLockProvider`.
+- `OnLockReleased` extension to nudge monitors.
+- `IDistributedLockProvider.GetLockIdAsync` (the validate-without-renew primitive surfaced as a first-class method).
+- Disposal reordering in `DisposableDistributedLock` (drain monitor → release) — closes #283.
+- Cross-storage harness tests + Redis-specific partition simulation.
+- Docs sync for `docs/llms/distributed-locks.md` and package READMEs.
+
+**Out of scope (this plan):**
+
+### Outside this product's identity
+
+- **`IDistributedLock.ReleaseAsync(CancellationToken)`** — not in Phase 2's contract. #283 closes by drain-order. Adding cancellation to the handle-level release surface is a future, separately-justified change.
+- **Promotion to correctness locks** — Phase 2 stays in the efficiency-lock category per the RedLock decision. Fencing token / safety-category docs work is tracked separately (#298 in the tracking issue).
+
+### Deferred for later
+
+- **Phase 3a (RW lock)** — #290, depends on this phase.
+- **Phase 3b (semaphore)** — #291, depends on this phase.
+- **Phase 3c (composite acquire)** — #292, depends on this phase.
+- **Phase 4a (Postgres provider)** — #293, depends on this phase.
+- **Phase 4b (SQL Server provider)** — #294, depends on this phase.
+- **Phase 4c (Azure blob lease provider)** — #295, depends on this phase.
+
+### Deferred to Follow-Up Work
+
+- **Tightening `DistributedLockProvider`'s `_releasePipeline` retry budget under `IHostApplicationLifetime.ApplicationStopping`** — explicitly deferred. AC7's closure of #283 covers the monitor's contribution to shutdown latency; the underlying `ReleaseAsync` 15-retry pipeline still exists for `releaseOnDispose: true` callers and remains best-effort. Two viable follow-up shapes if usage demands it: (a) clamp `_releasePipeline.MaxRetryAttempts` to ~2 when `IHostApplicationLifetime.ApplicationStopping` has fired (path b from #283's original recommendation); (b) add `DistributedLockOptions.DisposalReleaseTimeout` (default 1s) that wraps `ReleaseAsync` in a bounded CT when called from `DisposeAsync`. Neither is in Phase 2 scope — file as a follow-up issue if post-deploy data shows the hang persists for any consumer.
+- **`_activeMonitors` capacity guard** — currently unbounded by design (mirrors `_autoResetEvents` which has DoS guards via `MaxConcurrentWaitingResources` / `MaxWaitersPerResource`). If `monitorLease: true` becomes the dominant acquire mode, add a parallel DoS guard. Defer until usage signals it.
+- **Auto-detect `monitorLease` requirement from messaging consumers** — `Headless.Messaging` could request `monitorLease: true` by default; out of scope here, file as a `Headless.Messaging` issue if useful.
+
+---
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Dispose race: monitor's `_handleLostSource.Cancel()` runs continuations under loop lock, deadlocking with caller's `DisposeAsync` | Medium | High | Cancel on a background thread (`Task.Run(() => _handleLostSource.Cancel())`); track the task in `_cancellationTask` and dispose the source only after the task completes (per the reference sketch). Apply circuit-breaker pattern 5 (dispose-race lock) from `docs/solutions/concurrency/circuit-breaker-transport-thread-safety-patterns.md`. |
+| Weak-ref capture leaks: closure inadvertently retains `this` | Medium | High | Static `_MonitoringLoopAsync` method receiving `WeakReference<LeaseMonitor>` + value types only; no instance method as the loop body. Test AC6 (GC abandonment) is the verification. |
+| Stale monitor still receives outbox nudges after deregistration | Low | Low | Deregistration runs in `DisposableDistributedLock.DisposeAsync` after monitor drain; `OnLockReleased` reads the registry under no lock (`ConcurrentDictionary` semantics); a brief window where the nudge fires on a disposing monitor is harmless because `TriggerImmediateValidation` is `Set()` on an already-cancelled-source-aware `SafeWaitAsync` — no exception, no state corruption. |
+| Cadence-fraction misconfiguration produces pathological loops | Low | Medium | `InclusiveBetween(0.1, 0.5)` validator catches at startup via `ValidateOnStart()`. Test U4 covers boundaries. |
+| Breaking `IDistributedLock` consumer (`Headless.Messaging`) doesn't compile | Medium | Medium | Single-commit-reachable consumers; `make build` from solution root catches at plan execution. U7's verification gate is explicitly cross-project build clean. |
+| AC7 shutdown-disposal — `releaseOnDispose: true` under degraded storage still pays the 15-retry budget on `ReleaseAsync` | Medium | Medium | Resolved: AC7 is scoped to `releaseOnDispose: false`. The monitor adds zero shutdown latency; the underlying `_releasePipeline` retry budget on `ReleaseAsync` is tracked in Deferred to Follow-Up Work and is the right scope for a separate plan if usage demands it. Documented in Key Technical Decisions and U9 AC7 scenario. |
+| Registry strong-ref defeats the loop's `WeakReference<LeaseMonitor>` and leaks abandoned monitors | Medium | High | Registry holds `WeakReference<LeaseMonitor>` per Key Technical Decisions. Dead entries lazy-evict on `OnLockReleased` sweeps. U6 has explicit "registry weak-ref does not pin the monitor" regression test. |
+| Outbox fast-path test (AC3) is flaky on slow CI | Medium | Low | Use FakeTimeProvider where possible; if a real-time measurement is required, set the assertion bound to `< 500ms` for CI tolerance and document the local-target `< 100ms` separately. |
+| Source-gen logger EventId collision across the new LeaseMonitorLog + existing LoggerExtensions | Low | Low | Reserve EventIds 1-9 for `LeaseMonitorLog` (file-local), continue from 20 in `RegularLockLoggerExtensions` (the sibling file pattern). Audit existing max EventId before adding new ones. |
+
+---
+
+## Dependencies / Prerequisites
+
+- **Phase 1 (#288)** must be landed — it is. Confirmed in `main` at commit `9dd381d9 feat(distributed-locks): improve lock acquisition ergonomics (#322)`.
+- **`Headless.Messaging.Core`** must compile against the new `IDistributedLock` shape — verify with `make build` during U3 review.
+- **`Headless.Extensions.Threading.AsyncExExtensions.SafeWaitAsync`** must exist — confirmed at `src/Headless.Extensions/Threading/AsyncExExtensions.cs:30`.
+- **No new NuGet dependencies** — everything needed is already referenced (`Nito.AsyncEx`, `Microsoft.Extensions.Time.Testing`, `Polly`, FluentValidation).
+
+---
+
+## Phased Delivery
+
+The plan is one logical phase but breaks naturally into three near-atomic deliveries that can land as separate commits within the same PR or as sequential PRs depending on reviewer preference:
+
+1. **Shape unit** — U3 + U4 (and the type definitions inside `LeaseMonitor.cs` from U2). Lands type definitions (`LeaseState`, `ILeaseHandle`, `HandleLostToken`, `LockHandleLostException`, options fields + validator). No behavior change beyond exposed surface.
+2. **Behavior unit** — U2 + U5 + U6 + U7 + U8. Lands the monitor, the handle wiring, the registry, the acquire-time params, and the unit-level cross-component tests. This is where #283 closes.
+3. **Coverage + docs unit** — U9 + U10. Lands the cross-storage harness tests and the documentation sync.
+
+Delivery decision is the implementer's — landing all in one PR is reasonable given the small-monorepo single-team posture; splitting helps if reviewer cycles are tight.
+
+---
+
+## Verification Criteria (Phase-Level)
+
+The phase is complete when:
+
+- All ten implementation units' verification gates pass.
+- All eight acceptance criteria from issue #289 are covered by tests in U8 and U9.
+- `make build` is clean across the solution; specifically `Headless.Messaging.Core` compiles against the new `IDistributedLock.HandleLostToken`.
+- `make test` passes; `make test-integration` passes (requires Docker).
+- Coverage targets per `CLAUDE.md` met for the touched packages: line ≥ 85%, branch ≥ 80%.
+- `make format-check` clean.
+- `docs/llms/distributed-locks.md` and the six package READMEs updated; drift checks in `docs/authoring/AUTHORING.md` pass.
+- Issue #283 can be closed (referenced from the Phase 2 PR via `Closes #283`).
+- Issue #289 acceptance checklist is fully checked.
+
+---
+
+## Documentation Plan
+
+| Surface | Action | Unit |
+|---|---|---|
+| `docs/llms/distributed-locks.md` | New "Lease lifecycle and `HandleLostToken`" section; extend "Messaging Wake-ups" | U10 |
+| `src/Headless.DistributedLocks.Abstractions/README.md` | Public API update — `HandleLostToken`, `LockHandleLostException`, acquire params | U10 |
+| `src/Headless.DistributedLocks.Core/README.md` | Setup notes — cadence fractions; safety-category framing | U10 |
+| `src/Headless.DistributedLocks.{Redis,Cache}/README.md` | Note Phase 2 is storage-agnostic; no provider-side changes | U10 |
+| XML doc on `IDistributedLock.HandleLostToken` | Inline safety-category framing pointing to RedLock decision doc | U3 |
+| XML doc on `AcquireAsync` / `TryAcquireAsync` params | New `monitorLease` and `autoExtend` semantics | U7 |
+
+Drift checks per `docs/authoring/AUTHORING.md` are mandatory before declaring the phase complete.
+
+---
+
+## Operational / Rollout Notes
+
+- **No deployment artifacts change.** This is a library-only change consumed in-process by other Headless packages.
+- **Breaking change scope.** The single breaking change is the new `HandleLostToken` member on `IDistributedLock`. Any in-repo implementation of `IDistributedLock` (currently only `DisposableDistributedLock` and the `NullDistributedLockProvider`'s nested type) must be updated. External implementations would fail to compile — none exist yet (no shipped NuGet consumers).
+- **Default opt-in posture preserves current behavior.** Both `monitorLease` and `autoExtend` default to `false`. Existing consumers (`Headless.Messaging`) continue to work unchanged unless they opt in. `Headless.Messaging` can opt in as a follow-up — out of scope here.
+- **Observability surface.** Add `LeaseMonitorLog` events (start, state transition, nudge, loss-fired, dispose) at appropriate levels (Trace for cadence; Debug for state changes; Warning for self-loss; no Error level — loss is expected behavior, not an error). Consider adding OpenTelemetry counters via `DistributedLockMetrics` for `LeaseLost` and `LeaseRenewed` — defer unless the implementer sees a clean home for it.
+- **Backout posture.** Reverting Phase 2 is a single-commit revert plus a single-commit `Closes #283` re-open. No data layer changes; no persistent state introduced.
+
+---
+
+## Unresolved Questions
+
+These are knowable-during-implementation, not blocking the plan:
+
+1. **Whether to expose `_activeMonitors` count via a public observability API** — for parity with `GetActiveLocksCountAsync`, a `GetActiveMonitorsCountAsync` could land. Defer unless integration tests show it's needed for assertion shape.
+2. **`OpenTelemetry` activity tags on monitor lifecycle** — Phase 1 added activity instrumentation on acquire; Phase 2 could extend to monitor state transitions. Out of scope unless implementer sees a low-cost home.
+3. **`LeaseMonitor` placement** — the plan places it under `RegularLocks/`. If Phase 3 adds RW lock / semaphore that share the monitor, a future move to a shared `LeaseLifecycle/` folder may be useful. Defer; Phase 3 plan owns the decision.

--- a/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
@@ -166,9 +166,12 @@ internal sealed partial class IdempotencyMiddleware(
                 winnerLock = await lockProvider
                     .TryAcquireAsync(
                         $"lock:{cacheKey}",
-                        timeUntilExpires: options.WinnerLockLease,
-                        acquireTimeout: TimeSpan.Zero,
-                        cancellationToken: ct
+                        new DistributedLockAcquireOptions
+                        {
+                            TimeUntilExpires = options.WinnerLockLease,
+                            AcquireTimeout = TimeSpan.Zero,
+                        },
+                        ct
                     )
                     .ConfigureAwait(false);
             }
@@ -422,9 +425,12 @@ internal sealed partial class IdempotencyMiddleware(
             dlock = await lockProvider
                 .TryAcquireAsync(
                     lockKey,
-                    timeUntilExpires: options.WinnerLockLease,
-                    acquireTimeout: options.InFlightLockTimeout,
-                    cancellationToken: ct
+                    new DistributedLockAcquireOptions
+                    {
+                        TimeUntilExpires = options.WinnerLockLease,
+                        AcquireTimeout = options.InFlightLockTimeout,
+                    },
+                    ct
                 )
                 .ConfigureAwait(false);
         }

--- a/src/Headless.DistributedLocks.Abstractions/Exceptions/LockAcquisitionTimeoutException.cs
+++ b/src/Headless.DistributedLocks.Abstractions/Exceptions/LockAcquisitionTimeoutException.cs
@@ -11,7 +11,7 @@ namespace Headless.DistributedLocks;
 /// <see cref="TimeoutException"/>. Callers writing <c>catch (TimeoutException)</c> will NOT catch
 /// this exception — they must catch <see cref="LockAcquisitionTimeoutException"/> directly or its
 /// base <see cref="DistributedLockException"/>. The hierarchy preserves room for additional
-/// lock-specific exceptions (for example, a future <c>LockHandleLostException</c>) under the same
+/// lock-specific exceptions such as <see cref="LockHandleLostException"/> under the same
 /// base, while keeping lock-acquisition timeouts distinct from generic I/O-style timeouts.
 /// </remarks>
 [PublicAPI]

--- a/src/Headless.DistributedLocks.Abstractions/Exceptions/LockHandleLostException.cs
+++ b/src/Headless.DistributedLocks.Abstractions/Exceptions/LockHandleLostException.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Checks;
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace
+namespace Headless.DistributedLocks;
+
+/// <summary>Exception raised by consumers when work should stop because the observed lock handle was lost.</summary>
+[PublicAPI]
+public sealed class LockHandleLostException : DistributedLockException
+{
+    public LockHandleLostException(string resource, string lockId)
+        : this(
+            Argument.IsNotNullOrWhiteSpace(resource),
+            Argument.IsNotNullOrWhiteSpace(lockId),
+            $"Distributed lock handle '{lockId}' for resource '{resource}' was lost."
+        ) { }
+
+    public LockHandleLostException(string resource, string lockId, string? message)
+        : base(message)
+    {
+        Resource = Argument.IsNotNullOrWhiteSpace(resource);
+        LockId = Argument.IsNotNullOrWhiteSpace(lockId);
+    }
+
+    public LockHandleLostException(string resource, string lockId, string? message, Exception? innerException)
+        : base(message, innerException)
+    {
+        Resource = Argument.IsNotNullOrWhiteSpace(resource);
+        LockId = Argument.IsNotNullOrWhiteSpace(lockId);
+    }
+
+    /// <summary>The resource whose lock handle was lost.</summary>
+    public string Resource { get; }
+
+    /// <summary>The lock id that was being observed.</summary>
+    public string LockId { get; }
+}

--- a/src/Headless.DistributedLocks.Abstractions/Exceptions/LockHandleLostException.cs
+++ b/src/Headless.DistributedLocks.Abstractions/Exceptions/LockHandleLostException.cs
@@ -10,6 +10,7 @@ namespace Headless.DistributedLocks;
 [PublicAPI]
 public sealed class LockHandleLostException : DistributedLockException
 {
+    /// <summary>Initializes an exception with the default lost-handle message.</summary>
     public LockHandleLostException(string resource, string lockId)
         : this(
             Argument.IsNotNullOrWhiteSpace(resource),
@@ -17,6 +18,7 @@ public sealed class LockHandleLostException : DistributedLockException
             $"Distributed lock handle '{lockId}' for resource '{resource}' was lost."
         ) { }
 
+    /// <summary>Initializes an exception with a custom lost-handle message.</summary>
     public LockHandleLostException(string resource, string lockId, string? message)
         : base(message)
     {
@@ -24,6 +26,7 @@ public sealed class LockHandleLostException : DistributedLockException
         LockId = Argument.IsNotNullOrWhiteSpace(lockId);
     }
 
+    /// <summary>Initializes an exception with a custom lost-handle message and inner cause.</summary>
     public LockHandleLostException(string resource, string lockId, string? message, Exception? innerException)
         : base(message, innerException)
     {

--- a/src/Headless.DistributedLocks.Abstractions/README.md
+++ b/src/Headless.DistributedLocks.Abstractions/README.md
@@ -16,7 +16,8 @@ Lets application and domain code depend on lock interfaces without referencing a
 ## Design Notes
 
 - `AcquireAsync(...)` is a throwing convenience over `TryAcquireAsync(...)`. It does not provide stronger safety guarantees.
-- `releaseOnDispose: false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
+- Per-call configuration (`TimeUntilExpires`, `AcquireTimeout`, `ReleaseOnDispose`, `Monitoring`) is bundled into `DistributedLockAcquireOptions`. Omit the argument to use defaults; use `with` expressions to derive variants.
+- `ReleaseOnDispose = false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
 - `HandleLostToken` is `CancellationToken.None` unless the acquire call enables monitoring (check `IsMonitored` to disambiguate). It is an observability signal; fence protected writes with `LockId` when correctness matters. A faulted monitor is surfaced as cancellation here as a fail-safe so a silently dead monitor cannot keep appearing healthy.
 
 ## Installation
@@ -34,10 +35,13 @@ public sealed class OrderWorker(IDistributedLockProvider lockProvider)
     {
         await using var lease = await lockProvider.AcquireAsync(
             $"order:{orderId}",
-            timeUntilExpires: TimeSpan.FromMinutes(5),
-            acquireTimeout: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: ct
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromMinutes(5),
+                AcquireTimeout = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            ct
         );
 
         using var lostRegistration = lease.HandleLostToken.Register(() => { /* stop work */ });

--- a/src/Headless.DistributedLocks.Abstractions/README.md
+++ b/src/Headless.DistributedLocks.Abstractions/README.md
@@ -9,14 +9,15 @@ Lets application and domain code depend on lock interfaces without referencing a
 ## Key Features
 
 - `IDistributedLockProvider` with `TryAcquireAsync(...)` and `AcquireAsync(...)`.
-- `IDistributedLock` handle with `LockId`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
-- `LockAcquisitionTimeoutException` and `DistributedLockException` for lock-specific failures.
-- Lock inspection methods for expiration, active count, active list, and lock info.
+- `IDistributedLock` handle with `LockId`, `HandleLostToken`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
+- `LockAcquisitionTimeoutException`, `LockHandleLostException`, and `DistributedLockException` for lock-specific failures.
+- Lock inspection methods for current lock id, expiration, active count, active list, and lock info.
 
 ## Design Notes
 
 - `AcquireAsync(...)` is a throwing convenience over `TryAcquireAsync(...)`. It does not provide stronger safety guarantees.
 - `releaseOnDispose: false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
+- `HandleLostToken` is `CancellationToken.None` unless the acquire call enables monitoring. It is an observability signal; fence protected writes with `LockId` when correctness matters.
 
 ## Installation
 
@@ -35,9 +36,11 @@ public sealed class OrderWorker(IDistributedLockProvider lockProvider)
             $"order:{orderId}",
             timeUntilExpires: TimeSpan.FromMinutes(5),
             acquireTimeout: TimeSpan.FromSeconds(10),
+            monitorLease: true,
             cancellationToken: ct
         );
 
+        using var lostRegistration = lease.HandleLostToken.Register(() => { /* stop work */ });
         // process the order while the lease is held
     }
 }

--- a/src/Headless.DistributedLocks.Abstractions/README.md
+++ b/src/Headless.DistributedLocks.Abstractions/README.md
@@ -10,8 +10,9 @@ Lets application and domain code depend on lock interfaces without referencing a
 
 - `IDistributedLockProvider` with `TryAcquireAsync(...)` and `AcquireAsync(...)`.
 - `IDistributedLock` handle with `LockId`, `HandleLostToken`, `IsMonitored`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
+- `TryUsingAsync(resource, work, ...)` convenience that acquires, executes work, and releases — prefer this over manual try/finally for simple guarded execution.
 - `LockAcquisitionTimeoutException`, `LockHandleLostException`, and `DistributedLockException` for lock-specific failures.
-- Lock inspection methods for current lock id, expiration, active count, active list, and lock info.
+- Lock inspection methods for current lock id, expiration, active count, active list, and lock info. `GetLockIdAsync` does not renew a lease; monitored holders should use `HandleLostToken` for lease-loss observation.
 
 ## Design Notes
 
@@ -19,6 +20,7 @@ Lets application and domain code depend on lock interfaces without referencing a
 - Per-call configuration (`TimeUntilExpires`, `AcquireTimeout`, `ReleaseOnDispose`, `Monitoring`) is bundled into `DistributedLockAcquireOptions`. Omit the argument to use defaults; use `with` expressions to derive variants.
 - `ReleaseOnDispose = false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
 - `HandleLostToken` is `CancellationToken.None` unless the acquire call enables monitoring (check `IsMonitored` to disambiguate). It is an observability signal; fence protected writes with `LockId` when correctness matters. A faulted monitor is surfaced as cancellation here as a fail-safe so a silently dead monitor cannot keep appearing healthy.
+- `TimeUntilExpires = null` uses the provider default. Built-in providers use a finite 20-minute default, so `null` is valid with `LockMonitoringMode.AutoExtend`; `Timeout.InfiniteTimeSpan` is not.
 
 ## Installation
 

--- a/src/Headless.DistributedLocks.Abstractions/README.md
+++ b/src/Headless.DistributedLocks.Abstractions/README.md
@@ -9,7 +9,7 @@ Lets application and domain code depend on lock interfaces without referencing a
 ## Key Features
 
 - `IDistributedLockProvider` with `TryAcquireAsync(...)` and `AcquireAsync(...)`.
-- `IDistributedLock` handle with `LockId`, `HandleLostToken`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
+- `IDistributedLock` handle with `LockId`, `HandleLostToken`, `IsMonitored`, `RenewAsync(...)`, and `ReleaseAsync(...)`.
 - `LockAcquisitionTimeoutException`, `LockHandleLostException`, and `DistributedLockException` for lock-specific failures.
 - Lock inspection methods for current lock id, expiration, active count, active list, and lock info.
 
@@ -17,7 +17,7 @@ Lets application and domain code depend on lock interfaces without referencing a
 
 - `AcquireAsync(...)` is a throwing convenience over `TryAcquireAsync(...)`. It does not provide stronger safety guarantees.
 - `releaseOnDispose: false` prevents dispose-time release but does not disable explicit `ReleaseAsync(...)`.
-- `HandleLostToken` is `CancellationToken.None` unless the acquire call enables monitoring. It is an observability signal; fence protected writes with `LockId` when correctness matters.
+- `HandleLostToken` is `CancellationToken.None` unless the acquire call enables monitoring (check `IsMonitored` to disambiguate). It is an observability signal; fence protected writes with `LockId` when correctness matters. A faulted monitor is surfaced as cancellation here as a fail-safe so a silently dead monitor cannot keep appearing healthy.
 
 ## Installation
 

--- a/src/Headless.DistributedLocks.Abstractions/README.md
+++ b/src/Headless.DistributedLocks.Abstractions/README.md
@@ -36,7 +36,7 @@ public sealed class OrderWorker(IDistributedLockProvider lockProvider)
             $"order:{orderId}",
             timeUntilExpires: TimeSpan.FromMinutes(5),
             acquireTimeout: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: ct
         );
 

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockAcquireOptions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockAcquireOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace
+namespace Headless.DistributedLocks;
+
+/// <summary>Per-call configuration for <see cref="IDistributedLockProvider.AcquireAsync"/> / <see cref="IDistributedLockProvider.TryAcquireAsync"/>.</summary>
+/// <remarks>
+/// All fields are optional; pass <see langword="null"/> (or omit the argument) to use defaults.
+/// Records support <c>with</c> expressions for variants: <c>options with { Monitoring = LockMonitoringMode.AutoExtend }</c>.
+/// </remarks>
+[PublicAPI]
+public sealed record DistributedLockAcquireOptions
+{
+    /// <summary>How long the storage row should be considered held before the lease expires. <see langword="null"/> uses the provider's default (typically infinite for fire-and-forget, or whatever the configured baseline is).</summary>
+    public TimeSpan? TimeUntilExpires { get; init; }
+
+    /// <summary>Maximum time to wait for the lock to become available before <see cref="IDistributedLockProvider.AcquireAsync"/> throws or <see cref="IDistributedLockProvider.TryAcquireAsync"/> returns null. <see langword="null"/> uses the provider's default.</summary>
+    public TimeSpan? AcquireTimeout { get; init; }
+
+    /// <summary><see langword="true"/> (default) to release the lock when the handle is disposed; <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>. Use <see langword="false"/> when the caller needs to bound release time with their own <see cref="CancellationToken"/>.</summary>
+    public bool ReleaseOnDispose { get; init; } = true;
+
+    /// <summary>Controls whether and how the lease is monitored for liveness. See <see cref="LockMonitoringMode"/> for per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and <see cref="LockMonitoringMode.AutoExtend"/> require a finite <see cref="TimeUntilExpires"/>; combining either with <see cref="Timeout.InfiniteTimeSpan"/> (or omitting <see cref="TimeUntilExpires"/>) throws <see cref="ArgumentException"/>.</summary>
+    public LockMonitoringMode Monitoring { get; init; } = LockMonitoringMode.None;
+}

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockAcquireOptions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockAcquireOptions.cs
@@ -12,7 +12,7 @@ namespace Headless.DistributedLocks;
 [PublicAPI]
 public sealed record DistributedLockAcquireOptions
 {
-    /// <summary>How long the storage row should be considered held before the lease expires. <see langword="null"/> uses the provider's default (typically infinite for fire-and-forget, or whatever the configured baseline is).</summary>
+    /// <summary>How long the storage row should be considered held before the lease expires. <see langword="null"/> uses the provider's finite default (20 minutes for the built-in providers). <see cref="Timeout.InfiniteTimeSpan"/> disables expiration only when monitoring is disabled; monitored modes require a finite lease duration.</summary>
     public TimeSpan? TimeUntilExpires { get; init; }
 
     /// <summary>Maximum time to wait for the lock to become available before <see cref="IDistributedLockProvider.AcquireAsync"/> throws or <see cref="IDistributedLockProvider.TryAcquireAsync"/> returns null. <see langword="null"/> uses the provider's default.</summary>

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockAcquireOptions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockAcquireOptions.cs
@@ -21,6 +21,6 @@ public sealed record DistributedLockAcquireOptions
     /// <summary><see langword="true"/> (default) to release the lock when the handle is disposed; <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>. Use <see langword="false"/> when the caller needs to bound release time with their own <see cref="CancellationToken"/>.</summary>
     public bool ReleaseOnDispose { get; init; } = true;
 
-    /// <summary>Controls whether and how the lease is monitored for liveness. See <see cref="LockMonitoringMode"/> for per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and <see cref="LockMonitoringMode.AutoExtend"/> require a finite <see cref="TimeUntilExpires"/>; combining either with <see cref="Timeout.InfiniteTimeSpan"/> (or omitting <see cref="TimeUntilExpires"/>) throws <see cref="ArgumentException"/>.</summary>
+    /// <summary>Controls whether and how the lease is monitored for liveness. See <see cref="LockMonitoringMode"/> for per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and <see cref="LockMonitoringMode.AutoExtend"/> require a finite lease duration; <see langword="null"/> uses the provider default, while <see cref="Timeout.InfiniteTimeSpan"/> throws <see cref="ArgumentException"/>.</summary>
     public LockMonitoringMode Monitoring { get; init; } = LockMonitoringMode.None;
 }

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -34,7 +34,7 @@ public static class DistributedLockProviderExtensions
         }
 
         /// <summary>
-        /// Tries to acquire a lock for a specified <paramref name="resource"/> and execute the <paramref name="work"/>
+        /// Tries to acquire a lock for a specified <paramref name="resource"/> and execute the <paramref name="work"/>.
         /// </summary>
         /// <param name="timeUntilExpires">
         /// The amount of time until the lock expires. The allowed values are:
@@ -52,11 +52,21 @@ public static class DistributedLockProviderExtensions
         /// <item>Value greater than or equal to 0.</item>
         /// </list>
         /// </param>
+        /// <param name="monitorLease">
+        /// <see langword="true"/> to enable background lease monitoring. Overloads taking a
+        /// <see cref="CancellationToken"/>-receiving <paramref name="work"/> delegate forward a token
+        /// that is also cancelled when the lease is lost.
+        /// </param>
+        /// <param name="autoExtend">
+        /// <see langword="true"/> to renew the lease in the background while monitoring. Implies <paramref name="monitorLease"/>.
+        /// </param>
         public async Task<bool> TryUsingAsync(
             string resource,
             Func<Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -66,6 +76,8 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
+                    monitorLease: monitorLease,
+                    autoExtend: autoExtend,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -87,13 +99,15 @@ public static class DistributedLockProviderExtensions
             }
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Func<TState, Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -103,6 +117,8 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
+                    monitorLease: monitorLease,
+                    autoExtend: autoExtend,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -124,12 +140,14 @@ public static class DistributedLockProviderExtensions
             }
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
         public async Task<bool> TryUsingAsync(
             string resource,
             Func<CancellationToken, Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -139,6 +157,8 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
+                    monitorLease: monitorLease,
+                    autoExtend: autoExtend,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -150,7 +170,21 @@ public static class DistributedLockProviderExtensions
 
             try
             {
-                await work(cancellationToken).ConfigureAwait(false);
+                // When monitoring is enabled, link the caller's CT with the lease-lost token so
+                // the work delegate observes lease loss promptly via its CancellationToken.
+                if (distributedLock.IsMonitored)
+                {
+                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                        cancellationToken,
+                        distributedLock.HandleLostToken
+                    );
+
+                    await work(linkedCts.Token).ConfigureAwait(false);
+                }
+                else
+                {
+                    await work(cancellationToken).ConfigureAwait(false);
+                }
 
                 return true;
             }
@@ -160,13 +194,15 @@ public static class DistributedLockProviderExtensions
             }
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Func<TState, CancellationToken, Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -176,6 +212,8 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
+                    monitorLease: monitorLease,
+                    autoExtend: autoExtend,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -187,7 +225,19 @@ public static class DistributedLockProviderExtensions
 
             try
             {
-                await work(state, cancellationToken).ConfigureAwait(false);
+                if (distributedLock.IsMonitored)
+                {
+                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                        cancellationToken,
+                        distributedLock.HandleLostToken
+                    );
+
+                    await work(state, linkedCts.Token).ConfigureAwait(false);
+                }
+                else
+                {
+                    await work(state, cancellationToken).ConfigureAwait(false);
+                }
 
                 return true;
             }
@@ -197,12 +247,14 @@ public static class DistributedLockProviderExtensions
             }
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
         public async Task<bool> TryUsingAsync(
             string resource,
             Action work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -212,6 +264,8 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
+                    monitorLease: monitorLease,
+                    autoExtend: autoExtend,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -233,13 +287,15 @@ public static class DistributedLockProviderExtensions
             }
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Action<TState> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -249,6 +305,8 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
+                    monitorLease: monitorLease,
+                    autoExtend: autoExtend,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -70,7 +70,7 @@ public static class DistributedLockProviderExtensions
             CancellationToken cancellationToken = default
         )
         {
-            var distributedLock = await provider
+            await using var distributedLock = await provider
                 .TryAcquireAsync(
                     resource,
                     timeUntilExpires,
@@ -87,16 +87,12 @@ public static class DistributedLockProviderExtensions
                 return false;
             }
 
-            try
-            {
-                await work().ConfigureAwait(false);
+            // `await using` ensures DisposeAsync runs on exit — DisposeAsync drains the lease
+            // monitor (cancelling its CTS) and then releases the storage row. ReleaseAsync alone
+            // would leave the monitor's internal CTS un-cancelled until GC.
+            await work().ConfigureAwait(false);
 
-                return true;
-            }
-            finally
-            {
-                await distributedLock.ReleaseAsync();
-            }
+            return true;
         }
 
         /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
@@ -111,7 +107,7 @@ public static class DistributedLockProviderExtensions
             CancellationToken cancellationToken = default
         )
         {
-            var distributedLock = await provider
+            await using var distributedLock = await provider
                 .TryAcquireAsync(
                     resource,
                     timeUntilExpires,
@@ -128,16 +124,9 @@ public static class DistributedLockProviderExtensions
                 return false;
             }
 
-            try
-            {
-                await work(state).ConfigureAwait(false);
+            await work(state).ConfigureAwait(false);
 
-                return true;
-            }
-            finally
-            {
-                await distributedLock.ReleaseAsync();
-            }
+            return true;
         }
 
         /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
@@ -151,7 +140,7 @@ public static class DistributedLockProviderExtensions
             CancellationToken cancellationToken = default
         )
         {
-            var distributedLock = await provider
+            await using var distributedLock = await provider
                 .TryAcquireAsync(
                     resource,
                     timeUntilExpires,
@@ -168,30 +157,23 @@ public static class DistributedLockProviderExtensions
                 return false;
             }
 
-            try
+            // When monitoring is enabled, link the caller's CT with the lease-lost token so
+            // the work delegate observes lease loss promptly via its CancellationToken.
+            if (distributedLock.IsMonitored)
             {
-                // When monitoring is enabled, link the caller's CT with the lease-lost token so
-                // the work delegate observes lease loss promptly via its CancellationToken.
-                if (distributedLock.IsMonitored)
-                {
-                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                        cancellationToken,
-                        distributedLock.HandleLostToken
-                    );
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    distributedLock.HandleLostToken
+                );
 
-                    await work(linkedCts.Token).ConfigureAwait(false);
-                }
-                else
-                {
-                    await work(cancellationToken).ConfigureAwait(false);
-                }
-
-                return true;
+                await work(linkedCts.Token).ConfigureAwait(false);
             }
-            finally
+            else
             {
-                await distributedLock.ReleaseAsync();
+                await work(cancellationToken).ConfigureAwait(false);
             }
+
+            return true;
         }
 
         /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
@@ -206,7 +188,7 @@ public static class DistributedLockProviderExtensions
             CancellationToken cancellationToken = default
         )
         {
-            var distributedLock = await provider
+            await using var distributedLock = await provider
                 .TryAcquireAsync(
                     resource,
                     timeUntilExpires,
@@ -223,49 +205,45 @@ public static class DistributedLockProviderExtensions
                 return false;
             }
 
-            try
+            if (distributedLock.IsMonitored)
             {
-                if (distributedLock.IsMonitored)
-                {
-                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                        cancellationToken,
-                        distributedLock.HandleLostToken
-                    );
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    distributedLock.HandleLostToken
+                );
 
-                    await work(state, linkedCts.Token).ConfigureAwait(false);
-                }
-                else
-                {
-                    await work(state, cancellationToken).ConfigureAwait(false);
-                }
-
-                return true;
+                await work(state, linkedCts.Token).ConfigureAwait(false);
             }
-            finally
+            else
             {
-                await distributedLock.ReleaseAsync();
+                await work(state, cancellationToken).ConfigureAwait(false);
             }
+
+            return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
+        /// <summary>
+        /// Tries to acquire a lock for <paramref name="resource"/> and runs a synchronous
+        /// <paramref name="work"/> delegate. Synchronous work cannot observe a lease-lost
+        /// cancellation, so this overload does NOT expose <c>monitorLease</c>/<c>autoExtend</c>.
+        /// Use the <see cref="Func{Task}"/>-receiving overload when you want lease monitoring.
+        /// </summary>
         public async Task<bool> TryUsingAsync(
             string resource,
             Action work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
-            bool monitorLease = false,
-            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
-            var distributedLock = await provider
+            await using var distributedLock = await provider
                 .TryAcquireAsync(
                     resource,
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: monitorLease,
-                    autoExtend: autoExtend,
+                    monitorLease: false,
+                    autoExtend: false,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -275,38 +253,29 @@ public static class DistributedLockProviderExtensions
                 return false;
             }
 
-            try
-            {
-                work();
+            work();
 
-                return true;
-            }
-            finally
-            {
-                await distributedLock.ReleaseAsync();
-            }
+            return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Action,TimeSpan?,TimeSpan?,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Action<TState> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
-            bool monitorLease = false,
-            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
-            var distributedLock = await provider
+            await using var distributedLock = await provider
                 .TryAcquireAsync(
                     resource,
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: monitorLease,
-                    autoExtend: autoExtend,
+                    monitorLease: false,
+                    autoExtend: false,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -316,16 +285,9 @@ public static class DistributedLockProviderExtensions
                 return false;
             }
 
-            try
-            {
-                work(state);
+            work(state);
 
-                return true;
-            }
-            finally
-            {
-                await distributedLock.ReleaseAsync();
-            }
+            return true;
         }
     }
 }

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Checks;
+
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Headless.DistributedLocks;
 
@@ -11,7 +13,7 @@ public static class DistributedLockProviderExtensions
         /// <summary>Releases a resource lock for <paramref name="distributedLock"/>.</summary>
         public Task ReleaseAsync(IDistributedLock distributedLock, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(provider);
+            Argument.IsNotNull(provider);
 
             return provider.ReleaseAsync(distributedLock.Resource, distributedLock.LockId, cancellationToken);
         }

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -12,9 +12,8 @@ public static class DistributedLockProviderExtensions
         public Task ReleaseAsync(IDistributedLock distributedLock, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(provider);
-            cancellationToken.ThrowIfCancellationRequested();
 
-            return distributedLock.ReleaseAsync();
+            return provider.ReleaseAsync(distributedLock.Resource, distributedLock.LockId, cancellationToken);
         }
 
         /// <summary>

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -36,46 +36,27 @@ public static class DistributedLockProviderExtensions
         /// <summary>
         /// Tries to acquire a lock for a specified <paramref name="resource"/> and execute the <paramref name="work"/>.
         /// </summary>
-        /// <param name="timeUntilExpires">
-        /// The amount of time until the lock expires. The allowed values are:
-        /// <list type="bullet">
-        /// <item><see langword="null"/>: means the default value (20 minutes).</item>
-        /// <item><see cref="Timeout.InfiniteTimeSpan"/> (-1 milliseconds): means infinity no expiration set.</item>
-        /// <item>Value greater than 0.</item>
-        /// </list>
-        /// </param>
-        /// <param name="acquireTimeout">
-        /// The amount of time to wait for the lock to be acquired. The allowed values are:
-        /// <list type="bullet">
-        /// <item><see langword="null"/>: means the default value (30 seconds).</item>
-        /// <item><see cref="Timeout.InfiniteTimeSpan"/> (-1 millisecond): means infinity wait to acquire</item>
-        /// <item>Value greater than or equal to 0.</item>
-        /// </list>
-        /// </param>
-        /// <param name="monitoring">
-        /// Controls whether and how the lease is monitored. See <see cref="LockMonitoringMode"/>.
+        /// <param name="resource">The resource to acquire the lock for.</param>
+        /// <param name="work">The async work to execute while holding the lock.</param>
+        /// <param name="options">
+        /// Per-call configuration. See <see cref="DistributedLockAcquireOptions"/>.
+        /// The extension owns the handle lifetime, so <see cref="DistributedLockAcquireOptions.ReleaseOnDispose"/>
+        /// is forced to <see langword="true"/> regardless of what the caller sets.
         /// Overloads taking a <see cref="CancellationToken"/>-receiving <paramref name="work"/>
-        /// delegate forward a token that is also cancelled when the lease is lost (when monitoring
-        /// is enabled).
+        /// delegate forward a token that is also cancelled when the lease is lost (when monitoring is enabled).
         /// </param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public async Task<bool> TryUsingAsync(
             string resource,
             Func<Task> work,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
+            options = (options ?? new DistributedLockAcquireOptions()) with { ReleaseOnDispose = true };
+
             await using var distributedLock = await provider
-                .TryAcquireAsync(
-                    resource,
-                    timeUntilExpires,
-                    acquireTimeout,
-                    releaseOnDispose: true,
-                    monitoring: monitoring,
-                    cancellationToken: cancellationToken
-                )
+                .TryAcquireAsync(resource, options, cancellationToken)
                 .ConfigureAwait(false);
 
             if (distributedLock is null)
@@ -91,26 +72,19 @@ public static class DistributedLockProviderExtensions
             return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,LockMonitoringMode,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},DistributedLockAcquireOptions,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Func<TState, Task> work,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
+            options = (options ?? new DistributedLockAcquireOptions()) with { ReleaseOnDispose = true };
+
             await using var distributedLock = await provider
-                .TryAcquireAsync(
-                    resource,
-                    timeUntilExpires,
-                    acquireTimeout,
-                    releaseOnDispose: true,
-                    monitoring: monitoring,
-                    cancellationToken: cancellationToken
-                )
+                .TryAcquireAsync(resource, options, cancellationToken)
                 .ConfigureAwait(false);
 
             if (distributedLock is null)
@@ -123,25 +97,18 @@ public static class DistributedLockProviderExtensions
             return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,LockMonitoringMode,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},DistributedLockAcquireOptions,CancellationToken)"/>
         public async Task<bool> TryUsingAsync(
             string resource,
             Func<CancellationToken, Task> work,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
+            options = (options ?? new DistributedLockAcquireOptions()) with { ReleaseOnDispose = true };
+
             await using var distributedLock = await provider
-                .TryAcquireAsync(
-                    resource,
-                    timeUntilExpires,
-                    acquireTimeout,
-                    releaseOnDispose: true,
-                    monitoring: monitoring,
-                    cancellationToken: cancellationToken
-                )
+                .TryAcquireAsync(resource, options, cancellationToken)
                 .ConfigureAwait(false);
 
             if (distributedLock is null)
@@ -168,26 +135,19 @@ public static class DistributedLockProviderExtensions
             return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,LockMonitoringMode,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},DistributedLockAcquireOptions,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Func<TState, CancellationToken, Task> work,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
+            options = (options ?? new DistributedLockAcquireOptions()) with { ReleaseOnDispose = true };
+
             await using var distributedLock = await provider
-                .TryAcquireAsync(
-                    resource,
-                    timeUntilExpires,
-                    acquireTimeout,
-                    releaseOnDispose: true,
-                    monitoring: monitoring,
-                    cancellationToken: cancellationToken
-                )
+                .TryAcquireAsync(resource, options, cancellationToken)
                 .ConfigureAwait(false);
 
             if (distributedLock is null)
@@ -215,8 +175,8 @@ public static class DistributedLockProviderExtensions
         /// <summary>
         /// Tries to acquire a lock for <paramref name="resource"/> and runs a synchronous
         /// <paramref name="work"/> delegate. Synchronous work cannot observe a lease-lost
-        /// cancellation, so this overload does NOT expose a <see cref="LockMonitoringMode"/>
-        /// parameter. Use the <see cref="Func{Task}"/>-receiving overload when you want lease monitoring.
+        /// cancellation, so this overload always passes <see cref="LockMonitoringMode.None"/>.
+        /// Use the <see cref="Func{Task}"/>-receiving overload when you want lease monitoring.
         /// </summary>
         public async Task<bool> TryUsingAsync(
             string resource,
@@ -226,15 +186,16 @@ public static class DistributedLockProviderExtensions
             CancellationToken cancellationToken = default
         )
         {
+            var options = new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = timeUntilExpires,
+                AcquireTimeout = acquireTimeout,
+                ReleaseOnDispose = true,
+                Monitoring = LockMonitoringMode.None,
+            };
+
             await using var distributedLock = await provider
-                .TryAcquireAsync(
-                    resource,
-                    timeUntilExpires,
-                    acquireTimeout,
-                    releaseOnDispose: true,
-                    monitoring: LockMonitoringMode.None,
-                    cancellationToken: cancellationToken
-                )
+                .TryAcquireAsync(resource, options, cancellationToken)
                 .ConfigureAwait(false);
 
             if (distributedLock is null)
@@ -257,15 +218,16 @@ public static class DistributedLockProviderExtensions
             CancellationToken cancellationToken = default
         )
         {
+            var options = new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = timeUntilExpires,
+                AcquireTimeout = acquireTimeout,
+                ReleaseOnDispose = true,
+                Monitoring = LockMonitoringMode.None,
+            };
+
             await using var distributedLock = await provider
-                .TryAcquireAsync(
-                    resource,
-                    timeUntilExpires,
-                    acquireTimeout,
-                    releaseOnDispose: true,
-                    monitoring: LockMonitoringMode.None,
-                    cancellationToken: cancellationToken
-                )
+                .TryAcquireAsync(resource, options, cancellationToken)
                 .ConfigureAwait(false);
 
             if (distributedLock is null)

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -52,21 +52,18 @@ public static class DistributedLockProviderExtensions
         /// <item>Value greater than or equal to 0.</item>
         /// </list>
         /// </param>
-        /// <param name="monitorLease">
-        /// <see langword="true"/> to enable background lease monitoring. Overloads taking a
-        /// <see cref="CancellationToken"/>-receiving <paramref name="work"/> delegate forward a token
-        /// that is also cancelled when the lease is lost.
-        /// </param>
-        /// <param name="autoExtend">
-        /// <see langword="true"/> to renew the lease in the background while monitoring. Implies <paramref name="monitorLease"/>.
+        /// <param name="monitoring">
+        /// Controls whether and how the lease is monitored. See <see cref="LockMonitoringMode"/>.
+        /// Overloads taking a <see cref="CancellationToken"/>-receiving <paramref name="work"/>
+        /// delegate forward a token that is also cancelled when the lease is lost (when monitoring
+        /// is enabled).
         /// </param>
         public async Task<bool> TryUsingAsync(
             string resource,
             Func<Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -76,8 +73,7 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: monitorLease,
-                    autoExtend: autoExtend,
+                    monitoring: monitoring,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -95,15 +91,14 @@ public static class DistributedLockProviderExtensions
             return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,LockMonitoringMode,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Func<TState, Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -113,8 +108,7 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: monitorLease,
-                    autoExtend: autoExtend,
+                    monitoring: monitoring,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -129,14 +123,13 @@ public static class DistributedLockProviderExtensions
             return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,LockMonitoringMode,CancellationToken)"/>
         public async Task<bool> TryUsingAsync(
             string resource,
             Func<CancellationToken, Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -146,8 +139,7 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: monitorLease,
-                    autoExtend: autoExtend,
+                    monitoring: monitoring,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -176,15 +168,14 @@ public static class DistributedLockProviderExtensions
             return true;
         }
 
-        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,bool,bool,CancellationToken)"/>
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Func{Task},TimeSpan?,TimeSpan?,LockMonitoringMode,CancellationToken)"/>
         public async Task<bool> TryUsingAsync<TState>(
             string resource,
             TState state,
             Func<TState, CancellationToken, Task> work,
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -194,8 +185,7 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: monitorLease,
-                    autoExtend: autoExtend,
+                    monitoring: monitoring,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -225,8 +215,8 @@ public static class DistributedLockProviderExtensions
         /// <summary>
         /// Tries to acquire a lock for <paramref name="resource"/> and runs a synchronous
         /// <paramref name="work"/> delegate. Synchronous work cannot observe a lease-lost
-        /// cancellation, so this overload does NOT expose <c>monitorLease</c>/<c>autoExtend</c>.
-        /// Use the <see cref="Func{Task}"/>-receiving overload when you want lease monitoring.
+        /// cancellation, so this overload does NOT expose a <see cref="LockMonitoringMode"/>
+        /// parameter. Use the <see cref="Func{Task}"/>-receiving overload when you want lease monitoring.
         /// </summary>
         public async Task<bool> TryUsingAsync(
             string resource,
@@ -242,8 +232,7 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: false,
-                    autoExtend: false,
+                    monitoring: LockMonitoringMode.None,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -274,8 +263,7 @@ public static class DistributedLockProviderExtensions
                     timeUntilExpires,
                     acquireTimeout,
                     releaseOnDispose: true,
-                    monitorLease: false,
-                    autoExtend: false,
+                    monitoring: LockMonitoringMode.None,
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/DistributedLockProviderExtensions.cs
@@ -11,7 +11,10 @@ public static class DistributedLockProviderExtensions
         /// <summary>Releases a resource lock for <paramref name="distributedLock"/>.</summary>
         public Task ReleaseAsync(IDistributedLock distributedLock, CancellationToken cancellationToken = default)
         {
-            return provider.ReleaseAsync(distributedLock.Resource, distributedLock.LockId, cancellationToken);
+            ArgumentNullException.ThrowIfNull(provider);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return distributedLock.ReleaseAsync();
         }
 
         /// <summary>
@@ -190,6 +193,21 @@ public static class DistributedLockProviderExtensions
             {
                 TimeUntilExpires = timeUntilExpires,
                 AcquireTimeout = acquireTimeout,
+            };
+
+            return await provider.TryUsingAsync(resource, work, options, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc cref="TryUsingAsync(IDistributedLockProvider,string,Action,TimeSpan?,TimeSpan?,CancellationToken)"/>
+        public async Task<bool> TryUsingAsync(
+            string resource,
+            Action work,
+            DistributedLockAcquireOptions? options,
+            CancellationToken cancellationToken = default
+        )
+        {
+            options = (options ?? new DistributedLockAcquireOptions()) with
+            {
                 ReleaseOnDispose = true,
                 Monitoring = LockMonitoringMode.None,
             };
@@ -222,6 +240,22 @@ public static class DistributedLockProviderExtensions
             {
                 TimeUntilExpires = timeUntilExpires,
                 AcquireTimeout = acquireTimeout,
+            };
+
+            return await provider.TryUsingAsync(resource, state, work, options, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc cref="TryUsingAsync{TState}(IDistributedLockProvider,string,TState,Action{TState},TimeSpan?,TimeSpan?,CancellationToken)"/>
+        public async Task<bool> TryUsingAsync<TState>(
+            string resource,
+            TState state,
+            Action<TState> work,
+            DistributedLockAcquireOptions? options,
+            CancellationToken cancellationToken = default
+        )
+        {
+            options = (options ?? new DistributedLockAcquireOptions()) with
+            {
                 ReleaseOnDispose = true,
                 Monitoring = LockMonitoringMode.None,
             };

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLock.cs
@@ -27,11 +27,20 @@ public interface IDistributedLock : IAsyncDisposable
 
     /// <summary>
     /// Cancellation token that is cancelled when the lock lease is detected as lost.
-    /// Returns <see cref="CancellationToken.None"/> when lease monitoring was not enabled for the acquire call.
+    /// Returns <see cref="CancellationToken.None"/> when lease monitoring was not enabled for the acquire call
+    /// (check <see cref="IsMonitored"/> first).
     /// This is an observability signal. Consumers needing correctness must validate <see cref="LockId"/> at the
-    /// protected resource.
+    /// protected resource. A faulted monitor (e.g., logger or storage initialization throws unexpectedly) is
+    /// surfaced as cancellation here as a fail-safe so a silently dead monitor cannot keep appearing healthy.
     /// </summary>
     CancellationToken HandleLostToken { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the handle was acquired with lease monitoring enabled and
+    /// <see cref="HandleLostToken"/> carries a live signal. <see langword="false"/> when monitoring was
+    /// disabled and <see cref="HandleLostToken"/> returns <see cref="CancellationToken.None"/>.
+    /// </summary>
+    bool IsMonitored { get; }
 
     /// <summary>Releases the lock.</summary>
     Task ReleaseAsync();

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLock.cs
@@ -25,6 +25,14 @@ public interface IDistributedLock : IAsyncDisposable
     /// <summary>The amount of time waited to acquire the lock.</summary>
     TimeSpan TimeWaitedForLock { get; }
 
+    /// <summary>
+    /// Cancellation token that is cancelled when the lock lease is detected as lost.
+    /// Returns <see cref="CancellationToken.None"/> when lease monitoring was not enabled for the acquire call.
+    /// This is an observability signal. Consumers needing correctness must validate <see cref="LockId"/> at the
+    /// protected resource.
+    /// </summary>
+    CancellationToken HandleLostToken { get; }
+
     /// <summary>Releases the lock.</summary>
     Task ReleaseAsync();
 

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
@@ -81,7 +81,11 @@ public interface IDistributedLockProvider
         CancellationToken cancellationToken = default
     );
 
-    /// <summary>Gets the current lock id for a specified <paramref name="resource"/>, or null when it is not locked.</summary>
+    /// <summary>
+    /// Gets the current lock id for a specified <paramref name="resource"/>, or null when it is not locked.
+    /// This is an inspection/read primitive; it does not renew the lease. Consumers that already hold a
+    /// monitored handle should prefer <see cref="IDistributedLock.HandleLostToken"/> for lease-loss signals.
+    /// </summary>
     Task<string?> GetLockIdAsync(string resource, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
@@ -33,12 +33,22 @@ public interface IDistributedLockProvider
     /// <see langword="true"/> to release the lock when the returned handle is disposed;
     /// <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>.
     /// </param>
+    /// <param name="monitorLease">
+    /// <see langword="true"/> to enable background lease monitoring and a live
+    /// <see cref="IDistributedLock.HandleLostToken"/> signal.
+    /// </param>
+    /// <param name="autoExtend">
+    /// <see langword="true"/> to renew the lease in the background while monitoring. This implies
+    /// <paramref name="monitorLease"/>.
+    /// </param>
     /// <param name="cancellationToken"></param>
     Task<IDistributedLock> AcquireAsync(
         string resource,
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
+        bool monitorLease = false,
+        bool autoExtend = false,
         CancellationToken cancellationToken = default
     );
 
@@ -63,6 +73,14 @@ public interface IDistributedLockProvider
     /// <see langword="true"/> to release the lock when the returned handle is disposed;
     /// <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>.
     /// </param>
+    /// <param name="monitorLease">
+    /// <see langword="true"/> to enable background lease monitoring and a live
+    /// <see cref="IDistributedLock.HandleLostToken"/> signal.
+    /// </param>
+    /// <param name="autoExtend">
+    /// <see langword="true"/> to renew the lease in the background while monitoring. This implies
+    /// <paramref name="monitorLease"/>.
+    /// </param>
     /// <param name="cancellationToken"></param>
     /// <returns>
     /// A task that represents the asynchronous operation.
@@ -82,6 +100,8 @@ public interface IDistributedLockProvider
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
+        bool monitorLease = false,
+        bool autoExtend = false,
         CancellationToken cancellationToken = default
     );
 
@@ -96,6 +116,9 @@ public interface IDistributedLockProvider
         TimeSpan? timeUntilExpires = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>Gets the current lock id for a specified <paramref name="resource"/>, or null when it is not locked.</summary>
+    Task<string?> GetLockIdAsync(string resource, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Releases a resource lock for a specified <paramref name="resource"/>

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
@@ -33,16 +33,12 @@ public interface IDistributedLockProvider
     /// <see langword="true"/> to release the lock when the returned handle is disposed;
     /// <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>.
     /// </param>
-    /// <param name="monitorLease">
-    /// <see langword="true"/> to enable background lease monitoring and a live
-    /// <see cref="IDistributedLock.HandleLostToken"/> signal. Requires a finite
-    /// <paramref name="timeUntilExpires"/>; combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
-    /// throws <see cref="ArgumentException"/>.
-    /// </param>
-    /// <param name="autoExtend">
-    /// <see langword="true"/> to renew the lease in the background while monitoring. This implies
-    /// <paramref name="monitorLease"/>. Requires a finite <paramref name="timeUntilExpires"/>;
-    /// combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws <see cref="ArgumentException"/>.
+    /// <param name="monitoring">
+    /// Controls whether and how the lease is monitored. See <see cref="LockMonitoringMode"/> for
+    /// per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and
+    /// <see cref="LockMonitoringMode.AutoExtend"/> require a finite <paramref name="timeUntilExpires"/>;
+    /// combining either with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws
+    /// <see cref="ArgumentException"/>.
     /// </param>
     /// <param name="cancellationToken"></param>
     Task<IDistributedLock> AcquireAsync(
@@ -50,8 +46,7 @@ public interface IDistributedLockProvider
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
-        bool monitorLease = false,
-        bool autoExtend = false,
+        LockMonitoringMode monitoring = LockMonitoringMode.None,
         CancellationToken cancellationToken = default
     );
 
@@ -76,16 +71,12 @@ public interface IDistributedLockProvider
     /// <see langword="true"/> to release the lock when the returned handle is disposed;
     /// <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>.
     /// </param>
-    /// <param name="monitorLease">
-    /// <see langword="true"/> to enable background lease monitoring and a live
-    /// <see cref="IDistributedLock.HandleLostToken"/> signal. Requires a finite
-    /// <paramref name="timeUntilExpires"/>; combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
-    /// throws <see cref="ArgumentException"/>.
-    /// </param>
-    /// <param name="autoExtend">
-    /// <see langword="true"/> to renew the lease in the background while monitoring. This implies
-    /// <paramref name="monitorLease"/>. Requires a finite <paramref name="timeUntilExpires"/>;
-    /// combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws <see cref="ArgumentException"/>.
+    /// <param name="monitoring">
+    /// Controls whether and how the lease is monitored. See <see cref="LockMonitoringMode"/> for
+    /// per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and
+    /// <see cref="LockMonitoringMode.AutoExtend"/> require a finite <paramref name="timeUntilExpires"/>;
+    /// combining either with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws
+    /// <see cref="ArgumentException"/>.
     /// </param>
     /// <param name="cancellationToken"></param>
     /// <returns>
@@ -106,8 +97,7 @@ public interface IDistributedLockProvider
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
-        bool monitorLease = false,
-        bool autoExtend = false,
+        LockMonitoringMode monitoring = LockMonitoringMode.None,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
@@ -35,11 +35,14 @@ public interface IDistributedLockProvider
     /// </param>
     /// <param name="monitorLease">
     /// <see langword="true"/> to enable background lease monitoring and a live
-    /// <see cref="IDistributedLock.HandleLostToken"/> signal.
+    /// <see cref="IDistributedLock.HandleLostToken"/> signal. Requires a finite
+    /// <paramref name="timeUntilExpires"/>; combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
+    /// throws <see cref="ArgumentException"/>.
     /// </param>
     /// <param name="autoExtend">
     /// <see langword="true"/> to renew the lease in the background while monitoring. This implies
-    /// <paramref name="monitorLease"/>.
+    /// <paramref name="monitorLease"/>. Requires a finite <paramref name="timeUntilExpires"/>;
+    /// combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws <see cref="ArgumentException"/>.
     /// </param>
     /// <param name="cancellationToken"></param>
     Task<IDistributedLock> AcquireAsync(
@@ -75,11 +78,14 @@ public interface IDistributedLockProvider
     /// </param>
     /// <param name="monitorLease">
     /// <see langword="true"/> to enable background lease monitoring and a live
-    /// <see cref="IDistributedLock.HandleLostToken"/> signal.
+    /// <see cref="IDistributedLock.HandleLostToken"/> signal. Requires a finite
+    /// <paramref name="timeUntilExpires"/>; combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
+    /// throws <see cref="ArgumentException"/>.
     /// </param>
     /// <param name="autoExtend">
     /// <see langword="true"/> to renew the lease in the background while monitoring. This implies
-    /// <paramref name="monitorLease"/>.
+    /// <paramref name="monitorLease"/>. Requires a finite <paramref name="timeUntilExpires"/>;
+    /// combining with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws <see cref="ArgumentException"/>.
     /// </param>
     /// <param name="cancellationToken"></param>
     /// <returns>

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/IDistributedLockProvider.cs
@@ -14,90 +14,58 @@ public interface IDistributedLockProvider
     /// <summary>
     /// Acquires a resource lock for a specified resource and throws
     /// <see cref="LockAcquisitionTimeoutException"/> if the lock is not acquired before
-    /// <paramref name="acquireTimeout"/> is reached.
+    /// <see cref="DistributedLockAcquireOptions.AcquireTimeout"/> is reached.
     /// </summary>
     /// <param name="resource">The resource to acquire the lock for.</param>
-    /// <param name="timeUntilExpires">
-    /// The amount of time until the lock expires. The allowed values are:<br/>
-    /// * <see langword="null"/>: means the default value <see cref="DefaultTimeUntilExpires"/> (20 minutes).<br/>
-    /// * <see cref="Timeout.InfiniteTimeSpan"/> (-1 milliseconds): means infinity no expiration set.<br/>
-    /// * Value greater than 0.<br/>
-    /// </param>
-    /// <param name="acquireTimeout">
-    /// The amount of time to wait for the lock to be acquired. The allowed values are:<br/>
-    /// * <see langword="null"/>: means the default value <see cref="DefaultAcquireTimeout"/> (30 seconds).<br/>
-    /// * <see cref="Timeout.InfiniteTimeSpan"/> (-1 millisecond): means infinity wait to acquire<br/>
-    /// * Value greater than or equal to 0.<br/>
-    /// </param>
-    /// <param name="releaseOnDispose">
-    /// <see langword="true"/> to release the lock when the returned handle is disposed;
-    /// <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>.
-    /// </param>
-    /// <param name="monitoring">
-    /// Controls whether and how the lease is monitored. See <see cref="LockMonitoringMode"/> for
-    /// per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and
-    /// <see cref="LockMonitoringMode.AutoExtend"/> require a finite <paramref name="timeUntilExpires"/>;
-    /// combining either with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws
-    /// <see cref="ArgumentException"/>.
+    /// <param name="options">
+    /// Per-call configuration (lease TTL, acquire timeout, release-on-dispose, monitoring mode).
+    /// <see langword="null"/> applies the provider defaults. See <see cref="DistributedLockAcquireOptions"/>.
     /// </param>
     /// <param name="cancellationToken"></param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <see cref="DistributedLockAcquireOptions.Monitoring"/> is
+    /// <see cref="LockMonitoringMode.Monitor"/> or <see cref="LockMonitoringMode.AutoExtend"/> but
+    /// <see cref="DistributedLockAcquireOptions.TimeUntilExpires"/> is <see cref="Timeout.InfiniteTimeSpan"/>
+    /// (monitoring requires a finite lease).
+    /// </exception>
     Task<IDistributedLock> AcquireAsync(
         string resource,
-        TimeSpan? timeUntilExpires = null,
-        TimeSpan? acquireTimeout = null,
-        bool releaseOnDispose = true,
-        LockMonitoringMode monitoring = LockMonitoringMode.None,
+        DistributedLockAcquireOptions? options = null,
         CancellationToken cancellationToken = default
     );
 
     /// <summary>
     /// Acquires a resource lock for a specified resource this method will block
-    /// until the lock is acquired or the <paramref name="acquireTimeout"/> is reached.
+    /// until the lock is acquired or the <see cref="DistributedLockAcquireOptions.AcquireTimeout"/> is reached.
     /// </summary>
     /// <param name="resource">The resource to acquire the lock for.</param>
-    /// <param name="timeUntilExpires">
-    /// The amount of time until the lock expires. The allowed values are:<br/>
-    /// * <see langword="null"/>: means the default value <see cref="DefaultTimeUntilExpires"/> (20 minutes).<br/>
-    /// * <see cref="Timeout.InfiniteTimeSpan"/> (-1 milliseconds): means infinity no expiration set.<br/>
-    /// * Value greater than 0.<br/>
-    /// </param>
-    /// <param name="acquireTimeout">
-    /// The amount of time to wait for the lock to be acquired. The allowed values are:<br/>
-    /// * <see langword="null"/>: means the default value <see cref="DefaultAcquireTimeout"/> (30 seconds).<br/>
-    /// * <see cref="Timeout.InfiniteTimeSpan"/> (-1 millisecond): means infinity wait to acquire<br/>
-    /// * Value greater than or equal to 0.<br/>
-    /// </param>
-    /// <param name="releaseOnDispose">
-    /// <see langword="true"/> to release the lock when the returned handle is disposed;
-    /// <see langword="false"/> to require explicit <see cref="IDistributedLock.ReleaseAsync"/>.
-    /// </param>
-    /// <param name="monitoring">
-    /// Controls whether and how the lease is monitored. See <see cref="LockMonitoringMode"/> for
-    /// per-value behavior. <see cref="LockMonitoringMode.Monitor"/> and
-    /// <see cref="LockMonitoringMode.AutoExtend"/> require a finite <paramref name="timeUntilExpires"/>;
-    /// combining either with <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> throws
-    /// <see cref="ArgumentException"/>.
+    /// <param name="options">
+    /// Per-call configuration (lease TTL, acquire timeout, release-on-dispose, monitoring mode).
+    /// <see langword="null"/> applies the provider defaults. See <see cref="DistributedLockAcquireOptions"/>.
     /// </param>
     /// <param name="cancellationToken"></param>
     /// <returns>
     /// A task that represents the asynchronous operation.
     /// The task result contains the acquired lock or null if the lock could not be acquired.
     /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <see cref="DistributedLockAcquireOptions.Monitoring"/> is
+    /// <see cref="LockMonitoringMode.Monitor"/> or <see cref="LockMonitoringMode.AutoExtend"/> but
+    /// <see cref="DistributedLockAcquireOptions.TimeUntilExpires"/> is <see cref="Timeout.InfiniteTimeSpan"/>
+    /// (monitoring requires a finite lease).
+    /// </exception>
     /// <remarks>
-    /// When <paramref name="acquireTimeout"/> is <see cref="TimeSpan.Zero"/> the implementation runs a single
-    /// storage attempt with no retry loop (the "try once, no wait" semantic). The attempt is bounded by an
-    /// internal safety deadline so a stalled lock-store call cannot hang the caller indefinitely, even when
-    /// <paramref name="cancellationToken"/> is <see cref="CancellationToken.None"/>. The deadline is a ceiling
-    /// on the storage round-trip, not a wait budget — under healthy lock-store conditions the call completes
-    /// well within it. The caller's <paramref name="cancellationToken"/> still takes precedence if it fires
-    /// first. See issue #297 and the F#2 review finding from PR #284 for the rationale.
+    /// When <see cref="DistributedLockAcquireOptions.AcquireTimeout"/> is <see cref="TimeSpan.Zero"/> the
+    /// implementation runs a single storage attempt with no retry loop (the "try once, no wait" semantic).
+    /// The attempt is bounded by an internal safety deadline so a stalled lock-store call cannot hang the
+    /// caller indefinitely, even when <paramref name="cancellationToken"/> is <see cref="CancellationToken.None"/>.
+    /// The deadline is a ceiling on the storage round-trip, not a wait budget — under healthy lock-store
+    /// conditions the call completes well within it. The caller's <paramref name="cancellationToken"/> still
+    /// takes precedence if it fires first. See issue #297 and the F#2 review finding from PR #284 for the rationale.
     /// </remarks>
     Task<IDistributedLock?> TryAcquireAsync(
         string resource,
-        TimeSpan? timeUntilExpires = null,
-        TimeSpan? acquireTimeout = null,
-        bool releaseOnDispose = true,
-        LockMonitoringMode monitoring = LockMonitoringMode.None,
+        DistributedLockAcquireOptions? options = null,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/LockMonitoringMode.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/LockMonitoringMode.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace
+namespace Headless.DistributedLocks;
+
+/// <summary>Controls whether and how a held lease is monitored for liveness.</summary>
+[PublicAPI]
+public enum LockMonitoringMode
+{
+    /// <summary>No background monitor. <see cref="IDistributedLock.HandleLostToken"/> is <see cref="CancellationToken.None"/>. Lowest cost; suitable for short-lived locks where lease-loss detection is not needed.</summary>
+    None = 0,
+
+    /// <summary>Background monitor validates the lease at the configured polling cadence (default ½ TTL). <see cref="IDistributedLock.HandleLostToken"/> cancels when the lease is detected lost (storage shows a different lockId) or when accumulated transient failures cross the safety-net threshold. No background renewal — work past TTL fires <c>HandleLostToken</c>.</summary>
+    Monitor = 1,
+
+    /// <summary>Background monitor renews the lease at the configured auto-extension cadence (default 1/3 TTL) and validates between renewals. Work past TTL succeeds; <see cref="IDistributedLock.HandleLostToken"/> cancels only on confirmed loss or self-loss after repeated transient failures. Implies <see cref="Monitor"/> behavior plus extension.</summary>
+    AutoExtend = 2,
+}

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
@@ -21,8 +21,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
-        bool monitorLease = false,
-        bool autoExtend = false,
+        LockMonitoringMode monitoring = LockMonitoringMode.None,
         CancellationToken cancellationToken = default
     )
     {
@@ -36,8 +35,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
-        bool monitorLease = false,
-        bool autoExtend = false,
+        LockMonitoringMode monitoring = LockMonitoringMode.None,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
@@ -113,6 +113,8 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
 
         public CancellationToken HandleLostToken => CancellationToken.None;
 
+        public bool IsMonitored => false;
+
         public Task ReleaseAsync()
         {
             return Task.CompletedTask;

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
@@ -25,9 +25,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         cancellationToken.ThrowIfCancellationRequested();
         _ValidateAcquireOptions(options);
 
-        return Task.FromResult<IDistributedLock>(
-            new NullDistributedLock(resource, timeProvider, _IsMonitoringRequested(options))
-        );
+        return Task.FromResult<IDistributedLock>(new NullDistributedLock(resource, timeProvider));
     }
 
     public Task<IDistributedLock?> TryAcquireAsync(
@@ -39,9 +37,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         cancellationToken.ThrowIfCancellationRequested();
         _ValidateAcquireOptions(options);
 
-        return Task.FromResult<IDistributedLock?>(
-            new NullDistributedLock(resource, timeProvider, _IsMonitoringRequested(options))
-        );
+        return Task.FromResult<IDistributedLock?>(new NullDistributedLock(resource, timeProvider));
     }
 
     public Task<bool> RenewAsync(
@@ -111,11 +107,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         return options is { Monitoring: not LockMonitoringMode.None };
     }
 
-    private sealed class NullDistributedLock(
-        string resource,
-        TimeProvider timeProvider,
-        bool isMonitored
-    ) : IDistributedLock
+    private sealed class NullDistributedLock(string resource, TimeProvider timeProvider) : IDistributedLock
     {
         private int _renewalCount;
 
@@ -131,7 +123,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
 
         public CancellationToken HandleLostToken => CancellationToken.None;
 
-        public bool IsMonitored { get; } = isMonitored;
+        public bool IsMonitored => false;
 
         public Task ReleaseAsync()
         {

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
@@ -18,10 +18,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
 
     public Task<IDistributedLock> AcquireAsync(
         string resource,
-        TimeSpan? timeUntilExpires = null,
-        TimeSpan? acquireTimeout = null,
-        bool releaseOnDispose = true,
-        LockMonitoringMode monitoring = LockMonitoringMode.None,
+        DistributedLockAcquireOptions? options = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -32,10 +29,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
 
     public Task<IDistributedLock?> TryAcquireAsync(
         string resource,
-        TimeSpan? timeUntilExpires = null,
-        TimeSpan? acquireTimeout = null,
-        bool releaseOnDispose = true,
-        LockMonitoringMode monitoring = LockMonitoringMode.None,
+        DistributedLockAcquireOptions? options = null,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
@@ -23,8 +23,11 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _ValidateAcquireOptions(options);
 
-        return Task.FromResult<IDistributedLock>(new NullDistributedLock(resource, timeProvider));
+        return Task.FromResult<IDistributedLock>(
+            new NullDistributedLock(resource, timeProvider, _IsMonitoringRequested(options))
+        );
     }
 
     public Task<IDistributedLock?> TryAcquireAsync(
@@ -34,8 +37,11 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _ValidateAcquireOptions(options);
 
-        return Task.FromResult<IDistributedLock?>(new NullDistributedLock(resource, timeProvider));
+        return Task.FromResult<IDistributedLock?>(
+            new NullDistributedLock(resource, timeProvider, _IsMonitoringRequested(options))
+        );
     }
 
     public Task<bool> RenewAsync(
@@ -89,7 +95,27 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         return Task.FromResult(0L);
     }
 
-    private sealed class NullDistributedLock(string resource, TimeProvider timeProvider) : IDistributedLock
+    private static void _ValidateAcquireOptions(DistributedLockAcquireOptions? options)
+    {
+        if (_IsMonitoringRequested(options) && options?.TimeUntilExpires == Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentException(
+                "Lease monitoring requires a finite time until expiration.",
+                nameof(options)
+            );
+        }
+    }
+
+    private static bool _IsMonitoringRequested(DistributedLockAcquireOptions? options)
+    {
+        return options is { Monitoring: not LockMonitoringMode.None };
+    }
+
+    private sealed class NullDistributedLock(
+        string resource,
+        TimeProvider timeProvider,
+        bool isMonitored
+    ) : IDistributedLock
     {
         private int _renewalCount;
 
@@ -105,7 +131,7 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
 
         public CancellationToken HandleLostToken => CancellationToken.None;
 
-        public bool IsMonitored => false;
+        public bool IsMonitored { get; } = isMonitored;
 
         public Task ReleaseAsync()
         {

--- a/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Abstractions/RegularLocks/NullDistributedLockProvider.cs
@@ -21,6 +21,8 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
+        bool monitorLease = false,
+        bool autoExtend = false,
         CancellationToken cancellationToken = default
     )
     {
@@ -34,6 +36,8 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
+        bool monitorLease = false,
+        bool autoExtend = false,
         CancellationToken cancellationToken = default
     )
     {
@@ -52,6 +56,13 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         cancellationToken.ThrowIfCancellationRequested();
 
         return Task.FromResult(true);
+    }
+
+    public Task<string?> GetLockIdAsync(string resource, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult<string?>(null);
     }
 
     public Task ReleaseAsync(string resource, string lockId, CancellationToken cancellationToken = default)
@@ -99,6 +110,8 @@ public sealed class NullDistributedLockProvider(TimeProvider timeProvider) : IDi
         public DateTimeOffset DateAcquired { get; } = timeProvider.GetUtcNow();
 
         public TimeSpan TimeWaitedForLock => TimeSpan.Zero;
+
+        public CancellationToken HandleLostToken => CancellationToken.None;
 
         public Task ReleaseAsync()
         {

--- a/src/Headless.DistributedLocks.Cache/README.md
+++ b/src/Headless.DistributedLocks.Cache/README.md
@@ -10,7 +10,8 @@ Stores lock records through `ICache` so applications can reuse an existing cache
 
 - `CacheDistributedLockStorage` implements `IDistributedLockStorage`.
 - Uses cache TTL for lock expiration.
-- Works with memory, Redis, hybrid, or custom cache providers through `ICache`.
+- Works with memory, Redis, or custom cache providers through `ICache`.
+- Do not use `HybridCache` for monitored or auto-extending leases; local L1 reads can outlive the distributed lock TTL and hide lease loss.
 
 ## Installation
 
@@ -32,6 +33,8 @@ builder.Services.AddDistributedLock<CacheDistributedLockStorage>(options =>
 ## Configuration
 
 No storage-specific configuration. Configure the selected `ICache` provider and `DistributedLockOptions`. `LockMonitoringMode` (lease monitoring and auto-extension) is a storage-agnostic provider feature configured through `Headless.DistributedLocks.Core`.
+
+Avoid `HybridCache` for `LockMonitoringMode.Monitor` and `LockMonitoringMode.AutoExtend`. Lease validation reads the current lock id through `ICache`; `HybridCache` may satisfy that read from its local L1 cache even after the distributed TTL has expired. Use `Headless.DistributedLocks.Redis` for monitored Redis-backed locks, or use a cache provider whose reads are distributed and TTL-accurate.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Cache/README.md
+++ b/src/Headless.DistributedLocks.Cache/README.md
@@ -31,7 +31,7 @@ builder.Services.AddDistributedLock<CacheDistributedLockStorage>(options =>
 
 ## Configuration
 
-No storage-specific configuration. Configure the selected `ICache` provider and `DistributedLockOptions`.
+No storage-specific configuration. Configure the selected `ICache` provider and `DistributedLockOptions`. Lease monitoring and `autoExtend` are storage-agnostic provider features configured through `Headless.DistributedLocks.Core`.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Cache/README.md
+++ b/src/Headless.DistributedLocks.Cache/README.md
@@ -31,7 +31,7 @@ builder.Services.AddDistributedLock<CacheDistributedLockStorage>(options =>
 
 ## Configuration
 
-No storage-specific configuration. Configure the selected `ICache` provider and `DistributedLockOptions`. Lease monitoring and `autoExtend` are storage-agnostic provider features configured through `Headless.DistributedLocks.Core`.
+No storage-specific configuration. Configure the selected `ICache` provider and `DistributedLockOptions`. `LockMonitoringMode` (lease monitoring and auto-extension) is a storage-agnostic provider feature configured through `Headless.DistributedLocks.Core`.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Core/Headless.DistributedLocks.Core.csproj
+++ b/src/Headless.DistributedLocks.Core/Headless.DistributedLocks.Core.csproj
@@ -4,6 +4,9 @@
     <RootNamespace>Headless.DistributedLocks</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Headless.DistributedLocks.Tests.Unit" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" />
     <PackageReference Include="Polly.Core" />
   </ItemGroup>

--- a/src/Headless.DistributedLocks.Core/README.md
+++ b/src/Headless.DistributedLocks.Core/README.md
@@ -17,7 +17,7 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 
 - `IOutboxPublisher` is optional. Without it, release notifications fall back to polling backoff and a warning is logged once when the provider is constructed.
 - `TryAcquireAsync(..., acquireTimeout: TimeSpan.Zero)` performs a single storage attempt with an internal safety deadline.
-- Lease monitors are opt-in per acquire call through `monitorLease: true`; `autoExtend: true` implies monitoring and renews the lease in the background. Both require a finite `timeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
+- Lease monitors are opt-in per acquire call through `monitoring: LockMonitoringMode.Monitor` (validate only) or `monitoring: LockMonitoringMode.AutoExtend` (validate + renew). Both require a finite `timeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
 - Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence. Self-release deregisters the monitor before publishing so direct `ReleaseAsync` does not produce a spurious lost signal.
 - Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 1`) for programmatic log filtering. `GetActiveMonitorCount` is `internal` and intended for tests only.
 
@@ -51,7 +51,7 @@ options.PollingCadenceFraction = 0.5;
 options.AutoExtensionCadenceFraction = 1.0 / 3.0;
 ```
 
-Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per `AcquireAsync(...)` or `TryAcquireAsync(...)` call. Use `monitorLease: true` for `HandleLostToken` loss detection and `autoExtend: true` for background renewal.
+Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per `AcquireAsync(...)` or `TryAcquireAsync(...)` call. Use `monitoring: LockMonitoringMode.Monitor` for `HandleLostToken` loss detection and `monitoring: LockMonitoringMode.AutoExtend` for background renewal.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Core/README.md
+++ b/src/Headless.DistributedLocks.Core/README.md
@@ -16,8 +16,8 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 ## Design Notes
 
 - `IOutboxPublisher` is optional. Without it, release notifications fall back to polling backoff and a warning is logged once when the provider is constructed.
-- `TryAcquireAsync(..., acquireTimeout: TimeSpan.Zero)` performs a single storage attempt with an internal safety deadline.
-- Lease monitors are opt-in per acquire call through `monitoring: LockMonitoringMode.Monitor` (validate only) or `monitoring: LockMonitoringMode.AutoExtend` (validate + renew). Both require a finite `timeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
+- `TryAcquireAsync(..., new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero })` performs a single storage attempt with an internal safety deadline.
+- Lease monitors are opt-in per acquire call through `Monitoring = LockMonitoringMode.Monitor` (validate only) or `Monitoring = LockMonitoringMode.AutoExtend` (validate + renew) on `DistributedLockAcquireOptions`. Both require a finite `TimeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
 - Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence. Self-release deregisters the monitor before publishing so direct `ReleaseAsync` does not produce a spurious lost signal.
 - Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 1`) for programmatic log filtering. `GetActiveMonitorCount` is `internal` and intended for tests only.
 
@@ -51,7 +51,7 @@ options.PollingCadenceFraction = 0.5;
 options.AutoExtensionCadenceFraction = 1.0 / 3.0;
 ```
 
-Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per `AcquireAsync(...)` or `TryAcquireAsync(...)` call. Use `monitoring: LockMonitoringMode.Monitor` for `HandleLostToken` loss detection and `monitoring: LockMonitoringMode.AutoExtend` for background renewal.
+Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per call by passing a `DistributedLockAcquireOptions` instance to `AcquireAsync(...)` or `TryAcquireAsync(...)`. Set `Monitoring = LockMonitoringMode.Monitor` for `HandleLostToken` loss detection and `Monitoring = LockMonitoringMode.AutoExtend` for background renewal.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Core/README.md
+++ b/src/Headless.DistributedLocks.Core/README.md
@@ -17,8 +17,9 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 
 - `IOutboxPublisher` is optional. Without it, release notifications fall back to polling backoff and a warning is logged once when the provider is constructed.
 - `TryAcquireAsync(..., acquireTimeout: TimeSpan.Zero)` performs a single storage attempt with an internal safety deadline.
-- Lease monitors are opt-in per acquire call through `monitorLease: true`; `autoExtend: true` implies monitoring and renews the lease in the background.
-- Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence.
+- Lease monitors are opt-in per acquire call through `monitorLease: true`; `autoExtend: true` implies monitoring and renews the lease in the background. Both require a finite `timeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
+- Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence. Self-release deregisters the monitor before publishing so direct `ReleaseAsync` does not produce a spurious lost signal.
+- Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 1`) for programmatic log filtering. `GetActiveMonitorCount` is `internal` and intended for tests only.
 
 ## Installation
 

--- a/src/Headless.DistributedLocks.Core/README.md
+++ b/src/Headless.DistributedLocks.Core/README.md
@@ -19,7 +19,7 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 - `TryAcquireAsync(..., new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero })` performs a single storage attempt with an internal safety deadline.
 - Lease monitors are opt-in per acquire call through `Monitoring = LockMonitoringMode.Monitor` (validate only) or `Monitoring = LockMonitoringMode.AutoExtend` (validate + renew) on `DistributedLockAcquireOptions`. Both require a finite `TimeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
 - Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence. Self-release deregisters the monitor before publishing so direct `ReleaseAsync` does not produce a spurious lost signal.
-- Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 1`) for programmatic log filtering. `GetActiveMonitorCount` is `internal` and intended for tests only.
+- Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 30`) for programmatic log filtering. `GetActiveMonitorCount` is `internal` and intended for tests only.
 
 ## Installation
 

--- a/src/Headless.DistributedLocks.Core/README.md
+++ b/src/Headless.DistributedLocks.Core/README.md
@@ -19,7 +19,7 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 - `TryAcquireAsync(..., new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero })` performs a single storage attempt with an internal safety deadline.
 - Lease monitors are opt-in per acquire call through `Monitoring = LockMonitoringMode.Monitor` (validate only) or `Monitoring = LockMonitoringMode.AutoExtend` (validate + renew) on `DistributedLockAcquireOptions`. Both require a finite `TimeUntilExpires`; combining with `Timeout.InfiniteTimeSpan` throws `ArgumentException`.
 - Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence. Self-release deregisters the monitor before publishing so direct `ReleaseAsync` does not produce a spurious lost signal.
-- Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 30`) for programmatic log filtering. `GetActiveMonitorCount` is `internal` and intended for tests only.
+- Intermediate monitor states are surfaced via the `LeaseMonitorStateChanged` log event (`EventId = 30`) for programmatic log filtering. Structured fields are `Resource`, `LockId`, `PreviousState`, and `NextState`. `GetActiveMonitorCount` is `internal` and intended for tests only.
 
 ## Installation
 
@@ -52,6 +52,20 @@ options.AutoExtensionCadenceFraction = 1.0 / 3.0;
 ```
 
 Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per call by passing a `DistributedLockAcquireOptions` instance to `AcquireAsync(...)` or `TryAcquireAsync(...)`. Set `Monitoring = LockMonitoringMode.Monitor` for `HandleLostToken` loss detection and `Monitoring = LockMonitoringMode.AutoExtend` for background renewal.
+
+Use `AutoExtend` when the protected work can exceed the initial TTL and should keep the lease alive while the process is healthy:
+
+```csharp
+await using var lease = await lockProvider.AcquireAsync(
+    "orders:123",
+    new DistributedLockAcquireOptions
+    {
+        TimeUntilExpires = TimeSpan.FromMinutes(5),
+        Monitoring = LockMonitoringMode.AutoExtend,
+    },
+    ct
+);
+```
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Core/README.md
+++ b/src/Headless.DistributedLocks.Core/README.md
@@ -10,13 +10,15 @@ Implements lock acquisition, renewal, release, inspection, timeout handling, and
 
 - `DistributedLockProvider` implements `IDistributedLockProvider`.
 - `DisposableDistributedLock` releases on dispose by default.
-- `DistributedLockOptions` configures key prefix, resource name length, and waiter limits.
+- `DistributedLockOptions` configures key prefix, resource name length, waiter limits, and lease-monitor cadence fractions.
 - `AddDistributedLock(...)` overloads wire storage, options, time provider, ID generator, and optional release consumers.
 
 ## Design Notes
 
 - `IOutboxPublisher` is optional. Without it, release notifications fall back to polling backoff and a warning is logged once when the provider is constructed.
 - `TryAcquireAsync(..., acquireTimeout: TimeSpan.Zero)` performs a single storage attempt with an internal safety deadline.
+- Lease monitors are opt-in per acquire call through `monitorLease: true`; `autoExtend: true` implies monitoring and renews the lease in the background.
+- Release messages also nudge active monitors so lost-handle detection can happen before the next polling cadence.
 
 ## Installation
 
@@ -44,9 +46,11 @@ options.KeyPrefix = "distributed-lock:";
 options.MaxResourceNameLength = 512;
 options.MaxConcurrentWaitingResources = 10_000;
 options.MaxWaitersPerResource = 1_000;
+options.PollingCadenceFraction = 0.5;
+options.AutoExtensionCadenceFraction = 1.0 / 3.0;
 ```
 
-Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per `AcquireAsync(...)` or `TryAcquireAsync(...)` call.
+Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per `AcquireAsync(...)` or `TryAcquireAsync(...)` call. Use `monitorLease: true` for `HandleLostToken` loss detection and `autoExtend: true` for background renewal.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
@@ -217,21 +217,37 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
         // deadline trip we classify as Unknown (transient) and let the safety net self-promote
         // on repeated misses.
         var leaseProbe = _GetOrStartLeaseProbe(cancellationToken);
+        var clearCompletedProbe = false;
 
         try
         {
-            return await _WithStorageDeadlineAsync(
+            var result = await _WithStorageDeadlineAsync(
                     leaseProbe,
                     _storageDeadlineSnapshot,
                     _timeProvider,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+            clearCompletedProbe = true;
+
+            return result;
         }
         catch (TimeoutException)
         {
             // Per-iteration deadline fired without caller cancellation — surface as transient.
             return LeaseMonitor.LeaseState.Unknown;
+        }
+        catch
+        {
+            clearCompletedProbe = true;
+            throw;
+        }
+        finally
+        {
+            if (clearCompletedProbe)
+            {
+                _ClearLeaseProbeIfCurrent(leaseProbe);
+            }
         }
     }
 
@@ -262,6 +278,17 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
             );
 
             return leaseProbe;
+        }
+    }
+
+    private void _ClearLeaseProbeIfCurrent(Task<LeaseMonitor.LeaseState> leaseProbe)
+    {
+        lock (_leaseProbeLock)
+        {
+            if (ReferenceEquals(_pendingLeaseProbe, leaseProbe))
+            {
+                _pendingLeaseProbe = null;
+            }
         }
     }
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
@@ -60,6 +60,8 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
     private readonly long _timestamp;
     private readonly DistributedLockOptions _options;
     private LeaseMonitor? _monitor;
+    private readonly Lock _leaseProbeLock = new();
+    private Task<LeaseMonitor.LeaseState>? _pendingLeaseProbe;
 
     // Snapshotted cadence + per-iteration storage deadline. Avoids re-reading the
     // interface-cast MonitoringCadence on every iteration (which recomputes ticks * fraction
@@ -153,6 +155,7 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
                 _logger.LogDisposableLockReleasing(Resource, LockId, elapsed);
             }
 
+            await _StopMonitorAsync().ConfigureAwait(false);
             await _lockProvider.ReleaseAsync(Resource, LockId, CancellationToken.None).ConfigureAwait(false);
         }
     }
@@ -176,21 +179,7 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
 
         try
         {
-            if (_monitor is not null)
-            {
-                try
-                {
-                    await _monitor.DisposeAsync().ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogDisposableLockMonitorDisposeFailed(e, Resource, LockId);
-                }
-                finally
-                {
-                    _deregisterMonitor?.Invoke(Resource, LockId);
-                }
-            }
+            await _StopMonitorAsync().ConfigureAwait(false);
 
             if (_releaseOnDispose)
             {
@@ -227,50 +216,118 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
         // awaits that task. Capped at min(5s, cadence) and snapshotted at construction. On
         // deadline trip we classify as Unknown (transient) and let the safety net self-promote
         // on repeated misses.
-        using var deadlineSource = _timeProvider.CreateCancellationTokenSource(_storageDeadlineSnapshot);
-        using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            deadlineSource.Token
-        );
+        var leaseProbe = _GetOrStartLeaseProbe(cancellationToken);
 
         try
         {
-            if (_autoExtend)
-            {
-                var renewed = await _lockProvider
-                    .RenewAsync(Resource, LockId, _leaseDuration, linkedSource.Token)
-                    .ConfigureAwait(false);
-
-                if (renewed)
-                {
-                    Interlocked.Increment(ref _renewalCount);
-                    return LeaseMonitor.LeaseState.Renewed;
-                }
-
-                // Disambiguate: RenewAsync returns false for both fence mismatch and transient
-                // retry-exhaustion. Probe ownership before declaring Lost — a transient renewal
-                // failure must not cancel HandleLostToken when storage still confirms ownership.
-                var currentLockIdAfterRenew = await _lockProvider
-                    .GetLockIdAsync(Resource, linkedSource.Token)
-                    .ConfigureAwait(false);
-
-                return string.Equals(currentLockIdAfterRenew, LockId, StringComparison.Ordinal)
-                    ? LeaseMonitor.LeaseState.Unknown
-                    : LeaseMonitor.LeaseState.Lost;
-            }
-
-            var currentLockId = await _lockProvider
-                .GetLockIdAsync(Resource, linkedSource.Token)
+            return await _WithStorageDeadlineAsync(
+                    leaseProbe,
+                    _storageDeadlineSnapshot,
+                    _timeProvider,
+                    cancellationToken
+                )
                 .ConfigureAwait(false);
-
-            return string.Equals(currentLockId, LockId, StringComparison.Ordinal)
-                ? LeaseMonitor.LeaseState.Held
-                : LeaseMonitor.LeaseState.Lost;
         }
-        catch (OperationCanceledException) when (deadlineSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (TimeoutException)
         {
             // Per-iteration deadline fired without caller cancellation — surface as transient.
             return LeaseMonitor.LeaseState.Unknown;
+        }
+    }
+
+    private Task<LeaseMonitor.LeaseState> _GetOrStartLeaseProbe(CancellationToken cancellationToken)
+    {
+        lock (_leaseProbeLock)
+        {
+            if (_pendingLeaseProbe is { } pending)
+            {
+                if (!pending.IsCompleted)
+                {
+                    return pending;
+                }
+
+                _ = pending.Exception;
+                _pendingLeaseProbe = null;
+            }
+
+            var leaseProbe = _RunStorageLeaseProbeAsync(cancellationToken);
+            _pendingLeaseProbe = leaseProbe;
+            _ = leaseProbe.ContinueWith(
+                static task => _ = task.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+            );
+
+            return leaseProbe;
+        }
+    }
+
+    private async Task<LeaseMonitor.LeaseState> _RunStorageLeaseProbeAsync(CancellationToken cancellationToken)
+    {
+        if (_autoExtend)
+        {
+            var renewed = await _lockProvider
+                .RenewAsync(Resource, LockId, _leaseDuration, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (renewed)
+            {
+                Interlocked.Increment(ref _renewalCount);
+                return LeaseMonitor.LeaseState.Renewed;
+            }
+
+            // Disambiguate: RenewAsync returns false for both fence mismatch and transient
+            // retry-exhaustion. Probe ownership before declaring Lost — a transient renewal
+            // failure must not cancel HandleLostToken when storage still confirms ownership.
+            var currentLockIdAfterRenew = await _lockProvider
+                .GetLockIdAsync(Resource, cancellationToken)
+                .ConfigureAwait(false);
+
+            return string.Equals(currentLockIdAfterRenew, LockId, StringComparison.Ordinal)
+                ? LeaseMonitor.LeaseState.Unknown
+                : LeaseMonitor.LeaseState.Lost;
+        }
+
+        var currentLockId = await _lockProvider
+            .GetLockIdAsync(Resource, cancellationToken)
+            .ConfigureAwait(false);
+
+        return string.Equals(currentLockId, LockId, StringComparison.Ordinal)
+            ? LeaseMonitor.LeaseState.Held
+            : LeaseMonitor.LeaseState.Lost;
+    }
+
+    private static async Task<T> _WithStorageDeadlineAsync<T>(
+        Task<T> operation,
+        TimeSpan timeout,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken
+    )
+    {
+        return await operation.WaitAsync(timeout, timeProvider, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask _StopMonitorAsync()
+    {
+        var monitor = Interlocked.Exchange(ref _monitor, null);
+
+        if (monitor is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await monitor.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDisposableLockMonitorDisposeFailed(e, Resource, LockId);
+        }
+        finally
+        {
+            _deregisterMonitor?.Invoke(Resource, LockId);
         }
     }
 }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
@@ -6,46 +6,84 @@ using Nito.AsyncEx;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Headless.DistributedLocks;
 
-public sealed class DisposableDistributedLock(
-    string resource,
-    string lockId,
-    TimeSpan leaseDuration,
-    TimeSpan timeWaitedForLock,
-    IDistributedLockProvider lockProvider,
-    bool releaseOnDispose,
-    bool autoExtend,
-    DistributedLockOptions options,
-    TimeProvider timeProvider,
-    Action<string, string>? deregisterMonitor,
-    ILogger logger
-) : IDistributedLock, LeaseMonitor.ILeaseHandle
+public sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.ILeaseHandle
 {
+    private readonly TimeSpan _leaseDuration;
+    private readonly IDistributedLockProvider _lockProvider;
+    private readonly bool _releaseOnDispose;
+    private readonly bool _autoExtend;
+    private readonly TimeProvider _timeProvider;
+    private readonly Action<string, string>? _deregisterMonitor;
+    private readonly ILogger _logger;
+
+    internal DisposableDistributedLock(
+        string resource,
+        string lockId,
+        TimeSpan leaseDuration,
+        TimeSpan timeWaitedForLock,
+        IDistributedLockProvider lockProvider,
+        bool releaseOnDispose,
+        bool autoExtend,
+        DistributedLockOptions options,
+        TimeProvider timeProvider,
+        Action<string, string>? deregisterMonitor,
+        ILogger logger
+    )
+    {
+        LockId = lockId;
+        Resource = resource;
+        DateAcquired = timeProvider.GetUtcNow();
+        TimeWaitedForLock = timeWaitedForLock;
+        _timestamp = timeProvider.GetTimestamp();
+        _options = options;
+        _leaseDuration = leaseDuration;
+        _lockProvider = lockProvider;
+        _releaseOnDispose = releaseOnDispose;
+        _autoExtend = autoExtend;
+        _timeProvider = timeProvider;
+        _deregisterMonitor = deregisterMonitor;
+        _logger = logger;
+    }
+
     private volatile bool _isReleased;
     private readonly AsyncLock _lock = new();
-    private readonly long _timestamp = timeProvider.GetTimestamp();
-    private readonly DistributedLockOptions _options = options;
+    private readonly long _timestamp;
+    private readonly DistributedLockOptions _options;
     private LeaseMonitor? _monitor;
 
-    public string LockId { get; } = lockId;
+    // Snapshotted at AttachMonitor time so reads after the monitor's underlying CTS is disposed
+    // do not throw ObjectDisposedException. CancellationToken values are valid after the source
+    // is disposed; only IsCancellationRequested/Register on disposed sources throws — and the
+    // snapshot's IsCancellationRequested observes the final cancellation state set during dispose.
+#pragma warning disable IDE0032 // Field-backed by intent (not promoted to auto-property): the
+    // setter is internal (AttachMonitor) but the property must be public on IDistributedLock.
+    private CancellationToken _handleLostToken = CancellationToken.None;
+#pragma warning restore IDE0032
 
-    public string Resource { get; } = resource;
+    public string LockId { get; }
 
-    public DateTimeOffset DateAcquired { get; } = timeProvider.GetUtcNow();
+    public string Resource { get; }
 
-    public TimeSpan TimeWaitedForLock { get; } = timeWaitedForLock;
+    public DateTimeOffset DateAcquired { get; }
 
-    public CancellationToken HandleLostToken => _monitor?.HandleLostToken ?? CancellationToken.None;
+    public TimeSpan TimeWaitedForLock { get; }
 
-    public int RenewalCount { get; private set; }
+    public CancellationToken HandleLostToken => _handleLostToken;
 
-    TimeSpan LeaseMonitor.ILeaseHandle.LeaseDuration => leaseDuration;
+    public bool IsMonitored => _monitor is not null;
+
+    private int _renewalCount;
+
+    public int RenewalCount => Volatile.Read(ref _renewalCount);
+
+    TimeSpan LeaseMonitor.ILeaseHandle.LeaseDuration => _leaseDuration;
 
     TimeSpan LeaseMonitor.ILeaseHandle.MonitoringCadence
     {
         get
         {
-            var fraction = autoExtend ? _options.AutoExtensionCadenceFraction : _options.PollingCadenceFraction;
-            var ticks = Math.Max(1, (long)(leaseDuration.Ticks * fraction));
+            var fraction = _autoExtend ? _options.AutoExtensionCadenceFraction : _options.PollingCadenceFraction;
+            var ticks = Math.Max(1, (long)(_leaseDuration.Ticks * fraction));
 
             return TimeSpan.FromTicks(ticks);
         }
@@ -54,31 +92,32 @@ public sealed class DisposableDistributedLock(
     internal void AttachMonitor(LeaseMonitor monitor)
     {
         _monitor = monitor;
+        _handleLostToken = monitor.HandleLostToken;
     }
 
     public async Task<bool> RenewAsync(TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
-        if (logger.IsEnabled(LogLevel.Trace))
+        if (_logger.IsEnabled(LogLevel.Trace))
         {
-            logger.LogDisposableLockRenewing(Resource, LockId);
+            _logger.LogDisposableLockRenewing(Resource, LockId);
         }
 
-        var result = await lockProvider
+        var result = await _lockProvider
             .RenewAsync(Resource, LockId, timeUntilExpires, cancellationToken)
             .ConfigureAwait(false);
 
         if (!result)
         {
-            logger.LogDisposableLockRenewFailed(Resource, LockId);
+            _logger.LogDisposableLockRenewFailed(Resource, LockId);
 
             return false;
         }
 
-        RenewalCount++;
+        Interlocked.Increment(ref _renewalCount);
 
-        if (logger.IsEnabled(LogLevel.Debug))
+        if (_logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDisposableLockRenewed(Resource, LockId);
+            _logger.LogDisposableLockRenewed(Resource, LockId);
         }
 
         return true;
@@ -100,24 +139,24 @@ public sealed class DisposableDistributedLock(
 
             _isReleased = true;
 
-            if (logger.IsEnabled(LogLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                var elapsed = timeProvider.GetElapsedTime(_timestamp);
+                var elapsed = _timeProvider.GetElapsedTime(_timestamp);
 
-                logger.LogDisposableLockReleasing(Resource, LockId, elapsed);
+                _logger.LogDisposableLockReleasing(Resource, LockId, elapsed);
             }
 
-            await lockProvider.ReleaseAsync(Resource, LockId, CancellationToken.None).ConfigureAwait(false);
+            await _lockProvider.ReleaseAsync(Resource, LockId, CancellationToken.None).ConfigureAwait(false);
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        var isTraceLogLevelEnabled = logger.IsEnabled(LogLevel.Trace);
+        var isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
 
         if (isTraceLogLevelEnabled)
         {
-            logger.LogDisposableLockDisposing(Resource, LockId);
+            _logger.LogDisposableLockDisposing(Resource, LockId);
         }
 
         try
@@ -130,51 +169,96 @@ public sealed class DisposableDistributedLock(
                 }
                 catch (Exception e)
                 {
-                    logger.LogDisposableLockMonitorDisposeFailed(e, Resource, LockId);
+                    _logger.LogDisposableLockMonitorDisposeFailed(e, Resource, LockId);
                 }
                 finally
                 {
-                    deregisterMonitor?.Invoke(Resource, LockId);
+                    _deregisterMonitor?.Invoke(Resource, LockId);
                 }
             }
 
-            if (releaseOnDispose)
+            if (_releaseOnDispose)
             {
                 await ReleaseAsync().ConfigureAwait(false);
             }
         }
         catch (Exception e)
         {
-            if (logger.IsEnabled(LogLevel.Error))
-            {
-                logger.LogDisposableLockReleaseFailed(e, Resource, LockId);
-            }
+            _logger.LogDisposableLockReleaseFailed(e, Resource, LockId);
         }
 
         if (isTraceLogLevelEnabled)
         {
-            logger.LogDisposableLockDisposed(Resource, LockId);
+            _logger.LogDisposableLockDisposed(Resource, LockId);
         }
     }
 
+    /// <summary>
+    /// Auto-extend mode: attempt <see cref="IDistributedLockProvider.RenewAsync"/>. A successful
+    /// renewal returns <see cref="LeaseMonitor.LeaseState.Renewed"/>. A <see langword="false"/>
+    /// result is ambiguous (genuine fence mismatch vs. transient retry-exhaustion), so we probe
+    /// ownership via <see cref="IDistributedLockProvider.GetLockIdAsync"/>: matching id ⇒
+    /// <see cref="LeaseMonitor.LeaseState.Unknown"/> (let the safety net self-promote on
+    /// repeated failures), differing or absent id ⇒ <see cref="LeaseMonitor.LeaseState.Lost"/>.
+    /// Polling mode: only probe ownership.
+    /// </summary>
     async Task<LeaseMonitor.LeaseState> LeaseMonitor.ILeaseHandle.RenewOrValidateLeaseAsync(
         CancellationToken cancellationToken
     )
     {
-        if (autoExtend)
+        // Per-iteration deadline: bounds a single storage round-trip so a stuck/blocked
+        // storage call (e.g., StackExchange.Redis reconnect storm that ignores its CT) cannot
+        // wedge MonitoringTask — and therefore cannot wedge LeaseMonitor.DisposeAsync, which
+        // awaits that task. Capped at min(5s, cadence). On deadline trip we classify as
+        // Unknown (transient) and let the safety net self-promote on repeated misses.
+        var cadence = ((LeaseMonitor.ILeaseHandle)this).MonitoringCadence;
+        var deadline = cadence.TotalSeconds < 5.0 ? cadence : TimeSpan.FromSeconds(5);
+
+        using var deadlineSource = _timeProvider.CreateCancellationTokenSource(deadline);
+        using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            deadlineSource.Token
+        );
+
+        try
         {
-            var renewed = await lockProvider
-                .RenewAsync(Resource, LockId, leaseDuration, cancellationToken)
+            if (_autoExtend)
+            {
+                var renewed = await _lockProvider
+                    .RenewAsync(Resource, LockId, _leaseDuration, linkedSource.Token)
+                    .ConfigureAwait(false);
+
+                if (renewed)
+                {
+                    Interlocked.Increment(ref _renewalCount);
+                    return LeaseMonitor.LeaseState.Renewed;
+                }
+
+                // Disambiguate: RenewAsync returns false for both fence mismatch and transient
+                // retry-exhaustion. Probe ownership before declaring Lost — a transient renewal
+                // failure must not cancel HandleLostToken when storage still confirms ownership.
+                var currentLockIdAfterRenew = await _lockProvider
+                    .GetLockIdAsync(Resource, linkedSource.Token)
+                    .ConfigureAwait(false);
+
+                return string.Equals(currentLockIdAfterRenew, LockId, StringComparison.Ordinal)
+                    ? LeaseMonitor.LeaseState.Unknown
+                    : LeaseMonitor.LeaseState.Lost;
+            }
+
+            var currentLockId = await _lockProvider
+                .GetLockIdAsync(Resource, linkedSource.Token)
                 .ConfigureAwait(false);
 
-            return renewed ? LeaseMonitor.LeaseState.Renewed : LeaseMonitor.LeaseState.Lost;
+            return string.Equals(currentLockId, LockId, StringComparison.Ordinal)
+                ? LeaseMonitor.LeaseState.Held
+                : LeaseMonitor.LeaseState.Lost;
         }
-
-        var currentLockId = await lockProvider.GetLockIdAsync(Resource, cancellationToken).ConfigureAwait(false);
-
-        return string.Equals(currentLockId, LockId, StringComparison.Ordinal)
-            ? LeaseMonitor.LeaseState.Held
-            : LeaseMonitor.LeaseState.Lost;
+        catch (OperationCanceledException) when (deadlineSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Per-iteration deadline fired without caller cancellation — surface as transient.
+            return LeaseMonitor.LeaseState.Unknown;
+        }
     }
 }
 
@@ -186,7 +270,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Trace,
         Message = "Renewing lock {Resource} ({LockId})"
     )]
-    public static partial void LogDisposableLockRenewing(this ILogger logger, string resource, string lockId);
+    public static partial void LogDisposableLockRenewing(this ILogger _logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 2,
@@ -194,7 +278,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Debug,
         Message = "Unable to renew lock {Resource} ({LockId})"
     )]
-    public static partial void LogDisposableLockRenewFailed(this ILogger logger, string resource, string lockId);
+    public static partial void LogDisposableLockRenewFailed(this ILogger _logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 3,
@@ -202,7 +286,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Debug,
         Message = "Renewed lock {Resource} ({LockId})"
     )]
-    public static partial void LogDisposableLockRenewed(this ILogger logger, string resource, string lockId);
+    public static partial void LogDisposableLockRenewed(this ILogger _logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 4,
@@ -211,7 +295,7 @@ internal static partial class DisposableDistributedLockLog
         Message = "Releasing lock: R={Resource} Id={LockId} after {Duration:g}"
     )]
     public static partial void LogDisposableLockReleasing(
-        this ILogger logger,
+        this ILogger _logger,
         string resource,
         string lockId,
         TimeSpan duration
@@ -223,7 +307,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Trace,
         Message = "Disposing lock: R={Resource} Id={LockId}"
     )]
-    public static partial void LogDisposableLockDisposing(this ILogger logger, string resource, string lockId);
+    public static partial void LogDisposableLockDisposing(this ILogger _logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 6,
@@ -232,7 +316,7 @@ internal static partial class DisposableDistributedLockLog
         Message = "Unable to release lock: R={Resource} Id={LockId}"
     )]
     public static partial void LogDisposableLockReleaseFailed(
-        this ILogger logger,
+        this ILogger _logger,
         Exception exception,
         string resource,
         string lockId
@@ -244,7 +328,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Trace,
         Message = "Disposed lock: R={Resource} Id={LockId}"
     )]
-    public static partial void LogDisposableLockDisposed(this ILogger logger, string resource, string lockId);
+    public static partial void LogDisposableLockDisposed(this ILogger _logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 8,
@@ -253,7 +337,7 @@ internal static partial class DisposableDistributedLockLog
         Message = "Unable to dispose lease monitor before releasing lock: R={Resource} Id={LockId}"
     )]
     public static partial void LogDisposableLockMonitorDisposeFailed(
-        this ILogger logger,
+        this ILogger _logger,
         Exception exception,
         string resource,
         string lockId

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
@@ -9,16 +9,22 @@ namespace Headless.DistributedLocks;
 public sealed class DisposableDistributedLock(
     string resource,
     string lockId,
+    TimeSpan leaseDuration,
     TimeSpan timeWaitedForLock,
     IDistributedLockProvider lockProvider,
     bool releaseOnDispose,
+    bool autoExtend,
+    DistributedLockOptions options,
     TimeProvider timeProvider,
+    Action<string, string>? deregisterMonitor,
     ILogger logger
-) : IDistributedLock
+) : IDistributedLock, LeaseMonitor.ILeaseHandle
 {
     private volatile bool _isReleased;
     private readonly AsyncLock _lock = new();
     private readonly long _timestamp = timeProvider.GetTimestamp();
+    private readonly DistributedLockOptions _options = options;
+    private LeaseMonitor? _monitor;
 
     public string LockId { get; } = lockId;
 
@@ -28,7 +34,27 @@ public sealed class DisposableDistributedLock(
 
     public TimeSpan TimeWaitedForLock { get; } = timeWaitedForLock;
 
+    public CancellationToken HandleLostToken => _monitor?.HandleLostToken ?? CancellationToken.None;
+
     public int RenewalCount { get; private set; }
+
+    TimeSpan LeaseMonitor.ILeaseHandle.LeaseDuration => leaseDuration;
+
+    TimeSpan LeaseMonitor.ILeaseHandle.MonitoringCadence
+    {
+        get
+        {
+            var fraction = autoExtend ? _options.AutoExtensionCadenceFraction : _options.PollingCadenceFraction;
+            var ticks = Math.Max(1, (long)(leaseDuration.Ticks * fraction));
+
+            return TimeSpan.FromTicks(ticks);
+        }
+    }
+
+    internal void AttachMonitor(LeaseMonitor monitor)
+    {
+        _monitor = monitor;
+    }
 
     public async Task<bool> RenewAsync(TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
@@ -96,6 +122,22 @@ public sealed class DisposableDistributedLock(
 
         try
         {
+            if (_monitor is not null)
+            {
+                try
+                {
+                    await _monitor.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    logger.LogDisposableLockMonitorDisposeFailed(e, Resource, LockId);
+                }
+                finally
+                {
+                    deregisterMonitor?.Invoke(Resource, LockId);
+                }
+            }
+
             if (releaseOnDispose)
             {
                 await ReleaseAsync().ConfigureAwait(false);
@@ -113,6 +155,26 @@ public sealed class DisposableDistributedLock(
         {
             logger.LogDisposableLockDisposed(Resource, LockId);
         }
+    }
+
+    async Task<LeaseMonitor.LeaseState> LeaseMonitor.ILeaseHandle.RenewOrValidateLeaseAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        if (autoExtend)
+        {
+            var renewed = await lockProvider
+                .RenewAsync(Resource, LockId, leaseDuration, cancellationToken)
+                .ConfigureAwait(false);
+
+            return renewed ? LeaseMonitor.LeaseState.Renewed : LeaseMonitor.LeaseState.Lost;
+        }
+
+        var currentLockId = await lockProvider.GetLockIdAsync(Resource, cancellationToken).ConfigureAwait(false);
+
+        return string.Equals(currentLockId, LockId, StringComparison.Ordinal)
+            ? LeaseMonitor.LeaseState.Held
+            : LeaseMonitor.LeaseState.Lost;
     }
 }
 
@@ -183,4 +245,17 @@ internal static partial class DisposableDistributedLockLog
         Message = "Disposed lock: R={Resource} Id={LockId}"
     )]
     public static partial void LogDisposableLockDisposed(this ILogger logger, string resource, string lockId);
+
+    [LoggerMessage(
+        EventId = 8,
+        EventName = "DisposableLockMonitorDisposeFailed",
+        Level = LogLevel.Warning,
+        Message = "Unable to dispose lease monitor before releasing lock: R={Resource} Id={LockId}"
+    )]
+    public static partial void LogDisposableLockMonitorDisposeFailed(
+        this ILogger logger,
+        Exception exception,
+        string resource,
+        string lockId
+    );
 }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
@@ -248,6 +248,8 @@ internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor
 
                 _ = pending.Exception;
                 _pendingLeaseProbe = null;
+
+                return pending;
             }
 
             var leaseProbe = _RunStorageLeaseProbeAsync(cancellationToken);

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DisposableDistributedLock.cs
@@ -6,7 +6,7 @@ using Nito.AsyncEx;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Headless.DistributedLocks;
 
-public sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.ILeaseHandle
+internal sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.ILeaseHandle
 {
     private readonly TimeSpan _leaseDuration;
     private readonly IDistributedLockProvider _lockProvider;
@@ -43,13 +43,29 @@ public sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.I
         _timeProvider = timeProvider;
         _deregisterMonitor = deregisterMonitor;
         _logger = logger;
+
+        // Snapshot cadence + storage deadline once. Both are constant for the lifetime of this
+        // handle and were previously recomputed on every monitor iteration.
+        var fraction = autoExtend ? options.AutoExtensionCadenceFraction : options.PollingCadenceFraction;
+        var cadenceTicks = Math.Max(1, (long)(leaseDuration.Ticks * fraction));
+        _monitoringCadenceSnapshot = TimeSpan.FromTicks(cadenceTicks);
+        _storageDeadlineSnapshot = _monitoringCadenceSnapshot.TotalSeconds < 5.0
+            ? _monitoringCadenceSnapshot
+            : TimeSpan.FromSeconds(5);
     }
 
     private volatile bool _isReleased;
+    private int _disposed;
     private readonly AsyncLock _lock = new();
     private readonly long _timestamp;
     private readonly DistributedLockOptions _options;
     private LeaseMonitor? _monitor;
+
+    // Snapshotted cadence + per-iteration storage deadline. Avoids re-reading the
+    // interface-cast MonitoringCadence on every iteration (which recomputes ticks * fraction
+    // and allocates) and is constant for the lifetime of this handle.
+    private readonly TimeSpan _monitoringCadenceSnapshot;
+    private readonly TimeSpan _storageDeadlineSnapshot;
 
     // Snapshotted at AttachMonitor time so reads after the monitor's underlying CTS is disposed
     // do not throw ObjectDisposedException. CancellationToken values are valid after the source
@@ -78,16 +94,7 @@ public sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.I
 
     TimeSpan LeaseMonitor.ILeaseHandle.LeaseDuration => _leaseDuration;
 
-    TimeSpan LeaseMonitor.ILeaseHandle.MonitoringCadence
-    {
-        get
-        {
-            var fraction = _autoExtend ? _options.AutoExtensionCadenceFraction : _options.PollingCadenceFraction;
-            var ticks = Math.Max(1, (long)(_leaseDuration.Ticks * fraction));
-
-            return TimeSpan.FromTicks(ticks);
-        }
-    }
+    TimeSpan LeaseMonitor.ILeaseHandle.MonitoringCadence => _monitoringCadenceSnapshot;
 
     internal void AttachMonitor(LeaseMonitor monitor)
     {
@@ -152,6 +159,14 @@ public sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.I
 
     public async ValueTask DisposeAsync()
     {
+        // Idempotency: matches the LeaseMonitor.DisposeAsync pattern. Re-entry (e.g., a
+        // HandleLostToken callback that disposes the handle while the caller also disposes)
+        // must be a no-op rather than running release/monitor-dispose twice.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
         var isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
 
         if (isTraceLogLevelEnabled)
@@ -209,12 +224,10 @@ public sealed class DisposableDistributedLock : IDistributedLock, LeaseMonitor.I
         // Per-iteration deadline: bounds a single storage round-trip so a stuck/blocked
         // storage call (e.g., StackExchange.Redis reconnect storm that ignores its CT) cannot
         // wedge MonitoringTask — and therefore cannot wedge LeaseMonitor.DisposeAsync, which
-        // awaits that task. Capped at min(5s, cadence). On deadline trip we classify as
-        // Unknown (transient) and let the safety net self-promote on repeated misses.
-        var cadence = ((LeaseMonitor.ILeaseHandle)this).MonitoringCadence;
-        var deadline = cadence.TotalSeconds < 5.0 ? cadence : TimeSpan.FromSeconds(5);
-
-        using var deadlineSource = _timeProvider.CreateCancellationTokenSource(deadline);
+        // awaits that task. Capped at min(5s, cadence) and snapshotted at construction. On
+        // deadline trip we classify as Unknown (transient) and let the safety net self-promote
+        // on repeated misses.
+        using var deadlineSource = _timeProvider.CreateCancellationTokenSource(_storageDeadlineSnapshot);
         using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
             deadlineSource.Token
@@ -270,7 +283,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Trace,
         Message = "Renewing lock {Resource} ({LockId})"
     )]
-    public static partial void LogDisposableLockRenewing(this ILogger _logger, string resource, string lockId);
+    public static partial void LogDisposableLockRenewing(this ILogger logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 2,
@@ -278,7 +291,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Debug,
         Message = "Unable to renew lock {Resource} ({LockId})"
     )]
-    public static partial void LogDisposableLockRenewFailed(this ILogger _logger, string resource, string lockId);
+    public static partial void LogDisposableLockRenewFailed(this ILogger logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 3,
@@ -286,7 +299,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Debug,
         Message = "Renewed lock {Resource} ({LockId})"
     )]
-    public static partial void LogDisposableLockRenewed(this ILogger _logger, string resource, string lockId);
+    public static partial void LogDisposableLockRenewed(this ILogger logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 4,
@@ -295,7 +308,7 @@ internal static partial class DisposableDistributedLockLog
         Message = "Releasing lock: R={Resource} Id={LockId} after {Duration:g}"
     )]
     public static partial void LogDisposableLockReleasing(
-        this ILogger _logger,
+        this ILogger logger,
         string resource,
         string lockId,
         TimeSpan duration
@@ -307,7 +320,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Trace,
         Message = "Disposing lock: R={Resource} Id={LockId}"
     )]
-    public static partial void LogDisposableLockDisposing(this ILogger _logger, string resource, string lockId);
+    public static partial void LogDisposableLockDisposing(this ILogger logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 6,
@@ -316,7 +329,7 @@ internal static partial class DisposableDistributedLockLog
         Message = "Unable to release lock: R={Resource} Id={LockId}"
     )]
     public static partial void LogDisposableLockReleaseFailed(
-        this ILogger _logger,
+        this ILogger logger,
         Exception exception,
         string resource,
         string lockId
@@ -328,7 +341,7 @@ internal static partial class DisposableDistributedLockLog
         Level = LogLevel.Trace,
         Message = "Disposed lock: R={Resource} Id={LockId}"
     )]
-    public static partial void LogDisposableLockDisposed(this ILogger _logger, string resource, string lockId);
+    public static partial void LogDisposableLockDisposed(this ILogger logger, string resource, string lockId);
 
     [LoggerMessage(
         EventId = 8,
@@ -337,7 +350,7 @@ internal static partial class DisposableDistributedLockLog
         Message = "Unable to dispose lease monitor before releasing lock: R={Resource} Id={LockId}"
     )]
     public static partial void LogDisposableLockMonitorDisposeFailed(
-        this ILogger _logger,
+        this ILogger logger,
         Exception exception,
         string resource,
         string lockId

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
@@ -21,8 +21,11 @@ public sealed class DistributedLockOptions
 
     /// <summary>Fraction of the lease TTL used as the polling cadence when validating without renewal.</summary>
     /// <remarks>
-    /// Maximum allowed value is 0.5 so at least two probes occur per lease window — keeps
-    /// the safety net effective under cadence jitter.
+    /// Default is 0.5 (½ TTL) — the safety-net cadence for lease validation when the outbox fast-path
+    /// is unavailable. The validator allows tuning <em>downward</em> to 0.1 (1/10 TTL) for workloads
+    /// that need lower lease-loss detection latency at the cost of more frequent storage polls. The
+    /// 0.5 ceiling is the design's slowest acceptable cadence: any slower and a lost lease could go
+    /// undetected for longer than the lease itself.
     /// </remarks>
     public double PollingCadenceFraction { get; set; } = 0.5;
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
@@ -20,9 +20,17 @@ public sealed class DistributedLockOptions
     public int? MaxWaitersPerResource { get; set; } = 1_000;
 
     /// <summary>Fraction of the lease TTL used as the polling cadence when validating without renewal.</summary>
+    /// <remarks>
+    /// Capped at 0.5 so at least two probes occur per lease window — keeps the safety net
+    /// effective under cadence jitter.
+    /// </remarks>
     public double PollingCadenceFraction { get; set; } = 0.5;
 
     /// <summary>Fraction of the lease TTL used as the polling cadence when auto-extending leases.</summary>
+    /// <remarks>
+    /// Capped at 0.5 so at least two extensions occur per lease window — keeps the safety net
+    /// effective under cadence jitter.
+    /// </remarks>
     public double AutoExtensionCadenceFraction { get; set; } = 1.0 / 3.0;
 }
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
@@ -18,6 +18,12 @@ public sealed class DistributedLockOptions
 
     /// <summary>Maximum concurrent waiters per resource. Default: 1,000.</summary>
     public int? MaxWaitersPerResource { get; set; } = 1_000;
+
+    /// <summary>Fraction of the lease TTL used as the polling cadence when validating without renewal.</summary>
+    public double PollingCadenceFraction { get; set; } = 0.5;
+
+    /// <summary>Fraction of the lease TTL used as the polling cadence when auto-extending leases.</summary>
+    public double AutoExtensionCadenceFraction { get; set; } = 1.0 / 3.0;
 }
 
 internal sealed class DistributedLockOptionsValidator : AbstractValidator<DistributedLockOptions>
@@ -28,5 +34,7 @@ internal sealed class DistributedLockOptionsValidator : AbstractValidator<Distri
         RuleFor(x => x.MaxResourceNameLength).InclusiveBetween(1, 10_000);
         RuleFor(x => x.MaxConcurrentWaitingResources).InclusiveBetween(1, 1_000_000);
         RuleFor(x => x.MaxWaitersPerResource).InclusiveBetween(1, 100_000);
+        RuleFor(x => x.PollingCadenceFraction).InclusiveBetween(0.1, 0.5);
+        RuleFor(x => x.AutoExtensionCadenceFraction).InclusiveBetween(0.1, 0.5);
     }
 }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Headless.DistributedLocks;
 
+[PublicAPI]
 public sealed class DistributedLockOptions
 {
     /// <summary>Resource lock key prefix.</summary>

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockOptions.cs
@@ -21,15 +21,15 @@ public sealed class DistributedLockOptions
 
     /// <summary>Fraction of the lease TTL used as the polling cadence when validating without renewal.</summary>
     /// <remarks>
-    /// Capped at 0.5 so at least two probes occur per lease window — keeps the safety net
-    /// effective under cadence jitter.
+    /// Maximum allowed value is 0.5 so at least two probes occur per lease window — keeps
+    /// the safety net effective under cadence jitter.
     /// </remarks>
     public double PollingCadenceFraction { get; set; } = 0.5;
 
     /// <summary>Fraction of the lease TTL used as the polling cadence when auto-extending leases.</summary>
     /// <remarks>
-    /// Capped at 0.5 so at least two extensions occur per lease window — keeps the safety net
-    /// effective under cadence jitter.
+    /// Maximum allowed value is 0.5 so at least two extensions occur per lease window — keeps
+    /// the safety net effective under cadence jitter.
     /// </remarks>
     public double AutoExtensionCadenceFraction { get; set; } = 1.0 / 3.0;
 }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -85,9 +85,6 @@ public sealed class DistributedLockProvider(
         CancellationToken cancellationToken = default
     )
     {
-        options ??= new DistributedLockAcquireOptions();
-        _ValidateAcquireTimeout(options.AcquireTimeout);
-
         var acquired = await TryAcquireAsync(resource, options, cancellationToken).ConfigureAwait(false);
 
         if (acquired is not null)
@@ -95,7 +92,7 @@ public sealed class DistributedLockProvider(
             return acquired;
         }
 
-        throw options.AcquireTimeout == TimeSpan.Zero
+        throw options?.AcquireTimeout == TimeSpan.Zero
             ? LockAcquisitionTimeoutException.ForTryOnceContention(resource)
             : new LockAcquisitionTimeoutException(resource);
     }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -36,8 +36,7 @@ public sealed class DistributedLockProvider(
         StringComparer.Ordinal
     );
 
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, WeakReference<LeaseMonitor>>>
-        _activeMonitors = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, MonitorBucket> _activeMonitors = new(StringComparer.Ordinal);
 
     private readonly Lock _resetEventLock = new();
 
@@ -490,12 +489,6 @@ public sealed class DistributedLockProvider(
         Argument.IsNotNullOrWhiteSpace(resource);
         Argument.IsNotNullOrWhiteSpace(lockId);
 
-        // Deregister the monitor BEFORE publishing the outbox message. Otherwise the outbox
-        // consumer's _NudgeActiveMonitors would wake the still-registered monitor for the
-        // released lockId — the monitor probes storage, sees the row gone (because we just
-        // removed it), and declares Lost. That's a spurious signal on a self-release.
-        _DeregisterMonitor(resource, lockId);
-
         logger.LogReleaseStarted(resource, lockId);
 
         // If a transient exception fires AFTER storage has already deleted the row but BEFORE
@@ -528,6 +521,26 @@ public sealed class DistributedLockProvider(
             .ConfigureAwait(false);
 
         var removed = observedAttemptSucceeded || lastResult;
+
+        if (removed)
+        {
+            // Deregister after confirmed storage removal but before publishing the outbox
+            // message. If release fails or retries are still in progress, the monitor must
+            // remain visible so lease-loss detection continues for the still-held lock.
+            var monitor = _TryDeregisterMonitor(resource, lockId);
+
+            if (monitor is not null)
+            {
+                try
+                {
+                    await monitor.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    logger.LogLeaseMonitorFaulted(exception, resource, lockId);
+                }
+            }
+        }
 
         // Only publish if we actually removed the lock.
         // Publish notifies waiters immediately; if skipped, waiters retry via backoff.
@@ -873,57 +886,201 @@ public sealed class DistributedLockProvider(
 
     private void _RegisterMonitor(string resource, string lockId, LeaseMonitor monitor)
     {
-        var monitors = _activeMonitors.GetOrAdd(
-            resource,
-            static _ => new ConcurrentDictionary<string, WeakReference<LeaseMonitor>>(StringComparer.Ordinal)
-        );
+        while (true)
+        {
+            var bucket = _activeMonitors.GetOrAdd(resource, static _ => new MonitorBucket());
 
-        monitors[lockId] = new WeakReference<LeaseMonitor>(monitor);
-        logger.LogLeaseMonitorRegistered(resource, lockId);
+            if (bucket.TryRegister(lockId, monitor))
+            {
+                logger.LogLeaseMonitorRegistered(resource, lockId);
+
+                return;
+            }
+
+            _TryRemoveMonitorBucket(resource, bucket);
+        }
     }
 
     private void _DeregisterMonitor(string resource, string lockId)
     {
-        if (!_activeMonitors.TryGetValue(resource, out var monitors))
+        _TryDeregisterMonitor(resource, lockId);
+    }
+
+    private LeaseMonitor? _TryDeregisterMonitor(string resource, string lockId)
+    {
+        if (!_activeMonitors.TryGetValue(resource, out var bucket))
         {
-            return;
+            return null;
         }
 
-        monitors.TryRemove(lockId, out _);
-        logger.LogLeaseMonitorDeregistered(resource, lockId);
+        if (bucket.TryDeregister(lockId, out var monitor, out var removeBucket))
+        {
+            logger.LogLeaseMonitorDeregistered(resource, lockId);
+        }
 
-        // Intentionally do NOT TryRemove the outer dict entry when the inner is empty:
-        // an `IsEmpty` + `TryRemove` pair is not atomic on ConcurrentDictionary, and a
-        // racing registration could repopulate the inner map between the two calls,
-        // leaving us with a removed-but-still-referenced inner map. Dead WeakReferences
-        // are cleared opportunistically in _NudgeActiveMonitors, and the GC reclaims
-        // empty per-resource maps naturally once no future acquire hits that resource.
+        if (removeBucket)
+        {
+            _TryRemoveMonitorBucket(resource, bucket);
+        }
+
+        return monitor;
     }
 
     private void _NudgeActiveMonitors(string resource)
     {
-        if (!_activeMonitors.TryGetValue(resource, out var monitors))
+        if (!_activeMonitors.TryGetValue(resource, out var bucket))
         {
             return;
         }
 
-        foreach (var (lockId, weakReference) in monitors)
+        var liveMonitors = bucket.GetLiveMonitorsForNudge(out var removeBucket);
+
+        if (removeBucket)
         {
-            if (weakReference.TryGetTarget(out var monitor))
-            {
-                monitor.TriggerImmediateValidation();
-                logger.LogLeaseMonitorNudged(resource, lockId);
+            _TryRemoveMonitorBucket(resource, bucket);
+        }
 
-                continue;
-            }
-
-            monitors.TryRemove(lockId, out _);
+        foreach (var (lockId, monitor) in liveMonitors)
+        {
+            monitor.TriggerImmediateValidation();
+            logger.LogLeaseMonitorNudged(resource, lockId);
         }
     }
 
     internal int GetActiveMonitorCount(string resource)
     {
-        return _activeMonitors.TryGetValue(resource, out var monitors) ? monitors.Count : 0;
+        return _activeMonitors.TryGetValue(resource, out var bucket) ? bucket.GetMonitorCount() : 0;
+    }
+
+    internal int GetActiveMonitorResourceCount() => _activeMonitors.Count;
+
+    private void _TryRemoveMonitorBucket(string resource, MonitorBucket bucket)
+    {
+        var pair = new KeyValuePair<string, MonitorBucket>(resource, bucket);
+        ((ICollection<KeyValuePair<string, MonitorBucket>>)_activeMonitors).Remove(pair);
+    }
+
+    private sealed class MonitorBucket
+    {
+        private readonly Lock _syncRoot = new();
+
+        private readonly Dictionary<string, WeakReference<LeaseMonitor>> _monitors = new(StringComparer.Ordinal);
+
+        private bool _isRemoved;
+
+        public bool TryRegister(string lockId, LeaseMonitor monitor)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    return false;
+                }
+
+                // Proactive clean-up of dead weak references to prevent memory leak of abandoned locks
+                List<string>? deadKeys = null;
+                foreach (var (id, weakReference) in _monitors)
+                {
+                    if (!weakReference.TryGetTarget(out _))
+                    {
+                        deadKeys ??= new List<string>();
+                        deadKeys.Add(id);
+                    }
+                }
+
+                if (deadKeys is not null)
+                {
+                    foreach (var id in deadKeys)
+                    {
+                        _monitors.Remove(id);
+                    }
+                }
+
+                _monitors[lockId] = new WeakReference<LeaseMonitor>(monitor);
+                return true;
+            }
+        }
+
+        public bool TryDeregister(string lockId, out LeaseMonitor? monitor, out bool removeBucket)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    monitor = null;
+                    removeBucket = false;
+                    return false;
+                }
+
+                monitor = _monitors.Remove(lockId, out var weakReference) && weakReference.TryGetTarget(out var target)
+                    ? target
+                    : null;
+                removeBucket = _MarkRemovedIfEmpty();
+
+                return true;
+            }
+        }
+
+        public List<(string LockId, LeaseMonitor Monitor)> GetLiveMonitorsForNudge(out bool removeBucket)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    removeBucket = false;
+                    return [];
+                }
+
+                List<string>? deadKeys = null;
+                List<(string LockId, LeaseMonitor Monitor)>? liveMonitors = null;
+
+                foreach (var (lockId, weakReference) in _monitors)
+                {
+                    if (weakReference.TryGetTarget(out var monitor))
+                    {
+                        liveMonitors ??= [];
+                        liveMonitors.Add((lockId, monitor));
+                    }
+                    else
+                    {
+                        deadKeys ??= new List<string>();
+                        deadKeys.Add(lockId);
+                    }
+                }
+
+                if (deadKeys is not null)
+                {
+                    foreach (var id in deadKeys)
+                    {
+                        _monitors.Remove(id);
+                    }
+                }
+
+                removeBucket = _MarkRemovedIfEmpty();
+
+                return liveMonitors ?? [];
+            }
+        }
+
+        public int GetMonitorCount()
+        {
+            lock (_syncRoot)
+            {
+                return _isRemoved ? 0 : _monitors.Count;
+            }
+        }
+
+        private bool _MarkRemovedIfEmpty()
+        {
+            if (_monitors.Count > 0)
+            {
+                return false;
+            }
+
+            _isRemoved = true;
+
+            return true;
+        }
     }
 
     internal sealed class LockReleasedConsumer(ICanReceiveLockReleased receiver, ILogger<LockReleasedConsumer> logger)

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -949,10 +949,35 @@ public sealed class DistributedLockProvider(
 
     internal int GetActiveMonitorCount(string resource)
     {
-        return _activeMonitors.TryGetValue(resource, out var bucket) ? bucket.GetMonitorCount() : 0;
+        if (!_activeMonitors.TryGetValue(resource, out var bucket))
+        {
+            return 0;
+        }
+
+        var count = bucket.GetMonitorCount(out var removeBucket);
+
+        if (removeBucket)
+        {
+            _TryRemoveMonitorBucket(resource, bucket);
+        }
+
+        return count;
     }
 
-    internal int GetActiveMonitorResourceCount() => _activeMonitors.Count;
+    internal int GetActiveMonitorResourceCount()
+    {
+        foreach (var (resource, bucket) in _activeMonitors)
+        {
+            _ = bucket.GetMonitorCount(out var removeBucket);
+
+            if (removeBucket)
+            {
+                _TryRemoveMonitorBucket(resource, bucket);
+            }
+        }
+
+        return _activeMonitors.Count;
+    }
 
     private void _TryRemoveMonitorBucket(string resource, MonitorBucket bucket)
     {
@@ -1062,11 +1087,37 @@ public sealed class DistributedLockProvider(
             }
         }
 
-        public int GetMonitorCount()
+        public int GetMonitorCount(out bool removeBucket)
         {
             lock (_syncRoot)
             {
-                return _isRemoved ? 0 : _monitors.Count;
+                if (_isRemoved)
+                {
+                    removeBucket = false;
+                    return 0;
+                }
+
+                List<string>? deadKeys = null;
+                foreach (var (id, weakReference) in _monitors)
+                {
+                    if (!weakReference.TryGetTarget(out _))
+                    {
+                        deadKeys ??= [];
+                        deadKeys.Add(id);
+                    }
+                }
+
+                if (deadKeys is not null)
+                {
+                    foreach (var id in deadKeys)
+                    {
+                        _monitors.Remove(id);
+                    }
+                }
+
+                removeBucket = _MarkRemovedIfEmpty();
+
+                return _monitors.Count;
             }
         }
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -84,8 +84,7 @@ public sealed class DistributedLockProvider(
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
-        bool monitorLease = false,
-        bool autoExtend = false,
+        LockMonitoringMode monitoring = LockMonitoringMode.None,
         CancellationToken cancellationToken = default
     )
     {
@@ -96,8 +95,7 @@ public sealed class DistributedLockProvider(
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose,
-                monitorLease,
-                autoExtend,
+                monitoring,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -117,8 +115,7 @@ public sealed class DistributedLockProvider(
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
-        bool monitorLease = false,
-        bool autoExtend = false,
+        LockMonitoringMode monitoring = LockMonitoringMode.None,
         CancellationToken cancellationToken = default
     )
     {
@@ -128,8 +125,9 @@ public sealed class DistributedLockProvider(
         cancellationToken.ThrowIfCancellationRequested();
 
         timeUntilExpires = _NormalizeTimeUntilExpires(timeUntilExpires);
-        var effectiveMonitorLease = monitorLease || autoExtend;
-        var leaseDuration = _RequireFiniteLeaseDuration(timeUntilExpires, effectiveMonitorLease);
+        var monitorLease = monitoring != LockMonitoringMode.None;
+        var autoExtend = monitoring == LockMonitoringMode.AutoExtend;
+        var leaseDuration = _RequireFiniteLeaseDuration(timeUntilExpires, monitorLease);
         var lockId = longIdGenerator.Create().ToString(CultureInfo.InvariantCulture);
 
         logger.LogAttemptingToAcquireLock(resource, lockId);
@@ -152,7 +150,7 @@ public sealed class DistributedLockProvider(
                     timeUntilExpires,
                     timestamp,
                     releaseOnDispose,
-                    effectiveMonitorLease,
+                    monitorLease,
                     autoExtend,
                     leaseDuration,
                     cancellationToken
@@ -284,7 +282,7 @@ public sealed class DistributedLockProvider(
             leaseDuration,
             timeWaitedForLock,
             releaseOnDispose,
-            effectiveMonitorLease,
+            monitorLease,
             autoExtend
         );
     }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -36,6 +36,9 @@ public sealed class DistributedLockProvider(
         StringComparer.Ordinal
     );
 
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, WeakReference<LeaseMonitor>>>
+        _activeMonitors = new(StringComparer.Ordinal);
+
     private readonly Lock _resetEventLock = new();
 
     ILogger IHaveLogger.Logger => logger;
@@ -81,6 +84,8 @@ public sealed class DistributedLockProvider(
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
+        bool monitorLease = false,
+        bool autoExtend = false,
         CancellationToken cancellationToken = default
     )
     {
@@ -91,6 +96,8 @@ public sealed class DistributedLockProvider(
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose,
+                monitorLease,
+                autoExtend,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -110,6 +117,8 @@ public sealed class DistributedLockProvider(
         TimeSpan? timeUntilExpires = null,
         TimeSpan? acquireTimeout = null,
         bool releaseOnDispose = true,
+        bool monitorLease = false,
+        bool autoExtend = false,
         CancellationToken cancellationToken = default
     )
     {
@@ -119,6 +128,8 @@ public sealed class DistributedLockProvider(
         cancellationToken.ThrowIfCancellationRequested();
 
         timeUntilExpires = _NormalizeTimeUntilExpires(timeUntilExpires);
+        var effectiveMonitorLease = monitorLease || autoExtend;
+        var leaseDuration = _RequireFiniteLeaseDuration(timeUntilExpires, effectiveMonitorLease);
         var lockId = longIdGenerator.Create().ToString(CultureInfo.InvariantCulture);
 
         logger.LogAttemptingToAcquireLock(resource, lockId);
@@ -141,6 +152,9 @@ public sealed class DistributedLockProvider(
                     timeUntilExpires,
                     timestamp,
                     releaseOnDispose,
+                    effectiveMonitorLease,
+                    autoExtend,
+                    leaseDuration,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -264,14 +278,14 @@ public sealed class DistributedLockProvider(
             logger.LogAcquiredLock(resource, lockId, timeWaitedForLock);
         }
 
-        return new DisposableDistributedLock(
+        return _CreateLockHandle(
             resource,
             lockId,
+            leaseDuration,
             timeWaitedForLock,
-            this,
             releaseOnDispose,
-            timeProvider,
-            logger
+            effectiveMonitorLease,
+            autoExtend
         );
     }
 
@@ -281,6 +295,9 @@ public sealed class DistributedLockProvider(
         TimeSpan? timeUntilExpires,
         long timestamp,
         bool releaseOnDispose,
+        bool monitorLease,
+        bool autoExtend,
+        TimeSpan leaseDuration,
         CancellationToken callerToken
     )
     {
@@ -347,15 +364,53 @@ public sealed class DistributedLockProvider(
             logger.LogAcquiredLock(resource, lockId, timeWaitedForLock);
         }
 
-        return new DisposableDistributedLock(
+        return _CreateLockHandle(
             resource,
             lockId,
+            leaseDuration,
+            timeWaitedForLock,
+            releaseOnDispose,
+            monitorLease,
+            autoExtend
+        );
+    }
+
+    private DisposableDistributedLock _CreateLockHandle(
+        string resource,
+        string lockId,
+        TimeSpan leaseDuration,
+        TimeSpan timeWaitedForLock,
+        bool releaseOnDispose,
+        bool monitorLease,
+        bool autoExtend
+    )
+    {
+        var handle = new DisposableDistributedLock(
+            resource,
+            lockId,
+            leaseDuration,
             timeWaitedForLock,
             this,
             releaseOnDispose,
+            autoExtend,
+            options,
             timeProvider,
+            _DeregisterMonitor,
             logger
         );
+
+        if (!monitorLease)
+        {
+            return handle;
+        }
+
+#pragma warning disable CA2000 // Ownership is transferred to the returned handle and drained from DisposeAsync.
+        var monitor = new LeaseMonitor(handle, timeProvider, logger);
+#pragma warning restore CA2000
+        _RegisterMonitor(resource, lockId, monitor);
+        handle.AttachMonitor(monitor);
+
+        return handle;
     }
 
     private ResetEventWithRefCount _IncrementResetEvent(string resource)
@@ -538,6 +593,23 @@ public sealed class DistributedLockProvider(
 
     #endregion
 
+    #region Lease validation
+
+    public Task<string?> GetLockIdAsync(string resource, CancellationToken cancellationToken = default)
+    {
+        Argument.IsNotNullOrWhiteSpace(resource);
+
+        return _queryPipeline
+            .ExecuteAsync(
+                static async (state, ct) => await state._storage.GetAsync(state.resource, ct).ConfigureAwait(false),
+                (_storage, resource),
+                cancellationToken
+            )
+            .AsTask();
+    }
+
+    #endregion
+
     #region IsLocked
 
     public async Task<bool> IsLockedAsync(string resource, CancellationToken cancellationToken = default)
@@ -646,6 +718,18 @@ public sealed class DistributedLockProvider(
         return timeUntilExpires is null ? DefaultTimeUntilExpires
             : timeUntilExpires == Timeout.InfiniteTimeSpan ? null
             : Argument.IsPositive(timeUntilExpires.Value);
+    }
+
+    private static TimeSpan _RequireFiniteLeaseDuration(TimeSpan? timeUntilExpires, bool monitorLease)
+    {
+        if (timeUntilExpires is { } leaseDuration)
+        {
+            return leaseDuration;
+        }
+
+        Ensure.False(monitorLease, "Lease monitoring requires a finite timeUntilExpires value.");
+
+        return Timeout.InfiniteTimeSpan;
     }
 
     private static void _ValidateAcquireTimeout(TimeSpan? acquireTimeout)
@@ -785,6 +869,66 @@ public sealed class DistributedLockProvider(
         {
             autoResetEvent.Target.Set();
         }
+
+        _NudgeActiveMonitors(message.Resource);
+    }
+
+    private void _RegisterMonitor(string resource, string lockId, LeaseMonitor monitor)
+    {
+        var monitors = _activeMonitors.GetOrAdd(
+            resource,
+            static _ => new ConcurrentDictionary<string, WeakReference<LeaseMonitor>>(StringComparer.Ordinal)
+        );
+
+        monitors[lockId] = new WeakReference<LeaseMonitor>(monitor);
+        logger.LogLeaseMonitorRegistered(resource, lockId);
+    }
+
+    private void _DeregisterMonitor(string resource, string lockId)
+    {
+        if (!_activeMonitors.TryGetValue(resource, out var monitors))
+        {
+            return;
+        }
+
+        monitors.TryRemove(lockId, out _);
+        logger.LogLeaseMonitorDeregistered(resource, lockId);
+
+        if (monitors.IsEmpty)
+        {
+            _activeMonitors.TryRemove(resource, out _);
+        }
+    }
+
+    private void _NudgeActiveMonitors(string resource)
+    {
+        if (!_activeMonitors.TryGetValue(resource, out var monitors))
+        {
+            return;
+        }
+
+        foreach (var (lockId, weakReference) in monitors)
+        {
+            if (weakReference.TryGetTarget(out var monitor))
+            {
+                monitor.TriggerImmediateValidation();
+                logger.LogLeaseMonitorNudged(resource, lockId);
+
+                continue;
+            }
+
+            monitors.TryRemove(lockId, out _);
+        }
+
+        if (monitors.IsEmpty)
+        {
+            _activeMonitors.TryRemove(resource, out _);
+        }
+    }
+
+    internal int GetActiveMonitorCount(string resource)
+    {
+        return _activeMonitors.TryGetValue(resource, out var monitors) ? monitors.Count : 0;
     }
 
     internal sealed class LockReleasedConsumer(ICanReceiveLockReleased receiver, ILogger<LockReleasedConsumer> logger)

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -36,7 +36,7 @@ public sealed class DistributedLockProvider(
         StringComparer.Ordinal
     );
 
-    private readonly ConcurrentDictionary<string, MonitorBucket> _activeMonitors = new(StringComparer.Ordinal);
+    private readonly LeaseMonitorRegistry _monitorRegistry = new(logger);
 
     private readonly Lock _resetEventLock = new();
 
@@ -734,10 +734,10 @@ public sealed class DistributedLockProvider(
 
         if (monitorLease)
         {
-            // Lease monitoring requires a finite timeUntilExpires; null encodes the
-            // Timeout.InfiniteTimeSpan sentinel here. Use Argument.IsNotNull to surface
-            // the framework's standard ArgumentNullException with paramName set.
-            Argument.IsNotNull(timeUntilExpires, paramName: nameof(timeUntilExpires));
+            throw new ArgumentException(
+                "Lease monitoring requires a finite timeUntilExpires; Timeout.InfiniteTimeSpan is not valid.",
+                nameof(timeUntilExpires)
+            );
         }
 
         return Timeout.InfiniteTimeSpan;
@@ -886,252 +886,32 @@ public sealed class DistributedLockProvider(
 
     private void _RegisterMonitor(string resource, string lockId, LeaseMonitor monitor)
     {
-        while (true)
-        {
-            var bucket = _activeMonitors.GetOrAdd(resource, static _ => new MonitorBucket());
-
-            if (bucket.TryRegister(lockId, monitor))
-            {
-                logger.LogLeaseMonitorRegistered(resource, lockId);
-
-                return;
-            }
-
-            _TryRemoveMonitorBucket(resource, bucket);
-        }
+        _monitorRegistry.Register(resource, lockId, monitor);
     }
 
     private void _DeregisterMonitor(string resource, string lockId)
     {
-        _TryDeregisterMonitor(resource, lockId);
+        _monitorRegistry.Deregister(resource, lockId);
     }
 
     private LeaseMonitor? _TryDeregisterMonitor(string resource, string lockId)
     {
-        if (!_activeMonitors.TryGetValue(resource, out var bucket))
-        {
-            return null;
-        }
-
-        if (bucket.TryDeregister(lockId, out var monitor, out var removeBucket))
-        {
-            logger.LogLeaseMonitorDeregistered(resource, lockId);
-        }
-
-        if (removeBucket)
-        {
-            _TryRemoveMonitorBucket(resource, bucket);
-        }
-
-        return monitor;
+        return _monitorRegistry.TryDeregister(resource, lockId);
     }
 
     private void _NudgeActiveMonitors(string resource)
     {
-        if (!_activeMonitors.TryGetValue(resource, out var bucket))
-        {
-            return;
-        }
-
-        var liveMonitors = bucket.GetLiveMonitorsForNudge(out var removeBucket);
-
-        if (removeBucket)
-        {
-            _TryRemoveMonitorBucket(resource, bucket);
-        }
-
-        foreach (var (lockId, monitor) in liveMonitors)
-        {
-            monitor.TriggerImmediateValidation();
-            logger.LogLeaseMonitorNudged(resource, lockId);
-        }
+        _monitorRegistry.NudgeActive(resource);
     }
 
     internal int GetActiveMonitorCount(string resource)
     {
-        if (!_activeMonitors.TryGetValue(resource, out var bucket))
-        {
-            return 0;
-        }
-
-        var count = bucket.GetMonitorCount(out var removeBucket);
-
-        if (removeBucket)
-        {
-            _TryRemoveMonitorBucket(resource, bucket);
-        }
-
-        return count;
+        return _monitorRegistry.GetMonitorCount(resource);
     }
 
     internal int GetActiveMonitorResourceCount()
     {
-        foreach (var (resource, bucket) in _activeMonitors)
-        {
-            _ = bucket.GetMonitorCount(out var removeBucket);
-
-            if (removeBucket)
-            {
-                _TryRemoveMonitorBucket(resource, bucket);
-            }
-        }
-
-        return _activeMonitors.Count;
-    }
-
-    private void _TryRemoveMonitorBucket(string resource, MonitorBucket bucket)
-    {
-        var pair = new KeyValuePair<string, MonitorBucket>(resource, bucket);
-        ((ICollection<KeyValuePair<string, MonitorBucket>>)_activeMonitors).Remove(pair);
-    }
-
-    private sealed class MonitorBucket
-    {
-        private readonly Lock _syncRoot = new();
-
-        private readonly Dictionary<string, WeakReference<LeaseMonitor>> _monitors = new(StringComparer.Ordinal);
-
-        private bool _isRemoved;
-
-        public bool TryRegister(string lockId, LeaseMonitor monitor)
-        {
-            lock (_syncRoot)
-            {
-                if (_isRemoved)
-                {
-                    return false;
-                }
-
-                // Proactive clean-up of dead weak references to prevent memory leak of abandoned locks
-                List<string>? deadKeys = null;
-                foreach (var (id, weakReference) in _monitors)
-                {
-                    if (!weakReference.TryGetTarget(out _))
-                    {
-                        deadKeys ??= new List<string>();
-                        deadKeys.Add(id);
-                    }
-                }
-
-                if (deadKeys is not null)
-                {
-                    foreach (var id in deadKeys)
-                    {
-                        _monitors.Remove(id);
-                    }
-                }
-
-                _monitors[lockId] = new WeakReference<LeaseMonitor>(monitor);
-                return true;
-            }
-        }
-
-        public bool TryDeregister(string lockId, out LeaseMonitor? monitor, out bool removeBucket)
-        {
-            lock (_syncRoot)
-            {
-                if (_isRemoved)
-                {
-                    monitor = null;
-                    removeBucket = false;
-                    return false;
-                }
-
-                monitor = _monitors.Remove(lockId, out var weakReference) && weakReference.TryGetTarget(out var target)
-                    ? target
-                    : null;
-                removeBucket = _MarkRemovedIfEmpty();
-
-                return true;
-            }
-        }
-
-        public List<(string LockId, LeaseMonitor Monitor)> GetLiveMonitorsForNudge(out bool removeBucket)
-        {
-            lock (_syncRoot)
-            {
-                if (_isRemoved)
-                {
-                    removeBucket = false;
-                    return [];
-                }
-
-                List<string>? deadKeys = null;
-                List<(string LockId, LeaseMonitor Monitor)>? liveMonitors = null;
-
-                foreach (var (lockId, weakReference) in _monitors)
-                {
-                    if (weakReference.TryGetTarget(out var monitor))
-                    {
-                        liveMonitors ??= [];
-                        liveMonitors.Add((lockId, monitor));
-                    }
-                    else
-                    {
-                        deadKeys ??= new List<string>();
-                        deadKeys.Add(lockId);
-                    }
-                }
-
-                if (deadKeys is not null)
-                {
-                    foreach (var id in deadKeys)
-                    {
-                        _monitors.Remove(id);
-                    }
-                }
-
-                removeBucket = _MarkRemovedIfEmpty();
-
-                return liveMonitors ?? [];
-            }
-        }
-
-        public int GetMonitorCount(out bool removeBucket)
-        {
-            lock (_syncRoot)
-            {
-                if (_isRemoved)
-                {
-                    removeBucket = false;
-                    return 0;
-                }
-
-                List<string>? deadKeys = null;
-                foreach (var (id, weakReference) in _monitors)
-                {
-                    if (!weakReference.TryGetTarget(out _))
-                    {
-                        deadKeys ??= [];
-                        deadKeys.Add(id);
-                    }
-                }
-
-                if (deadKeys is not null)
-                {
-                    foreach (var id in deadKeys)
-                    {
-                        _monitors.Remove(id);
-                    }
-                }
-
-                removeBucket = _MarkRemovedIfEmpty();
-
-                return _monitors.Count;
-            }
-        }
-
-        private bool _MarkRemovedIfEmpty()
-        {
-            if (_monitors.Count > 0)
-            {
-                return false;
-            }
-
-            _isRemoved = true;
-
-            return true;
-        }
+        return _monitorRegistry.GetResourceCount();
     }
 
     internal sealed class LockReleasedConsumer(ICanReceiveLockReleased receiver, ILogger<LockReleasedConsumer> logger)

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -735,10 +735,10 @@ public sealed class DistributedLockProvider(
 
         if (monitorLease)
         {
-            throw new ArgumentException(
-                "Lease monitoring requires a finite timeUntilExpires value; pass a TimeSpan instead of Timeout.InfiniteTimeSpan.",
-                nameof(timeUntilExpires)
-            );
+            // Lease monitoring requires a finite timeUntilExpires; null encodes the
+            // Timeout.InfiniteTimeSpan sentinel here. Use Argument.IsNotNull to surface
+            // the framework's standard ArgumentNullException with paramName set.
+            Argument.IsNotNull(timeUntilExpires, paramName: nameof(timeUntilExpires));
         }
 
         return Timeout.InfiniteTimeSpan;
@@ -906,10 +906,12 @@ public sealed class DistributedLockProvider(
         monitors.TryRemove(lockId, out _);
         logger.LogLeaseMonitorDeregistered(resource, lockId);
 
-        if (monitors.IsEmpty)
-        {
-            _activeMonitors.TryRemove(resource, out _);
-        }
+        // Intentionally do NOT TryRemove the outer dict entry when the inner is empty:
+        // an `IsEmpty` + `TryRemove` pair is not atomic on ConcurrentDictionary, and a
+        // racing registration could repopulate the inner map between the two calls,
+        // leaving us with a removed-but-still-referenced inner map. Dead WeakReferences
+        // are cleared opportunistically in _NudgeActiveMonitors, and the GC reclaims
+        // empty per-resource maps naturally once no future acquire hits that resource.
     }
 
     private void _NudgeActiveMonitors(string resource)
@@ -930,11 +932,6 @@ public sealed class DistributedLockProvider(
             }
 
             monitors.TryRemove(lockId, out _);
-        }
-
-        if (monitors.IsEmpty)
-        {
-            _activeMonitors.TryRemove(resource, out _);
         }
     }
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -392,7 +392,7 @@ public sealed class DistributedLockProvider(
 #pragma warning disable CA2000 // Ownership is transferred to the returned handle and drained from DisposeAsync.
         var monitor = new LeaseMonitor(handle, timeProvider, logger);
 #pragma warning restore CA2000
-        _RegisterMonitor(resource, lockId, monitor);
+        _monitorRegistry.Register(resource, lockId, monitor);
         handle.AttachMonitor(monitor);
 
         return handle;
@@ -527,7 +527,7 @@ public sealed class DistributedLockProvider(
             // Deregister after confirmed storage removal but before publishing the outbox
             // message. If release fails or retries are still in progress, the monitor must
             // remain visible so lease-loss detection continues for the still-held lock.
-            var monitor = _TryDeregisterMonitor(resource, lockId);
+            var monitor = _monitorRegistry.TryDeregister(resource, lockId);
 
             if (monitor is not null)
             {
@@ -881,27 +881,12 @@ public sealed class DistributedLockProvider(
             autoResetEvent.Target.Set();
         }
 
-        _NudgeActiveMonitors(message.Resource);
-    }
-
-    private void _RegisterMonitor(string resource, string lockId, LeaseMonitor monitor)
-    {
-        _monitorRegistry.Register(resource, lockId, monitor);
+        _monitorRegistry.NudgeActive(message.Resource);
     }
 
     private void _DeregisterMonitor(string resource, string lockId)
     {
-        _monitorRegistry.Deregister(resource, lockId);
-    }
-
-    private LeaseMonitor? _TryDeregisterMonitor(string resource, string lockId)
-    {
-        return _monitorRegistry.TryDeregister(resource, lockId);
-    }
-
-    private void _NudgeActiveMonitors(string resource)
-    {
-        _monitorRegistry.NudgeActive(resource);
+        _ = _monitorRegistry.TryDeregister(resource, lockId);
     }
 
     internal int GetActiveMonitorCount(string resource)

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -81,50 +81,41 @@ public sealed class DistributedLockProvider(
 
     public async Task<IDistributedLock> AcquireAsync(
         string resource,
-        TimeSpan? timeUntilExpires = null,
-        TimeSpan? acquireTimeout = null,
-        bool releaseOnDispose = true,
-        LockMonitoringMode monitoring = LockMonitoringMode.None,
+        DistributedLockAcquireOptions? options = null,
         CancellationToken cancellationToken = default
     )
     {
-        _ValidateAcquireTimeout(acquireTimeout);
+        options ??= new DistributedLockAcquireOptions();
+        _ValidateAcquireTimeout(options.AcquireTimeout);
 
-        var acquired = await TryAcquireAsync(
-                resource,
-                timeUntilExpires,
-                acquireTimeout,
-                releaseOnDispose,
-                monitoring,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
+        var acquired = await TryAcquireAsync(resource, options, cancellationToken).ConfigureAwait(false);
 
         if (acquired is not null)
         {
             return acquired;
         }
 
-        throw acquireTimeout == TimeSpan.Zero
+        throw options.AcquireTimeout == TimeSpan.Zero
             ? LockAcquisitionTimeoutException.ForTryOnceContention(resource)
             : new LockAcquisitionTimeoutException(resource);
     }
 
     public async Task<IDistributedLock?> TryAcquireAsync(
         string resource,
-        TimeSpan? timeUntilExpires = null,
-        TimeSpan? acquireTimeout = null,
-        bool releaseOnDispose = true,
-        LockMonitoringMode monitoring = LockMonitoringMode.None,
+        DistributedLockAcquireOptions? options = null,
         CancellationToken cancellationToken = default
     )
     {
         Argument.IsNotNullOrWhiteSpace(resource);
         Argument.IsLessThanOrEqualTo(resource.Length, _maxResourceNameLength, paramName: nameof(resource));
-        _ValidateAcquireTimeout(acquireTimeout);
+        options ??= new DistributedLockAcquireOptions();
+        _ValidateAcquireTimeout(options.AcquireTimeout);
         cancellationToken.ThrowIfCancellationRequested();
 
-        timeUntilExpires = _NormalizeTimeUntilExpires(timeUntilExpires);
+        var timeUntilExpires = _NormalizeTimeUntilExpires(options.TimeUntilExpires);
+        var acquireTimeout = options.AcquireTimeout;
+        var releaseOnDispose = options.ReleaseOnDispose;
+        var monitoring = options.Monitoring;
         var monitorLease = monitoring != LockMonitoringMode.None;
         var autoExtend = monitoring == LockMonitoringMode.AutoExtend;
         var leaseDuration = _RequireFiniteLeaseDuration(timeUntilExpires, monitorLease);

--- a/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/DistributedLockProvider.cs
@@ -504,6 +504,12 @@ public sealed class DistributedLockProvider(
         Argument.IsNotNullOrWhiteSpace(resource);
         Argument.IsNotNullOrWhiteSpace(lockId);
 
+        // Deregister the monitor BEFORE publishing the outbox message. Otherwise the outbox
+        // consumer's _NudgeActiveMonitors would wake the still-registered monitor for the
+        // released lockId — the monitor probes storage, sees the row gone (because we just
+        // removed it), and declares Lost. That's a spurious signal on a self-release.
+        _DeregisterMonitor(resource, lockId);
+
         logger.LogReleaseStarted(resource, lockId);
 
         // If a transient exception fires AFTER storage has already deleted the row but BEFORE
@@ -727,7 +733,13 @@ public sealed class DistributedLockProvider(
             return leaseDuration;
         }
 
-        Ensure.False(monitorLease, "Lease monitoring requires a finite timeUntilExpires value.");
+        if (monitorLease)
+        {
+            throw new ArgumentException(
+                "Lease monitoring requires a finite timeUntilExpires value; pass a TimeSpan instead of Timeout.InfiniteTimeSpan.",
+                nameof(timeUntilExpires)
+            );
+        }
 
         return Timeout.InfiniteTimeSpan;
     }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -262,32 +262,27 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             return;
         }
 
-        // Cancel asynchronously off the loop thread so that any synchronous callbacks (e.g.,
-        // disposing or releasing the handle) do not deadlock awaiting the loop thread's exit.
-        _ = Task.Run(() =>
+        try
+        {
+            _handleLostSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed concurrently; treat as already-cancelled.
+        }
+        catch (AggregateException aggregate)
         {
             try
             {
-                _handleLostSource.Cancel();
+                _logger.LogLeaseMonitorFaulted(aggregate, _leaseHandle.Resource, _leaseHandle.LockId);
             }
-            catch (ObjectDisposedException)
-            {
-                // Disposed concurrently; treat as already-cancelled.
-            }
-            catch (AggregateException aggregate)
-            {
-                try
-                {
-                    _logger.LogLeaseMonitorFaulted(aggregate, _leaseHandle.Resource, _leaseHandle.LockId);
-                }
 #pragma warning disable ERP022, CA1031 // Defensive: best-effort log from detached cancellation task.
-                catch
-                {
-                    // Intentionally empty.
-                }
-#pragma warning restore ERP022, CA1031
+            catch
+            {
+                // Intentionally empty.
             }
-        });
+#pragma warning restore ERP022, CA1031
+        }
     }
 
     private static async Task _MonitoringLoopAsync(MonitoringLoopState state)

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -19,8 +19,6 @@ internal sealed class LeaseMonitor : IAsyncDisposable
     private readonly Lock _syncLock = new();
     private int _disposed;
     private Task? _handleLostCancellationTask;
-    [ThreadStatic]
-    private static bool s_isCancelingHandleLost;
     private LeaseState _state = LeaseState.Held;
     private LeaseState State
     {
@@ -152,7 +150,9 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             return;
         }
 
-        var disposeHandleLostSource = !s_isCancelingHandleLost;
+        var handleLostCancellationTask = Volatile.Read(ref _handleLostCancellationTask);
+        var disposeHandleLostSource =
+            handleLostCancellationTask is null || Task.CurrentId != handleLostCancellationTask.Id;
 
         try
         {
@@ -187,9 +187,9 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
 #pragma warning restore VSTHRD003
 
-            var handleLostCancellationTask = Volatile.Read(ref _handleLostCancellationTask);
+            handleLostCancellationTask = Volatile.Read(ref _handleLostCancellationTask);
 
-            if (handleLostCancellationTask is not null && !s_isCancelingHandleLost)
+            if (handleLostCancellationTask is not null && Task.CurrentId != handleLostCancellationTask.Id)
             {
                 await handleLostCancellationTask.ConfigureAwait(false);
             }
@@ -217,7 +217,7 @@ internal sealed class LeaseMonitor : IAsyncDisposable
         // leaseTimestamp in the monitoring loop, so a long Held streak in polling mode never
         // crosses the safety-net threshold. Only Unknown (transient) leaves leaseTimestamp
         // unchanged, allowing the elapsed window to accumulate.
-        if (leaseLifetime > _leaseDuration && State == LeaseState.Unknown)
+        if (leaseLifetime >= _leaseDuration && State == LeaseState.Unknown)
         {
             _SetState(LeaseState.Lost);
             return LeaseState.Lost;
@@ -285,8 +285,6 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
     private void _CancelHandleLostSource()
     {
-        s_isCancelingHandleLost = true;
-
         try
         {
             _handleLostSource.Cancel();
@@ -310,8 +308,6 @@ internal sealed class LeaseMonitor : IAsyncDisposable
         }
         finally
         {
-            s_isCancelingHandleLost = false;
-
             if (Volatile.Read(ref _disposed) != 0)
             {
                 _handleLostSource.Dispose();

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -18,7 +18,17 @@ internal sealed class LeaseMonitor : IAsyncDisposable
     private readonly TimeSpan _leaseDuration;
     private readonly Lock _syncLock = new();
     private int _disposed;
-    private LeaseState State { get; set; } = LeaseState.Held;
+    private LeaseState _state = LeaseState.Held;
+    private LeaseState State
+    {
+        get
+        {
+            lock (_syncLock)
+            {
+                return _state;
+            }
+        }
+    }
 
     public LeaseMonitor(ILeaseHandle leaseHandle, TimeProvider timeProvider, ILogger logger)
     {
@@ -181,6 +191,11 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
     private async Task<LeaseState> _RunIterationAsync(TimeSpan leaseLifetime)
     {
+        if (_disposalSource.IsCancellationRequested)
+        {
+            return State;
+        }
+
         // Safety-net self-promotion: only when prior probes were transient (Unknown).
         // A confirmed Held/Renewed from storage MUST NOT trip the safety net — both reset
         // leaseTimestamp in the monitoring loop, so a long Held streak in polling mode never
@@ -208,6 +223,11 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             nextState = LeaseState.Unknown;
         }
 
+        if (_disposalSource.IsCancellationRequested)
+        {
+            return State;
+        }
+
         _SetState(nextState);
 
         return nextState;
@@ -216,42 +236,58 @@ internal sealed class LeaseMonitor : IAsyncDisposable
     private void _SetState(LeaseState nextState)
     {
         bool shouldCancel;
+        LeaseState previousState;
 
         lock (_syncLock)
         {
-            if (State == LeaseState.Lost)
+            if (_state == LeaseState.Lost)
             {
                 return;
             }
 
-            if (State == nextState)
+            if (_state == nextState)
             {
                 return;
             }
 
-            _logger.LogLeaseMonitorStateChanged(_leaseHandle.Resource, _leaseHandle.LockId, State, nextState);
-            State = nextState;
+            previousState = _state;
+            _state = nextState;
             shouldCancel = nextState == LeaseState.Lost;
         }
+
+        _logger.LogLeaseMonitorStateChanged(_leaseHandle.Resource, _leaseHandle.LockId, previousState, nextState);
 
         if (!shouldCancel)
         {
             return;
         }
 
-        // Cancel synchronously rather than via Task.Run. A HandleLostToken callback that disposes
-        // the handle would otherwise self-await via DisposeAsync → await _cancellationTask, where
-        // _cancellationTask is the Task.Run running the callback that's calling DisposeAsync.
-        // Cancel() is contracted (per IDistributedLock.HandleLostToken docs) as observability;
-        // consumers MUST NOT run blocking work inline in callbacks.
-        try
+        // Cancel asynchronously off the loop thread so that any synchronous callbacks (e.g.,
+        // disposing or releasing the handle) do not deadlock awaiting the loop thread's exit.
+        _ = Task.Run(() =>
         {
-            _handleLostSource.Cancel();
-        }
-        catch (ObjectDisposedException)
-        {
-            // Disposed concurrently; treat as already-cancelled.
-        }
+            try
+            {
+                _handleLostSource.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Disposed concurrently; treat as already-cancelled.
+            }
+            catch (AggregateException aggregate)
+            {
+                try
+                {
+                    _logger.LogLeaseMonitorFaulted(aggregate, _leaseHandle.Resource, _leaseHandle.LockId);
+                }
+#pragma warning disable ERP022, CA1031 // Defensive: best-effort log from detached cancellation task.
+                catch
+                {
+                    // Intentionally empty.
+                }
+#pragma warning restore ERP022, CA1031
+            }
+        });
     }
 
     private static async Task _MonitoringLoopAsync(MonitoringLoopState state)
@@ -261,12 +297,7 @@ internal sealed class LeaseMonitor : IAsyncDisposable
         while (!state.DisposalToken.IsCancellationRequested)
         {
             using var cadenceSource = state.TimeProvider.CreateCancellationTokenSource(state.Cadence);
-            using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
-                cadenceSource.Token,
-                state.DisposalToken
-            );
-
-            await state.NudgeSignal.SafeWaitAsync(linkedSource.Token).ConfigureAwait(false);
+            await state.NudgeSignal.SafeWaitAsync(cadenceSource.Token).ConfigureAwait(false);
 
             if (state.DisposalToken.IsCancellationRequested)
             {
@@ -332,7 +363,7 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 internal static partial class LeaseMonitorLog
 {
     [LoggerMessage(
-        EventId = 1,
+        EventId = 30,
         EventName = "LeaseMonitorStateChanged",
         Level = LogLevel.Debug,
         Message = "Lease monitor state changed: R={Resource} Id={LockId} {PreviousState} -> {NextState}"
@@ -346,7 +377,7 @@ internal static partial class LeaseMonitorLog
     );
 
     [LoggerMessage(
-        EventId = 2,
+        EventId = 31,
         EventName = "LeaseMonitorValidationUnknown",
         Level = LogLevel.Debug,
         Message = "Lease monitor validation failed transiently: R={Resource} Id={LockId}"
@@ -359,7 +390,7 @@ internal static partial class LeaseMonitorLog
     );
 
     [LoggerMessage(
-        EventId = 3,
+        EventId = 32,
         EventName = "LeaseMonitorFaulted",
         Level = LogLevel.Error,
         Message = "Lease monitor loop faulted: R={Resource} Id={LockId}"

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -18,6 +18,9 @@ internal sealed class LeaseMonitor : IAsyncDisposable
     private readonly TimeSpan _leaseDuration;
     private readonly Lock _syncLock = new();
     private int _disposed;
+    private Task? _handleLostCancellationTask;
+    [ThreadStatic]
+    private static bool s_isCancelingHandleLost;
     private LeaseState _state = LeaseState.Held;
     private LeaseState State
     {
@@ -149,6 +152,8 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             return;
         }
 
+        var disposeHandleLostSource = !s_isCancelingHandleLost;
+
         try
         {
             await _disposalSource.CancelAsync().ConfigureAwait(false);
@@ -181,11 +186,22 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             }
 
 #pragma warning restore VSTHRD003
+
+            var handleLostCancellationTask = Volatile.Read(ref _handleLostCancellationTask);
+
+            if (handleLostCancellationTask is not null && !s_isCancelingHandleLost)
+            {
+                await handleLostCancellationTask.ConfigureAwait(false);
+            }
         }
         finally
         {
             _disposalSource.Dispose();
-            _handleLostSource.Dispose();
+
+            if (disposeHandleLostSource)
+            {
+                _handleLostSource.Dispose();
+            }
         }
     }
 
@@ -262,6 +278,15 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             return;
         }
 
+        var cancellationTask = new Task(_CancelHandleLostSource);
+        Volatile.Write(ref _handleLostCancellationTask, cancellationTask);
+        cancellationTask.Start(TaskScheduler.Default);
+    }
+
+    private void _CancelHandleLostSource()
+    {
+        s_isCancelingHandleLost = true;
+
         try
         {
             _handleLostSource.Cancel();
@@ -282,6 +307,15 @@ internal sealed class LeaseMonitor : IAsyncDisposable
                 // Intentionally empty.
             }
 #pragma warning restore ERP022, CA1031
+        }
+        finally
+        {
+            s_isCancelingHandleLost = false;
+
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                _handleLostSource.Dispose();
+            }
         }
     }
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -44,28 +44,58 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             _disposalSource.Token
         );
 
+        // Continuation state holds strong refs to the CTS and logger so the static continuation
+        // lambda below does NOT capture `this` — capturing `this` would strong-root the monitor
+        // for the lifetime of MonitoringTask and defeat the WeakReference<LeaseMonitor>
+        // GC-abandonment invariant (consumers that drop the handle without disposing rely on
+        // the loop noticing the dead weak ref and exiting).
+        var continuationState = new FaultContinuationState(
+            _handleLostSource,
+            _logger,
+            leaseHandle.Resource,
+            leaseHandle.LockId
+        );
+
         MonitoringTask = Task.Run(() => _MonitoringLoopAsync(loopState));
 
         _ = MonitoringTask.ContinueWith(
-            (task, state) =>
+            static (task, state) =>
             {
-                var loopState = (MonitoringLoopState)state!;
+                var faultState = (FaultContinuationState)state!;
 
                 // Fail-safe FIRST: a faulted monitor cannot keep providing liveness signals, so
                 // signal loss to consumers via HandleLostToken before doing anything that could
-                // itself throw (e.g., a misbehaving logger).
+                // itself throw (e.g., a misbehaving logger). Catch both ObjectDisposedException
+                // (CTS already disposed during teardown) and AggregateException (a registered
+                // HandleLostToken callback threw — Cancel() wraps the failures).
                 try
                 {
-                    _handleLostSource.Cancel();
+                    faultState.HandleLostSource.Cancel();
                 }
                 catch (ObjectDisposedException)
                 {
                     // DisposeAsync already disposed the CTS — fault arrived during/after teardown.
                 }
+                catch (AggregateException aggregate)
+                {
+                    // A registered HandleLostToken callback threw. The original fault is still
+                    // logged below; log the aggregated callback failures defensively so they are
+                    // not silently swallowed.
+                    try
+                    {
+                        faultState.Logger.LogLeaseMonitorFaulted(aggregate, faultState.Resource, faultState.LockId);
+                    }
+#pragma warning disable ERP022, CA1031 // Defensive: a faulting logger must not propagate from this continuation.
+                    catch
+                    {
+                        // Intentionally empty.
+                    }
+#pragma warning restore ERP022, CA1031
+                }
 
                 try
                 {
-                    loopState.Logger.LogLeaseMonitorFaulted(task.Exception!, loopState.Resource, loopState.LockId);
+                    faultState.Logger.LogLeaseMonitorFaulted(task.Exception!, faultState.Resource, faultState.LockId);
                 }
 #pragma warning disable ERP022, CA1031 // Defensive: a faulting logger must not propagate from this continuation.
                 catch
@@ -74,12 +104,22 @@ internal sealed class LeaseMonitor : IAsyncDisposable
                 }
 #pragma warning restore ERP022, CA1031
             },
-            loopState,
+            continuationState,
             CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskContinuationOptions.OnlyOnFaulted,
             TaskScheduler.Default
         );
     }
+
+    // Strong-ref state for the OnlyOnFaulted continuation. Kept separate from MonitoringLoopState
+    // (which holds a WeakReference<LeaseMonitor>) so the continuation can fire even after the
+    // monitor instance has been GC'd — the CTS and logger are what the fail-safe needs.
+    private sealed record FaultContinuationState(
+        CancellationTokenSource HandleLostSource,
+        ILogger Logger,
+        string Resource,
+        string LockId
+    );
 
     private readonly AsyncAutoResetEvent _nudgeSignal;
 
@@ -142,9 +182,10 @@ internal sealed class LeaseMonitor : IAsyncDisposable
     private async Task<LeaseState> _RunIterationAsync(TimeSpan leaseLifetime)
     {
         // Safety-net self-promotion: only when prior probes were transient (Unknown).
-        // A confirmed Held/Renewed from storage MUST NOT trip the safety net — that would
-        // produce a false-positive Lost in polling mode where Held repeats indefinitely
-        // and leaseTimestamp is only reset on Renewed.
+        // A confirmed Held/Renewed from storage MUST NOT trip the safety net — both reset
+        // leaseTimestamp in the monitoring loop, so a long Held streak in polling mode never
+        // crosses the safety-net threshold. Only Unknown (transient) leaves leaseTimestamp
+        // unchanged, allowing the elapsed window to accumulate.
         if (leaseLifetime > _leaseDuration && State == LeaseState.Unknown)
         {
             _SetState(LeaseState.Lost);
@@ -240,7 +281,10 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             var leaseLifetime = state.TimeProvider.GetElapsedTime(leaseTimestamp);
             var nextState = await monitor._RunIterationAsync(leaseLifetime).ConfigureAwait(false);
 
-            if (nextState == LeaseState.Renewed)
+            // Both Renewed (auto-extend success) and Held (polling-mode positive ownership confirmation)
+            // are positive ownership signals from storage and reset the safety-net window. Unknown
+            // (transient) does NOT reset — that's the signal the safety net is designed to catch.
+            if (nextState is LeaseState.Renewed or LeaseState.Held)
             {
                 leaseTimestamp = state.TimeProvider.GetTimestamp();
             }

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Checks;
+using Microsoft.Extensions.Logging;
+using Nito.AsyncEx;
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace
+namespace Headless.DistributedLocks;
+
+internal sealed class LeaseMonitor : IAsyncDisposable
+{
+    private readonly CancellationTokenSource _disposalSource = new();
+    private readonly CancellationTokenSource _handleLostSource = new();
+    private readonly ILeaseHandle _leaseHandle;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger _logger;
+    private readonly TimeSpan _leaseDuration;
+    private readonly Lock _syncLock = new();
+    private Task? _cancellationTask;
+    private int _disposed;
+    private LeaseState State { get; set; } = LeaseState.Held;
+
+    public LeaseMonitor(ILeaseHandle leaseHandle, TimeProvider timeProvider, ILogger logger)
+    {
+        _leaseHandle = Argument.IsNotNull(leaseHandle);
+        _timeProvider = Argument.IsNotNull(timeProvider);
+        _logger = Argument.IsNotNull(logger);
+        _leaseDuration = Argument.IsGreaterThanOrEqualTo(
+            leaseHandle.LeaseDuration,
+            leaseHandle.MonitoringCadence,
+            paramName: nameof(leaseHandle.LeaseDuration)
+        );
+
+        NudgeSignal = new AsyncAutoResetEvent();
+
+        var loopState = new MonitoringLoopState(
+            new WeakReference<LeaseMonitor>(this),
+            NudgeSignal,
+            _timeProvider,
+            leaseHandle.MonitoringCadence,
+            leaseHandle.Resource,
+            leaseHandle.LockId,
+            _logger,
+            _disposalSource.Token
+        );
+
+        MonitoringTask = Task.Factory.StartNew(
+            static state => _MonitoringLoopAsync((MonitoringLoopState)state!),
+            loopState,
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default
+        ).Unwrap();
+
+        _ = MonitoringTask.ContinueWith(
+            static (task, state) =>
+            {
+                var loopState = (MonitoringLoopState)state!;
+                loopState.Logger.LogLeaseMonitorFaulted(task.Exception!, loopState.Resource, loopState.LockId);
+            },
+            loopState,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default
+        );
+    }
+
+    internal AsyncAutoResetEvent NudgeSignal { get; }
+
+    internal Task MonitoringTask { get; }
+
+    public CancellationToken HandleLostToken => _handleLostSource.Token;
+
+    public void TriggerImmediateValidation()
+    {
+        NudgeSignal.Set();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _disposalSource.CancelAsync().ConfigureAwait(false);
+            NudgeSignal.Set();
+#pragma warning disable VSTHRD003 // DisposeAsync is the owner that drains the background monitor task.
+            await MonitoringTask.ConfigureAwait(false);
+
+            if (_cancellationTask is not null)
+            {
+                await _cancellationTask.ConfigureAwait(false);
+            }
+#pragma warning restore VSTHRD003
+        }
+        finally
+        {
+            _disposalSource.Dispose();
+            _handleLostSource.Dispose();
+        }
+    }
+
+    private async Task<LeaseState> _RunIterationAsync(TimeSpan leaseLifetime)
+    {
+        if (leaseLifetime > _leaseDuration)
+        {
+            _SetState(LeaseState.Lost);
+            return LeaseState.Lost;
+        }
+
+        LeaseState nextState;
+
+        try
+        {
+            nextState = await _leaseHandle.RenewOrValidateLeaseAsync(_disposalSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (_disposalSource.IsCancellationRequested)
+        {
+            return State;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogLeaseMonitorValidationUnknown(exception, _leaseHandle.Resource, _leaseHandle.LockId);
+            nextState = LeaseState.Unknown;
+        }
+
+        _SetState(nextState);
+
+        return nextState;
+    }
+
+    private void _SetState(LeaseState nextState)
+    {
+        Task? cancellationTask = null;
+
+        lock (_syncLock)
+        {
+            if (State == LeaseState.Lost)
+            {
+                return;
+            }
+
+            if (State == nextState)
+            {
+                return;
+            }
+
+            _logger.LogLeaseMonitorStateChanged(_leaseHandle.Resource, _leaseHandle.LockId, State, nextState);
+            State = nextState;
+
+            if (nextState == LeaseState.Lost)
+            {
+                var handleLostSource = _handleLostSource;
+                cancellationTask = Task.Run(
+                    async () => await handleLostSource.CancelAsync().ConfigureAwait(false),
+                    CancellationToken.None
+                );
+                _cancellationTask = cancellationTask;
+            }
+        }
+
+        if (cancellationTask is not null)
+        {
+            _ = cancellationTask.ContinueWith(
+                static task => _ = task.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+            );
+        }
+    }
+
+    private static async Task _MonitoringLoopAsync(MonitoringLoopState state)
+    {
+        var leaseTimestamp = state.TimeProvider.GetTimestamp();
+
+        while (!state.DisposalToken.IsCancellationRequested)
+        {
+            using var cadenceSource = state.TimeProvider.CreateCancellationTokenSource(state.Cadence);
+            using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+                cadenceSource.Token,
+                state.DisposalToken
+            );
+
+            await state.NudgeSignal.SafeWaitAsync(linkedSource.Token).ConfigureAwait(false);
+
+            if (state.DisposalToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (!state.Monitor.TryGetTarget(out var monitor))
+            {
+                return;
+            }
+
+            var leaseLifetime = state.TimeProvider.GetElapsedTime(leaseTimestamp);
+            var nextState = await monitor._RunIterationAsync(leaseLifetime).ConfigureAwait(false);
+
+            if (nextState == LeaseState.Renewed)
+            {
+                leaseTimestamp = state.TimeProvider.GetTimestamp();
+            }
+
+            if (nextState == LeaseState.Lost)
+            {
+                return;
+            }
+        }
+    }
+
+    internal enum LeaseState
+    {
+        Held,
+        Renewed,
+        Lost,
+        Unknown,
+    }
+
+    internal interface ILeaseHandle
+    {
+        string Resource { get; }
+
+        string LockId { get; }
+
+        TimeSpan LeaseDuration { get; }
+
+        TimeSpan MonitoringCadence { get; }
+
+        Task<LeaseState> RenewOrValidateLeaseAsync(CancellationToken cancellationToken);
+    }
+
+    private sealed record MonitoringLoopState(
+        WeakReference<LeaseMonitor> Monitor,
+        AsyncAutoResetEvent NudgeSignal,
+        TimeProvider TimeProvider,
+        TimeSpan Cadence,
+        string Resource,
+        string LockId,
+        ILogger Logger,
+        CancellationToken DisposalToken
+    );
+}
+
+internal static partial class LeaseMonitorLog
+{
+    [LoggerMessage(
+        EventId = 1,
+        EventName = "LeaseMonitorStateChanged",
+        Level = LogLevel.Debug,
+        Message = "Lease monitor state changed: R={Resource} Id={LockId} {PreviousState} -> {NextState}"
+    )]
+    public static partial void LogLeaseMonitorStateChanged(
+        this ILogger logger,
+        string resource,
+        string lockId,
+        LeaseMonitor.LeaseState previousState,
+        LeaseMonitor.LeaseState nextState
+    );
+
+    [LoggerMessage(
+        EventId = 2,
+        EventName = "LeaseMonitorValidationUnknown",
+        Level = LogLevel.Debug,
+        Message = "Lease monitor validation failed transiently: R={Resource} Id={LockId}"
+    )]
+    public static partial void LogLeaseMonitorValidationUnknown(
+        this ILogger logger,
+        Exception exception,
+        string resource,
+        string lockId
+    );
+
+    [LoggerMessage(
+        EventId = 3,
+        EventName = "LeaseMonitorFaulted",
+        Level = LogLevel.Error,
+        Message = "Lease monitor loop faulted: R={Resource} Id={LockId}"
+    )]
+    public static partial void LogLeaseMonitorFaulted(
+        this ILogger logger,
+        Exception exception,
+        string resource,
+        string lockId
+    );
+}

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitor.cs
@@ -17,7 +17,6 @@ internal sealed class LeaseMonitor : IAsyncDisposable
     private readonly ILogger _logger;
     private readonly TimeSpan _leaseDuration;
     private readonly Lock _syncLock = new();
-    private Task? _cancellationTask;
     private int _disposed;
     private LeaseState State { get; set; } = LeaseState.Held;
 
@@ -32,11 +31,11 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             paramName: nameof(leaseHandle.LeaseDuration)
         );
 
-        NudgeSignal = new AsyncAutoResetEvent();
+        _nudgeSignal = new AsyncAutoResetEvent();
 
         var loopState = new MonitoringLoopState(
             new WeakReference<LeaseMonitor>(this),
-            NudgeSignal,
+            _nudgeSignal,
             _timeProvider,
             leaseHandle.MonitoringCadence,
             leaseHandle.Resource,
@@ -45,19 +44,35 @@ internal sealed class LeaseMonitor : IAsyncDisposable
             _disposalSource.Token
         );
 
-        MonitoringTask = Task.Factory.StartNew(
-            static state => _MonitoringLoopAsync((MonitoringLoopState)state!),
-            loopState,
-            CancellationToken.None,
-            TaskCreationOptions.DenyChildAttach,
-            TaskScheduler.Default
-        ).Unwrap();
+        MonitoringTask = Task.Run(() => _MonitoringLoopAsync(loopState));
 
         _ = MonitoringTask.ContinueWith(
-            static (task, state) =>
+            (task, state) =>
             {
                 var loopState = (MonitoringLoopState)state!;
-                loopState.Logger.LogLeaseMonitorFaulted(task.Exception!, loopState.Resource, loopState.LockId);
+
+                // Fail-safe FIRST: a faulted monitor cannot keep providing liveness signals, so
+                // signal loss to consumers via HandleLostToken before doing anything that could
+                // itself throw (e.g., a misbehaving logger).
+                try
+                {
+                    _handleLostSource.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // DisposeAsync already disposed the CTS — fault arrived during/after teardown.
+                }
+
+                try
+                {
+                    loopState.Logger.LogLeaseMonitorFaulted(task.Exception!, loopState.Resource, loopState.LockId);
+                }
+#pragma warning disable ERP022, CA1031 // Defensive: a faulting logger must not propagate from this continuation.
+                catch
+                {
+                    // Intentionally empty.
+                }
+#pragma warning restore ERP022, CA1031
             },
             loopState,
             CancellationToken.None,
@@ -66,7 +81,7 @@ internal sealed class LeaseMonitor : IAsyncDisposable
         );
     }
 
-    internal AsyncAutoResetEvent NudgeSignal { get; }
+    private readonly AsyncAutoResetEvent _nudgeSignal;
 
     internal Task MonitoringTask { get; }
 
@@ -74,7 +89,7 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
     public void TriggerImmediateValidation()
     {
-        NudgeSignal.Set();
+        _nudgeSignal.Set();
     }
 
     public async ValueTask DisposeAsync()
@@ -87,14 +102,34 @@ internal sealed class LeaseMonitor : IAsyncDisposable
         try
         {
             await _disposalSource.CancelAsync().ConfigureAwait(false);
-            NudgeSignal.Set();
+            _nudgeSignal.Set();
 #pragma warning disable VSTHRD003 // DisposeAsync is the owner that drains the background monitor task.
-            await MonitoringTask.ConfigureAwait(false);
-
-            if (_cancellationTask is not null)
+            try
             {
-                await _cancellationTask.ConfigureAwait(false);
+                await MonitoringTask.ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                // Expected — disposal cancels the loop's wait/storage call.
+            }
+            catch (Exception exception)
+            {
+                // A fault in the monitoring loop is already surfaced via the OnlyOnFaulted
+                // continuation (logged + HandleLostToken cancelled). Swallow during dispose so
+                // teardown cannot throw on the caller of DisposeAsync. Log defensively — a
+                // misbehaving logger must not crash teardown.
+                try
+                {
+                    _logger.LogLeaseMonitorFaulted(exception, _leaseHandle.Resource, _leaseHandle.LockId);
+                }
+#pragma warning disable ERP022, CA1031 // Defensive: best-effort log; ignore further logger faults during teardown.
+                catch
+                {
+                    // Intentionally empty.
+                }
+#pragma warning restore ERP022, CA1031
+            }
+
 #pragma warning restore VSTHRD003
         }
         finally
@@ -106,7 +141,11 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
     private async Task<LeaseState> _RunIterationAsync(TimeSpan leaseLifetime)
     {
-        if (leaseLifetime > _leaseDuration)
+        // Safety-net self-promotion: only when prior probes were transient (Unknown).
+        // A confirmed Held/Renewed from storage MUST NOT trip the safety net — that would
+        // produce a false-positive Lost in polling mode where Held repeats indefinitely
+        // and leaseTimestamp is only reset on Renewed.
+        if (leaseLifetime > _leaseDuration && State == LeaseState.Unknown)
         {
             _SetState(LeaseState.Lost);
             return LeaseState.Lost;
@@ -135,7 +174,7 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
     private void _SetState(LeaseState nextState)
     {
-        Task? cancellationTask = null;
+        bool shouldCancel;
 
         lock (_syncLock)
         {
@@ -151,26 +190,26 @@ internal sealed class LeaseMonitor : IAsyncDisposable
 
             _logger.LogLeaseMonitorStateChanged(_leaseHandle.Resource, _leaseHandle.LockId, State, nextState);
             State = nextState;
-
-            if (nextState == LeaseState.Lost)
-            {
-                var handleLostSource = _handleLostSource;
-                cancellationTask = Task.Run(
-                    async () => await handleLostSource.CancelAsync().ConfigureAwait(false),
-                    CancellationToken.None
-                );
-                _cancellationTask = cancellationTask;
-            }
+            shouldCancel = nextState == LeaseState.Lost;
         }
 
-        if (cancellationTask is not null)
+        if (!shouldCancel)
         {
-            _ = cancellationTask.ContinueWith(
-                static task => _ = task.Exception,
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default
-            );
+            return;
+        }
+
+        // Cancel synchronously rather than via Task.Run. A HandleLostToken callback that disposes
+        // the handle would otherwise self-await via DisposeAsync → await _cancellationTask, where
+        // _cancellationTask is the Task.Run running the callback that's calling DisposeAsync.
+        // Cancel() is contracted (per IDistributedLock.HandleLostToken docs) as observability;
+        // consumers MUST NOT run blocking work inline in callbacks.
+        try
+        {
+            _handleLostSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed concurrently; treat as already-cancelled.
         }
     }
 

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitorRegistry.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitorRegistry.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace
+namespace Headless.DistributedLocks;
+
+internal sealed class LeaseMonitorRegistry(ILogger logger)
+{
+    private readonly ConcurrentDictionary<string, MonitorBucket> _activeMonitors = new(StringComparer.Ordinal);
+
+    public void Register(string resource, string lockId, LeaseMonitor monitor)
+    {
+        while (true)
+        {
+            var bucket = _activeMonitors.GetOrAdd(resource, static _ => new MonitorBucket());
+
+            if (bucket.TryRegister(lockId, monitor))
+            {
+                logger.LogLeaseMonitorRegistered(resource, lockId);
+
+                return;
+            }
+
+            _TryRemoveBucket(resource, bucket);
+        }
+    }
+
+    public void Deregister(string resource, string lockId)
+    {
+        _ = TryDeregister(resource, lockId);
+    }
+
+    public LeaseMonitor? TryDeregister(string resource, string lockId)
+    {
+        if (!_activeMonitors.TryGetValue(resource, out var bucket))
+        {
+            return null;
+        }
+
+        if (bucket.TryDeregister(lockId, out var monitor, out var removeBucket))
+        {
+            logger.LogLeaseMonitorDeregistered(resource, lockId);
+        }
+
+        if (removeBucket)
+        {
+            _TryRemoveBucket(resource, bucket);
+        }
+
+        return monitor;
+    }
+
+    public void NudgeActive(string resource)
+    {
+        if (!_activeMonitors.TryGetValue(resource, out var bucket))
+        {
+            return;
+        }
+
+        var liveMonitors = bucket.GetLiveMonitorsForNudge(out var removeBucket);
+
+        if (removeBucket)
+        {
+            _TryRemoveBucket(resource, bucket);
+        }
+
+        foreach (var (lockId, monitor) in liveMonitors)
+        {
+            monitor.TriggerImmediateValidation();
+            logger.LogLeaseMonitorNudged(resource, lockId);
+        }
+    }
+
+    public int GetMonitorCount(string resource)
+    {
+        if (!_activeMonitors.TryGetValue(resource, out var bucket))
+        {
+            return 0;
+        }
+
+        var count = bucket.GetMonitorCount(out var removeBucket);
+
+        if (removeBucket)
+        {
+            _TryRemoveBucket(resource, bucket);
+        }
+
+        return count;
+    }
+
+    public int GetResourceCount()
+    {
+        foreach (var (resource, bucket) in _activeMonitors)
+        {
+            _ = bucket.GetMonitorCount(out var removeBucket);
+
+            if (removeBucket)
+            {
+                _TryRemoveBucket(resource, bucket);
+            }
+        }
+
+        return _activeMonitors.Count;
+    }
+
+    private void _TryRemoveBucket(string resource, MonitorBucket bucket)
+    {
+        var pair = new KeyValuePair<string, MonitorBucket>(resource, bucket);
+        ((ICollection<KeyValuePair<string, MonitorBucket>>)_activeMonitors).Remove(pair);
+    }
+
+    private sealed class MonitorBucket
+    {
+        private readonly Lock _syncRoot = new();
+        private readonly Dictionary<string, WeakReference<LeaseMonitor>> _monitors = new(StringComparer.Ordinal);
+        private bool _isRemoved;
+
+        public bool TryRegister(string lockId, LeaseMonitor monitor)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    return false;
+                }
+
+                _PruneDeadEntries();
+                _monitors[lockId] = new WeakReference<LeaseMonitor>(monitor);
+
+                return true;
+            }
+        }
+
+        public bool TryDeregister(string lockId, out LeaseMonitor? monitor, out bool removeBucket)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    monitor = null;
+                    removeBucket = false;
+
+                    return false;
+                }
+
+                monitor = _monitors.Remove(lockId, out var weakReference) && weakReference.TryGetTarget(out var target)
+                    ? target
+                    : null;
+                removeBucket = _MarkRemovedIfEmpty();
+
+                return true;
+            }
+        }
+
+        public List<(string LockId, LeaseMonitor Monitor)> GetLiveMonitorsForNudge(out bool removeBucket)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    removeBucket = false;
+
+                    return [];
+                }
+
+                List<(string LockId, LeaseMonitor Monitor)>? liveMonitors = null;
+
+                foreach (var (lockId, weakReference) in _monitors)
+                {
+                    if (!weakReference.TryGetTarget(out var monitor))
+                    {
+                        continue;
+                    }
+
+                    liveMonitors ??= [];
+                    liveMonitors.Add((lockId, monitor));
+                }
+
+                _PruneDeadEntries();
+                removeBucket = _MarkRemovedIfEmpty();
+
+                return liveMonitors ?? [];
+            }
+        }
+
+        public int GetMonitorCount(out bool removeBucket)
+        {
+            lock (_syncRoot)
+            {
+                if (_isRemoved)
+                {
+                    removeBucket = false;
+
+                    return 0;
+                }
+
+                _PruneDeadEntries();
+                removeBucket = _MarkRemovedIfEmpty();
+
+                return _monitors.Count;
+            }
+        }
+
+        private void _PruneDeadEntries()
+        {
+            List<string>? deadKeys = null;
+
+            foreach (var (lockId, weakReference) in _monitors)
+            {
+                if (weakReference.TryGetTarget(out _))
+                {
+                    continue;
+                }
+
+                deadKeys ??= [];
+                deadKeys.Add(lockId);
+            }
+
+            if (deadKeys is null)
+            {
+                return;
+            }
+
+            foreach (var lockId in deadKeys)
+            {
+                _monitors.Remove(lockId);
+            }
+        }
+
+        private bool _MarkRemovedIfEmpty()
+        {
+            if (_monitors.Count > 0)
+            {
+                return false;
+            }
+
+            _isRemoved = true;
+
+            return true;
+        }
+    }
+}

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitorRegistry.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LeaseMonitorRegistry.cs
@@ -28,11 +28,6 @@ internal sealed class LeaseMonitorRegistry(ILogger logger)
         }
     }
 
-    public void Deregister(string resource, string lockId)
-    {
-        _ = TryDeregister(resource, lockId);
-    }
-
     public LeaseMonitor? TryDeregister(string resource, string lockId)
     {
         if (!_activeMonitors.TryGetValue(resource, out var bucket))
@@ -93,6 +88,8 @@ internal sealed class LeaseMonitorRegistry(ILogger logger)
 
     public int GetResourceCount()
     {
+        var count = 0;
+
         foreach (var (resource, bucket) in _activeMonitors)
         {
             _ = bucket.GetMonitorCount(out var removeBucket);
@@ -100,10 +97,13 @@ internal sealed class LeaseMonitorRegistry(ILogger logger)
             if (removeBucket)
             {
                 _TryRemoveBucket(resource, bucket);
+                continue;
             }
+
+            count++;
         }
 
-        return _activeMonitors.Count;
+        return count;
     }
 
     private void _TryRemoveBucket(string resource, MonitorBucket bucket)

--- a/src/Headless.DistributedLocks.Core/RegularLocks/LoggerExtensions.cs
+++ b/src/Headless.DistributedLocks.Core/RegularLocks/LoggerExtensions.cs
@@ -211,4 +211,28 @@ public static partial class RegularLockLoggerExtensions
         TimeSpan delay,
         Exception? exception
     );
+
+    [LoggerMessage(
+        EventId = 20,
+        EventName = "LeaseMonitorRegistered",
+        Level = LogLevel.Trace,
+        Message = "Registered lease monitor: R={Resource} Id={LockId}"
+    )]
+    public static partial void LogLeaseMonitorRegistered(this ILogger logger, string resource, string lockId);
+
+    [LoggerMessage(
+        EventId = 21,
+        EventName = "LeaseMonitorDeregistered",
+        Level = LogLevel.Trace,
+        Message = "Deregistered lease monitor: R={Resource} Id={LockId}"
+    )]
+    public static partial void LogLeaseMonitorDeregistered(this ILogger logger, string resource, string lockId);
+
+    [LoggerMessage(
+        EventId = 22,
+        EventName = "LeaseMonitorNudged",
+        Level = LogLevel.Trace,
+        Message = "Nudged lease monitor: R={Resource} Id={LockId}"
+    )]
+    public static partial void LogLeaseMonitorNudged(this ILogger logger, string resource, string lockId);
 }

--- a/src/Headless.DistributedLocks.Redis/README.md
+++ b/src/Headless.DistributedLocks.Redis/README.md
@@ -34,7 +34,7 @@ builder.Services.AddRedisDistributedLock(options =>
 
 ## Configuration
 
-No Redis-specific options. Configure `IConnectionMultiplexer` and `DistributedLockOptions`. Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per lock-acquire call. Lease monitoring and `autoExtend` are storage-agnostic provider features configured through `Headless.DistributedLocks.Core`.
+No Redis-specific options. Configure `IConnectionMultiplexer` and `DistributedLockOptions`. Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per lock-acquire call. `LockMonitoringMode` (lease monitoring and auto-extension) is a storage-agnostic provider feature configured through `Headless.DistributedLocks.Core`.
 
 ## Dependencies
 

--- a/src/Headless.DistributedLocks.Redis/README.md
+++ b/src/Headless.DistributedLocks.Redis/README.md
@@ -34,7 +34,7 @@ builder.Services.AddRedisDistributedLock(options =>
 
 ## Configuration
 
-No Redis-specific options. Configure `IConnectionMultiplexer` and `DistributedLockOptions`. Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per lock-acquire call.
+No Redis-specific options. Configure `IConnectionMultiplexer` and `DistributedLockOptions`. Default lock expiration is 20 minutes and default acquire timeout is 30 seconds; override those per lock-acquire call. Lease monitoring and `autoExtend` are storage-agnostic provider features configured through `Headless.DistributedLocks.Core`.
 
 ## Dependencies
 

--- a/src/Headless.Features.Core/Definitions/DynamicFeatureDefinitionStore.cs
+++ b/src/Headless.Features.Core/Definitions/DynamicFeatureDefinitionStore.cs
@@ -177,9 +177,12 @@ public sealed class DynamicFeatureDefinitionStore(
         await using var distributedLock =
             await distributedLockProvider.TryAcquireAsync(
                 resource: _options.CrossApplicationsCommonLockKey,
-                timeUntilExpires: _options.CrossApplicationsCommonLockExpiration,
-                acquireTimeout: _options.CrossApplicationsCommonLockAcquireTimeout,
-                cancellationToken: cancellationToken
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = _options.CrossApplicationsCommonLockExpiration,
+                    AcquireTimeout = _options.CrossApplicationsCommonLockAcquireTimeout,
+                },
+                cancellationToken
             )
             ?? throw new InvalidOperationException(
                 "Could not acquire distributed lock for feature definition common stamp check!"
@@ -303,9 +306,12 @@ public sealed class DynamicFeatureDefinitionStore(
     {
         await using var appDistributedLock = await distributedLockProvider.TryAcquireAsync(
             _appSaveLockKey,
-            timeUntilExpires: _options.ApplicationSaveLockExpiration,
-            acquireTimeout: _options.ApplicationSaveLockAcquireTimeout,
-            cancellationToken: cancellationToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = _options.ApplicationSaveLockExpiration,
+                AcquireTimeout = _options.ApplicationSaveLockAcquireTimeout,
+            },
+            cancellationToken
         );
 
         if (appDistributedLock is null)
@@ -339,9 +345,12 @@ public sealed class DynamicFeatureDefinitionStore(
         await using var commonDistributedLock =
             await distributedLockProvider.TryAcquireAsync(
                 resource: _options.CrossApplicationsCommonLockKey,
-                timeUntilExpires: _options.CrossApplicationsCommonLockExpiration,
-                acquireTimeout: _options.CrossApplicationsCommonLockAcquireTimeout,
-                cancellationToken: cancellationToken
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = _options.CrossApplicationsCommonLockExpiration,
+                    AcquireTimeout = _options.CrossApplicationsCommonLockAcquireTimeout,
+                },
+                cancellationToken
             ) ?? throw new InvalidOperationException("Could not acquire distributed lock for saving static features!"); // It will re-try
 
         var (newGroups, updatedGroups, deletedGroups) = await _UpdateChangedFeatureGroupsAsync(

--- a/src/Headless.Generator.Primitives/Headless.Generator.Primitives.csproj
+++ b/src/Headless.Generator.Primitives/Headless.Generator.Primitives.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup Label="This ensures the library will be packaged as a source generator when we use `dotnet pack`">
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="buildTransitive\*.props" Pack="true" PackagePath="buildTransitive\" />
     <None Include="lib\netstandard2.0\_._" Pack="true" PackagePath="lib\netstandard2.0\" />
   </ItemGroup>

--- a/src/Headless.Messaging.Core/Processor/IProcessor.NeedRetry.cs
+++ b/src/Headless.Messaging.Core/Processor/IProcessor.NeedRetry.cs
@@ -349,9 +349,12 @@ public sealed class MessageNeedToRetryProcessor : IProcessor, IRetryProcessorMon
             return await LockProvider
                 .TryAcquireAsync(
                     resource,
-                    timeUntilExpires: _GetLockTtl(),
-                    acquireTimeout: TimeSpan.Zero,
-                    cancellationToken: context.CancellationToken
+                    new DistributedLockAcquireOptions
+                    {
+                        TimeUntilExpires = _GetLockTtl(),
+                        AcquireTimeout = TimeSpan.Zero,
+                    },
+                    context.CancellationToken
                 )
                 .ConfigureAwait(false);
         }

--- a/src/Headless.Permissions.Core/Definitions/DynamicPermissionDefinitionStore.cs
+++ b/src/Headless.Permissions.Core/Definitions/DynamicPermissionDefinitionStore.cs
@@ -149,9 +149,12 @@ public sealed class DynamicPermissionDefinitionStore(
         await using var commonLockHandle =
             await distributedLockProvider.TryAcquireAsync(
                 resource: _options.CrossApplicationsCommonLockKey,
-                timeUntilExpires: _options.CrossApplicationsCommonLockExpiration,
-                acquireTimeout: _options.CrossApplicationsCommonLockAcquireTimeout,
-                cancellationToken: cancellationToken
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = _options.CrossApplicationsCommonLockExpiration,
+                    AcquireTimeout = _options.CrossApplicationsCommonLockAcquireTimeout,
+                },
+                cancellationToken
             )
             ?? throw new InvalidOperationException(
                 "Could not acquire distributed lock for permission definition common stamp check!"
@@ -260,9 +263,12 @@ public sealed class DynamicPermissionDefinitionStore(
     {
         await using var appDistributedLock = await distributedLockProvider.TryAcquireAsync(
             _appSaveLockKey,
-            timeUntilExpires: _options.ApplicationSaveLockExpiration,
-            acquireTimeout: _options.ApplicationSaveLockAcquireTimeout,
-            cancellationToken: cancellationToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = _options.ApplicationSaveLockExpiration,
+                AcquireTimeout = _options.ApplicationSaveLockAcquireTimeout,
+            },
+            cancellationToken
         );
 
         if (appDistributedLock is null)
@@ -296,9 +302,12 @@ public sealed class DynamicPermissionDefinitionStore(
         await using var commonLockHandle =
             await distributedLockProvider.TryAcquireAsync(
                 resource: _options.CrossApplicationsCommonLockKey,
-                timeUntilExpires: _options.CrossApplicationsCommonLockExpiration,
-                acquireTimeout: _options.CrossApplicationsCommonLockAcquireTimeout,
-                cancellationToken: cancellationToken
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = _options.CrossApplicationsCommonLockExpiration,
+                    AcquireTimeout = _options.CrossApplicationsCommonLockAcquireTimeout,
+                },
+                cancellationToken
             )
             ?? throw new InvalidOperationException("Could not acquire distributed lock for saving static permissions!"); // It will re-try
 

--- a/src/Headless.Settings.Core/Definitions/DynamicSettingDefinitionStore.cs
+++ b/src/Headless.Settings.Core/Definitions/DynamicSettingDefinitionStore.cs
@@ -131,9 +131,12 @@ public sealed class DynamicSettingDefinitionStore(
             await distributedLockProvider
                 .TryAcquireAsync(
                     resource: _options.CrossApplicationsCommonLockKey,
-                    timeUntilExpires: _options.CrossApplicationsCommonLockExpiration,
-                    acquireTimeout: _options.CrossApplicationsCommonLockAcquireTimeout,
-                    cancellationToken: cancellationToken
+                    new DistributedLockAcquireOptions
+                    {
+                        TimeUntilExpires = _options.CrossApplicationsCommonLockExpiration,
+                        AcquireTimeout = _options.CrossApplicationsCommonLockAcquireTimeout,
+                    },
+                    cancellationToken
                 )
                 .ConfigureAwait(false)
             ?? throw new InvalidOperationException(
@@ -193,9 +196,12 @@ public sealed class DynamicSettingDefinitionStore(
         await using var applicationDistributedLock = await distributedLockProvider
             .TryAcquireAsync(
                 _appSaveLockKey,
-                timeUntilExpires: _options.ApplicationSaveLockExpiration,
-                acquireTimeout: _options.ApplicationSaveLockAcquireTimeout,
-                cancellationToken: cancellationToken
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = _options.ApplicationSaveLockExpiration,
+                    AcquireTimeout = _options.ApplicationSaveLockAcquireTimeout,
+                },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -222,9 +228,12 @@ public sealed class DynamicSettingDefinitionStore(
             await distributedLockProvider
                 .TryAcquireAsync(
                     _options.CrossApplicationsCommonLockKey,
-                    timeUntilExpires: 10.Minutes(),
-                    acquireTimeout: 5.Minutes(),
-                    cancellationToken: cancellationToken
+                    new DistributedLockAcquireOptions
+                    {
+                        TimeUntilExpires = 10.Minutes(),
+                        AcquireTimeout = 5.Minutes(),
+                    },
+                    cancellationToken
                 )
                 .ConfigureAwait(false)
             ?? throw new InvalidOperationException("Could not acquire distributed lock for saving static Settings!"); // It will re-try

--- a/src/Headless.Tus.DistributedLocks/DistributedLockTusFileLock.cs
+++ b/src/Headless.Tus.DistributedLocks/DistributedLockTusFileLock.cs
@@ -15,8 +15,11 @@ public sealed class DistributedLockTusFileLock(string fileId, IDistributedLockPr
     {
         _distributedLock = await distributedLockProvider.TryAcquireAsync(
             _resource,
-            timeUntilExpires: Timeout.InfiniteTimeSpan, // Lock never expires
-            acquireTimeout: TimeSpan.Zero // Do not wait to acquire the lock
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = Timeout.InfiniteTimeSpan, // Lock never expires
+                AcquireTimeout = TimeSpan.Zero, // Do not wait to acquire the lock
+            }
         );
 
         return _distributedLock is not null;

--- a/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
@@ -362,8 +362,7 @@ internal static class IdempotencyTestApp
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -372,8 +371,7 @@ internal static class IdempotencyTestApp
                         timeUntilExpires,
                         acquireTimeout,
                         releaseOnDispose,
-                        monitorLease,
-                        autoExtend,
+                        monitoring,
                         cancellationToken
                     )
                     .ConfigureAwait(false)
@@ -385,8 +383,7 @@ internal static class IdempotencyTestApp
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -442,8 +439,7 @@ internal static class IdempotencyTestApp
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose: true,
-                monitorLease: false,
-                autoExtend: false,
+                monitoring: LockMonitoringMode.None,
                 cancellationToken: cancellationToken
             );
         }

--- a/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
@@ -658,6 +658,8 @@ internal static class IdempotencyTestApp
 
         public CancellationToken HandleLostToken => CancellationToken.None;
 
+        public bool IsMonitored => false;
+
         public Task ReleaseAsync()
         {
             _ReleaseIfStillOwner();

--- a/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
@@ -359,34 +359,23 @@ internal static class IdempotencyTestApp
 
         public async Task<IDistributedLock> AcquireAsync(
             string resource,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            bool releaseOnDispose = true,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
-            return await TryAcquireAsync(
-                        resource,
-                        timeUntilExpires,
-                        acquireTimeout,
-                        releaseOnDispose,
-                        monitoring,
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false)
+            return await TryAcquireAsync(resource, options, cancellationToken).ConfigureAwait(false)
                 ?? throw new LockAcquisitionTimeoutException(resource);
         }
 
         public async Task<IDistributedLock?> TryAcquireAsync(
             string resource,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            bool releaseOnDispose = true,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
+            var timeUntilExpires = options?.TimeUntilExpires;
+            var acquireTimeout = options?.AcquireTimeout;
+
             if (BeforeAcquireAsync is not null)
             {
                 await BeforeAcquireAsync(resource, timeUntilExpires, acquireTimeout, cancellationToken)
@@ -425,23 +414,6 @@ internal static class IdempotencyTestApp
                     return null;
                 }
             }
-        }
-
-        public Task<IDistributedLock?> TryAcquireAsync(
-            string resource,
-            TimeSpan? timeUntilExpires,
-            TimeSpan? acquireTimeout,
-            CancellationToken cancellationToken
-        )
-        {
-            return TryAcquireAsync(
-                resource,
-                timeUntilExpires,
-                acquireTimeout,
-                releaseOnDispose: true,
-                monitoring: LockMonitoringMode.None,
-                cancellationToken: cancellationToken
-            );
         }
 
         public Task<bool> RenewAsync(

--- a/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Integration/IdempotencyTestApp.cs
@@ -362,6 +362,8 @@ internal static class IdempotencyTestApp
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -370,6 +372,8 @@ internal static class IdempotencyTestApp
                         timeUntilExpires,
                         acquireTimeout,
                         releaseOnDispose,
+                        monitorLease,
+                        autoExtend,
                         cancellationToken
                     )
                     .ConfigureAwait(false)
@@ -381,6 +385,8 @@ internal static class IdempotencyTestApp
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -436,6 +442,8 @@ internal static class IdempotencyTestApp
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose: true,
+                monitorLease: false,
+                autoExtend: false,
                 cancellationToken: cancellationToken
             );
         }
@@ -446,6 +454,9 @@ internal static class IdempotencyTestApp
             TimeSpan? timeUntilExpires = null,
             CancellationToken cancellationToken = default
         ) => throw new NotSupportedException();
+
+        public Task<string?> GetLockIdAsync(string resource, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
 
         public Task ReleaseAsync(string resource, string lockId, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
@@ -644,6 +655,8 @@ internal static class IdempotencyTestApp
         public DateTimeOffset DateAcquired { get; } = timeProvider.GetUtcNow();
 
         public TimeSpan TimeWaitedForLock => TimeSpan.Zero;
+
+        public CancellationToken HandleLostToken => CancellationToken.None;
 
         public Task ReleaseAsync()
         {

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
@@ -725,8 +725,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(_ =>
@@ -790,8 +789,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -837,8 +835,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns((IDistributedLock?)null);
@@ -897,8 +894,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -950,8 +946,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -1002,8 +997,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
@@ -725,6 +725,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(_ =>
@@ -788,6 +790,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -832,6 +836,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -891,6 +897,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -942,6 +950,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -991,6 +1001,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
@@ -722,10 +722,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(_ =>
@@ -786,10 +783,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -832,10 +826,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns((IDistributedLock?)null);
@@ -891,10 +882,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -943,10 +931,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);
@@ -994,10 +979,7 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(dlock);

--- a/tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryResourceLockProviderTests.cs
+++ b/tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryResourceLockProviderTests.cs
@@ -102,10 +102,6 @@ public sealed class InMemoryDistributedLockProviderTests : DistributedLockProvid
         base.should_expose_none_handle_lost_token_without_monitoring();
 
     [Fact]
-    public override Task should_cancel_handle_lost_token_after_ttl_without_auto_extend() =>
-        base.should_cancel_handle_lost_token_after_ttl_without_auto_extend();
-
-    [Fact]
-    public override Task should_keep_lock_past_ttl_when_auto_extend_is_enabled() =>
-        base.should_keep_lock_past_ttl_when_auto_extend_is_enabled();
+    public override Task should_keep_lock_alive_when_auto_extend_is_enabled_smoke() =>
+        base.should_keep_lock_alive_when_auto_extend_is_enabled_smoke();
 }

--- a/tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryResourceLockProviderTests.cs
+++ b/tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryResourceLockProviderTests.cs
@@ -96,4 +96,16 @@ public sealed class InMemoryDistributedLockProviderTests : DistributedLockProvid
 
     [Fact]
     public override Task should_get_active_locks_count() => base.should_get_active_locks_count();
+
+    [Fact]
+    public override Task should_expose_none_handle_lost_token_without_monitoring() =>
+        base.should_expose_none_handle_lost_token_without_monitoring();
+
+    [Fact]
+    public override Task should_cancel_handle_lost_token_after_ttl_without_auto_extend() =>
+        base.should_cancel_handle_lost_token_after_ttl_without_auto_extend();
+
+    [Fact]
+    public override Task should_keep_lock_past_ttl_when_auto_extend_is_enabled() =>
+        base.should_keep_lock_past_ttl_when_auto_extend_is_enabled();
 }

--- a/tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryResourceLockProviderTests.cs
+++ b/tests/Headless.DistributedLocks.InMemory.Tests.Integration/InMemoryResourceLockProviderTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
 using Headless.Caching;
 using Headless.DistributedLocks;
 using Headless.DistributedLocks.Cache;

--- a/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
+++ b/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
@@ -499,49 +499,25 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         handle!.HandleLostToken.Should().Be(CancellationToken.None);
     }
 
-    public virtual async Task should_cancel_handle_lost_token_after_ttl_without_auto_extend()
+    public virtual async Task should_keep_lock_alive_when_auto_extend_is_enabled_smoke()
     {
+        // Provider-level smoke test using real timers with a generous budget so wall-clock jitter
+        // does not flake CI. Deterministic auto-extend / handle-lost coverage lives in
+        // LeaseLifecycleIntegrationTests under FakeTimeProvider.
         var locker = GetLockProvider();
         var resource = Faker.Random.String2(3, 10);
 
         await using var handle = await locker.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromMilliseconds(300),
-            monitorLease: true
-        );
-
-        handle.Should().NotBeNull();
-        await _WaitUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested, TimeSpan.FromSeconds(2));
-
-        handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
-    }
-
-    public virtual async Task should_keep_lock_past_ttl_when_auto_extend_is_enabled()
-    {
-        var locker = GetLockProvider();
-        var resource = Faker.Random.String2(3, 10);
-
-        await using var handle = await locker.TryAcquireAsync(
-            resource,
-            timeUntilExpires: TimeSpan.FromMilliseconds(300),
+            timeUntilExpires: TimeSpan.FromSeconds(2),
             autoExtend: true
         );
 
         handle.Should().NotBeNull();
-        await Task.Delay(TimeSpan.FromMilliseconds(900), AbortToken);
+        await Task.Delay(TimeSpan.FromSeconds(3), AbortToken);
 
         (await locker.IsLockedAsync(resource, AbortToken)).Should().BeTrue();
         handle!.HandleLostToken.IsCancellationRequested.Should().BeFalse();
-    }
-
-    private static async Task _WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
-    {
-        var stopAt = DateTimeOffset.UtcNow + timeout;
-
-        while (DateTimeOffset.UtcNow < stopAt && !condition())
-        {
-            await Task.Delay(TimeSpan.FromMilliseconds(25), TestContext.Current.CancellationToken);
-        }
     }
 
     #endregion

--- a/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
+++ b/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
@@ -48,14 +48,15 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         var lockProvider = GetLockProvider();
         var resource = Faker.Random.String2(3, 20);
         var acquireTimeout = TimeSpan.FromSeconds(1);
+        var options = new DistributedLockAcquireOptions { AcquireTimeout = acquireTimeout };
 
-        await using (var handle = await lockProvider.TryAcquireAsync(resource, null, acquireTimeout))
+        await using (var handle = await lockProvider.TryAcquireAsync(resource, options))
         {
             handle.Should().NotBeNull();
 
             await Task.Run(async () =>
             {
-                await using var handle2 = await lockProvider.TryAcquireAsync(resource, null, acquireTimeout);
+                await using var handle2 = await lockProvider.TryAcquireAsync(resource, options);
 
                 handle2.Should().BeNull();
             });
@@ -63,7 +64,7 @@ public abstract class DistributedLockProviderTestsBase : TestBase
 
         await Task.Run(async () =>
         {
-            await using var handle = await lockProvider.TryAcquireAsync(resource, null, acquireTimeout);
+            await using var handle = await lockProvider.TryAcquireAsync(resource, options);
 
             handle.Should().NotBeNull();
         });
@@ -74,9 +75,13 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         var lockProvider = GetLockProvider();
         var resource = Faker.Random.String2(3, 20);
 
-        await using var handle = await lockProvider.AcquireAsync(resource, acquireTimeout: TimeSpan.FromSeconds(1));
+        await using var handle = await lockProvider.AcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(1) }
+        );
 
-        var act = async () => await lockProvider.AcquireAsync(resource, acquireTimeout: TimeSpan.Zero);
+        var act = async () =>
+            await lockProvider.AcquireAsync(resource, new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero });
 
         var assertion = await act.Should().ThrowAsync<LockAcquisitionTimeoutException>();
         assertion.Which.Resource.Should().Be(resource);
@@ -107,8 +112,11 @@ public abstract class DistributedLockProviderTestsBase : TestBase
 
         var lock1 = await locker.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(1),
-            acquireTimeout: TimeSpan.FromMilliseconds(100)
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(1),
+                AcquireTimeout = TimeSpan.FromMilliseconds(100),
+            }
         );
 
         lock1.Should().NotBeNull();
@@ -117,8 +125,11 @@ public abstract class DistributedLockProviderTestsBase : TestBase
 
         var lock2 = await locker.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(1),
-            acquireTimeout: TimeSpan.FromMilliseconds(100)
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(1),
+                AcquireTimeout = TimeSpan.FromMilliseconds(100),
+            }
         );
 
         lock2.Should().NotBeNull();
@@ -142,9 +153,12 @@ public abstract class DistributedLockProviderTestsBase : TestBase
 
         var handle = await locker.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(30),
-            acquireTimeout: TimeSpan.FromMilliseconds(100),
-            releaseOnDispose: false
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(30),
+                AcquireTimeout = TimeSpan.FromMilliseconds(100),
+                ReleaseOnDispose = false,
+            }
         );
 
         handle.Should().NotBeNull();
@@ -162,9 +176,12 @@ public abstract class DistributedLockProviderTestsBase : TestBase
 
         await using var handle = await locker.AcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(30),
-            acquireTimeout: TimeSpan.FromMilliseconds(100),
-            releaseOnDispose: false
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(30),
+                AcquireTimeout = TimeSpan.FromMilliseconds(100),
+                ReleaseOnDispose = false,
+            }
         );
 
         await handle.ReleaseAsync();
@@ -179,17 +196,26 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         var resource = Faker.Random.String2(3, 10);
 
         Logger.LogInformation("################## Acquiring lock #1");
-        var testLock = await locker.TryAcquireAsync(resource, timeUntilExpires: TimeSpan.FromMilliseconds(250));
+        var testLock = await locker.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMilliseconds(250) }
+        );
         Logger.LogInformation(testLock != null ? "Acquired lock #1" : "Unable to acquire lock #1");
         testLock.Should().NotBeNull();
 
         Logger.LogInformation("################## Acquiring lock #2");
-        testLock = await locker.TryAcquireAsync(resource, acquireTimeout: TimeSpan.FromMilliseconds(50));
+        testLock = await locker.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromMilliseconds(50) }
+        );
         Logger.LogInformation(testLock != null ? "Acquired lock #2" : "Unable to acquire lock #2");
         testLock.Should().BeNull();
 
         Logger.LogInformation("################## Acquiring lock #3");
-        testLock = await locker.TryAcquireAsync(resource, acquireTimeout: TimeSpan.FromSeconds(10));
+        testLock = await locker.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(10) }
+        );
         Logger.LogInformation(testLock != null ? "Acquired lock #3" : "Unable to acquire lock #3");
         testLock.Should().NotBeNull();
     }
@@ -202,8 +228,11 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         // Try to acquire a lock
         var lock1 = await locker.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(1),
-            acquireTimeout: TimeSpan.FromMilliseconds(200)
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(1),
+                AcquireTimeout = TimeSpan.FromMilliseconds(200),
+            }
         );
 
         try
@@ -213,7 +242,10 @@ public abstract class DistributedLockProviderTestsBase : TestBase
             (await locker.IsLockedAsync(resource)).Should().BeTrue();
 
             // Cannot acquire a lock on the same resource
-            var lock2Task = locker.TryAcquireAsync(resource, acquireTimeout: TimeSpan.FromMilliseconds(250));
+            var lock2Task = locker.TryAcquireAsync(
+                resource,
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromMilliseconds(250) }
+            );
             await Task.Delay(TimeSpan.FromMilliseconds(250), TimeProvider);
             (await lock2Task).Should().BeNull();
         }
@@ -268,8 +300,11 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         {
             await using var myLock = await locker.TryAcquireAsync(
                 resource: "test",
-                timeUntilExpires: TimeSpan.FromMinutes(2),
-                acquireTimeout: TimeSpan.FromMinutes(2)
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = TimeSpan.FromMinutes(2),
+                    AcquireTimeout = TimeSpan.FromMinutes(2),
+                }
             );
 
             myLock.Should().NotBeNull();
@@ -305,9 +340,12 @@ public abstract class DistributedLockProviderTestsBase : TestBase
             {
                 await using var myLock = await locker.TryAcquireAsync(
                     resource: "test",
-                    timeUntilExpires: TimeSpan.FromMinutes(2),
-                    acquireTimeout: TimeSpan.FromMinutes(2),
-                    cancellationToken: ct
+                    new DistributedLockAcquireOptions
+                    {
+                        TimeUntilExpires = TimeSpan.FromMinutes(2),
+                        AcquireTimeout = TimeSpan.FromMinutes(2),
+                    },
+                    ct
                 );
 
                 myLock.Should().NotBeNull();
@@ -391,8 +429,11 @@ public abstract class DistributedLockProviderTestsBase : TestBase
             return locker.TryUsingAsync(
                 resource: resource,
                 work: async () => await Task.Delay(300),
-                timeUntilExpires: TimeSpan.FromMinutes(1),
-                acquireTimeout: TimeSpan.Zero // No waiting just single try
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = TimeSpan.FromMinutes(1),
+                    AcquireTimeout = TimeSpan.Zero, // No waiting just single try
+                }
             );
         }
     }
@@ -405,7 +446,10 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         var resource = Faker.Random.String2(3, 10);
         var ttl = TimeSpan.FromMinutes(5);
 
-        await using var handle = await locker.TryAcquireAsync(resource, timeUntilExpires: ttl);
+        await using var handle = await locker.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { TimeUntilExpires = ttl }
+        );
         handle.Should().NotBeNull();
 
         var expiration = await locker.GetExpirationAsync(resource);
@@ -430,7 +474,10 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         var resource = Faker.Random.String2(3, 10);
         var ttl = TimeSpan.FromMinutes(5);
 
-        await using var handle = await locker.TryAcquireAsync(resource, timeUntilExpires: ttl);
+        await using var handle = await locker.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { TimeUntilExpires = ttl }
+        );
         handle.Should().NotBeNull();
 
         var info = await locker.GetLockInfoAsync(resource);
@@ -509,8 +556,11 @@ public abstract class DistributedLockProviderTestsBase : TestBase
 
         await using var handle = await locker.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(2),
-            monitoring: LockMonitoringMode.AutoExtend
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(2),
+                Monitoring = LockMonitoringMode.AutoExtend,
+            }
         );
 
         handle.Should().NotBeNull();

--- a/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
+++ b/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
@@ -485,4 +485,64 @@ public abstract class DistributedLockProviderTestsBase : TestBase
     }
 
     #endregion
+
+    #region Lease Monitoring Tests
+
+    public virtual async Task should_expose_none_handle_lost_token_without_monitoring()
+    {
+        var locker = GetLockProvider();
+        var resource = Faker.Random.String2(3, 10);
+
+        await using var handle = await locker.TryAcquireAsync(resource);
+
+        handle.Should().NotBeNull();
+        handle!.HandleLostToken.Should().Be(CancellationToken.None);
+    }
+
+    public virtual async Task should_cancel_handle_lost_token_after_ttl_without_auto_extend()
+    {
+        var locker = GetLockProvider();
+        var resource = Faker.Random.String2(3, 10);
+
+        await using var handle = await locker.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromMilliseconds(300),
+            monitorLease: true
+        );
+
+        handle.Should().NotBeNull();
+        await _WaitUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested, TimeSpan.FromSeconds(2));
+
+        handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    public virtual async Task should_keep_lock_past_ttl_when_auto_extend_is_enabled()
+    {
+        var locker = GetLockProvider();
+        var resource = Faker.Random.String2(3, 10);
+
+        await using var handle = await locker.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromMilliseconds(300),
+            autoExtend: true
+        );
+
+        handle.Should().NotBeNull();
+        await Task.Delay(TimeSpan.FromMilliseconds(900), AbortToken);
+
+        (await locker.IsLockedAsync(resource, AbortToken)).Should().BeTrue();
+        handle!.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+    }
+
+    private static async Task _WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopAt = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < stopAt && !condition())
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(25), TestContext.Current.CancellationToken);
+        }
+    }
+
+    #endregion
 }

--- a/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
+++ b/tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs
@@ -510,7 +510,7 @@ public abstract class DistributedLockProviderTestsBase : TestBase
         await using var handle = await locker.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(2),
-            autoExtend: true
+            monitoring: LockMonitoringMode.AutoExtend
         );
 
         handle.Should().NotBeNull();

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -8,20 +8,24 @@ namespace Tests;
 public sealed class DistributedLockProviderExtensionsTests : TestBase
 {
     [Fact]
-    public async Task should_release_handle_through_distributed_lock()
+    public async Task should_release_handle_through_provider()
     {
         // given
         var provider = Substitute.For<IDistributedLockProvider>();
         var distributedLock = Substitute.For<IDistributedLock>();
+        distributedLock.Resource.Returns("resource");
+        distributedLock.LockId.Returns("lock-id");
+        using var cts = new CancellationTokenSource();
+        provider.ReleaseAsync("resource", "lock-id", cts.Token).Returns(Task.CompletedTask);
 
         // when
-        await provider.ReleaseAsync(distributedLock);
+        await provider.ReleaseAsync(distributedLock, cts.Token);
 
         // then
-        await distributedLock.Received(1).ReleaseAsync();
+        await distributedLock.DidNotReceive().ReleaseAsync();
         await provider
-            .DidNotReceive()
-            .ReleaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .Received(1)
+            .ReleaseAsync("resource", "lock-id", cts.Token);
     }
 
     [Fact]

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -8,6 +8,23 @@ namespace Tests;
 public sealed class DistributedLockProviderExtensionsTests : TestBase
 {
     [Fact]
+    public async Task should_release_handle_through_distributed_lock()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLockProvider>();
+        var distributedLock = Substitute.For<IDistributedLock>();
+
+        // when
+        await provider.ReleaseAsync(distributedLock);
+
+        // then
+        await distributedLock.Received(1).ReleaseAsync();
+        await provider
+            .DidNotReceive()
+            .ReleaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task should_return_false_when_lock_not_acquired()
     {
         // given
@@ -119,6 +136,95 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                     && o.Monitoring == LockMonitoringMode.None
                 ),
                 cancellationToken
+            );
+    }
+
+    [Fact]
+    public async Task should_pass_options_to_sync_try_using_and_force_monitoring_off()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLockProvider>();
+        var distributedLock = Substitute.For<IDistributedLock>();
+        provider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
+        var workExecuted = false;
+        var options = new DistributedLockAcquireOptions
+        {
+            TimeUntilExpires = TimeSpan.FromSeconds(10),
+            AcquireTimeout = TimeSpan.FromSeconds(2),
+            ReleaseOnDispose = false,
+            Monitoring = LockMonitoringMode.Monitor,
+        };
+
+        // when
+        var result = await provider.TryUsingAsync(
+            "resource",
+            () => workExecuted = true,
+            options,
+            AbortToken
+        );
+
+        // then
+        result.Should().BeTrue();
+        workExecuted.Should().BeTrue();
+        await provider
+            .Received(1)
+            .TryAcquireAsync(
+                "resource",
+                Arg.Is<DistributedLockAcquireOptions?>(o =>
+                    o != null
+                    && o.TimeUntilExpires == options.TimeUntilExpires
+                    && o.AcquireTimeout == options.AcquireTimeout
+                    && o.ReleaseOnDispose
+                    && o.Monitoring == LockMonitoringMode.None
+                ),
+                AbortToken
+            );
+    }
+
+    [Fact]
+    public async Task should_pass_options_to_sync_state_try_using()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLockProvider>();
+        var distributedLock = Substitute.For<IDistributedLock>();
+        provider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
+        var observedState = 0;
+
+        // when
+        var result = await provider.TryUsingAsync(
+            "resource",
+            42,
+            state => observedState = state,
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromSeconds(10) },
+            AbortToken
+        );
+
+        // then
+        result.Should().BeTrue();
+        observedState.Should().Be(42);
+        await provider
+            .Received(1)
+            .TryAcquireAsync(
+                "resource",
+                Arg.Is<DistributedLockAcquireOptions?>(o =>
+                    o != null
+                    && o.TimeUntilExpires == TimeSpan.FromSeconds(10)
+                    && o.ReleaseOnDispose
+                    && o.Monitoring == LockMonitoringMode.None
+                ),
+                AbortToken
             );
     }
 

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -18,8 +18,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -54,8 +53,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
@@ -94,8 +92,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
@@ -123,8 +120,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose: true,
-                monitorLease: false,
-                autoExtend: false,
+                monitoring: LockMonitoringMode.None,
                 cancellationToken: cancellationToken
             );
     }
@@ -147,8 +143,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
@@ -169,7 +164,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 }
                 catch (OperationCanceledException) { }
             },
-            monitorLease: true
+            monitoring: LockMonitoringMode.Monitor
         );
 
         await started.Task;
@@ -187,8 +182,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 releaseOnDispose: true,
-                monitorLease: true,
-                autoExtend: false,
+                monitoring: LockMonitoringMode.Monitor,
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -15,17 +15,16 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         var distributedLock = Substitute.For<IDistributedLock>();
         distributedLock.Resource.Returns("resource");
         distributedLock.LockId.Returns("lock-id");
-        using var cts = new CancellationTokenSource();
-        provider.ReleaseAsync("resource", "lock-id", cts.Token).Returns(Task.CompletedTask);
+        provider.ReleaseAsync("resource", "lock-id", AbortToken).Returns(Task.CompletedTask);
 
         // when
-        await provider.ReleaseAsync(distributedLock, cts.Token);
+        await provider.ReleaseAsync(distributedLock, AbortToken);
 
         // then
         await distributedLock.DidNotReceive().ReleaseAsync();
         await provider
             .Received(1)
-            .ReleaseAsync("resource", "lock-id", cts.Token);
+            .ReleaseAsync("resource", "lock-id", AbortToken);
     }
 
     [Fact]
@@ -112,8 +111,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         const string resource = "test-resource";
         var timeUntilExpires = TimeSpan.FromMinutes(10);
         var acquireTimeout = TimeSpan.FromSeconds(5);
-        using var cts = new CancellationTokenSource();
-        var cancellationToken = cts.Token;
+        var cancellationToken = AbortToken;
 
         // when
         await provider.TryUsingAsync(

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -15,10 +15,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         provider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -50,10 +47,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         provider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
@@ -89,10 +83,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         provider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
@@ -107,9 +98,12 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         await provider.TryUsingAsync(
             resource,
             () => Task.CompletedTask,
-            timeUntilExpires,
-            acquireTimeout,
-            cancellationToken: cancellationToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = timeUntilExpires,
+                AcquireTimeout = acquireTimeout,
+            },
+            cancellationToken
         );
 
         // then
@@ -117,11 +111,14 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 resource,
-                timeUntilExpires,
-                acquireTimeout,
-                releaseOnDispose: true,
-                monitoring: LockMonitoringMode.None,
-                cancellationToken: cancellationToken
+                Arg.Is<DistributedLockAcquireOptions?>(o =>
+                    o != null
+                    && o.TimeUntilExpires == timeUntilExpires
+                    && o.AcquireTimeout == acquireTimeout
+                    && o.ReleaseOnDispose
+                    && o.Monitoring == LockMonitoringMode.None
+                ),
+                cancellationToken
             );
     }
 
@@ -140,10 +137,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         provider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
@@ -164,7 +158,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 }
                 catch (OperationCanceledException) { }
             },
-            monitoring: LockMonitoringMode.Monitor
+            new DistributedLockAcquireOptions { Monitoring = LockMonitoringMode.Monitor }
         );
 
         await started.Task;
@@ -179,11 +173,10 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 "resource",
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                releaseOnDispose: true,
-                monitoring: LockMonitoringMode.Monitor,
-                cancellationToken: Arg.Any<CancellationToken>()
+                Arg.Is<DistributedLockAcquireOptions?>(o =>
+                    o != null && o.Monitoring == LockMonitoringMode.Monitor && o.ReleaseOnDispose
+                ),
+                Arg.Any<CancellationToken>()
             );
     }
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -75,7 +75,10 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
         // then
         result.Should().BeTrue();
         workExecuted.Should().BeTrue();
-        await distributedLock.Received(1).ReleaseAsync();
+        // TryUsingAsync uses `await using` so DisposeAsync is invoked (which drains the lease
+        // monitor and then releases the storage row). Asserting on DisposeAsync rather than
+        // ReleaseAsync because the extension no longer calls ReleaseAsync directly.
+        await distributedLock.Received(1).DisposeAsync();
     }
 
     [Fact]

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -18,6 +18,8 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -51,6 +53,8 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -86,6 +90,8 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockProviderExtensionsTests.cs
@@ -109,7 +109,7 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
             () => Task.CompletedTask,
             timeUntilExpires,
             acquireTimeout,
-            cancellationToken
+            cancellationToken: cancellationToken
         );
 
         // then
@@ -120,7 +120,73 @@ public sealed class DistributedLockProviderExtensionsTests : TestBase
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose: true,
+                monitorLease: false,
+                autoExtend: false,
                 cancellationToken: cancellationToken
+            );
+    }
+
+    [Fact]
+    public async Task should_pass_monitor_flags_and_link_handle_lost_token_into_work()
+    {
+        // given - a real provider-built handle is needed to flow IsMonitored/HandleLostToken.
+        // Stub with NSubstitute returning a Substitute-backed IDistributedLock whose IsMonitored
+        // is true and HandleLostToken is a CTS we control. Verify the work delegate receives a
+        // linked token that becomes cancelled when HandleLostToken fires.
+        var provider = Substitute.For<IDistributedLockProvider>();
+        var distributedLock = Substitute.For<IDistributedLock>();
+        using var leaseLostCts = new CancellationTokenSource();
+        distributedLock.IsMonitored.Returns(true);
+        distributedLock.HandleLostToken.Returns(leaseLostCts.Token);
+        provider
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IDistributedLock?>(distributedLock));
+
+        CancellationToken observedToken = default;
+        var started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // when
+        var task = provider.TryUsingAsync(
+            "resource",
+            async ct =>
+            {
+                observedToken = ct;
+                started.SetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                }
+                catch (OperationCanceledException) { }
+            },
+            monitorLease: true
+        );
+
+        await started.Task;
+        await leaseLostCts.CancelAsync();
+        var result = await task;
+
+        // then
+        result.Should().BeTrue();
+        observedToken.CanBeCanceled.Should().BeTrue();
+        observedToken.IsCancellationRequested.Should().BeTrue();
+        await provider
+            .Received(1)
+            .TryAcquireAsync(
+                "resource",
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<TimeSpan?>(),
+                releaseOnDispose: true,
+                monitorLease: true,
+                autoExtend: false,
+                cancellationToken: Arg.Any<CancellationToken>()
             );
     }
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/Exceptions/LockHandleLostExceptionTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Exceptions/LockHandleLostExceptionTests.cs
@@ -49,4 +49,17 @@ public sealed class LockHandleLostExceptionTests : TestBase
         // then
         exception.Should().BeAssignableTo<DistributedLockException>();
     }
+
+    [Fact]
+    public void should_preserve_inner_exception()
+    {
+        // given
+        var cause = new InvalidOperationException("inner");
+
+        // when
+        var exception = new LockHandleLostException("resource", "lock-id", "message", cause);
+
+        // then
+        exception.InnerException.Should().BeSameAs(cause);
+    }
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/Exceptions/LockHandleLostExceptionTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Exceptions/LockHandleLostExceptionTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+
+namespace Tests.Exceptions;
+
+public sealed class LockHandleLostExceptionTests : TestBase
+{
+    [Fact]
+    public void should_store_resource_lock_id_and_default_message()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+
+        // when
+        var exception = new LockHandleLostException(resource, lockId);
+
+        // then
+        exception.Resource.Should().Be(resource);
+        exception.LockId.Should().Be(lockId);
+        exception.Message.Should().Contain(resource).And.Contain(lockId);
+    }
+
+    [Theory]
+    [InlineData(null, "lock-id")]
+    [InlineData("", "lock-id")]
+    [InlineData("resource", null)]
+    [InlineData("resource", "")]
+    public void should_throw_when_resource_or_lock_id_is_null_or_whitespace(string? resource, string? lockId)
+    {
+        // when
+        var act = () => new LockHandleLostException(resource!, lockId!);
+
+        // then
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void should_inherit_from_distributed_lock_exception()
+    {
+        // when
+        var exception = new LockHandleLostException("resource", "lock-id");
+
+        // then
+        exception.Should().BeAssignableTo<DistributedLockException>();
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/Exceptions/LockHandleLostExceptionTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Exceptions/LockHandleLostExceptionTests.cs
@@ -30,11 +30,14 @@ public sealed class LockHandleLostExceptionTests : TestBase
     [InlineData("resource", "")]
     public void should_throw_when_resource_or_lock_id_is_null_or_whitespace(string? resource, string? lockId)
     {
-        // when
-        var act = () => new LockHandleLostException(resource!, lockId!);
+        var act1 = () => { _ = new LockHandleLostException(resource!, lockId!); };
+        act1.Should().Throw<ArgumentException>();
 
-        // then
-        act.Should().Throw<ArgumentException>();
+        var act2 = () => { _ = new LockHandleLostException(resource!, lockId!, "message"); };
+        act2.Should().Throw<ArgumentException>();
+
+        var act3 = () => { _ = new LockHandleLostException(resource!, lockId!, "message", new System.Exception()); };
+        act3.Should().Throw<ArgumentException>();
     }
 
     [Fact]

--- a/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeDistributedLockStorage.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeDistributedLockStorage.cs
@@ -131,5 +131,15 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     // Test helpers
     public void Clear() => _locks.Clear();
 
+    public void SetLock(string key, string lockId, TimeSpan? ttl = null)
+    {
+        _locks[key] = new LockEntry(lockId, ttl.HasValue ? DateTime.UtcNow.Add(ttl.Value) : null);
+    }
+
+    public void RemoveLock(string key)
+    {
+        _locks.TryRemove(key, out _);
+    }
+
     private sealed record LockEntry(string LockId, DateTime? Expiration);
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeDistributedLockStorage.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeDistributedLockStorage.cs
@@ -8,6 +8,14 @@ namespace Tests.Fakes;
 internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
 {
     private readonly ConcurrentDictionary<string, LockEntry> _locks = new(StringComparer.Ordinal);
+    private readonly TimeProvider _timeProvider;
+
+    public FakeDistributedLockStorage(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    private DateTime _UtcNow() => _timeProvider.GetUtcNow().UtcDateTime;
 
     public ValueTask<bool> InsertAsync(
         string key,
@@ -17,7 +25,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var entry = new LockEntry(lockId, ttl.HasValue ? DateTime.UtcNow.Add(ttl.Value) : null);
+        var entry = new LockEntry(lockId, ttl.HasValue ? _UtcNow().Add(ttl.Value) : null);
         var added = _locks.TryAdd(key, entry);
         return ValueTask.FromResult(added);
     }
@@ -36,7 +44,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
             return ValueTask.FromResult(false);
         }
 
-        var newEntry = new LockEntry(newId, newTtl.HasValue ? DateTime.UtcNow.Add(newTtl.Value) : null);
+        var newEntry = new LockEntry(newId, newTtl.HasValue ? _UtcNow().Add(newTtl.Value) : null);
         var replaced = _locks.TryUpdate(key, newEntry, existing);
         return ValueTask.FromResult(replaced);
     }
@@ -65,7 +73,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
             return ValueTask.FromResult<TimeSpan?>(null);
         }
 
-        var remaining = entry.Expiration.Value - DateTime.UtcNow;
+        var remaining = entry.Expiration.Value - _UtcNow();
         return ValueTask.FromResult<TimeSpan?>(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
     }
 
@@ -107,7 +115,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
                 kv =>
                 {
                     var remaining = kv.Value.Expiration.HasValue
-                        ? kv.Value.Expiration.Value - DateTime.UtcNow
+                        ? kv.Value.Expiration.Value - _UtcNow()
                         : (TimeSpan?)null;
                     var ttl = remaining > TimeSpan.Zero ? remaining : (remaining.HasValue ? TimeSpan.Zero : null);
                     return (kv.Value.LockId, ttl);
@@ -133,7 +141,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
 
     public void SetLock(string key, string lockId, TimeSpan? ttl = null)
     {
-        _locks[key] = new LockEntry(lockId, ttl.HasValue ? DateTime.UtcNow.Add(ttl.Value) : null);
+        _locks[key] = new LockEntry(lockId, ttl.HasValue ? _UtcNow().Add(ttl.Value) : null);
     }
 
     public void RemoveLock(string key)

--- a/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeDistributedLockStorage.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeDistributedLockStorage.cs
@@ -25,6 +25,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _RemoveIfExpired(key);
         var entry = new LockEntry(lockId, ttl.HasValue ? _UtcNow().Add(ttl.Value) : null);
         var added = _locks.TryAdd(key, entry);
         return ValueTask.FromResult(added);
@@ -39,7 +40,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (!_locks.TryGetValue(key, out var existing) || existing.LockId != expectedId)
+        if (!_TryGetLiveEntry(key, out var existing) || existing.LockId != expectedId)
         {
             return ValueTask.FromResult(false);
         }
@@ -56,7 +57,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (!_locks.TryGetValue(key, out var existing) || existing.LockId != expectedId)
+        if (!_TryGetLiveEntry(key, out var existing) || existing.LockId != expectedId)
         {
             return ValueTask.FromResult(false);
         }
@@ -68,7 +69,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     public ValueTask<TimeSpan?> GetExpirationAsync(string key, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (!_locks.TryGetValue(key, out var entry) || entry.Expiration is null)
+        if (!_TryGetLiveEntry(key, out var entry) || entry.Expiration is null)
         {
             return ValueTask.FromResult<TimeSpan?>(null);
         }
@@ -80,13 +81,13 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     public ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(_locks.ContainsKey(key));
+        return ValueTask.FromResult(_TryGetLiveEntry(key, out _));
     }
 
     public ValueTask<string?> GetAsync(string key, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(_locks.TryGetValue(key, out var entry) ? entry.LockId : null);
+        return ValueTask.FromResult(_TryGetLiveEntry(key, out var entry) ? entry.LockId : null);
     }
 
     public ValueTask<IReadOnlyDictionary<string, string>> GetAllByPrefixAsync(
@@ -95,6 +96,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _PruneExpired();
         var result = _locks
             .Where(kv => kv.Key.StartsWith(prefix, StringComparison.Ordinal))
             .ToDictionary(kv => kv.Key, kv => kv.Value.LockId, StringComparer.Ordinal);
@@ -108,6 +110,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _PruneExpired();
         var result = _locks
             .Where(kv => kv.Key.StartsWith(prefix, StringComparison.Ordinal))
             .ToDictionary(
@@ -129,6 +132,7 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     public ValueTask<long> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        _PruneExpired();
         var count = string.IsNullOrEmpty(prefix)
             ? (long)_locks.Count
             : _locks.Count(kv => kv.Key.StartsWith(prefix, StringComparison.Ordinal));
@@ -150,4 +154,38 @@ internal sealed class FakeDistributedLockStorage : IDistributedLockStorage
     }
 
     private sealed record LockEntry(string LockId, DateTime? Expiration);
+
+    private bool _TryGetLiveEntry(string key, out LockEntry entry)
+    {
+        if (_locks.TryGetValue(key, out entry!) && !_IsExpired(entry))
+        {
+            return true;
+        }
+
+        _RemoveIfExpired(key);
+        entry = null!;
+
+        return false;
+    }
+
+    private void _PruneExpired()
+    {
+        foreach (var key in _locks.Keys)
+        {
+            _RemoveIfExpired(key);
+        }
+    }
+
+    private void _RemoveIfExpired(string key)
+    {
+        if (_locks.TryGetValue(key, out var entry) && _IsExpired(entry))
+        {
+            _locks.TryRemove(key, out _);
+        }
+    }
+
+    private bool _IsExpired(LockEntry entry)
+    {
+        return entry.Expiration is { } expiration && expiration <= _UtcNow();
+    }
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeLeaseHandle.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/Fakes/FakeLeaseHandle.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+
+namespace Tests.Fakes;
+
+internal sealed class FakeLeaseHandle : LeaseMonitor.ILeaseHandle
+{
+    private readonly Queue<object> _results = [];
+
+    public string Resource { get; init; } = "test-resource";
+
+    public string LockId { get; init; } = "test-lock";
+
+    public TimeSpan LeaseDuration { get; init; } = TimeSpan.FromSeconds(10);
+
+    public TimeSpan MonitoringCadence { get; init; } = TimeSpan.FromSeconds(5);
+
+    public int InvocationCount { get; private set; }
+
+    public void Enqueue(LeaseMonitor.LeaseState state) => _results.Enqueue(state);
+
+    public void Enqueue(Exception exception) => _results.Enqueue(exception);
+
+    public Task<LeaseMonitor.LeaseState> RenewOrValidateLeaseAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        InvocationCount++;
+
+        if (_results.Count == 0)
+        {
+            return Task.FromResult(LeaseMonitor.LeaseState.Held);
+        }
+
+        var result = _results.Dequeue();
+
+        return result switch
+        {
+            LeaseMonitor.LeaseState state => Task.FromResult(state),
+            Exception exception => Task.FromException<LeaseMonitor.LeaseState>(exception),
+            _ => throw new InvalidOperationException("Unsupported fake lease result."),
+        };
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
@@ -147,7 +147,67 @@ public sealed class DisposableDistributedLockTests : TestBase
 
         // then
         result.Should().Be(LeaseMonitor.LeaseState.Renewed);
-        await _lockProvider.Received(1).RenewAsync(resource, lockId, TimeSpan.FromSeconds(10), AbortToken);
+        await _lockProvider
+            .Received(1)
+            .RenewAsync(resource, lockId, TimeSpan.FromSeconds(10), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_treat_renew_false_with_matching_lock_id_as_unknown_under_auto_extend()
+    {
+        // given - autoExtend handle whose RenewAsync returns false (transient retry-exhaustion),
+        // but ownership probe via GetLockIdAsync still shows our LockId — i.e., we still own it.
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider
+            .RenewAsync(resource, lockId, Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _lockProvider.GetLockIdAsync(resource, Arg.Any<CancellationToken>()).Returns(lockId);
+        var sut = _CreateLock(resource, lockId, autoExtend: true);
+
+        // when
+        var result = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(AbortToken);
+
+        // then - we still own the lock; classify as Unknown so the safety net governs.
+        result.Should().Be(LeaseMonitor.LeaseState.Unknown);
+    }
+
+    [Fact]
+    public async Task should_treat_renew_false_with_differing_lock_id_as_lost_under_auto_extend()
+    {
+        // given - autoExtend handle whose RenewAsync returns false and probe shows a different owner.
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider
+            .RenewAsync(resource, lockId, Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _lockProvider.GetLockIdAsync(resource, Arg.Any<CancellationToken>()).Returns("foreign-lock");
+        var sut = _CreateLock(resource, lockId, autoExtend: true);
+
+        // when
+        var result = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(AbortToken);
+
+        // then - genuine loss: a different owner holds the lock.
+        result.Should().Be(LeaseMonitor.LeaseState.Lost);
+    }
+
+    [Fact]
+    public async Task should_treat_renew_false_with_null_probe_as_lost_under_auto_extend()
+    {
+        // given - autoExtend handle whose RenewAsync returns false and probe shows nothing.
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider
+            .RenewAsync(resource, lockId, Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _lockProvider.GetLockIdAsync(resource, Arg.Any<CancellationToken>()).Returns((string?)null);
+        var sut = _CreateLock(resource, lockId, autoExtend: true);
+
+        // when
+        var result = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(AbortToken);
+
+        // then - storage no longer has the row; genuine loss.
+        result.Should().Be(LeaseMonitor.LeaseState.Lost);
     }
 
     [Fact]
@@ -156,7 +216,7 @@ public sealed class DisposableDistributedLockTests : TestBase
         // given
         var resource = Faker.Random.AlphaNumeric(10);
         var lockId = Faker.Random.Guid().ToString();
-        _lockProvider.GetLockIdAsync(resource, AbortToken).Returns(lockId);
+        _lockProvider.GetLockIdAsync(resource, Arg.Any<CancellationToken>()).Returns(lockId);
         var sut = _CreateLock(resource, lockId);
 
         // when
@@ -164,7 +224,66 @@ public sealed class DisposableDistributedLockTests : TestBase
 
         // then
         result.Should().Be(LeaseMonitor.LeaseState.Held);
-        await _lockProvider.Received(1).GetLockIdAsync(resource, AbortToken);
+        await _lockProvider.Received(1).GetLockIdAsync(resource, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_not_throw_when_handle_lost_token_is_read_after_dispose()
+    {
+        // given - acquire a monitor-backed handle and dispose it (which disposes the inner CTS).
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider.GetLockIdAsync(resource, Arg.Any<CancellationToken>()).Returns(lockId);
+        var sut = _CreateLock(resource, lockId);
+        var monitor = new LeaseMonitor(
+            (LeaseMonitor.ILeaseHandle)sut,
+            _timeProvider,
+            LoggerFactory.CreateLogger(nameof(LeaseMonitor))
+        );
+        sut.AttachMonitor(monitor);
+
+        // when - dispose (which disposes the monitor's _handleLostSource CTS).
+        await sut.DisposeAsync();
+
+        // then - reading HandleLostToken after dispose must not throw ObjectDisposedException.
+        var act = () =>
+        {
+            var token = sut.HandleLostToken;
+            _ = token.IsCancellationRequested;
+        };
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task should_apply_per_iteration_deadline_when_storage_blocks_indefinitely()
+    {
+        // given - storage that respects only the token passed in (not the caller's CT). The
+        // per-iteration deadline created inside RenewOrValidateLeaseAsync must link the
+        // caller's token with a TimeProvider-backed deadline; when the deadline fires the
+        // storage call is cancelled, RenewOrValidateLeaseAsync catches and classifies as
+        // Unknown so DisposeAsync does not wedge waiting on a stuck storage round-trip.
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider
+            .GetLockIdAsync(resource, Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var ct = ci.Arg<CancellationToken>();
+                var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                ct.Register(() => tcs.TrySetCanceled(ct));
+                return tcs.Task;
+            });
+        var sut = _CreateLock(resource, lockId);
+
+        // when - call the iteration with an uncancellable caller token, then advance fake time
+        // past the per-iteration deadline.
+        var task = ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(CancellationToken.None);
+        await Task.Yield();
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+
+        // then - completes within a bounded real time and classifies as Unknown.
+        var result = await task.WaitAsync(TimeSpan.FromSeconds(5));
+        result.Should().Be(LeaseMonitor.LeaseState.Unknown);
     }
 
     [Fact]

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
@@ -433,6 +433,34 @@ public sealed class DisposableDistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_not_replay_successful_probe_after_it_was_observed()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        var currentLockId = lockId;
+        var callCount = 0;
+        _lockProvider
+            .GetLockIdAsync(resource, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref callCount);
+                return Task.FromResult<string?>(currentLockId);
+            });
+        var sut = _CreateLock(resource, lockId);
+
+        // when
+        var firstResult = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(CancellationToken.None);
+        currentLockId = "foreign-lock";
+        var secondResult = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(CancellationToken.None);
+
+        // then - the second probe must hit storage again instead of replaying stale Held.
+        firstResult.Should().Be(LeaseMonitor.LeaseState.Held);
+        secondResult.Should().Be(LeaseMonitor.LeaseState.Lost);
+        callCount.Should().Be(2);
+    }
+
+    [Fact]
     public async Task should_calculate_locked_duration()
     {
         // given

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
@@ -399,6 +399,40 @@ public sealed class DisposableDistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_observe_late_successful_probe_after_iteration_deadline()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        var probe = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        _lockProvider
+            .GetLockIdAsync(resource, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref callCount);
+                return probe.Task;
+            });
+        var sut = _CreateLock(resource, lockId);
+
+        // when - first iteration times out before storage replies.
+        var first = ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(CancellationToken.None);
+        await Task.Yield();
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        var firstResult = await first.WaitAsync(TimeSpan.FromSeconds(5));
+
+        probe.SetResult(lockId);
+        var secondResult = await ((LeaseMonitor.ILeaseHandle)sut)
+            .RenewOrValidateLeaseAsync(CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        // then - the completed single-flight result is consumed once instead of being discarded.
+        firstResult.Should().Be(LeaseMonitor.LeaseState.Unknown);
+        secondResult.Should().Be(LeaseMonitor.LeaseState.Held);
+        callCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task should_calculate_locked_duration()
     {
         // given

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
@@ -88,6 +88,19 @@ public sealed class DisposableDistributedLockTests : TestBase
     }
 
     [Fact]
+    public void should_return_none_handle_lost_token_when_monitor_is_absent()
+    {
+        // given
+        var sut = _CreateLock(Faker.Random.AlphaNumeric(10), Faker.Random.Guid().ToString());
+
+        // when
+        var token = sut.HandleLostToken;
+
+        // then
+        token.Should().Be(CancellationToken.None);
+    }
+
+    [Fact]
     public async Task should_release_explicitly_when_release_on_dispose_is_false()
     {
         // given
@@ -121,6 +134,40 @@ public sealed class DisposableDistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_route_auto_extend_lease_validation_to_renew()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider.RenewAsync(resource, lockId, Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>()).Returns(true);
+        var sut = _CreateLock(resource, lockId, autoExtend: true);
+
+        // when
+        var result = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(AbortToken);
+
+        // then
+        result.Should().Be(LeaseMonitor.LeaseState.Renewed);
+        await _lockProvider.Received(1).RenewAsync(resource, lockId, TimeSpan.FromSeconds(10), AbortToken);
+    }
+
+    [Fact]
+    public async Task should_route_monitor_only_lease_validation_to_get_lock_id()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        _lockProvider.GetLockIdAsync(resource, AbortToken).Returns(lockId);
+        var sut = _CreateLock(resource, lockId);
+
+        // when
+        var result = await ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(AbortToken);
+
+        // then
+        result.Should().Be(LeaseMonitor.LeaseState.Held);
+        await _lockProvider.Received(1).GetLockIdAsync(resource, AbortToken);
+    }
+
+    [Fact]
     public async Task should_calculate_locked_duration()
     {
         // given
@@ -143,16 +190,21 @@ public sealed class DisposableDistributedLockTests : TestBase
         string resource,
         string lockId,
         TimeSpan? timeWaitedForLock = null,
-        bool releaseOnDispose = true
+        bool releaseOnDispose = true,
+        bool autoExtend = false
     )
     {
         return new DisposableDistributedLock(
             resource,
             lockId,
+            TimeSpan.FromSeconds(10),
             timeWaitedForLock ?? TimeSpan.Zero,
             _lockProvider,
             releaseOnDispose,
+            autoExtend,
+            new DistributedLockOptions(),
             _timeProvider,
+            deregisterMonitor: null,
             LoggerFactory.CreateLogger(nameof(DisposableDistributedLock))
         );
     }

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DisposableDistributedLockTests.cs
@@ -98,6 +98,7 @@ public sealed class DisposableDistributedLockTests : TestBase
 
         // then
         token.Should().Be(CancellationToken.None);
+        sut.IsMonitored.Should().BeFalse();
     }
 
     [Fact]
@@ -134,6 +135,44 @@ public sealed class DisposableDistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_stop_monitor_on_explicit_release_without_signaling_loss()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        var deregisterCount = 0;
+        var sut = _CreateLock(
+            resource,
+            lockId,
+            deregisterMonitor: (actualResource, actualLockId) =>
+            {
+                actualResource.Should().Be(resource);
+                actualLockId.Should().Be(lockId);
+                Interlocked.Increment(ref deregisterCount);
+            }
+        );
+        var monitor = new LeaseMonitor(
+            (LeaseMonitor.ILeaseHandle)sut,
+            _timeProvider,
+            LoggerFactory.CreateLogger(nameof(LeaseMonitor))
+        );
+        sut.AttachMonitor(monitor);
+        sut.IsMonitored.Should().BeTrue();
+        var handleLostToken = sut.HandleLostToken;
+
+        // when
+        await sut.ReleaseAsync();
+        _timeProvider.Advance(TimeSpan.FromSeconds(20));
+
+        // then
+        sut.IsMonitored.Should().BeFalse();
+        monitor.MonitoringTask.IsCompleted.Should().BeTrue();
+        handleLostToken.IsCancellationRequested.Should().BeFalse();
+        deregisterCount.Should().Be(1);
+        await _lockProvider.Received(1).ReleaseAsync(resource, lockId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task should_route_auto_extend_lease_validation_to_renew()
     {
         // given
@@ -147,6 +186,7 @@ public sealed class DisposableDistributedLockTests : TestBase
 
         // then
         result.Should().Be(LeaseMonitor.LeaseState.Renewed);
+        sut.RenewalCount.Should().Be(1);
         await _lockProvider
             .Received(1)
             .RenewAsync(resource, lockId, TimeSpan.FromSeconds(10), Arg.Any<CancellationToken>());
@@ -287,6 +327,78 @@ public sealed class DisposableDistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_dispose_monitor_when_storage_ignores_cancellation()
+    {
+        // given - storage operation never completes and ignores the provided token. DisposeAsync
+        // must still drain the monitor after the TimeProvider-backed deadline fires.
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        var validationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _lockProvider
+            .GetLockIdAsync(resource, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                validationStarted.TrySetResult();
+                var blocked = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                return blocked.Task;
+            });
+        var sut = _CreateLock(resource, lockId);
+        var monitor = new LeaseMonitor(
+            (LeaseMonitor.ILeaseHandle)sut,
+            _timeProvider,
+            LoggerFactory.CreateLogger(nameof(LeaseMonitor))
+        );
+        sut.AttachMonitor(monitor);
+        monitor.TriggerImmediateValidation();
+        await validationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // when
+        var disposeTask = sut.DisposeAsync().AsTask();
+        await Task.Yield();
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+
+        // then
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        monitor.MonitoringTask.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_not_start_parallel_monitor_probes_when_storage_ignores_cancellation()
+    {
+        // given
+        var resource = Faker.Random.AlphaNumeric(10);
+        var lockId = Faker.Random.Guid().ToString();
+        var callCount = 0;
+        _lockProvider
+            .GetLockIdAsync(resource, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref callCount);
+                var blocked = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                return blocked.Task;
+            });
+        var sut = _CreateLock(resource, lockId);
+
+        // when
+        var first = ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(CancellationToken.None);
+        await Task.Yield();
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        var firstResult = await first.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var second = ((LeaseMonitor.ILeaseHandle)sut).RenewOrValidateLeaseAsync(CancellationToken.None);
+        await Task.Yield();
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        var secondResult = await second.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // then
+        firstResult.Should().Be(LeaseMonitor.LeaseState.Unknown);
+        secondResult.Should().Be(LeaseMonitor.LeaseState.Unknown);
+        callCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task should_calculate_locked_duration()
     {
         // given
@@ -310,7 +422,8 @@ public sealed class DisposableDistributedLockTests : TestBase
         string lockId,
         TimeSpan? timeWaitedForLock = null,
         bool releaseOnDispose = true,
-        bool autoExtend = false
+        bool autoExtend = false,
+        Action<string, string>? deregisterMonitor = null
     )
     {
         return new DisposableDistributedLock(
@@ -323,7 +436,7 @@ public sealed class DisposableDistributedLockTests : TestBase
             autoExtend,
             new DistributedLockOptions(),
             _timeProvider,
-            deregisterMonitor: null,
+            deregisterMonitor,
             LoggerFactory.CreateLogger(nameof(DisposableDistributedLock))
         );
     }

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockOptionsValidatorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockOptionsValidatorTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+
+namespace Tests.RegularLocks;
+
+public sealed class DistributedLockOptionsValidatorTests : TestBase
+{
+    private readonly DistributedLockOptionsValidator _validator = new();
+
+    [Fact]
+    public void should_validate_defaults()
+    {
+        // when
+        var result = _validator.Validate(new DistributedLockOptions());
+
+        // then
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0.1)]
+    [InlineData(0.5)]
+    public void should_validate_cadence_fraction_boundaries(double fraction)
+    {
+        // given
+        var options = new DistributedLockOptions
+        {
+            PollingCadenceFraction = fraction,
+            AutoExtensionCadenceFraction = fraction,
+        };
+
+        // when
+        var result = _validator.Validate(options);
+
+        // then
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0.09)]
+    [InlineData(0.51)]
+    public void should_reject_cadence_fractions_outside_bounds(double fraction)
+    {
+        // given
+        var options = new DistributedLockOptions
+        {
+            PollingCadenceFraction = fraction,
+            AutoExtensionCadenceFraction = fraction,
+        };
+
+        // when
+        var result = _validator.Validate(options);
+
+        // then
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(DistributedLockOptions.PollingCadenceFraction));
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(DistributedLockOptions.AutoExtensionCadenceFraction));
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs
@@ -129,8 +129,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when - try to acquire second lock with zero timeout (immediate)
         var result = await provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            AbortToken
         );
 
         // then
@@ -168,7 +168,11 @@ public sealed class DistributedLockProviderTests : TestBase
 
         // when
         var act = async () =>
-            await provider.AcquireAsync(resource, acquireTimeout: TimeSpan.Zero, cancellationToken: AbortToken);
+            await provider.AcquireAsync(
+                resource,
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+                AbortToken
+            );
 
         // then
         var assertion = await act.Should().ThrowAsync<LockAcquisitionTimeoutException>();
@@ -203,8 +207,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var acquireTask = provider.AcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.FromSeconds(30),
-            cancellationToken: cts.Token
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+            cts.Token
         );
         await Task.Delay(50, AbortToken);
         await cts.CancelAsync();
@@ -220,7 +224,11 @@ public sealed class DistributedLockProviderTests : TestBase
         // given
         var provider = _CreateProvider();
         var resource = Faker.Random.AlphaNumeric(10);
-        var handle = await provider.AcquireAsync(resource, releaseOnDispose: false, cancellationToken: AbortToken);
+        var handle = await provider.AcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { ReleaseOnDispose = false },
+            AbortToken
+        );
 
         // when
         await handle.DisposeAsync();
@@ -240,8 +248,8 @@ public sealed class DistributedLockProviderTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         await using var handle = await provider.AcquireAsync(
             resource,
-            releaseOnDispose: false,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { ReleaseOnDispose = false },
+            AbortToken
         );
 
         // when
@@ -271,8 +279,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when - try to acquire on a FREE resource with zero acquire timeout
         var result = await provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            AbortToken
         );
 
         // then - handle must be returned; Zero is "no wait", not "no attempt"
@@ -302,8 +310,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // Start acquisition task
         var acquireTask = provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.FromSeconds(30),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+            AbortToken
         );
 
         // Drive the provider's retry loop by advancing fake time until it acquires.
@@ -343,8 +351,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when - use zero timeout for immediate failure
         var result = await provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            AbortToken
         );
 
         // then
@@ -369,8 +377,8 @@ public sealed class DistributedLockProviderTests : TestBase
         var act = async () =>
             await provider.TryAcquireAsync(
                 resource,
-                acquireTimeout: TimeSpan.FromMinutes(1),
-                cancellationToken: cts.Token
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromMinutes(1) },
+                cts.Token
             );
 
         // then
@@ -403,8 +411,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var result = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: customTtl,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = customTtl },
+            AbortToken
         );
 
         // then
@@ -425,8 +433,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var result = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: Timeout.InfiniteTimeSpan,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = Timeout.InfiniteTimeSpan },
+            AbortToken
         );
 
         // then
@@ -454,15 +462,15 @@ public sealed class DistributedLockProviderTests : TestBase
 #pragma warning disable AsyncFixer04 // Intentionally not awaiting to simulate concurrent waiters
             _ = provider.TryAcquireAsync(
                 resource,
-                acquireTimeout: TimeSpan.FromSeconds(30),
-                cancellationToken: cts.Token
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+                cts.Token
             );
             await Task.Delay(100, AbortToken); // Give time for waiter1 to enter retry loop
 
             _ = provider.TryAcquireAsync(
                 resource,
-                acquireTimeout: TimeSpan.FromSeconds(30),
-                cancellationToken: cts.Token
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+                cts.Token
             );
             await Task.Delay(100, AbortToken); // Give time for waiter2 to enter retry loop
 #pragma warning restore AsyncFixer04
@@ -471,8 +479,8 @@ public sealed class DistributedLockProviderTests : TestBase
             var act = async () =>
                 await provider.TryAcquireAsync(
                     resource,
-                    acquireTimeout: TimeSpan.FromSeconds(30),
-                    cancellationToken: cts.Token
+                    new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+                    cts.Token
                 );
 
             // then
@@ -504,15 +512,15 @@ public sealed class DistributedLockProviderTests : TestBase
 #pragma warning disable AsyncFixer04 // Intentionally not awaiting to simulate concurrent waiters
             _ = provider.TryAcquireAsync(
                 "resource1",
-                acquireTimeout: TimeSpan.FromSeconds(30),
-                cancellationToken: cts.Token
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+                cts.Token
             );
             await Task.Delay(100, AbortToken);
 
             _ = provider.TryAcquireAsync(
                 "resource2",
-                acquireTimeout: TimeSpan.FromSeconds(30),
-                cancellationToken: cts.Token
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+                cts.Token
             );
             await Task.Delay(100, AbortToken);
 #pragma warning restore AsyncFixer04
@@ -521,8 +529,8 @@ public sealed class DistributedLockProviderTests : TestBase
             var act = async () =>
                 await provider.TryAcquireAsync(
                     "resource3",
-                    acquireTimeout: TimeSpan.FromSeconds(30),
-                    cancellationToken: cts.Token
+                    new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+                    cts.Token
                 );
 
             // then
@@ -579,8 +587,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when — Zero acquireTimeout, CancellationToken.None (no caller-side bound)
         var acquireTask = provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: CancellationToken.None
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            CancellationToken.None
         );
 
         // Advance past the safety deadline — virtualised via FakeTimeProvider, no wall-clock wait.
@@ -609,8 +617,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var acquireTask = provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: callerCts.Token
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            callerCts.Token
         );
 
         _timeProvider.Advance(TimeSpan.FromSeconds(_SafetyDeadlineSeconds + 1));
@@ -635,7 +643,11 @@ public sealed class DistributedLockProviderTests : TestBase
 
         // when — caller token is already cancelled BEFORE the call enters the helper
         var act = async () =>
-            await provider.TryAcquireAsync(resource, acquireTimeout: TimeSpan.Zero, cancellationToken: callerCts.Token);
+            await provider.TryAcquireAsync(
+                resource,
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+                callerCts.Token
+            );
 
         // then — the pre-call ThrowIfCancellationRequested guard fires (no storage call reached)
         await act.Should().ThrowAsync<OperationCanceledException>();
@@ -663,7 +675,11 @@ public sealed class DistributedLockProviderTests : TestBase
 
         // when
         var act = async () =>
-            await provider.TryAcquireAsync(resource, acquireTimeout: TimeSpan.Zero, cancellationToken: callerCts.Token);
+            await provider.TryAcquireAsync(
+                resource,
+                new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+                callerCts.Token
+            );
 
         // then — OCE must propagate to caller, AND best-effort orphan cleanup must fire
         await act.Should().ThrowAsync<OperationCanceledException>();
@@ -696,8 +712,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var result = await provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            AbortToken
         );
 
         // then — single attempt, no retry loop entered. Subsequent fake-time advances must not
@@ -729,8 +745,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var acquireTask = provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: CancellationToken.None
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            CancellationToken.None
         );
 
         _timeProvider.Advance(TimeSpan.FromSeconds(_SafetyDeadlineSeconds + 1));
@@ -762,8 +778,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var result = await provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: callerCts.Token
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.Zero },
+            callerCts.Token
         );
 
         // then
@@ -916,8 +932,8 @@ public sealed class DistributedLockProviderTests : TestBase
         // when
         var acquireTask = provider.TryAcquireAsync(
             resource,
-            acquireTimeout: TimeSpan.FromSeconds(30),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { AcquireTimeout = TimeSpan.FromSeconds(30) },
+            AbortToken
         );
         await Task.Delay(50, AbortToken);
         await existing.ReleaseAsync();
@@ -1026,8 +1042,8 @@ public sealed class DistributedLockProviderTests : TestBase
 
         var acquiredLock = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromMinutes(5),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMinutes(5) },
+            AbortToken
         );
         acquiredLock.Should().NotBeNull();
 
@@ -1071,8 +1087,8 @@ public sealed class DistributedLockProviderTests : TestBase
 
         var acquiredLock = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromMinutes(5),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMinutes(5) },
+            AbortToken
         );
         acquiredLock.Should().NotBeNull();
 
@@ -1160,7 +1176,11 @@ public sealed class DistributedLockProviderTests : TestBase
         var provider = _CreateProvider();
         var resource = Faker.Random.AlphaNumeric(10);
         var ttl = TimeSpan.FromMinutes(10);
-        await provider.TryAcquireAsync(resource, timeUntilExpires: ttl, cancellationToken: AbortToken);
+        await provider.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions { TimeUntilExpires = ttl },
+            AbortToken
+        );
 
         // when
         var result = await provider.GetExpirationAsync(resource, AbortToken);
@@ -1192,8 +1212,8 @@ public sealed class DistributedLockProviderTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         var acquiredLock = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromMinutes(5),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMinutes(5) },
+            AbortToken
         );
 
         // when

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs
@@ -882,6 +882,41 @@ public sealed class DistributedLockProviderTests : TestBase
     }
 
     [Fact]
+    public async Task should_keep_monitor_registered_when_release_fails()
+    {
+        // given
+        var storage = Substitute.For<IDistributedLockStorage>();
+        storage
+            .InsertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        storage
+            .RemoveIfEqualAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<ValueTask<bool>>(_ => throw new InvalidOperationException("release failed"));
+        var provider = _CreateProvider(storage: storage);
+        var resource = Faker.Random.AlphaNumeric(10);
+        var handle = await provider.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+                ReleaseOnDispose = false,
+            },
+            AbortToken
+        );
+        handle.Should().NotBeNull();
+
+        // when
+        var act = async () => await provider.ReleaseAsync(resource, handle!.LockId, AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        provider.GetActiveMonitorCount(resource).Should().Be(1);
+
+        await handle!.DisposeAsync();
+    }
+
+    [Fact]
     public async Task should_publish_lock_released_message()
     {
         // given

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -49,7 +49,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
 
@@ -72,7 +72,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();
@@ -97,7 +97,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            autoExtend: true,
+            monitoring: LockMonitoringMode.AutoExtend,
             cancellationToken: AbortToken
         );
 
@@ -118,7 +118,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(1),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();
@@ -142,7 +142,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(3),
-            autoExtend: true,
+            monitoring: LockMonitoringMode.AutoExtend,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();
@@ -168,7 +168,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(3),
-            autoExtend: true,
+            monitoring: LockMonitoringMode.AutoExtend,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();
@@ -212,7 +212,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var monitored = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
 
@@ -242,7 +242,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();
@@ -279,7 +279,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();
@@ -308,7 +308,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
             provider.TryAcquireAsync(
                 resource,
                 timeUntilExpires: Timeout.InfiniteTimeSpan,
-                monitorLease: true,
+                monitoring: LockMonitoringMode.Monitor,
                 cancellationToken: AbortToken
             );
 
@@ -329,7 +329,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await using var handle = await provider.TryAcquireAsync(
             resource,
             timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitorLease: true,
+            monitoring: LockMonitoringMode.Monitor,
             cancellationToken: AbortToken
         );
         handle.Should().NotBeNull();

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -36,6 +36,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         handle.Should().NotBeNull();
         handle!.HandleLostToken.Should().Be(CancellationToken.None);
         provider.GetActiveMonitorCount(resource).Should().Be(0);
+        provider.GetActiveMonitorResourceCount().Should().Be(0);
     }
 
     [Fact]
@@ -60,9 +61,11 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         handle.Should().NotBeNull();
         handle!.HandleLostToken.Should().NotBe(CancellationToken.None);
         provider.GetActiveMonitorCount(resource).Should().Be(1);
+        provider.GetActiveMonitorResourceCount().Should().Be(1);
 
         await handle.DisposeAsync();
         provider.GetActiveMonitorCount(resource).Should().Be(0);
+        provider.GetActiveMonitorResourceCount().Should().Be(0);
     }
 
     [Fact]
@@ -315,10 +318,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         // historically nudge the still-alive monitor for that resource.
         await provider.ReleaseAsync(resource, handle!.LockId, AbortToken);
         ((ICanReceiveLockReleased)provider).OnLockReleased(new DistributedLockReleased(resource, handle.LockId));
-        await _DrainUntilAsync(() => handle.HandleLostToken.IsCancellationRequested);
+        _timeProvider.Advance(TimeSpan.FromSeconds(6));
+        await _DrainUntilAsync(() => provider.GetActiveMonitorCount(resource) == 0);
 
-        // then - HandleLostToken stays unfired (self-release deregistered the monitor first).
+        // then - HandleLostToken stays unfired after a monitor cadence opportunity.
         handle.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+        provider.GetActiveMonitorCount(resource).Should().Be(0);
 
         await handle.DisposeAsync();
     }
@@ -367,11 +372,14 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         );
         handle.Should().NotBeNull();
 
-        // when - foreign party takes over the row; advance the clock past a cadence interval.
+        // when - foreign party takes over the row; advance the clock past cadence intervals.
         _storage.SetLock(options.KeyPrefix + resource, "foreign-lock", TimeSpan.FromSeconds(10));
-        _timeProvider.Advance(TimeSpan.FromSeconds(6));
 
-        await _DrainUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested);
+        for (var i = 0; i < 10 && !handle!.HandleLostToken.IsCancellationRequested; i++)
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(6));
+            await _DrainUntilAsync(() => handle.HandleLostToken.IsCancellationRequested);
+        }
 
         // then - polling cadence alone (no nudge) was sufficient to detect loss.
         handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -317,13 +317,43 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         exception.Which.ParamName.Should().Be("timeUntilExpires");
     }
 
+    [Fact]
+    public async Task should_signal_lease_loss_via_polling_when_outbox_publisher_is_null()
+    {
+        // AC8 — without an outbox publisher, the only way the monitor can learn of loss is
+        // via its own cadence-driven probe. Confirm that polling alone (no nudge) eventually
+        // surfaces HandleLostToken when storage is mutated by another party.
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options, outboxPublisher: null);
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+
+        // when - foreign party takes over the row; advance the clock past a cadence interval.
+        _storage.SetLock(options.KeyPrefix + resource, "foreign-lock", TimeSpan.FromSeconds(10));
+        _timeProvider.Advance(TimeSpan.FromSeconds(6));
+
+        await _DrainUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested);
+
+        // then - polling cadence alone (no nudge) was sufficient to detect loss.
+        handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+    }
+
     private DistributedLockProvider _CreateProvider(DistributedLockOptions? options = null)
+        => _CreateProvider(options, Substitute.For<IOutboxPublisher>());
+
+    private DistributedLockProvider _CreateProvider(DistributedLockOptions? options, IOutboxPublisher? outboxPublisher)
     {
         _longIdGenerator.Create().Returns(_ => Interlocked.Increment(ref _lockIdCounter));
 
         return new DistributedLockProvider(
             _storage,
-            Substitute.For<IOutboxPublisher>(),
+            outboxPublisher,
             options ?? new DistributedLockOptions(),
             _longIdGenerator,
             _timeProvider,

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -138,13 +138,44 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         );
         handle.Should().NotBeNull();
 
-        // when - simulate TTL expiry by removing the storage row, then advance time.
-        _storage.RemoveLock(options.KeyPrefix + resource);
+        // when - advance beyond the real storage TTL and confirm storage expires it.
+        (await provider.IsLockedAsync(resource, AbortToken)).Should().BeTrue();
+        _timeProvider.Advance(TimeSpan.FromSeconds(2));
+        (await provider.IsLockedAsync(resource, AbortToken)).Should().BeFalse();
+        (await provider.GetLockIdAsync(resource, AbortToken)).Should().BeNull();
+        (await provider.GetExpirationAsync(resource, AbortToken)).Should().BeNull();
+
         _timeProvider.Advance(TimeSpan.FromSeconds(2));
         await _DrainUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested);
 
         // then
         handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_remove_empty_monitor_bucket_after_abandoned_handle_is_collected()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+        await _AcquireMonitoredHandleAndDropReference(provider, resource);
+
+        provider.GetActiveMonitorCount(resource).Should().Be(1);
+        provider.GetActiveMonitorResourceCount().Should().Be(1);
+
+        // when
+        for (var i = 0; i < 20 && provider.GetActiveMonitorResourceCount() != 0; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            _timeProvider.Advance(TimeSpan.FromSeconds(2));
+            await Task.Yield();
+        }
+
+        // then
+        provider.GetActiveMonitorCount(resource).Should().Be(0);
+        provider.GetActiveMonitorResourceCount().Should().Be(0);
     }
 
     [Fact]
@@ -400,6 +431,21 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
             _timeProvider,
             LoggerFactory.CreateLogger<DistributedLockProvider>()
         );
+    }
+
+    private static async Task _AcquireMonitoredHandleAndDropReference(DistributedLockProvider provider, string resource)
+    {
+        var handle = await provider.TryAcquireAsync(
+            resource,
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            }
+        );
+        handle.Should().NotBeNull();
+        handle = null;
+        _ = handle;
     }
 
     private static async Task _DrainUntilAsync(Func<bool> condition)

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -13,7 +13,12 @@ namespace Tests.RegularLocks;
 public sealed class LeaseLifecycleIntegrationTests : TestBase
 {
     private readonly FakeTimeProvider _timeProvider = new();
-    private readonly FakeDistributedLockStorage _storage = new();
+    private readonly FakeDistributedLockStorage _storage;
+
+    public LeaseLifecycleIntegrationTests()
+    {
+        _storage = new FakeDistributedLockStorage(_timeProvider);
+    }
     private readonly ILongIdGenerator _longIdGenerator = Substitute.For<ILongIdGenerator>();
     private long _lockIdCounter = 2000;
 
@@ -100,6 +105,216 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         handle.Should().NotBeNull();
         provider.GetActiveMonitorCount(resource).Should().Be(1);
         handle!.HandleLostToken.Should().NotBe(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task should_cancel_handle_lost_token_after_ttl_without_auto_extend()
+    {
+        // given - monitor-only mode. After lease TTL elapses without renewal the storage row
+        // is gone, so the next probe sees absence (or differing id) and declares Lost.
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options);
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(1),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+
+        // when - simulate TTL expiry by removing the storage row, then advance time.
+        _storage.RemoveLock(options.KeyPrefix + resource);
+        _timeProvider.Advance(TimeSpan.FromSeconds(2));
+        await _DrainUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested);
+
+        // then
+        handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_keep_lock_past_ttl_when_auto_extend_is_enabled()
+    {
+        // given - auto-extend mode renews via RenewAsync each cadence tick; storage row stays.
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options);
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(3),
+            autoExtend: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+
+        // when - advance past TTL multiple cadence intervals.
+        for (var i = 0; i < 4; i++)
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+            await Task.Yield();
+        }
+
+        // then - HandleLostToken still not fired (auto-extend kept storage row alive).
+        handle!.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_increment_renewal_count_when_background_auto_extend_renews()
+    {
+        // given - auto-extend handle: each cadence tick that succeeds calls RenewAsync.
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options);
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(3),
+            autoExtend: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+
+        // when - drive several cadence intervals; background loop should renew.
+        for (var i = 0; i < 5; i++)
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+            await _DrainUntilAsync(() => handle!.RenewalCount >= i + 1);
+        }
+
+        // then - background renewals were recorded.
+        handle!.RenewalCount.Should().BeGreaterThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public async Task should_report_null_provider_lock_as_unmonitored()
+    {
+        // given
+        var provider = new NullDistributedLockProvider(_timeProvider);
+
+        // when
+        await using var handle = await provider.TryAcquireAsync(
+            Faker.Random.AlphaNumeric(10),
+            cancellationToken: AbortToken
+        );
+
+        // then
+        handle!.IsMonitored.Should().BeFalse();
+        handle.HandleLostToken.Should().Be(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task should_expose_is_monitored_flag()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when - monitor enabled
+        await using var monitored = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+
+        // then
+        monitored!.IsMonitored.Should().BeTrue();
+
+        await monitored.DisposeAsync();
+
+        // when - monitor disabled
+        await using var unmonitored = await provider.TryAcquireAsync(
+            Faker.Random.AlphaNumeric(10),
+            cancellationToken: AbortToken
+        );
+
+        // then
+        unmonitored!.IsMonitored.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_deadlock_when_handle_lost_callback_disposes_handle()
+    {
+        // given - acquire with monitorLease enabled; register a HandleLostToken callback that
+        // disposes the handle. Storage row swap triggers Lost on the next probe.
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options);
+        var resource = Faker.Random.AlphaNumeric(10);
+        var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+        var disposalDone = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        handle!
+            .HandleLostToken.Register(
+                () =>
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        await handle.DisposeAsync();
+                        disposalDone.TrySetResult(true);
+                    });
+                }
+            );
+        _storage.SetLock(options.KeyPrefix + resource, "foreign-lock", TimeSpan.FromSeconds(10));
+
+        // when - trigger validation
+        ((ICanReceiveLockReleased)provider).OnLockReleased(new DistributedLockReleased(resource, "foreign-lock"));
+
+        // then - dispose path completes in bounded time (no deadlock).
+        var work = Task.Run(async () => await disposalDone.Task);
+        await work.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task should_not_signal_handle_lost_on_self_release()
+    {
+        // given - monitor-backed handle, then provider.ReleaseAsync (direct) instead of dispose.
+        // The release path's OnLockReleased nudge must not declare Lost for the same lockId.
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options);
+        var resource = Faker.Random.AlphaNumeric(10);
+        var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+
+        // when - direct release of the same lockId; this triggers the outbox path and would
+        // historically nudge the still-alive monitor for that resource.
+        await provider.ReleaseAsync(resource, handle!.LockId, AbortToken);
+        ((ICanReceiveLockReleased)provider).OnLockReleased(new DistributedLockReleased(resource, handle.LockId));
+        await _DrainUntilAsync(() => handle.HandleLostToken.IsCancellationRequested);
+
+        // then - HandleLostToken stays unfired (self-release deregistered the monitor first).
+        handle.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+
+        await handle.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task should_throw_argument_exception_when_monitor_lease_with_infinite_ttl()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        var act = () =>
+            provider.TryAcquireAsync(
+                resource,
+                timeUntilExpires: Timeout.InfiniteTimeSpan,
+                monitorLease: true,
+                cancellationToken: AbortToken
+            );
+
+        // then
+        var exception = await act.Should().ThrowAsync<ArgumentException>();
+        exception.Which.ParamName.Should().Be("timeUntilExpires");
     }
 
     private DistributedLockProvider _CreateProvider(DistributedLockOptions? options = null)

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -48,9 +48,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         // when
         var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
 
         // then
@@ -71,9 +74,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         await using var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
         _storage.SetLock(options.KeyPrefix + resource, "foreign-lock", TimeSpan.FromSeconds(10));
@@ -96,9 +102,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         // when
         await using var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.AutoExtend,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.AutoExtend,
+            },
+            AbortToken
         );
 
         // then
@@ -117,9 +126,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         await using var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(1),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(1),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
 
@@ -141,9 +153,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         await using var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(3),
-            monitoring: LockMonitoringMode.AutoExtend,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(3),
+                Monitoring = LockMonitoringMode.AutoExtend,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
 
@@ -167,9 +182,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         await using var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(3),
-            monitoring: LockMonitoringMode.AutoExtend,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(3),
+                Monitoring = LockMonitoringMode.AutoExtend,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
 
@@ -211,9 +229,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         // when - monitor enabled
         await using var monitored = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
 
         // then
@@ -241,9 +262,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
         var disposalDone = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -278,9 +302,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
 
@@ -307,9 +334,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var act = () =>
             provider.TryAcquireAsync(
                 resource,
-                timeUntilExpires: Timeout.InfiniteTimeSpan,
-                monitoring: LockMonitoringMode.Monitor,
-                cancellationToken: AbortToken
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = Timeout.InfiniteTimeSpan,
+                    Monitoring = LockMonitoringMode.Monitor,
+                },
+                AbortToken
             );
 
         // then
@@ -328,9 +358,12 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         var resource = Faker.Random.AlphaNumeric(10);
         await using var handle = await provider.TryAcquireAsync(
             resource,
-            timeUntilExpires: TimeSpan.FromSeconds(10),
-            monitoring: LockMonitoringMode.Monitor,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromSeconds(10),
+                Monitoring = LockMonitoringMode.Monitor,
+            },
+            AbortToken
         );
         handle.Should().NotBeNull();
 

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.DistributedLocks;
+using Headless.Messaging;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Tests.Fakes;
+
+namespace Tests.RegularLocks;
+
+public sealed class LeaseLifecycleIntegrationTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly FakeDistributedLockStorage _storage = new();
+    private readonly ILongIdGenerator _longIdGenerator = Substitute.For<ILongIdGenerator>();
+    private long _lockIdCounter = 2000;
+
+    [Fact]
+    public async Task should_not_create_monitor_by_default()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await using var handle = await provider.TryAcquireAsync(resource, cancellationToken: AbortToken);
+
+        // then
+        handle.Should().NotBeNull();
+        handle!.HandleLostToken.Should().Be(CancellationToken.None);
+        provider.GetActiveMonitorCount(resource).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_create_monitor_when_monitor_lease_is_enabled_and_deregister_on_dispose()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+
+        // then
+        handle.Should().NotBeNull();
+        handle!.HandleLostToken.Should().NotBe(CancellationToken.None);
+        provider.GetActiveMonitorCount(resource).Should().Be(1);
+
+        await handle.DisposeAsync();
+        provider.GetActiveMonitorCount(resource).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_cancel_handle_lost_token_when_monitored_lock_id_changes()
+    {
+        // given
+        var options = new DistributedLockOptions();
+        var provider = _CreateProvider(options);
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            monitorLease: true,
+            cancellationToken: AbortToken
+        );
+        handle.Should().NotBeNull();
+        _storage.SetLock(options.KeyPrefix + resource, "foreign-lock", TimeSpan.FromSeconds(10));
+
+        // when
+        ((ICanReceiveLockReleased)provider).OnLockReleased(new DistributedLockReleased(resource, "foreign-lock"));
+        await _DrainUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested);
+
+        // then
+        handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_auto_promote_monitor_when_auto_extend_is_enabled()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await using var handle = await provider.TryAcquireAsync(
+            resource,
+            timeUntilExpires: TimeSpan.FromSeconds(10),
+            autoExtend: true,
+            cancellationToken: AbortToken
+        );
+
+        // then
+        handle.Should().NotBeNull();
+        provider.GetActiveMonitorCount(resource).Should().Be(1);
+        handle!.HandleLostToken.Should().NotBe(CancellationToken.None);
+    }
+
+    private DistributedLockProvider _CreateProvider(DistributedLockOptions? options = null)
+    {
+        _longIdGenerator.Create().Returns(_ => Interlocked.Increment(ref _lockIdCounter));
+
+        return new DistributedLockProvider(
+            _storage,
+            Substitute.For<IOutboxPublisher>(),
+            options ?? new DistributedLockOptions(),
+            _longIdGenerator,
+            _timeProvider,
+            LoggerFactory.CreateLogger<DistributedLockProvider>()
+        );
+    }
+
+    private static async Task _DrainUntilAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 2000 && !condition(); i++)
+        {
+            if (i % 100 == 0)
+            {
+                await Task.Delay(1);
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -86,13 +86,19 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         );
         handle.Should().NotBeNull();
         _storage.SetLock(options.KeyPrefix + resource, "foreign-lock", TimeSpan.FromSeconds(10));
+        var lostSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var lostRegistration = handle!
+            .HandleLostToken.Register(static state => ((TaskCompletionSource)state!).TrySetResult(), lostSignal);
 
         // when
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         ((ICanReceiveLockReleased)provider).OnLockReleased(new DistributedLockReleased(resource, "foreign-lock"));
-        await _DrainUntilAsync(() => handle!.HandleLostToken.IsCancellationRequested);
+        await lostSignal.Task.WaitAsync(TimeSpan.FromMilliseconds(500));
+        stopwatch.Stop();
 
         // then
         handle!.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(200));
     }
 
     [Fact]

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorRegistryTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorRegistryTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Tests.Fakes;
+
+namespace Tests.RegularLocks;
+
+public sealed class LeaseMonitorRegistryTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    [Fact]
+    public void should_retry_registration_when_existing_bucket_was_already_removed()
+    {
+        // given
+        var sut = _CreateRegistry();
+        var resource = Faker.Random.AlphaNumeric(10);
+        using var originalMonitor = _CreateMonitor(resource, "original");
+        using var replacementMonitor = _CreateMonitor(resource, "replacement");
+        sut.Register(resource, "original", originalMonitor.Target);
+        _MarkBucketRemoved(sut, resource);
+
+        // when
+        sut.Register(resource, "replacement", replacementMonitor.Target);
+
+        // then
+        sut.GetMonitorCount(resource).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_remove_bucket_when_nudge_finds_only_collected_monitors()
+    {
+        // given
+        var sut = _CreateRegistry();
+        var resource = Faker.Random.AlphaNumeric(10);
+        _RegisterMonitorAndDropReference(
+            sut,
+            _timeProvider,
+            LoggerFactory.CreateLogger(nameof(LeaseMonitor)),
+            resource,
+            "abandoned"
+        );
+        _GetRawBucketCount(sut).Should().Be(1);
+
+        // when
+        for (var i = 0; i < 20 && _GetRawBucketCount(sut) != 0; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+            sut.NudgeActive(resource);
+            await Task.Yield();
+        }
+
+        // then
+        _GetRawBucketCount(sut).Should().Be(0);
+    }
+
+    private LeaseMonitorRegistry _CreateRegistry() => new(LoggerFactory.CreateLogger(nameof(LeaseMonitorRegistry)));
+
+    private LeaseMonitorScope _CreateMonitor(string resource, string lockId)
+    {
+        var monitor = new LeaseMonitor(
+            new FakeLeaseHandle
+            {
+                Resource = resource,
+                LockId = lockId,
+                LeaseDuration = TimeSpan.FromMinutes(1),
+                MonitoringCadence = TimeSpan.FromSeconds(1),
+            },
+            _timeProvider,
+            LoggerFactory.CreateLogger(nameof(LeaseMonitor))
+        );
+
+        return new LeaseMonitorScope(monitor);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void _RegisterMonitorAndDropReference(
+        LeaseMonitorRegistry registry,
+        FakeTimeProvider timeProvider,
+        ILogger logger,
+        string resource,
+        string lockId
+    )
+    {
+        var monitor = new LeaseMonitor(
+            new FakeLeaseHandle
+            {
+                Resource = resource,
+                LockId = lockId,
+                LeaseDuration = TimeSpan.FromMinutes(1),
+                MonitoringCadence = TimeSpan.FromSeconds(1),
+            },
+            timeProvider,
+            logger
+        );
+
+        registry.Register(resource, lockId, monitor);
+    }
+
+    private static void _MarkBucketRemoved(LeaseMonitorRegistry registry, string resource)
+    {
+        var bucket = _GetBucket(registry, resource);
+        var isRemovedField = bucket
+            .GetType()
+            .GetField("_isRemoved", BindingFlags.Instance | BindingFlags.NonPublic);
+        isRemovedField.Should().NotBeNull();
+        isRemovedField!.SetValue(bucket, true);
+    }
+
+    private static object _GetBucket(LeaseMonitorRegistry registry, string resource)
+    {
+        var activeMonitors = _GetActiveMonitors(registry);
+        var tryGetValue = activeMonitors
+            .GetType()
+            .GetMethod(
+                "TryGetValue",
+                [typeof(string), activeMonitors.GetType().GenericTypeArguments[1].MakeByRefType()]
+            );
+        tryGetValue.Should().NotBeNull();
+        var arguments = new object?[] { resource, null };
+        ((bool)tryGetValue!.Invoke(activeMonitors, arguments)!).Should().BeTrue();
+        arguments[1].Should().NotBeNull();
+
+        return arguments[1]!;
+    }
+
+    private static int _GetRawBucketCount(LeaseMonitorRegistry registry)
+    {
+        var activeMonitors = _GetActiveMonitors(registry);
+        var countProperty = activeMonitors.GetType().GetProperty("Count");
+        countProperty.Should().NotBeNull();
+
+        return (int)countProperty!.GetValue(activeMonitors)!;
+    }
+
+    private static object _GetActiveMonitors(LeaseMonitorRegistry registry)
+    {
+        var activeMonitorsField = typeof(LeaseMonitorRegistry).GetField(
+            "_activeMonitors",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        );
+        activeMonitorsField.Should().NotBeNull();
+
+        return activeMonitorsField!.GetValue(registry)!;
+    }
+
+    private readonly struct LeaseMonitorScope(LeaseMonitor target) : IDisposable
+    {
+        public LeaseMonitor Target { get; } = target;
+
+        public void Dispose()
+        {
+            Target.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -356,12 +356,12 @@ public sealed class LeaseMonitorTests : TestBase
         var sut = _CreateMonitor(handle);
 
         var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var disposeTask = Task.CompletedTask;
+        var callbackCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         sut.HandleLostToken.Register(() =>
         {
-            // Start disposal from the callback without blocking the monitor loop thread.
-            disposeTask = Task.Run(async () => await sut.DisposeAsync());
             callbackInvoked.TrySetResult();
+            sut.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            callbackCompleted.TrySetResult();
         });
 
         // when
@@ -371,8 +371,8 @@ public sealed class LeaseMonitorTests : TestBase
         await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         // then
-        // The dispose task should complete quickly without hanging/deadlocking.
-        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        // Synchronous callback disposal should complete without hanging/deadlocking.
+        await callbackCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         sut.MonitoringTask.IsCompleted.Should().BeTrue();
     }
 

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -177,9 +177,161 @@ public sealed class LeaseMonitorTests : TestBase
         sut.MonitoringTask.IsCompleted.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task should_exit_monitoring_loop_when_only_reference_is_garbage_collected()
+    {
+        // AC6 — GC abandonment. If a consumer drops the monitor without disposing it, the
+        // loop must observe a dead WeakReference<LeaseMonitor> on its next cadence iteration
+        // and exit. The OnlyOnFaulted continuation MUST NOT capture `this` (otherwise it would
+        // strong-root the monitor for the lifetime of MonitoringTask, defeating this invariant).
+        var handle = new FakeLeaseHandle { LeaseDuration = TimeSpan.FromMinutes(1), MonitoringCadence = TimeSpan.FromSeconds(1) };
+        var monitoringTask = _CreateMonitorAndDropReference(handle);
+
+        // when - force GC then drive a cadence so the loop's WeakReference.TryGetTarget fails.
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        _timeProvider.Advance(TimeSpan.FromSeconds(2));
+
+        // then - the loop exits within a bounded wall-clock budget. Generous timeout because
+        // FakeTimeProvider advances do not synchronously resume the loop; it still relies on
+        // the awaiter scheduling. 5 seconds is plenty without making the test flake-prone.
+        await monitoringTask.WaitAsync(TimeSpan.FromSeconds(5));
+        monitoringTask.IsCompleted.Should().BeTrue();
+    }
+
+    private Task _CreateMonitorAndDropReference(FakeLeaseHandle handle)
+    {
+        // Helper isolates the strong-reference scope so the JIT cannot keep the LeaseMonitor
+        // alive in a local on the caller's stack frame across GC.Collect.
+        var monitor = new LeaseMonitor(handle, _timeProvider, LoggerFactory.CreateLogger(nameof(LeaseMonitor)));
+        var task = monitor.MonitoringTask;
+        monitor = null;
+        _ = monitor; // suppress "unused" — intent is to overwrite the local.
+        return task;
+    }
+
+    [Fact]
+    public async Task should_complete_dispose_within_bounded_time_when_handle_call_blocks()
+    {
+        // AC7 — disposal timing. A blocking RenewOrValidateLeaseAsync must not strand
+        // DisposeAsync; the loop's cancellation token must propagate so the blocking call
+        // unblocks promptly.
+        using var blockSignal = new CancellationTokenSource();
+        var handle = new BlockingLeaseHandle(blockSignal.Token);
+        var sut = _CreateMonitor(handle);
+
+        // Trigger an iteration that will block inside RenewOrValidateLeaseAsync.
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.IsBlocking);
+
+        // when
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await sut.DisposeAsync();
+        stopwatch.Stop();
+
+        // then - generous 500ms bound. Spec aims for ~100ms but CI variability matters; this
+        // budget catches an actual deadlock or unbounded wait while remaining stable in CI.
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(500);
+        handle.ExitedBeforeRelease.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_not_self_mark_lost_when_held_streak_followed_by_single_unknown()
+    {
+        // Regression for the "Held resets leaseTimestamp too" fix (issue #6). Without it, a
+        // long Held streak in polling mode would let the safety-net elapsed window grow even
+        // though storage repeatedly confirmed ownership. After enough Held probes, a single
+        // transient Unknown would then trip the safety net on the FOLLOWING iteration — a
+        // false-positive Lost when ownership was never actually in question.
+        //
+        // With the fix, Held resets leaseTimestamp on every probe, so the elapsed window
+        // starts fresh after each confirmed-ownership signal. A single subsequent Unknown
+        // cannot accumulate enough elapsed time to trip the safety net.
+        //
+        // Use a long cadence so the cadence timer never fires inside the test window — we
+        // drive iterations only via TriggerImmediateValidation to keep the sequence deterministic.
+        var handle = new FakeLeaseHandle
+        {
+            LeaseDuration = TimeSpan.FromSeconds(10),
+            MonitoringCadence = TimeSpan.FromSeconds(10),
+        };
+        for (var i = 0; i < 3; i++)
+        {
+            handle.Enqueue(LeaseMonitor.LeaseState.Held);
+        }
+        handle.Enqueue(new TimeoutException("transient"));
+
+        await using var sut = _CreateMonitor(handle);
+
+        // Drive three Held probes, advancing the clock so each carries a leaseLifetime that
+        // would individually exceed the lease window if the prior Held had not reset it. The
+        // advance happens AFTER the iteration was triggered and observed, but BEFORE we
+        // probe the safety-net check on the next iteration.
+        await _RunIterationAndWait(sut, handle, expectedCount: 1);
+        _timeProvider.Advance(TimeSpan.FromSeconds(9));
+        await _RunIterationAndWait(sut, handle, expectedCount: 2);
+        _timeProvider.Advance(TimeSpan.FromSeconds(9));
+        await _RunIterationAndWait(sut, handle, expectedCount: 3);
+
+        // Modest advance, then the Unknown probe. Total elapsed since the LAST Held reset is
+        // small, so the safety net should NOT fire.
+        _timeProvider.Advance(TimeSpan.FromSeconds(3));
+        await _RunIterationAndWait(sut, handle, expectedCount: 4);
+
+        sut.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+    }
+
+    private static async Task _RunIterationAndWait(LeaseMonitor sut, FakeLeaseHandle handle, int expectedCount)
+    {
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.InvocationCount >= expectedCount);
+    }
+
     private LeaseMonitor _CreateMonitor(FakeLeaseHandle handle)
     {
         return new LeaseMonitor(handle, _timeProvider, LoggerFactory.CreateLogger(nameof(LeaseMonitor)));
+    }
+
+    private LeaseMonitor _CreateMonitor(LeaseMonitor.ILeaseHandle handle)
+    {
+        return new LeaseMonitor(handle, _timeProvider, LoggerFactory.CreateLogger(nameof(LeaseMonitor)));
+    }
+
+    private sealed class BlockingLeaseHandle : LeaseMonitor.ILeaseHandle
+    {
+        private readonly CancellationToken _externalAbort;
+        public string Resource => "blocking-resource";
+        public string LockId => "blocking-lock";
+        public TimeSpan LeaseDuration => TimeSpan.FromSeconds(10);
+        public TimeSpan MonitoringCadence => TimeSpan.FromSeconds(5);
+        public bool IsBlocking { get; private set; }
+        public bool ExitedBeforeRelease { get; private set; }
+
+        public BlockingLeaseHandle(CancellationToken externalAbort)
+        {
+            _externalAbort = externalAbort;
+        }
+
+        public async Task<LeaseMonitor.LeaseState> RenewOrValidateLeaseAsync(CancellationToken cancellationToken)
+        {
+            IsBlocking = true;
+
+            try
+            {
+                // Block until the disposal token (passed by the monitor loop) cancels.
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _externalAbort);
+                await Task.Delay(Timeout.Infinite, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                ExitedBeforeRelease = true;
+                throw;
+            }
+
+            return LeaseMonitor.LeaseState.Held;
+        }
     }
 
     private static async Task _DrainUntilAsync(Func<bool> condition)

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -96,6 +96,19 @@ public sealed class LeaseMonitorTests : TestBase
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void should_throw_argument_null_exception_on_constructor_null_parameters(bool nullHandle, bool nullTimeProvider, bool nullLogger)
+    {
+        var handle = nullHandle ? null : new FakeLeaseHandle();
+        var timeProvider = nullTimeProvider ? null : _timeProvider;
+        var logger = nullLogger ? null : LoggerFactory.CreateLogger(nameof(LeaseMonitor));
+        var act = () => new LeaseMonitor(handle!, timeProvider!, logger!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
     [Fact]
     public async Task should_not_self_mark_lost_when_polling_returns_held_past_lease_window()
     {
@@ -332,6 +345,38 @@ public sealed class LeaseMonitorTests : TestBase
 
             return LeaseMonitor.LeaseState.Held;
         }
+    }
+
+    [Fact]
+    public async Task should_not_deadlock_when_callback_disposes_monitor()
+    {
+        // given
+        var handle = new FakeLeaseHandle();
+        handle.Enqueue(LeaseMonitor.LeaseState.Lost);
+        var sut = _CreateMonitor(handle);
+
+        var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disposeTask = Task.CompletedTask;
+        sut.HandleLostToken.Register(() =>
+        {
+            // Synchronously start disposal on the callback thread.
+            // Under synchronous Cancel(), this runs on the loop thread, causing deadlock.
+            // Under asynchronous Cancel() via Task.Run, this runs on a ThreadPool thread
+            // and completes cleanly.
+            disposeTask = Task.Run(async () => await sut.DisposeAsync());
+            callbackInvoked.TrySetResult();
+        });
+
+        // when
+        sut.TriggerImmediateValidation();
+
+        // Wait for the callback to be invoked.
+        await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // then
+        // The dispose task should complete quickly without hanging/deadlocking.
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        sut.MonitoringTask.IsCompleted.Should().BeTrue();
     }
 
     private static async Task _DrainUntilAsync(Func<bool> condition)

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -2,6 +2,7 @@
 
 using Headless.DistributedLocks;
 using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Tests.Fakes;
 
@@ -37,7 +38,7 @@ public sealed class LeaseMonitorTests : TestBase
         handle.Enqueue(LeaseMonitor.LeaseState.Renewed);
         await using var sut = _CreateMonitor(handle);
 
-        // when
+        // when - Unknown then Renewed within budget — must NOT cancel.
         sut.TriggerImmediateValidation();
         await _DrainUntilAsync(() => handle.InvocationCount == 1);
         _timeProvider.Advance(TimeSpan.FromSeconds(3));
@@ -47,8 +48,15 @@ public sealed class LeaseMonitorTests : TestBase
         sut.TriggerImmediateValidation();
         await _DrainUntilAsync(() => handle.InvocationCount == 3);
 
-        // then
+        // then - still alive after Unknown → Renewed.
         sut.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+
+        // and - convert the negative assertion into a positive observation: enqueue Lost and
+        // confirm the monitor DOES react when storage subsequently confirms loss.
+        handle.Enqueue(LeaseMonitor.LeaseState.Lost);
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => sut.HandleLostToken.IsCancellationRequested);
+        sut.HandleLostToken.IsCancellationRequested.Should().BeTrue();
     }
 
     [Fact]
@@ -86,6 +94,73 @@ public sealed class LeaseMonitorTests : TestBase
 
         // then
         act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public async Task should_not_self_mark_lost_when_polling_returns_held_past_lease_window()
+    {
+        // given - polling mode (no auto-extend) where every iteration returns Held.
+        // The safety net "leaseLifetime > _leaseDuration => Lost" must only fire from Unknown,
+        // not from Held returned by storage confirming continued ownership.
+        var handle = new FakeLeaseHandle();
+        for (var i = 0; i < 7; i++)
+        {
+            handle.Enqueue(LeaseMonitor.LeaseState.Held);
+        }
+
+        await using var sut = _CreateMonitor(handle);
+
+        // when - drive multiple cadence iterations past 2x lease duration (10s) with Held returns.
+        for (var i = 0; i < 6; i++)
+        {
+            sut.TriggerImmediateValidation();
+            await _DrainUntilAsync(() => handle.InvocationCount >= i + 1);
+            _timeProvider.Advance(TimeSpan.FromSeconds(5));
+        }
+
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.InvocationCount >= 7);
+
+        // then - storage repeatedly confirmed ownership; monitor must not declare Lost.
+        sut.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+
+        // and - positive observation: when storage subsequently confirms loss, the monitor DOES react.
+        handle.Enqueue(LeaseMonitor.LeaseState.Lost);
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => sut.HandleLostToken.IsCancellationRequested);
+        sut.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_signal_handle_lost_when_monitor_loop_faults()
+    {
+        // given - a logger that throws on Log calls. The first state transition logs via
+        // LogLeaseMonitorStateChanged; the throw escapes _SetState → _RunIterationAsync →
+        // _MonitoringLoopAsync, faulting MonitoringTask. The OnlyOnFaulted continuation MUST
+        // cancel HandleLostToken as a fail-safe.
+        var handle = new FakeLeaseHandle();
+        handle.Enqueue(LeaseMonitor.LeaseState.Renewed);
+        var logger = Substitute.For<ILogger>();
+        logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+        logger
+            .When(l =>
+                l.Log(
+                    Arg.Any<LogLevel>(),
+                    Arg.Any<EventId>(),
+                    Arg.Any<object>(),
+                    Arg.Any<Exception?>(),
+                    Arg.Any<Func<object, Exception?, string>>()
+                )
+            )
+            .Do(_ => throw new InvalidOperationException("logger boom"));
+        await using var sut = new LeaseMonitor(handle, _timeProvider, logger);
+
+        // when
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => sut.HandleLostToken.IsCancellationRequested);
+
+        // then
+        sut.HandleLostToken.IsCancellationRequested.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+using Tests.Fakes;
+
+namespace Tests.RegularLocks;
+
+public sealed class LeaseMonitorTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    [Fact]
+    public async Task should_cancel_handle_lost_token_when_handle_returns_lost()
+    {
+        // given
+        var handle = new FakeLeaseHandle();
+        handle.Enqueue(LeaseMonitor.LeaseState.Lost);
+        await using var sut = _CreateMonitor(handle);
+
+        // when
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => sut.HandleLostToken.IsCancellationRequested);
+
+        // then
+        sut.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+        handle.InvocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_not_cancel_when_unknown_is_followed_by_renewed_before_lease_duration()
+    {
+        // given
+        var handle = new FakeLeaseHandle();
+        handle.Enqueue(new TimeoutException("transient"));
+        handle.Enqueue(LeaseMonitor.LeaseState.Renewed);
+        await using var sut = _CreateMonitor(handle);
+
+        // when
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.InvocationCount == 1);
+        _timeProvider.Advance(TimeSpan.FromSeconds(3));
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.InvocationCount == 2);
+        _timeProvider.Advance(TimeSpan.FromSeconds(6));
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.InvocationCount == 3);
+
+        // then
+        sut.HandleLostToken.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_self_mark_lost_when_unknown_lifetime_exceeds_lease_duration()
+    {
+        // given
+        var handle = new FakeLeaseHandle();
+        handle.Enqueue(new TimeoutException("transient"));
+        await using var sut = _CreateMonitor(handle);
+
+        // when
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => handle.InvocationCount == 1);
+        _timeProvider.Advance(TimeSpan.FromSeconds(11));
+        sut.TriggerImmediateValidation();
+        await _DrainUntilAsync(() => sut.HandleLostToken.IsCancellationRequested);
+
+        // then
+        sut.HandleLostToken.IsCancellationRequested.Should().BeTrue();
+        handle.InvocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_validate_constructor_cadence_is_not_longer_than_lease()
+    {
+        // given
+        var handle = new FakeLeaseHandle
+        {
+            LeaseDuration = TimeSpan.FromSeconds(5),
+            MonitoringCadence = TimeSpan.FromSeconds(6),
+        };
+
+        // when
+        var act = () => _CreateMonitor(handle);
+
+        // then
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public async Task should_dispose_idempotently()
+    {
+        // given
+        var sut = _CreateMonitor(new FakeLeaseHandle());
+
+        // when
+        await sut.DisposeAsync();
+        await sut.DisposeAsync();
+
+        // then
+        sut.MonitoringTask.IsCompleted.Should().BeTrue();
+    }
+
+    private LeaseMonitor _CreateMonitor(FakeLeaseHandle handle)
+    {
+        return new LeaseMonitor(handle, _timeProvider, LoggerFactory.CreateLogger(nameof(LeaseMonitor)));
+    }
+
+    private static async Task _DrainUntilAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 2000 && !condition(); i++)
+        {
+            if (i % 100 == 0)
+            {
+                await Task.Delay(1);
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -359,10 +359,7 @@ public sealed class LeaseMonitorTests : TestBase
         var disposeTask = Task.CompletedTask;
         sut.HandleLostToken.Register(() =>
         {
-            // Synchronously start disposal on the callback thread.
-            // Under synchronous Cancel(), this runs on the loop thread, causing deadlock.
-            // Under asynchronous Cancel() via Task.Run, this runs on a ThreadPool thread
-            // and completes cleanly.
+            // Start disposal from the callback without blocking the monitor loop thread.
             disposeTask = Task.Run(async () => await sut.DisposeAsync());
             callbackInvoked.TrySetResult();
         });

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -60,7 +60,7 @@ public sealed class LeaseMonitorTests : TestBase
     }
 
     [Fact]
-    public async Task should_self_mark_lost_when_unknown_lifetime_exceeds_lease_duration()
+    public async Task should_self_mark_lost_when_unknown_lifetime_reaches_lease_duration()
     {
         // given
         var handle = new FakeLeaseHandle();
@@ -70,7 +70,7 @@ public sealed class LeaseMonitorTests : TestBase
         // when
         sut.TriggerImmediateValidation();
         await _DrainUntilAsync(() => handle.InvocationCount == 1);
-        _timeProvider.Advance(TimeSpan.FromSeconds(11));
+        _timeProvider.Advance(handle.LeaseDuration);
         sut.TriggerImmediateValidation();
         await _DrainUntilAsync(() => sut.HandleLostToken.IsCancellationRequested);
 
@@ -113,7 +113,7 @@ public sealed class LeaseMonitorTests : TestBase
     public async Task should_not_self_mark_lost_when_polling_returns_held_past_lease_window()
     {
         // given - polling mode (no auto-extend) where every iteration returns Held.
-        // The safety net "leaseLifetime > _leaseDuration => Lost" must only fire from Unknown,
+        // The safety net "leaseLifetime >= _leaseDuration => Lost" must only fire from Unknown,
         // not from Held returned by storage confirming continued ownership.
         var handle = new FakeLeaseHandle();
         for (var i = 0; i < 7; i++)

--- a/tests/Headless.Messaging.Core.Tests.Unit/NullDistributedLockProviderTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/NullDistributedLockProviderTests.cs
@@ -109,7 +109,7 @@ public sealed class NullDistributedLockProviderTests
     }
 
     [Fact]
-    public async Task should_reflect_monitoring_option_on_acquired_handle()
+    public async Task should_report_handle_as_unmonitored_when_monitoring_is_requested()
     {
         // given
         var sut = new NullDistributedLockProvider(TimeProvider.System);
@@ -122,7 +122,7 @@ public sealed class NullDistributedLockProviderTests
 
         // then
         handle.Should().NotBeNull();
-        handle!.IsMonitored.Should().BeTrue();
+        handle!.IsMonitored.Should().BeFalse();
         handle.HandleLostToken.Should().Be(CancellationToken.None);
     }
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/NullDistributedLockProviderTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/NullDistributedLockProviderTests.cs
@@ -109,6 +109,45 @@ public sealed class NullDistributedLockProviderTests
     }
 
     [Fact]
+    public async Task should_reflect_monitoring_option_on_acquired_handle()
+    {
+        // given
+        var sut = new NullDistributedLockProvider(TimeProvider.System);
+
+        // when
+        var handle = await sut.TryAcquireAsync(
+            "test.resource",
+            new DistributedLockAcquireOptions { Monitoring = LockMonitoringMode.Monitor }
+        );
+
+        // then
+        handle.Should().NotBeNull();
+        handle!.IsMonitored.Should().BeTrue();
+        handle.HandleLostToken.Should().Be(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task should_reject_infinite_ttl_when_monitoring_is_enabled()
+    {
+        // given
+        var sut = new NullDistributedLockProvider(TimeProvider.System);
+
+        // when
+        var act = async () =>
+            await sut.TryAcquireAsync(
+                "test.resource",
+                new DistributedLockAcquireOptions
+                {
+                    TimeUntilExpires = Timeout.InfiniteTimeSpan,
+                    Monitoring = LockMonitoringMode.Monitor,
+                }
+            );
+
+        // then
+        await act.Should().ThrowAsync<ArgumentException>().WithParameterName("options");
+    }
+
+    [Fact]
     public async Task should_throw_OperationCanceledException_when_provider_RenewAsync_token_is_already_cancelled()
     {
         // given

--- a/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
@@ -710,8 +710,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns<Task<IDistributedLock?>>(_ => throw new InvalidOperationException("lock store down"));
@@ -721,8 +720,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -780,8 +778,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns<Task<IDistributedLock?>>(_ =>
@@ -804,8 +801,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -885,8 +881,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -924,8 +919,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(captured));
@@ -955,8 +949,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(_ => neverCompletes.Task);
@@ -992,8 +985,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(renewableLock));
@@ -1074,8 +1066,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(lostLock));
@@ -1139,8 +1130,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(acquiredLock));
@@ -1209,8 +1199,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(lostLock));
@@ -1286,8 +1275,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(failingLock));

--- a/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
@@ -707,20 +707,14 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Is<string>(s => s.Contains("publish-retry", StringComparison.Ordinal)),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns<Task<IDistributedLock?>>(_ => throw new InvalidOperationException("lock store down"));
         lockProvider
             .TryAcquireAsync(
                 Arg.Is<string>(s => s.Contains("receive-retry", StringComparison.Ordinal)),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -775,10 +769,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Is<string>(s => s.Contains("publish-retry", StringComparison.Ordinal)),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns<Task<IDistributedLock?>>(_ =>
@@ -798,10 +789,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Is<string>(s => s.Contains("receive-retry", StringComparison.Ordinal)),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(null));
@@ -878,10 +866,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
             .DidNotReceive()
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -916,10 +901,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(captured));
@@ -946,10 +928,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(_ => neverCompletes.Task);
@@ -982,10 +961,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(renewableLock));
@@ -1030,10 +1006,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
             .Received()
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                acquireTimeout: TimeSpan.Zero,
-                releaseOnDispose: Arg.Any<bool>(),
-                cancellationToken: Arg.Any<CancellationToken>()
+                Arg.Is<DistributedLockAcquireOptions?>(o => o != null && o.AcquireTimeout == TimeSpan.Zero),
+                Arg.Any<CancellationToken>()
             );
     }
 
@@ -1063,10 +1037,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(lostLock));
@@ -1127,10 +1098,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(acquiredLock));
@@ -1196,10 +1164,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(lostLock));
@@ -1272,10 +1237,7 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
         lockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(failingLock));

--- a/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Processor/MessageNeedToRetryProcessorTests.cs
@@ -710,6 +710,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns<Task<IDistributedLock?>>(_ => throw new InvalidOperationException("lock store down"));
@@ -718,6 +720,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Is<string>(s => s.Contains("receive-retry", StringComparison.Ordinal)),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -776,6 +780,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns<Task<IDistributedLock?>>(_ =>
@@ -797,6 +803,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Is<string>(s => s.Contains("receive-retry", StringComparison.Ordinal)),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -877,6 +885,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -914,6 +924,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(captured));
@@ -942,6 +954,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -977,6 +991,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -1058,6 +1074,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(lostLock));
@@ -1120,6 +1138,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -1188,6 +1208,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -1263,6 +1285,8 @@ public sealed class MessageNeedToRetryProcessorTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )

--- a/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
@@ -179,6 +179,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(fakeLock));
@@ -232,6 +234,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );
         await storage.Received().GetPublishedMessagesOfNeedRetryAsync(Arg.Any<CancellationToken>());
@@ -253,6 +257,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -374,6 +380,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -382,6 +390,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                         timeUntilExpires,
                         acquireTimeout,
                         releaseOnDispose,
+                        monitorLease,
+                        autoExtend,
                         cancellationToken
                     )
                     .ConfigureAwait(false)
@@ -396,6 +406,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
+            bool monitorLease = false,
+            bool autoExtend = false,
             CancellationToken cancellationToken = default
         )
         {
@@ -419,6 +431,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose: true,
+                monitorLease: false,
+                autoExtend: false,
                 cancellationToken: cancellationToken
             );
         }
@@ -429,6 +443,9 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
             TimeSpan? timeUntilExpires = null,
             CancellationToken cancellationToken = default
         ) => Task.FromResult(false);
+
+        public Task<string?> GetLockIdAsync(string resource, CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
 
         public Task ReleaseAsync(string resource, string lockId, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
@@ -458,6 +475,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         public int RenewalCount => Volatile.Read(ref _renewalCount);
         public DateTimeOffset DateAcquired => DateTimeOffset.UtcNow;
         public TimeSpan TimeWaitedForLock => TimeSpan.Zero;
+
+        public CancellationToken HandleLostToken => CancellationToken.None;
 
         public Task ReleaseAsync() => Task.CompletedTask;
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
@@ -51,8 +51,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         // Arrange — pre-acquire published lock so the processor's try-once acquire returns null
         var externalLock = await _realLockProvider.TryAcquireAsync(
             MessagingKeys.PublishRetryResource("v1"),
-            timeUntilExpires: TimeSpan.FromMinutes(1),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMinutes(1) },
+            AbortToken
         );
         externalLock.Should().NotBeNull("pre-condition: lock must be acquirable on empty store");
         await using var _ = externalLock!;
@@ -79,8 +79,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         // Arrange — pre-acquire received lock so the processor's try-once acquire returns null
         var externalLock = await _realLockProvider.TryAcquireAsync(
             MessagingKeys.ReceiveRetryResource("v1"),
-            timeUntilExpires: TimeSpan.FromMinutes(1),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMinutes(1) },
+            AbortToken
         );
         externalLock.Should().NotBeNull("pre-condition: lock must be acquirable on empty store");
         await using var _ = externalLock!;
@@ -176,10 +176,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         alwaysGranted
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(fakeLock));
@@ -230,10 +227,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
             .DidNotReceive()
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             );
         await storage.Received().GetPublishedMessagesOfNeedRetryAsync(Arg.Any<CancellationToken>());
@@ -253,10 +247,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         alwaysGranted
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(fakeLock));
@@ -311,8 +302,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         // Arrange — hold the lock with the first acquire
         var firstLock = await _realLockProvider.TryAcquireAsync(
             "pin-test-resource",
-            timeUntilExpires: TimeSpan.FromMinutes(1),
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions { TimeUntilExpires = TimeSpan.FromMinutes(1) },
+            AbortToken
         );
         firstLock.Should().NotBeNull("first acquire must succeed on an empty store");
         await using var _ = firstLock!;
@@ -320,9 +311,12 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
         // Act — try-once acquire with zero timeout while first is held
         var secondLock = await _realLockProvider.TryAcquireAsync(
             "pin-test-resource",
-            timeUntilExpires: TimeSpan.FromMinutes(1),
-            acquireTimeout: TimeSpan.Zero,
-            cancellationToken: AbortToken
+            new DistributedLockAcquireOptions
+            {
+                TimeUntilExpires = TimeSpan.FromMinutes(1),
+                AcquireTimeout = TimeSpan.Zero,
+            },
+            AbortToken
         );
 
         // Assert
@@ -374,22 +368,11 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
 
         public async Task<IDistributedLock> AcquireAsync(
             string resource,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            bool releaseOnDispose = true,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
-            return await TryAcquireAsync(
-                        resource,
-                        timeUntilExpires,
-                        acquireTimeout,
-                        releaseOnDispose,
-                        monitoring,
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false)
+            return await TryAcquireAsync(resource, options, cancellationToken).ConfigureAwait(false)
                 ?? throw new LockAcquisitionTimeoutException(resource);
         }
 
@@ -398,10 +381,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
 
         public Task<IDistributedLock?> TryAcquireAsync(
             string resource,
-            TimeSpan? timeUntilExpires = null,
-            TimeSpan? acquireTimeout = null,
-            bool releaseOnDispose = true,
-            LockMonitoringMode monitoring = LockMonitoringMode.None,
+            DistributedLockAcquireOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -411,23 +391,6 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 LastIssuedReceiveRetryLock = trackingLock;
             }
             return Task.FromResult<IDistributedLock?>(trackingLock);
-        }
-
-        public Task<IDistributedLock?> TryAcquireAsync(
-            string resource,
-            TimeSpan? timeUntilExpires,
-            TimeSpan? acquireTimeout,
-            CancellationToken cancellationToken
-        )
-        {
-            return TryAcquireAsync(
-                resource,
-                timeUntilExpires,
-                acquireTimeout,
-                releaseOnDispose: true,
-                monitoring: LockMonitoringMode.None,
-                cancellationToken: cancellationToken
-            );
         }
 
         public Task<bool> RenewAsync(

--- a/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
@@ -478,6 +478,8 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
 
         public CancellationToken HandleLostToken => CancellationToken.None;
 
+        public bool IsMonitored => false;
+
         public Task ReleaseAsync() => Task.CompletedTask;
 
         public Task<bool> RenewAsync(TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)

--- a/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/RetryProcessorDistributedLockTests.cs
@@ -179,8 +179,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(fakeLock));
@@ -234,8 +233,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
         await storage.Received().GetPublishedMessagesOfNeedRetryAsync(Arg.Any<CancellationToken>());
@@ -258,8 +256,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IDistributedLock?>(fakeLock));
@@ -380,8 +377,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -390,8 +386,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                         timeUntilExpires,
                         acquireTimeout,
                         releaseOnDispose,
-                        monitorLease,
-                        autoExtend,
+                        monitoring,
                         cancellationToken
                     )
                     .ConfigureAwait(false)
@@ -406,8 +401,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
             TimeSpan? timeUntilExpires = null,
             TimeSpan? acquireTimeout = null,
             bool releaseOnDispose = true,
-            bool monitorLease = false,
-            bool autoExtend = false,
+            LockMonitoringMode monitoring = LockMonitoringMode.None,
             CancellationToken cancellationToken = default
         )
         {
@@ -431,8 +425,7 @@ public sealed class RetryProcessorDistributedLockTests : IDisposable
                 timeUntilExpires,
                 acquireTimeout,
                 releaseOnDispose: true,
-                monitorLease: false,
-                autoExtend: false,
+                monitoring: LockMonitoringMode.None,
                 cancellationToken: cancellationToken
             );
         }

--- a/tests/Headless.Permissions.Tests.Unit/Definitions/DynamicPermissionDefinitionStoreTests.cs
+++ b/tests/Headless.Permissions.Tests.Unit/Definitions/DynamicPermissionDefinitionStoreTests.cs
@@ -233,8 +233,7 @@ public sealed class DynamicPermissionDefinitionStoreTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(lockHandle);

--- a/tests/Headless.Permissions.Tests.Unit/Definitions/DynamicPermissionDefinitionStoreTests.cs
+++ b/tests/Headless.Permissions.Tests.Unit/Definitions/DynamicPermissionDefinitionStoreTests.cs
@@ -230,10 +230,7 @@ public sealed class DynamicPermissionDefinitionStoreTests : TestBase
         _distributedLockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(lockHandle);

--- a/tests/Headless.Permissions.Tests.Unit/Definitions/DynamicPermissionDefinitionStoreTests.cs
+++ b/tests/Headless.Permissions.Tests.Unit/Definitions/DynamicPermissionDefinitionStoreTests.cs
@@ -233,6 +233,8 @@ public sealed class DynamicPermissionDefinitionStoreTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(lockHandle);

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
@@ -22,10 +22,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
         _distributedLockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -47,10 +44,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
         _distributedLockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns((IDistributedLock?)null);
@@ -79,10 +73,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 "tus-file-lock-my-upload-id",
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -102,10 +93,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Timeout.InfiniteTimeSpan,
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Is<DistributedLockAcquireOptions?>(o => o != null && o.TimeUntilExpires == Timeout.InfiniteTimeSpan),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -125,10 +113,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                TimeSpan.Zero,
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Is<DistributedLockAcquireOptions?>(o => o != null && o.AcquireTimeout == TimeSpan.Zero),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -150,10 +135,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
         _distributedLockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -178,10 +160,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
         _distributedLockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns((IDistributedLock?)null);

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
@@ -25,8 +25,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -51,8 +50,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns((IDistributedLock?)null);
@@ -84,8 +82,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -108,8 +105,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Timeout.InfiniteTimeSpan,
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -132,8 +128,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 TimeSpan.Zero,
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -158,8 +153,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -187,8 +181,7 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns((IDistributedLock?)null);

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
@@ -99,6 +99,26 @@ public sealed class DistributedLockTusFileLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_disable_monitoring_for_infinite_expiration()
+    {
+        // given
+        const string fileId = "test-file";
+        var sut = new DistributedLockTusFileLock(fileId, _distributedLockProvider);
+
+        // when
+        await sut.Lock();
+
+        // then
+        await _distributedLockProvider
+            .Received(1)
+            .TryAcquireAsync(
+                Arg.Any<string>(),
+                Arg.Is<DistributedLockAcquireOptions?>(o => o != null && o.Monitoring == LockMonitoringMode.None),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
     public async Task should_use_zero_acquire_timeout()
     {
         // given

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusFileLockTests.cs
@@ -25,6 +25,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -48,6 +50,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -80,6 +84,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -102,6 +108,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Timeout.InfiniteTimeSpan,
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -123,6 +131,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 TimeSpan.Zero,
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );
@@ -147,6 +157,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -174,6 +186,8 @@ public sealed class DistributedLockTusFileLockTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
@@ -42,10 +42,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 $"tus-file-lock-{fileId}",
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -59,10 +56,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
         _distributedLockProvider
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -79,10 +73,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
             .Received(1)
             .TryAcquireAsync(
                 Arg.Any<string>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<TimeSpan?>(),
-                Arg.Any<bool>(),
-                Arg.Any<LockMonitoringMode>(),
+                Arg.Any<DistributedLockAcquireOptions?>(),
                 Arg.Any<CancellationToken>()
             );
     }

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
@@ -45,6 +45,8 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -60,6 +62,8 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
@@ -79,6 +83,8 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
                 Arg.Any<string>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );

--- a/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
+++ b/tests/Headless.Tus.Tests.Unit/DistributedLock/DistributedLockTusLockProviderTests.cs
@@ -45,8 +45,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -63,8 +62,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(distributedLock);
@@ -84,8 +82,7 @@ public sealed class DistributedLockTusLockProviderTests : TestBase
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<TimeSpan?>(),
                 Arg.Any<bool>(),
-                Arg.Any<bool>(),
-                Arg.Any<bool>(),
+                Arg.Any<LockMonitoringMode>(),
                 Arg.Any<CancellationToken>()
             );
     }


### PR DESCRIPTION
## Summary
- add optional lease monitoring and auto-extension to distributed lock handles
- expose HandleLostToken, GetLockIdAsync, and LockHandleLostException for lease-loss handling
- add monitor lifecycle tests, provider integration coverage, and docs updates

## Validation
- make build
- make build-project PROJECT=src/Headless.DistributedLocks.Core/Headless.DistributedLocks.Core.csproj
- make test-project-fast TEST_PROJECT=tests/Headless.DistributedLocks.Tests.Unit
- make test-project-fast TEST_PROJECT=tests/Headless.DistributedLocks.InMemory.Tests.Integration
- focused impacted test suites passed before final rebase: Idempotency unit/integration, TUS unit, Permissions unit, Messaging Core unit

## Post-deploy monitoring
- watch lock lost/lease monitor logs for unexpected cancellation spikes
- watch long-running distributed-lock consumers for renewal failures under load
- verify Redis/cache-backed integrations keep existing acquisition and release behavior

Closes #289
