### PR TITLE
feat(caching): add Redis cache entry envelope

### DIFF
--- a/docs/brainstorms/2026-06-03-caching-redis-envelope-payload-requirements.md
+++ b/docs/brainstorms/2026-06-03-caching-redis-envelope-payload-requirements.md
@@ -1,0 +1,150 @@
+---
+date: 2026-06-03
+topic: caching-redis-envelope-payload
+issue: 372
+parent_issue: 369
+---
+
+# Cache entry envelope — Redis payload format
+
+## Summary
+
+Give the Redis provider a wire format that carries the entry-metadata envelope (#371) inside the serialized payload, so the logical/physical expiration split, the reserved last-factory-error and tags slots, and null-value handling survive in Redis the way they survive as live object fields in the Memory provider. The format is a **versioned binary framing**: a fixed-width header (`magic/version`, `flags`, `logicalExpiresAt`, `physicalExpiresAt`) followed by the raw serialized value bytes. This slice is behavior-preserving — logical == physical, reserved slots empty — but the format is shaped once so every later M1/M2/M3 feature rides it without a second migration.
+
+## Problem Frame
+
+#371 established the envelope as a Memory-provider concern: `LogicalExpiresAt`/`PhysicalExpiresAt`/`LastFactoryError`/`Tags` live as fields on an in-process `CacheEntry` object. That works because Memory keeps live object references. Redis is out-of-process — the moment an entry leaves the process, its metadata has to live **in the bytes** or it does not exist. Today the Redis provider stores only the raw serialized value plus a single Redis TTL; it has nowhere to put "the value is stale but still serveable," "the last factory call failed at time T," or "this entry carries tags X, Y."
+
+The roadmap's gating principle (#369) is "design the metadata model once; both M1 and M2 ride it." For Redis that cost is concentrated in the wire format: the M1 resilience family (#373–#376), the M2 tag index (#378–#380), and the M3 BCL-interop trio (#381–#383) all read or extend this payload. Getting the format wrong is paid as either inherited mistakes or repeated re-breaks across roughly a dozen issues.
+
+Two forces make the Redis decision sharper than the Memory one:
+
+- **Headless `ICache` is a power-user superset.** Unlike FusionCache (which runs purely on `IDistributedCache` and never touches the value server-side), Headless exposes `Increment`, compare-and-swap (`ReplaceIfEqual`/`RemoveIfEqual`), `SetIfHigher`/`SetIfLower`, prefix scan, and bulk — several of which operate on the **raw stored value** via Lua. Any format that buries the value inside a serialized graph breaks those scripts.
+- **M3 is the headline deliverable.** The BCL adapters (`HybridCache`, `IOutputCacheStore`, `IDistributedCache`) traffic in `byte[]`. They need the raw value bytes back cheaply, without deserializing-and-re-extracting a wrapper.
+
+This is deliberately a technical/architectural brainstorm — the wire format *is* the subject.
+
+## Key Decisions
+
+- **KD-1. Binary framing, not a whole-object wrapper, not a sidecar key.** The value is stored as a raw byte segment behind a fixed-width metadata header, all in one Redis string. This is the only layout that keeps the value *both* a recoverable raw segment (serving the atomic/CAS Lua superset and the M3 BCL adapters) *and* atomically co-evicted with its metadata. The whole-object wrapper (FusionCache's model) buries the value and fights both the superset and M3; the sidecar key keeps the value raw but cannot survive `maxmemory` — two keys have two independent LRU clocks and Redis has no primitive to evict them as a unit. A cache spends its life at `maxmemory`, so half-eviction is not a corner case.
+
+- **KD-2. Physical expiration drives the Redis TTL; logical expiration lives in the header.** Redis `PEXPIRE` is set to the physical deadline (when the entry is evicted); the logical deadline (when the value is stale) is carried in the payload and consulted by app-side read logic. This matches FusionCache's verified L2 model. In this slice the two are equal, so TTL behavior is identical to today; #373 (fail-safe) flips them apart by setting a longer physical TTL with no format change.
+
+- **KD-3. Null-value handling moves from a magic value to a header flag.** Today a cached C# null is stored as the literal `@@NULL` string, which means the literal string `"@@NULL"` cannot itself be cached. With framing, "value is null" becomes a bit in the `flags` byte and the value segment is empty. This preserves the null-round-trip behavior the conformance suite requires and removes the sentinel-collision wart.
+
+- **KD-4. Counters stay raw; framed entries cover value + CAS.** Atomic numeric entries (`Increment`/`SetIfHigher`/`SetIfLower`) have no logical-vs-physical meaning, no factory to fail-safe, and nothing to tag — so they remain plain Redis-native values and keep native `INCR` throughput. Compare-and-swap (`ReplaceIfEqual`/`RemoveIfEqual`) operates on real metadata-bearing values, so it stays on framed entries and compares the caller's `expected` against the **value segment**, not the whole payload. The reader discriminates framed vs raw via the magic byte. *(This is the one consciously flippable decision — see Assumptions.)*
+
+- **KD-5. Shared semantics, not a shared type — inherited from #371.** There is no shared CLR envelope type across providers. The field set and its semantics are the contract; Redis models them in its own wire format, Memory in live object fields. The cross-provider conformance harness is the drift guard. This keeps the caching provider assemblies decoupled and avoids the domain's first `InternalsVisibleTo` wiring.
+
+- **KD-6. The header is versioned for forward evolution.** A `magic/version` byte governs the format so #373 (last-factory-error) and #379 (tags) extend the header without a break. Greenfield posture: there is no read path for pre-envelope payloads; unversioned/unrecognized bytes are rejected or ignored, not migrated.
+
+### Wire layout: before / after
+
+```mermaid
+flowchart LR
+  subgraph Before["Redis value — today"]
+    B1["raw serialized value bytes"]
+    B2["( @@NULL literal when value is null )"]
+    B3["Redis TTL = single expiration"]
+  end
+  subgraph After["Redis value — #372 framing"]
+    A1["magic / version : 1 byte"]
+    A2["flags : 1 byte  (incl. is-null bit)"]
+    A3["logicalExpiresAt : 8 bytes"]
+    A4["physicalExpiresAt : 8 bytes"]
+    A5["value : raw serialized bytes (rest)"]
+    A6["Redis TTL = physical expiration"]
+  end
+  Before --> After
+```
+
+For #372, `logicalExpiresAt == physicalExpiresAt == now + duration` on every write, the `flags` carry only the is-null bit, and the reserved header capacity for last-factory-error (#373) and tags (#379) stays absent/empty — which is why behavior is unchanged.
+
+## Requirements
+
+### Wire format
+
+- R1. Redis value entries are stored as a versioned binary frame: a fixed-width header carrying a magic/version marker, a flags byte, a logical-expiration instant, and a physical-expiration instant, followed by the raw serialized value bytes at a constant offset.
+- R2. The value segment is the byte-for-byte output of the configured `ISerializer` (System.Text.Json or MessagePack) — framing wraps the serializer, it does not replace or nest inside it. The value bytes are recoverable by stripping the fixed header, without deserializing the value.
+- R3. The header is versioned so later issues (#373 last-factory-error, #379 tags) extend it additively. Readers encountering an unrecognized/absent version treat the payload as not-an-envelope per the greenfield posture (reject or ignore; no legacy read path).
+- R4. The header reserves capacity for the last-factory-error and tags fields defined by the envelope contract. In #372 these are absent/empty; #373 and #379 populate them.
+
+### Expiration & null handling
+
+- R5. The Redis key TTL (`PEXPIRE`) is set from the **physical** expiration. The **logical** expiration is carried in the header and is not enforced by Redis key expiry.
+- R6. For every write in this slice, logical == physical == `now + duration`, so the observable TTL and expiry timing are identical to today.
+- R7. A cached null value is represented by an is-null bit in the flags byte with an empty value segment, replacing the `@@NULL` literal. Round-tripping a null returns null; the literal string previously colliding with the sentinel is now cacheable.
+
+### Atomic & compare-and-swap operations
+
+- R8. Atomic numeric entries (`Increment`, `SetIfHigher`, `SetIfLower`) remain plain Redis-native values (no frame) and continue to use native/`INCR`-style operations. Reading such an entry back through the value path yields its numeric value.
+- R9. Compare-and-swap operations (`ReplaceIfEqual`, `RemoveIfEqual`) operate on framed entries by comparing the caller's expected value against the **value segment** of the stored frame, and (for replace) by writing a new frame that preserves/refreshes the header. The migrated Lua scripts reach the value at the known offset rather than comparing whole-payload bytes.
+- R10. The value read path discriminates framed entries from raw entries via the magic/version byte, so `GetAsync<T>` returns the correct value whether the entry was written framed (value/CAS) or raw (counter).
+
+### Behavior preservation & conformance
+
+- R11. With only a duration supplied (the only input available in this slice), the Redis provider's externally observable behavior — hits, misses, expiry timing, null round-trip, bulk/prefix operations, CAS, increment — is identical to the pre-change behavior. Existing Redis integration tests pass.
+- R12. The cross-provider conformance harness asserts the metadata round-trips through Redis: an entry written with metadata is read back with the same logical/physical instants and null-ness, and logical/physical **parity** plus reserved-slot emptiness holds for this slice. The same conformance scenarios pass on both Memory and Redis.
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R11.**
+  - **Given:** a value written via `UpsertAsync(key, value, TimeSpan.FromMinutes(10))`.
+  - **When:** the stored Redis payload is inspected and then read back via `GetAsync<T>`.
+  - **Then:** the payload begins with the versioned header and the value segment equals the raw `ISerializer` output; the read returns the original value.
+
+- AE2. **Covers R5, R6.**
+  - **Given:** the same 10-minute write.
+  - **When:** the Redis key TTL and the header instants are inspected.
+  - **Then:** the key TTL ≈ 10 minutes, `logicalExpiresAt == physicalExpiresAt == now + 10 minutes`, matching today's expiry timing.
+
+- AE3. **Covers R7.**
+  - **Given:** a null value cached under a key, and separately the literal string `"@@NULL"` cached under another key.
+  - **When:** both are read back.
+  - **Then:** the first returns null (is-null flag set, empty value segment); the second returns the literal string `"@@NULL"` intact.
+
+- AE4. **Covers R8, R10.**
+  - **Given:** `Increment(key, 1)` called several times, then `GetAsync<long>(key)`.
+  - **When:** the entry is stored and read.
+  - **Then:** it is stored as a raw native value (no frame), native increment applies, and the read returns the accumulated count.
+
+- AE5. **Covers R9.**
+  - **Given:** a framed value entry, and a `ReplaceIfEqual(key, expected, next)` call.
+  - **When:** `expected` matches the stored value segment.
+  - **Then:** the replacement succeeds and writes a new frame; when `expected` does not match the value segment, the operation is a no-op — comparison never sees header bytes.
+
+- AE6. **Covers R12.**
+  - **Given:** the cross-provider conformance suite for entry metadata.
+  - **When:** it runs against the Redis fixture.
+  - **Then:** metadata round-trips (logical/physical instants and null-ness survive), parity/emptiness invariants hold, and the suite is green on both Memory and Redis.
+
+## Scope Boundaries
+
+### Deferred to later issues (format is ready, not activated)
+
+- Divergent logical/physical TTL and serve-stale-on-failure — #373 sets a longer physical TTL and reads the logical instant.
+- Last-factory-error population and soft/hard factory timeouts — #373, #374; the header slot is reserved here.
+- Eager refresh and adaptive caching — #375, #376.
+- Tag header population, Redis reverse index, and `RemoveByTagAsync` — #378–#380; the tags slot is reserved here.
+- BCL `IDistributedCache` / `HybridCache` / `IOutputCacheStore` adapters consuming the raw value segment — #381–#383.
+- Sliding expiration — #377.
+
+### Outside this issue's shape
+
+- No change to the `ISerializer` abstraction or its implementations — framing sits above it.
+- No shared cross-provider envelope CLR type (KD-5).
+- No new public `ICache` surface; `CacheEntryOptions` members beyond `Duration` are added by the M1 PR that activates each one.
+- Collection/list/set operations keep their existing sorted-set representation; the envelope concerns scalar value entries.
+
+## Dependencies & Assumptions
+
+- **Depends on #371 (PR #389):** the envelope field set and `CacheEntryOptions` exist in the abstractions/Memory provider. #372 must land on a branch that includes #389.
+- **Assumption (flippable — KD-4): counters stay raw rather than framed.** Rationale: native `INCR` throughput and no metadata semantics on a counter. The alternative — uniform framing for every entry, with a custom Lua `INCR` that parses the header — buys a single on-wire format at the cost of native-increment speed and more Lua. If a uniform format is later judged worth that cost, the read path's magic-byte discrimination (R10) is the only thing that changes.
+- **Assumption:** fixed-width header fields (1+1+8+8 bytes) are sufficient for the M1 metadata; #373/#379 extend via the version byte and additional fixed or length-prefixed regions rather than reshaping the existing fields.
+- **Assumption:** the conformance harness scaffolding from #371 (R11/R12 there) is in place for Redis to attach its round-trip assertions; if not yet extracted, that extraction precedes or accompanies this slice (per the repo's harness-first rule for the 2nd provider).
+
+## Open Questions
+
+- OQ1. Exact header encoding of the expiration instants — Unix-ms `long` vs ticks — and endianness, settled at planning against the existing serializer/Redis byte conventions.
+- OQ2. Whether the magic/version marker is a single byte or a short multi-byte tag, balanced against false-positive risk of misreading a raw counter or an externally-written key as a frame.
+- OQ3. Migration mechanics of the CAS and set-if Lua scripts — whether the value-segment offset is passed as a script arg or hard-coded to the header width — decided when the scripts are rewritten.

--- a/docs/llms/caching.md
+++ b/docs/llms/caching.md
@@ -31,6 +31,7 @@ packages: Caching.Abstractions, Caching.Memory, Caching.Redis, Caching.Hybrid
 - [Headless.Caching.Redis](#headlesscachingredis)
     - [Problem Solved](#problem-solved-2)
     - [Key Features](#key-features-2)
+    - [Design Notes](#design-notes-2)
     - [Installation](#installation-2)
     - [Quick Start](#quick-start-2)
     - [Configuration](#configuration-2)
@@ -77,6 +78,7 @@ Use `CacheValue<T>` return type — check `.HasValue` before accessing `.Value`.
 - Key length validation is the consumer's responsibility. The framework does not enforce key length limits for DoS protection — validate at your application boundary.
 - StackExchange.Redis does not support `CancellationToken` — timeouts are configured via `ConfigurationOptions.SyncTimeout` and `AsyncTimeout`. Cancellation is checked at the start of operations only.
 - For Redis, SCAN-based operations (`RemoveByPrefixAsync`, `GetAllKeysByPrefixAsync`) are cancellable during iteration; single-key and batch operations complete atomically once started.
+- Redis scalar entries use a versioned binary envelope. Do not parse Redis string bytes as the application payload directly; strip the envelope first unless the key is a raw counter.
 - Use `options.KeyPrefix` to namespace cache keys per application or module.
 - Memory cache supports `CloneValues = true` for value isolation between callers — useful when cached objects are mutated after retrieval.
 - Hybrid cache `DefaultLocalExpiration` controls L1 TTL independently of L2. Set to shorter durations than L2 for freshness.
@@ -253,6 +255,12 @@ Provides distributed caching using Redis via the unified `ICache` abstraction, e
 - Set/list operations with pagination
 - Lua scripts for atomic multi-key operations
 - Redis Cluster support
+
+## Design Notes
+
+Redis scalar cache entries are stored as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is still mapped to the Redis key TTL; logical expiration rides in the payload so later fail-safe and refresh features can diverge logical staleness from physical eviction without changing the wire format.
+
+Null scalar values are represented by a header flag with an empty value segment. The literal string `"@@NULL"` is now a normal cacheable string when written through Redis cache APIs. Raw legacy keys containing `"@@NULL"` still read as null. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) remain raw Redis-native numeric strings so Redis can perform native atomic arithmetic; their read path falls back to the raw value codec.
 
 ## Installation
 

--- a/docs/llms/caching.md
+++ b/docs/llms/caching.md
@@ -258,7 +258,18 @@ Provides distributed caching using Redis via the unified `ICache` abstraction, e
 
 ## Design Notes
 
-Redis scalar cache entries are stored as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is still mapped to the Redis key TTL; logical expiration rides in the payload so later fail-safe and refresh features can diverge logical staleness from physical eviction without changing the wire format.
+Scalar write operations (`UpsertAsync`, `TryInsertAsync`, `TryReplaceAsync`, `TryReplaceIfEqualAsync`, `UpsertAllAsync`) store entries as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is still mapped to the Redis key TTL; logical expiration rides in the payload so later fail-safe and refresh features can diverge logical staleness from physical eviction without changing the wire format. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) bypass framing and write raw Redis-native numeric strings (see below).
+
+The envelope byte layout is:
+
+| Offset | Field | Description |
+| --- | --- | --- |
+| 0 | Magic | `0xFF` — marks a framed entry |
+| 1 | Version | `0x01` — current envelope version |
+| 2 | Flags | bit0 = `isNull`, bit1 = `hasLogicalExpiresAt`, bit2 = `hasPhysicalExpiresAt` |
+| 3–10 | LogicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit1 is set) |
+| 11–18 | PhysicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit2 is set) |
+| 19+ | ValueSegment | raw codec bytes; empty when `isNull` is set |
 
 Null scalar values are represented by a header flag with an empty value segment. The literal string `"@@NULL"` is now a normal cacheable string when written through Redis cache APIs. Raw legacy keys containing `"@@NULL"` still read as null. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) remain raw Redis-native numeric strings so Redis can perform native atomic arithmetic; their read path falls back to the raw value codec.
 

--- a/docs/plans/2026-06-03-001-feat-caching-redis-envelope-payload-plan.md
+++ b/docs/plans/2026-06-03-001-feat-caching-redis-envelope-payload-plan.md
@@ -1,0 +1,328 @@
+---
+status: completed
+date: 2026-06-03
+type: feat
+issue: 372
+parent_issue: 369
+origin: docs/brainstorms/2026-06-03-caching-redis-envelope-payload-requirements.md
+---
+
+# feat: Cache entry envelope — Redis payload format
+
+## Summary
+
+Give `Headless.Caching.Redis` a versioned binary framing format for scalar cache entries so the entry-metadata envelope (#371 / PR #389) survives in the Redis bytes: a fixed-width header (`magic/version`, `flags`, `logicalExpiresAt`, `physicalExpiresAt`) followed by the raw value bytes. Physical expiration drives the Redis key TTL; logical expiration rides in the header. Null moves from the `@@NULL` literal to a header flag bit. Atomic numeric counters stay raw (native `INCR`); compare-and-swap (`ReplaceIfEqual`/`RemoveIfEqual`) gains envelope-aware Lua that compares against the value segment. The slice is behavior-preserving — logical == physical, reserved slots empty — but settles the wire format for the whole M1/M2/M3 program. As part of this work, extract a `Headless.Caching.Tests.Harness` package so the cross-provider value-semantics contract (Memory + Redis) is proven against one conformance suite rather than drifting copies.
+
+**Target branch note:** #371's envelope landed as PR #389 (`3157122f5`) on `main` but is **not** on the current `xshaheen/messaging-message-options` branch. This work must branch from a base that includes #389 — `GetOrAddAsync` already takes `CacheEntryOptions`, and `InMemoryCache.CacheEntry` already carries `LogicalExpiresAt`/`PhysicalExpiresAt`/`LastFactoryError`/`Tags`.
+
+---
+
+## Problem Frame
+
+The Memory provider keeps entry metadata as live object fields (`InMemoryCache.CacheEntry`, post-#389). Redis is out-of-process, so the same metadata must live in the serialized bytes or it does not exist. Today `RedisCache` stores only the raw serialized value plus a single Redis TTL (`src/Headless.Caching.Redis/RedisCache.cs`, `_SetInternalAsync` 1047–1064), with null represented by an `@@NULL` literal (`_NullValue`, line 44; applied in `_ToRedisValue`/`_FromRedisValue`/`_RedisValueToCacheValue`, 958–1015). There is nowhere to record "the value is stale but serveable" (#373 fail-safe), "the last factory call failed at T" (#374), or "this entry carries tags X, Y" (#379).
+
+The roadmap (#369) gates most M1/M2 features on this format: the resilience family (#373–#376), the tag index (#378–#380), and the M3 BCL-interop trio (#381–#383) all read or extend this payload. Two repo facts make the Redis decision load-bearing:
+
+- **`string` values bypass the serializer** (`_ToRedisValue` returns the raw string; `_FromRedisValue` returns `redisValue.ToString()`). Framing therefore cannot live inside `_ToRedisValue`/`_FromRedisValue` — it must be a distinct layer at the StringGet/StringSet sites, applied uniformly to strings and serialized bytes alike.
+- **CAS passes `_ToRedisValue(expected)` as the comparison operand** (`TryReplaceIfEqualAsync` 202–242, `RemoveIfEqualAsync` 767–787). If framing were folded into `_ToRedisValue`, the expected operand would be framed and CAS would break. `_ToRedisValue` must stay a *bare* value codec.
+
+This is a technical/architectural plan — the wire format and the test-harness shape are the subject. See origin: `docs/brainstorms/2026-06-03-caching-redis-envelope-payload-requirements.md`.
+
+---
+
+## Key Technical Decisions
+
+- **KTD-1. Fixed-width 19-byte header.** Layout: bytes 0–1 = 2-byte magic/version prefix (byte 0 = `0xFF` magic to prevent UTF-8 multi-byte collisions, byte 1 = `0x01` version); byte 2 = `flags`; bytes 3–10 = `logicalExpiresAt`; bytes 11–18 = `physicalExpiresAt`; bytes 19+ = value segment. Expiration instants are Unix-epoch milliseconds as `Int64`, little-endian (`BinaryPrimitives`). Absence of an instant ("no expiry") is encoded by a `flags` bit, not a sentinel number. Fixed width keeps the value segment at a constant offset so Lua can slice it and BCL adapters can strip it. *(Resolves origin OQ1.)*
+
+- **KTD-2. Framing is a distinct layer, not inside the value codec.** `_ToRedisValue`/`_FromRedisValue` stay bare value codecs (so CAS can pass a bare `expected`). A new internal framing component encodes/decodes the header around those bare bytes, invoked only at the scalar StringGet/StringSet sites. This is the single most important seam in the change.
+
+- **KTD-3. Physical → Redis TTL; logical → header.** The Redis key `PEXPIRE`/`StringSet` expiry is set from the physical instant; the logical instant rides in the header and is not enforced by Redis key expiry. This slice writes logical == physical == `now + duration`, so observable TTL is identical to today; #373 diverges them with no format change. Matches FusionCache's verified L2 model (see origin Key Decisions).
+
+- **KTD-4. Null via `flags` bit; `@@NULL` retired.** "Value is null" becomes `flags` bit 0 with an empty value segment, replacing the `@@NULL` literal. This preserves null round-trip and makes the literal string `"@@NULL"` cacheable (removes a current wart).
+
+- **KTD-5. Counters stay raw; 2-byte magic prefix discriminates.** Atomic numeric entries (`Increment`, `SetIfHigher`, `SetIfLower`) remain plain Redis-native values using native `INCR` — they have no logical/physical/tag semantics. The read path distinguishes framed from raw by checking if the first byte is `0xFF` (magic) and the second byte is `0x01` (version). Using `0xFF` eliminates collision risk with UTF-8 character leading bytes (such as emojis or supplementary CJK planes, which occupy `0xF0`–`0xF4` at most) and MessagePack negative fixints (`0xf0`–`0xff`). Unframed bytes → raw/legacy path (deserialize directly, as today). *(Resolves origin OQ2.)*
+
+- **KTD-6. Dedicated CAS Lua scripts with framing safety checks; new value pre-framed in C#.** To avoid breaking `Headless.DistributedLocks.Redis` (which shares the general locking scripts), define caching-specific scripts (`CacheReplaceIfEqualScriptDefinition` and `CacheRemoveIfEqualScriptDefinition`) in `Headless.Caching.Redis`. The Lua scripts check if the current key exists before slicing, and check the magic byte prefix of the current value to discriminate framed vs raw. If it is raw/legacy, they compare against the entire un-sliced value. For `ReplaceIfEqual`, C# pre-frames the replacement value (it knows logical/physical) and passes it as `@value`; the script also takes `headerLen` as an ARGV constant. Null-expected equality is reconciled against the current frame's null flag. `Increment`/`SetIfHigher`/`SetIfLower` Lua are untouched. *(Resolves origin OQ3.)*
+
+- **KTD-7. Versioned header for forward evolution.** The version nibble governs the format so #373 (last-factory-error) and #379 (tags) extend the header additively. Greenfield posture: no read path for pre-envelope payloads; unrecognized bytes are treated as raw, not migrated.
+
+- **KTD-8. Extract `Headless.Caching.Tests.Harness` (cross-provider conformance).** Per the repo harness rule, the envelope makes Redis the provider whose value semantics must match Memory's. Rather than copy assertions, extract a `CacheConformanceTestsBase` over `ICache` plus a fixture seam; Memory and Redis each supply a concrete fixture. Portable value-semantics scenarios live in the base; backend-specific tests (Redis key-prefix, setup, cluster/Lua, concurrency contention) stay in the leaf project. Mirrors `tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs` (note: no leaf inherits that base yet, so this slice establishes the inheriting pattern). xUnit v3 does not auto-discover inherited virtual `[Fact]` methods unless the leaf re-declares them — each leaf class overrides the base scenarios and annotates them with `[Fact]` so they execute under the concrete provider.
+
+---
+
+## High-Level Technical Design
+
+*Directional guidance for reviewers, not implementation specification.*
+
+### Wire layout (framed scalar entry)
+
+```mermaid
+flowchart LR
+  subgraph Frame["Redis STRING value (framed)"]
+    H0["bytes 0-1<br/>magic/version 0xFF01"]
+    H1["byte 2<br/>flags: bit0 isNull,<br/>bit1 hasLogical, bit2 hasPhysical"]
+    H2["bytes 3-10<br/>logicalExpiresAt (unix-ms i64 LE)"]
+    H3["bytes 11-18<br/>physicalExpiresAt (unix-ms i64 LE)"]
+    V["bytes 19+<br/>value segment (raw _ToRedisValue output)"]
+  end
+  H0 --> H1 --> H2 --> H3 --> V
+```
+
+Redis key TTL = physical instant. Counters are NOT framed — stored as native ASCII integers, no magic byte.
+
+### Read discrimination
+
+```mermaid
+flowchart TD
+  G["StringGet(key) -> RedisValue"] --> HV{HasValue?}
+  HV -- no --> NV["CacheValue.NoValue"]
+  HV -- yes --> M{"bytes 0-1 == 0xFF01?"}
+  M -- no --> RAW["raw/legacy path:<br/>counter or pre-envelope -> _FromRedisValue as today"]
+  M -- yes --> F["unframe header"]
+  F --> NULLF{"flags.isNull?"}
+  NULLF -- yes --> NULLR["CacheValue.Null"]
+  NULLF -- no --> VAL["deserialize value segment -> CacheValue(value)"]
+```
+
+### CAS seam (CacheReplaceIfEqual)
+
+```mermaid
+sequenceDiagram
+  participant C as RedisCache (C#)
+  participant R as Redis (Lua)
+  C->>C: expected = _ToRedisValue(expected)  (bare)
+  C->>C: value = Frame(_ToRedisValue(value), logical, physical)  (pre-framed)
+  C->>R: EVAL CacheReplaceIfEqual KEYS=key ARGV=value,expected,expires,headerLen
+  R->>R: cur = GET key
+  alt cur == nil (or false)
+    R->>R: check expected is nil
+  else cur starts with 0xFF01 (framed)
+    R->>R: curValue = sub(cur, headerLen+1)
+  else cur is raw/unframed
+    R->>R: curValue = cur
+  end
+  alt curValue == expected
+    R->>R: SET key value [PX expires]
+    R-->>C: 1
+  else
+    R-->>C: -1
+  end
+```
+
+---
+
+## Output Structure
+
+```
+tests/Headless.Caching.Tests.Harness/
+├── Headless.Caching.Tests.Harness.csproj   # Headless.NET.Sdk.Test
+└── CacheConformanceTestsBase.cs            # abstract: ICache factory + virtual should_* scenarios
+```
+
+Leaf wiring (existing projects, new files):
+```
+tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheConformanceTests.cs   # : CacheConformanceTestsBase
+tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs # : CacheConformanceTestsBase
+tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs   # backend-specific frame assertions
+```
+
+The per-unit `**Files:**` sections remain authoritative; the implementer may adjust layout.
+
+---
+
+## Implementation Units
+
+### U1. Binary framing codec
+
+- **Goal:** A pure, internal encode/decode component for the 19-byte header + value segment, independent of Redis and the serializer.
+- **Requirements:** R1, R3, R4, R7 (origin).
+- **Dependencies:** none (branch must include #389).
+- **Files:**
+  - `src/Headless.Caching.Redis/RedisCacheEntryFrame.cs` (new — `internal static`/`readonly struct` encode/decode + flags/magic constants)
+  - `tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs` (new — pure unit tests; no container needed, but lives with Redis as it is Redis-internal)
+- **Approach:** Encode `(valueBytes, isNull, logical?, physical?)` → `byte[]`: write magic (`0xFF`), version (`0x01`), flags (isNull/hasLogical/hasPhysical bits), two `Int64` unix-ms instants via `BinaryPrimitives.WriteInt64LittleEndian`, then append value bytes. Decode returns `(isFramed, isNull, logical?, physical?, ReadOnlyMemory<byte> valueSegment)`; `isFramed=false` when byte 0 ≠ `0xFF` or byte 1 ≠ `0x01` or length < header. Expose `HeaderLength` const (19) for the Lua ARGV and read-path slicing. No `DateTime`↔ms helper duplication — centralize conversion here.
+- **Patterns to follow:** `BinaryPrimitives` for endian-safe packing; file header `// Copyright (c) Mahmoud Shaheen. All rights reserved.`; keep `internal sealed`/`static`.
+- **Test suite design:** Pure unit tests in the Redis integration project (no Testcontainers dependency for this class); they exercise the codec directly.
+- **Test scenarios:**
+  - Round-trip: value bytes + logical + physical → decode yields identical segment + instants.
+  - Null: encode `isNull=true` → empty value segment, flag set; decode restores null.
+  - No-expiry: `logical=null`/`physical=null` → hasLogical/hasPhysical bits clear; decode yields null instants.
+  - Discrimination: bytes not starting with `0xFF 0x01` sequence → `isFramed=false`; a buffer shorter than `HeaderLength` → `isFramed=false`.
+  - Boundary: empty value segment with non-null flag clear (zero-length value) round-trips distinctly from null.
+  - Endianness: a known instant encodes to the expected little-endian byte pattern (guards accidental host-endian drift).
+- **Verification:** New unit tests pass; codec has no Redis or serializer dependency.
+
+### U2. Frame the scalar write path
+
+- **Goal:** Writes store framed entries; Redis TTL is set from physical expiration.
+- **Requirements:** R1, R2, R5, R6 (origin).
+- **Dependencies:** U1.
+- **Files:**
+  - `src/Headless.Caching.Redis/RedisCache.cs` (`_SetInternalAsync` 1047–1064, `_SetAllInternalAsync` 1066–1092; thread logical/physical from the write call)
+  - `tests/Headless.Caching.Redis.Tests.Integration/UpsertTests.cs` (extend)
+- **Approach:** Keep `_ToRedisValue` producing bare bytes; after it, call the U1 encoder to wrap with `(isNull, logical, physical)`. This slice: `physical = logical = now + expiration` (single source from the existing `TimeSpan?`/`CacheEntryOptions.Duration`). Set the StringSet expiry from physical. `_SetAllInternalAsync` frames each pair value; null entries frame with the null flag (do not skip them — current code's null-skip in set-all is replaced by an explicit null frame so nulls round-trip). Strings are framed too (they no longer hit the raw `@@NULL` branch).
+- **Patterns to follow:** existing `_NormalizeExpiration`/expiry handling; MSETEX vs pipelined fallback branches unchanged except for the framed value bytes.
+- **Test suite design:** Redis integration (Testcontainers); behavioral assertions belong in the conformance base (U5) — here, assert framing/TTL specifics that are Redis-only.
+- **Test scenarios:**
+  - Upsert with duration → stored raw key begins with magic byte; Redis `PTTL` ≈ duration.
+  - Upsert null → stored frame has null flag, empty value segment; `GetAsync` returns null.
+  - `UpsertAll` with a null among non-nulls → each round-trips, including the null.
+  - Upsert with no expiration → frame has hasPhysical bit clear; key has no TTL.
+- **Verification:** New/updated Redis tests pass; existing upsert tests still green.
+
+### U3. Unframe the scalar read path
+
+- **Goal:** Reads detect frames, restore null via flag, and fall back to raw for counters/legacy.
+- **Requirements:** R7, R10, R11 (origin).
+- **Dependencies:** U1.
+- **Files:**
+  - `src/Headless.Caching.Redis/RedisCache.cs` (`_FromRedisValue` 973–991, `_RedisValueToCacheValue` 993–1015, `_RedisValuesToCacheValue` 1017–1045; `GetAsync` 525–532, `GetAllAsync` 534–591 inherit)
+  - `tests/Headless.Caching.Redis.Tests.Integration/GetTests.cs` (extend)
+- **Approach:** At the read sites, decode via U1 first. If `isFramed`: null flag → `CacheValue.Null`; else deserialize the value segment through the existing serializer/string branch. If not framed: preserve today's behavior exactly (raw deserialize) — this is the counter path (native-`INCR` ASCII). Retire `_NullValue`/`@@NULL` handling from the read path entirely: framed entries carry null in the flag, and counters never write `@@NULL`. Greenfield posture (KTD-7) — no pre-envelope payloads exist to read, so no legacy `@@NULL` fallback is retained. Collection/sorted-set ops are untouched (separate path).
+- **Patterns to follow:** keep the `typeof(T)==string` fast path, now applied to the value segment; keep `LogDeserializationFailed` behavior.
+- **Test suite design:** Redis integration; cross-provider behavior covered in U5.
+- **Test scenarios:**
+  - `Covers AE1.` Framed value written by U2 → `GetAsync<T>` returns the original.
+  - `Covers AE3.` Null framed entry → returns null; a value equal to the literal string `"@@NULL"` → returns `"@@NULL"` intact (when written as a versioned frame).
+  - `Covers AE3 (legacy).` Reading an unframed key containing `"@@NULL"` → returns null (retroactive compatibility check).
+  - `Covers AE4.` A counter written by `Increment` (raw, unframed) → `GetAsync<long>` returns the count via the raw path.
+  - `GetAll` over a mix of framed, null-framed, and missing keys → correct `CacheValue` for each.
+- **Verification:** New/updated Redis read tests pass; existing get tests green.
+
+### U4. Implement Cache CAS Lua script definitions
+
+- **Goal:** `ReplaceIfEqual`/`RemoveIfEqual` operate correctly against framed entries; counter scripts stay raw.
+- **Requirements:** R9 (origin).
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `src/Headless.Caching.Redis/CacheScriptDefinitions.cs` (new — define `CacheReplaceIfEqualScriptDefinition` and `CacheRemoveIfEqualScriptDefinition` specifically for caching to avoid breaking `DistributedLocks` shared scripts)
+  - `src/Headless.Caching.Redis/RedisCache.cs` (`TryReplaceIfEqualAsync` 202–242, `RemoveIfEqualAsync` 767–787; pre-frame `@value`, pass bare `@expected` + `headerLen`)
+  - `src/Headless.Caching.Redis/RedisCacheScriptsInitializer.cs` (register the new `CacheReplaceIfEqualScriptDefinition` and `CacheRemoveIfEqualScriptDefinition` here; verify script bodies load)
+  - `tests/Headless.Caching.Redis.Tests.Integration/TryReplaceTests.cs`, `RemoveTests.cs` (extend)
+- **Approach:** Both scripts fetch the current value and check if it is non-nil/non-false. In Lua, check if the value length >= headerLen and starts with the 2-byte magic prefix (`0xFF 0x01`). If framed, slice: `local curValue = string.sub(currentVal, @headerLen + 1)`; if unframed, do not slice: `local curValue = currentVal`. Compare `curValue` to bare `@expected`. `ReplaceIfEqual` writes the C#-pre-framed `@value` (header built in C#, not Lua). Reconcile null-expected: when the caller's expected is null, compare against the current frame's null flag (byte 2 bit 0) rather than a byte compare. Leave `Increment`/`SetIfHigher`/`SetIfLower` untouched.
+- **Execution note:** Start with a failing CAS-against-framed test before editing the Lua; the slicing/null interaction is the highest-risk part of the change.
+- **Patterns to follow:** existing `@param`-bound `LuaScript.Prepare` style; `HeadlessRedisScriptsLoader.EvaluateAsync` load/fallback.
+- **Test suite design:** Redis integration; the happy-path CAS scenarios also seed the conformance base (U5), but the null-expected and slicing edge cases are Redis-specific and stay here.
+- **Test scenarios:**
+  - `ReplaceIfEqual` where expected matches the stored value segment (not the whole blob) → replaces; resulting entry is a valid frame readable by U3.
+  - `ReplaceIfEqual` where expected differs → no-op (returns the not-equal sentinel).
+  - `ReplaceIfEqual` preserves/refreshes TTL via the pre-framed physical instant.
+  - `ReplaceIfEqual` / `RemoveIfEqual` against legacy unframed or raw values works without crash and compares against the entire raw string.
+  - `RemoveIfEqual` matches value segment → deletes; mismatch → no-op.
+  - Null-expected: `RemoveIfEqual`/`ReplaceIfEqual` against a null-framed entry with expected=null → matches; against a non-null entry → no-op.
+  - Two entries with identical value but different timestamps compare equal (proves comparison ignores header).
+- **Verification:** New CAS tests pass including null-expected; concurrency tests still green; scripts reload cleanly on startup.
+
+### U5. Extract `Headless.Caching.Tests.Harness` + wire Memory
+
+- **Goal:** A cross-provider conformance suite over `ICache`, proven first against Memory.
+- **Requirements:** R12 (origin); KTD-8.
+- **Dependencies:** none for the base + Memory wiring (Memory already has #389); the Redis pass is U6.
+- **Files:**
+  - `tests/Headless.Caching.Tests.Harness/Headless.Caching.Tests.Harness.csproj` (new — `Headless.NET.Sdk.Test`)
+  - `tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs` (new)
+  - `tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheConformanceTests.cs` (new — concrete fixture)
+  - `headless-framework.slnx` (attach new project)
+- **Approach:** Mirror `DistributedLockProviderTestsBase`: `abstract class CacheConformanceTestsBase : TestBase` with `protected abstract ICache CreateCache(string keyPrefix)` and an abstract/overridable `TimeProvider` so providers inject `FakeTimeProvider` (Memory) or real (Redis). `public virtual async Task should_*` scenarios cover the portable value-semantics contract. Memory leaf supplies `InMemoryCache`. Do not pull Redis-only assertions (frame bytes, TTL internals) into the base. In `InMemoryCacheConformanceTests.cs`, override each of the virtual conformance methods and decorate them with `[Fact]` to align with the framework's test discovery convention.
+- **Patterns to follow:** `tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs`; `Headless.Testing.Tests.TestBase`; AwesomeAssertions + Bogus; namespace `Tests`.
+- **Test suite design:** This unit *is* the shared harness. Base scenarios are the contract; leaves are thin. Memory runs them as unit tests (fake clock where timing matters); Redis (U6) runs them as integration tests.
+- **Test scenarios (the conformance contract — each a `should_*` in the base):**
+  - Round-trip an object value and a string value.
+  - `Covers AE3.` Null round-trips; the literal `"@@NULL"` round-trips as a normal string.
+  - `Covers AE2.` Absolute-expiry timing: value present before expiry, absent after.
+  - Bulk: `UpsertAll`/`GetAll` parity including a null member.
+  - `Covers AE4.` `Increment` accumulates and reads back as a number.
+  - `Covers AE5.` CAS: `ReplaceIfEqual`/`RemoveIfEqual` succeed on match, no-op on mismatch.
+  - `TryInsert` (not-exists) and `TryReplace` (exists) semantics.
+- **Verification:** Memory conformance class passes all base scenarios; project builds and is attached to the solution.
+
+### U6. Wire Redis to the harness; prune duplicated leaf tests
+
+- **Goal:** Redis passes the same conformance suite; the integration project keeps only backend-specific tests.
+- **Requirements:** R11, R12 (origin); KTD-8.
+- **Dependencies:** U1–U5.
+- **Files:**
+  - `tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs` (new — concrete fixture over the Testcontainers `RedisCacheFixture`)
+  - `tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs` (new — backend-specific frame assertions)
+  - Prune portable scenarios now owned by the base from: `GetTests.cs`, `UpsertTests.cs`, `IncrementTests.cs`, `TryReplaceTests.cs`, `TryInsertTests.cs`, `RemoveTests.cs` (keep backend-specific cases)
+  - Keep as-is (backend-specific): `KeyPrefixTests.cs`, `RedisCacheSetupTests.cs`, `ConcurrencyTests.cs`, `SetOperationsTests.cs`, `SetIfHigherLowerTests.cs`, `ExpirationTests.cs` (Redis TTL specifics)
+- **Approach:** `RedisCacheConformanceTests : CacheConformanceTestsBase` builds `RedisCache` via the existing fixture (`new SystemJsonSerializer()`, `Fixture.ScriptsLoader`, real `TimeProvider`), with per-test key-prefix isolation and `FlushAsync`. In `RedisCacheConformanceTests.cs`, override each of the virtual conformance methods and decorate them with `[Fact]` to align with the framework's test discovery convention. `RedisEnvelopeFormatTests` reads the raw key bytes to assert the magic bytes, null-flag, physical-TTL mapping, and that a counter key is stored unframed (raw ASCII). Remove leaf tests whose behavior the conformance base now guarantees to avoid drift; retain any Redis-specific edge of those operations.
+- **Patterns to follow:** `RedisCacheTestBase`/`RedisCacheFixture` lifecycle; conformance-base contract from U5.
+- **Test suite design:** Integration (Testcontainers). Conformance scenarios inherited; envelope-format assertions are the only net-new Redis-specific behavioral tests.
+- **Test scenarios:**
+  - All inherited `should_*` conformance scenarios pass against Redis.
+  - `Covers AE1.` Raw stored value begins with the magic byte and the value segment deserializes to the original.
+  - `Covers AE2.` Redis `PTTL` ≈ physical instant.
+  - `Covers AE4.` `Increment` key stored as raw ASCII (no magic byte) verified by raw read.
+  - Pruned-test audit: no portable scenario is lost — every removed assertion has a conformance-base equivalent.
+- **Verification:** Full Redis integration suite green; conformance scenarios identical to Memory's; no net loss of coverage vs pre-prune (spot-check the audit scenario).
+
+### U7. Documentation sync
+
+- **Goal:** Keep the two agent-facing doc surfaces in lockstep with the consumer-visible behavior change.
+- **Requirements:** docs sync trigger (consumer-visible behavior change: `@@NULL` literal now cacheable; Redis wire format).
+- **Dependencies:** U1–U4 (behavior settled).
+- **Files:**
+  - `docs/llms/caching.md`
+  - `src/Headless.Caching.Redis/README.md`
+- **Approach:** Document the Redis envelope wire format (header fields, physical-TTL mapping, logical-in-payload), the null-via-flag change and that `"@@NULL"` is now a normal cacheable string, and that counters remain raw. Follow `docs/authoring/AUTHORING.md` drift checks; explain the concept and the physical-vs-logical trade-off, not just the field list. Note the format is versioned for the M1/M2 roadmap.
+- **Test suite design:** N/A — docs.
+- **Test scenarios:** `Test expectation: none -- documentation-only unit.`
+- **Verification:** Both surfaces updated and consistent; AUTHORING drift checks pass; no stale `@@NULL`-limitation wording remains.
+
+---
+
+## Scope Boundaries
+
+### In scope
+- Versioned binary framing for scalar Redis value entries (write, read, CAS).
+- Physical→TTL / logical→header mapping; null-via-flag; counters-stay-raw.
+- `Headless.Caching.Tests.Harness` extraction + Memory and Redis conformance wiring.
+- Docs sync for the consumer-visible behavior change.
+
+### Deferred for later (origin roadmap — format ready, not activated)
+- Divergent logical/physical TTL and serve-stale-on-failure — #373.
+- Last-factory-error population, soft/hard factory timeouts — #373, #374.
+- Eager refresh, adaptive caching — #375, #376.
+- Tag header population, Redis reverse index, `RemoveByTagAsync` — #378–#380.
+- BCL `IDistributedCache`/`HybridCache`/`IOutputCacheStore` adapters consuming the raw value segment — #381–#383.
+- Sliding expiration — #377.
+
+### Deferred to follow-up work (plan-local)
+- Migrating the remaining backend-specific Redis tests into any future shared shape — only the portable value-semantics scenarios move now.
+- Hybrid provider (`Headless.Caching.Hybrid`) conformance participation — out of this slice; revisit when the L1+L2 path consumes the envelope.
+
+---
+
+## Risks & Mitigation
+
+- **CAS Lua correctness (highest risk).** Value-segment slicing + null-expected reconciliation are subtle. *Mitigation:* test-first on the framed-CAS path (U4 execution note); dedicated null-expected scenarios; checking key existence and framing before slicing; dedicated caching scripts to avoid collision with distributed lock storage scripts.
+- **Binary (non-text) payloads.** Prepending a binary header makes stored values non-UTF-8; tooling or assumptions expecting text break. *Mitigation:* `RedisValue` handles bytes natively; magic bytes make frames self-identifying; documented in U7.
+- **Read-path false positives (high-nibble collision).** A non-framework key or UTF-8 emoji/MessagePack fixint could be misread as a frame. *Mitigation:* Using a 2-byte magic prefix (`0xFF 0x01`) rather than a single-byte high-nibble check. `0xFF` is invalid in UTF-8, avoiding all emoji collisions.
+- **Harness extraction drift/scope.** Memory (unit) vs Redis (integration) and clock differences could leak Redis specifics into the base. *Mitigation:* base parameterizes `ICache` factory + `TimeProvider`; only portable scenarios in the base; pruning audit scenario guards against lost coverage.
+- **Branch base.** Building on a pre-#389 branch would miss the envelope and `CacheEntryOptions`. *Mitigation:* stated dependency — branch from a base including PR #389.
+
+---
+
+## Acceptance Traceability (origin)
+
+| Origin AE | Covered by |
+|---|---|
+| AE1 (frame round-trip) | U3, U6 |
+| AE2 (TTL ≈ physical) | U5, U6 |
+| AE3 (null + literal `@@NULL`) | U3, U5 |
+| AE4 (counter raw) | U3, U5, U6 |
+| AE5 (CAS value-segment) | U4, U5 |
+| AE6 (conformance green both providers) | U5, U6 |
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-06-03-caching-redis-envelope-payload-requirements.md`.
+- `#371`/PR #389 (`3157122f5`) envelope shape: `src/Headless.Caching.Abstractions/Contracts/CacheEntryOptions.cs`; `InMemoryCache.CacheEntry` fields.
+- Redis value path: `src/Headless.Caching.Redis/RedisCache.cs` (`_ToRedisValue`/`_FromRedisValue` 958–1015, `_SetInternalAsync` 1047–1064, CAS 202–242 / 767–787).
+- Lua: `src/Headless.Redis/RedisScriptDefinitions.cs`; loader `src/Headless.Redis/HeadlessRedisScriptsLoader.cs`; initializer `src/Headless.Caching.Redis/RedisCacheScriptsInitializer.cs`.
+- Serializer: `src/Headless.Serializer.Abstractions/SerializerExtensions.cs` (`SerializeToBytes`/`Deserialize<T>(byte[])`).
+- Harness shape: `tests/Headless.DistributedLocks.Tests.Harness/DistributedLockProviderTestsBase.cs`; repo harness rule in `CLAUDE.md`.
+- FusionCache L2 model (logical-in-payload, physical-as-TTL), verified: `ZiggyCreatures.FusionCache` `FusionCacheDistributedEntry<T>`.

--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -71,6 +71,7 @@
         <Project Path="tests\Headless.Caching.Abstractions.Tests.Unit\Headless.Caching.Abstractions.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Caching.Memory.Tests.Unit\Headless.Caching.Memory.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Caching.Redis.Tests.Integration\Headless.Caching.Redis.Tests.Integration.csproj" />
+        <Project Path="tests\Headless.Caching.Tests.Harness\Headless.Caching.Tests.Harness.csproj" />
         <Project Path="tests/Headless.Caching.Hybrid.Tests.Unit/Headless.Caching.Hybrid.Tests.Unit.csproj" />
     </Folder>
     <Folder Name="/Captcha/">

--- a/src/Headless.Caching.Redis/CacheScriptDefinitions.cs
+++ b/src/Headless.Caching.Redis/CacheScriptDefinitions.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Redis;
+
+namespace Headless.Caching;
+
+/// <summary>Atomically removes a cache key only if its framed or raw value matches the expected value.</summary>
+internal sealed class CacheRemoveIfEqualScriptDefinition : RedisScriptDefinition
+{
+    public static CacheRemoveIfEqualScriptDefinition Instance { get; } = new();
+
+    private CacheRemoveIfEqualScriptDefinition()
+        : base(
+            """
+            local currentVal = redis.call('get', @key)
+            if currentVal == false then
+              return 0
+            end
+
+            local expectedIsNull = tonumber(@expectedIsNull)
+            local headerLen = tonumber(@headerLen)
+            local isFramed =
+              string.len(currentVal) >= headerLen
+              and string.byte(currentVal, 1) == 255
+              and string.byte(currentVal, 2) == 1
+
+            if isFramed then
+              local flags = string.byte(currentVal, 3)
+              local currentIsNull = flags % 2 == 1
+
+              if expectedIsNull == 1 then
+                if currentIsNull then
+                  return redis.call('del', @key)
+                end
+
+                return 0
+              end
+
+              if currentIsNull then
+                return 0
+              end
+
+              if string.sub(currentVal, headerLen + 1) == @expected then
+                return redis.call('del', @key)
+              end
+
+              return 0
+            end
+
+            if expectedIsNull == 1 then
+              if currentVal == @nullValue then
+                return redis.call('del', @key)
+              end
+
+              return 0
+            end
+
+            if currentVal == @expected then
+              return redis.call('del', @key)
+            end
+
+            return 0
+            """
+        ) { }
+}
+
+/// <summary>Atomically replaces a cache key only if its framed or raw value matches the expected value.</summary>
+internal sealed class CacheReplaceIfEqualScriptDefinition : RedisScriptDefinition
+{
+    public static CacheReplaceIfEqualScriptDefinition Instance { get; } = new();
+
+    private CacheReplaceIfEqualScriptDefinition()
+        : base(
+            """
+            local currentVal = redis.call('get', @key)
+            if currentVal == false then
+              return 0
+            end
+
+            local expectedIsNull = tonumber(@expectedIsNull)
+            local headerLen = tonumber(@headerLen)
+            local matches = 0
+            local isFramed =
+              string.len(currentVal) >= headerLen
+              and string.byte(currentVal, 1) == 255
+              and string.byte(currentVal, 2) == 1
+
+            if isFramed then
+              local flags = string.byte(currentVal, 3)
+              local currentIsNull = flags % 2 == 1
+
+              if expectedIsNull == 1 then
+                if currentIsNull then
+                  matches = 1
+                end
+              elseif not currentIsNull and string.sub(currentVal, headerLen + 1) == @expected then
+                matches = 1
+              end
+            else
+              if expectedIsNull == 1 then
+                if currentVal == @nullValue then
+                  matches = 1
+                end
+              elseif currentVal == @expected then
+                matches = 1
+              end
+            end
+
+            if matches == 0 then
+              return -1
+            end
+
+            if (@expires ~= nil and @expires ~= '') then
+              return redis.call('set', @key, @value, 'PX', @expires) and 1 or 0
+            end
+
+            return redis.call('set', @key, @value) and 1 or 0
+            """
+        ) { }
+}

--- a/src/Headless.Caching.Redis/CacheScriptDefinitions.cs
+++ b/src/Headless.Caching.Redis/CacheScriptDefinitions.cs
@@ -1,5 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+// These CAS scripts are intentionally forked from Headless.Redis Remove/ReplaceIfEqualScriptDefinition.
+// Do NOT merge them back into the shared definitions: DistributedLocks.Redis depends on the unmodified
+// shared scripts (whole-value comparison), whereas these slice the framed cache-entry value segment
+// (skipping the envelope header) before comparing against the expected value. See project memory note
+// "Shared Redis CAS scripts".
+
 using Headless.Redis;
 
 namespace Headless.Caching;
@@ -19,10 +25,15 @@ internal sealed class CacheRemoveIfEqualScriptDefinition : RedisScriptDefinition
 
             local expectedIsNull = tonumber(@expectedIsNull)
             local headerLen = tonumber(@headerLen)
-            local isFramed =
+            local hasMagic =
               string.len(currentVal) >= headerLen
               and string.byte(currentVal, 1) == 255
-              and string.byte(currentVal, 2) == 1
+
+            if hasMagic and string.byte(currentVal, 2) ~= 1 then
+              return redis.error_reply('ERR unsupported cache frame version')
+            end
+
+            local isFramed = hasMagic and string.byte(currentVal, 2) == 1
 
             if isFramed then
               local flags = string.byte(currentVal, 3)
@@ -80,10 +91,15 @@ internal sealed class CacheReplaceIfEqualScriptDefinition : RedisScriptDefinitio
             local expectedIsNull = tonumber(@expectedIsNull)
             local headerLen = tonumber(@headerLen)
             local matches = 0
-            local isFramed =
+            local hasMagic =
               string.len(currentVal) >= headerLen
               and string.byte(currentVal, 1) == 255
-              and string.byte(currentVal, 2) == 1
+
+            if hasMagic and string.byte(currentVal, 2) ~= 1 then
+              return redis.error_reply('ERR unsupported cache frame version')
+            end
+
+            local isFramed = hasMagic and string.byte(currentVal, 2) == 1
 
             if isFramed then
               local flags = string.byte(currentVal, 3)
@@ -110,7 +126,8 @@ internal sealed class CacheReplaceIfEqualScriptDefinition : RedisScriptDefinitio
               return -1
             end
 
-            if (@expires ~= nil and @expires ~= '') then
+            -- RedisValue.EmptyString is the no-expiry sentinel passed for @expires.
+            if @expires ~= '' then
               return redis.call('set', @key, @value, 'PX', @expires) and 1 or 0
             end
 

--- a/src/Headless.Caching.Redis/README.md
+++ b/src/Headless.Caching.Redis/README.md
@@ -18,7 +18,18 @@ Provides distributed caching using Redis via the unified `ICache` abstraction, e
 
 ## Design Notes
 
-Redis scalar cache entries are stored as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is still mapped to the Redis key TTL; logical expiration rides in the payload so later fail-safe and refresh features can diverge logical staleness from physical eviction without changing the wire format.
+Scalar write operations (`UpsertAsync`, `TryInsertAsync`, `TryReplaceAsync`, `TryReplaceIfEqualAsync`, `UpsertAllAsync`) store entries as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is still mapped to the Redis key TTL; logical expiration rides in the payload so later fail-safe and refresh features can diverge logical staleness from physical eviction without changing the wire format. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) bypass framing and write raw Redis-native numeric strings (see below).
+
+The envelope byte layout is:
+
+| Offset | Field | Description |
+| --- | --- | --- |
+| 0 | Magic | `0xFF` — marks a framed entry |
+| 1 | Version | `0x01` — current envelope version |
+| 2 | Flags | bit0 = `isNull`, bit1 = `hasLogicalExpiresAt`, bit2 = `hasPhysicalExpiresAt` |
+| 3–10 | LogicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit1 is set) |
+| 11–18 | PhysicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit2 is set) |
+| 19+ | ValueSegment | raw codec bytes; empty when `isNull` is set |
 
 Null scalar values are represented by a header flag with an empty value segment. The literal string `"@@NULL"` is now a normal cacheable string when written through Redis cache APIs. Raw legacy keys containing `"@@NULL"` still read as null. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) remain raw Redis-native numeric strings so Redis can perform native atomic arithmetic; their read path falls back to the raw value codec.
 

--- a/src/Headless.Caching.Redis/README.md
+++ b/src/Headless.Caching.Redis/README.md
@@ -16,6 +16,12 @@ Provides distributed caching using Redis via the unified `ICache` abstraction, e
 - Lua scripts for atomic multi-key operations
 - Redis Cluster support
 
+## Design Notes
+
+Redis scalar cache entries are stored as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is still mapped to the Redis key TTL; logical expiration rides in the payload so later fail-safe and refresh features can diverge logical staleness from physical eviction without changing the wire format.
+
+Null scalar values are represented by a header flag with an empty value segment. The literal string `"@@NULL"` is now a normal cacheable string when written through Redis cache APIs. Raw legacy keys containing `"@@NULL"` still read as null. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) remain raw Redis-native numeric strings so Redis can perform native atomic arithmetic; their read path falls back to the raw value codec.
+
 ## Installation
 
 ```bash

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -24,10 +24,6 @@ namespace Headless.Caching;
 /// Exception: <see cref="RemoveByPrefixAsync"/> and <see cref="GetAllKeysByPrefixAsync"/> use streaming
 /// SCAN and support cancellation during iteration since they may process unbounded key sets.
 /// </para>
-/// <para>
-/// <b>Limitation:</b> The literal string "@@NULL" cannot be stored as a cache value since it is used
-/// internally as a sentinel to distinguish null from missing keys.
-/// </para>
 /// </remarks>
 public sealed class RedisCache(
     ISerializer serializer,
@@ -37,10 +33,7 @@ public sealed class RedisCache(
     ILogger<RedisCache>? logger = null
 ) : IRemoteCache, IDisposable
 {
-    /// <summary>
-    /// Sentinel value used to distinguish null from missing keys in Redis.
-    /// WARNING: The literal string "@@NULL" cannot be stored as a cache value.
-    /// </summary>
+    /// <summary>Legacy null sentinel retained only for raw pre-envelope payloads and collection entries.</summary>
     private static readonly RedisValue _NullValue = "@@NULL";
     private const int _BatchSize = 250;
 
@@ -154,7 +147,10 @@ public sealed class RedisCache(
         foreach (var kvp in value)
         {
             Argument.IsNotNullOrEmpty(kvp.Key);
-            pairs[index++] = new KeyValuePair<RedisKey, RedisValue>(_GetKey(kvp.Key), _ToRedisValue(kvp.Value));
+            pairs[index++] = new KeyValuePair<RedisKey, RedisValue>(
+                _GetKey(kvp.Key),
+                _ToFramedRedisValue(kvp.Value, expiration)
+            );
         }
 
         if (IsCluster)
@@ -219,7 +215,8 @@ public sealed class RedisCache(
             return false;
         }
 
-        var redisValue = _ToRedisValue(value);
+        var normalizedExpiration = _NormalizeExpiration(expiration);
+        var redisValue = _ToFramedRedisValue(value, normalizedExpiration);
         var expectedValue = _ToRedisValue(expected);
 
         var expiresMs = _GetExpirationMilliseconds(expiration);
@@ -228,13 +225,16 @@ public sealed class RedisCache(
         var redisResult = await scriptsLoader
             .EvaluateAsync(
                 _database,
-                ReplaceIfEqualScriptDefinition.Instance,
+                CacheReplaceIfEqualScriptDefinition.Instance,
                 new
                 {
                     key = (RedisKey)_GetKey(key),
                     value = redisValue,
                     expected = expectedValue,
+                    expectedIsNull = expected is null ? 1 : 0,
                     expires = expiresArg,
+                    headerLen = RedisCacheEntryFrame.HeaderLength,
+                    nullValue = _NullValue,
                 },
                 cancellationToken
             )
@@ -779,8 +779,15 @@ public sealed class RedisCache(
         var redisResult = await scriptsLoader
             .EvaluateAsync(
                 _database,
-                RemoveIfEqualScriptDefinition.Instance,
-                new { key = (RedisKey)_GetKey(key), expected = expectedValue },
+                CacheRemoveIfEqualScriptDefinition.Instance,
+                new
+                {
+                    key = (RedisKey)_GetKey(key),
+                    expected = expectedValue,
+                    expectedIsNull = expected is null ? 1 : 0,
+                    headerLen = RedisCacheEntryFrame.HeaderLength,
+                    nullValue = _NullValue,
+                },
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -972,14 +979,14 @@ public sealed class RedisCache(
         return serializer.SerializeToBytes(value);
     }
 
-    private T? _FromRedisValue<T>(RedisValue redisValue)
+    private T? _FromRedisValue<T>(RedisValue redisValue, bool treatNullSentinel = true)
     {
         if (!redisValue.HasValue)
         {
             return default;
         }
 
-        if (redisValue == _NullValue)
+        if (treatNullSentinel && redisValue == _NullValue)
         {
             return default;
         }
@@ -999,13 +1006,26 @@ public sealed class RedisCache(
             return CacheValue<T>.NoValue;
         }
 
-        if (redisValue == _NullValue)
-        {
-            return CacheValue<T>.Null;
-        }
-
         try
         {
+            var frame = RedisCacheEntryFrame.Decode(redisValue);
+
+            if (frame.IsFramed)
+            {
+                if (frame.IsNull)
+                {
+                    return CacheValue<T>.Null;
+                }
+
+                var framedValue = _FromRedisValue<T>(_ToRedisValue(frame.ValueSegment), treatNullSentinel: false);
+                return new CacheValue<T>(framedValue, true);
+            }
+
+            if (redisValue == _NullValue)
+            {
+                return CacheValue<T>.Null;
+            }
+
             var value = _FromRedisValue<T>(redisValue);
             return new CacheValue<T>(value, true);
         }
@@ -1048,7 +1068,7 @@ public sealed class RedisCache(
 
     private async Task<bool> _SetInternalAsync<T>(
         string key,
-        T value,
+        T? value,
         TimeSpan? expiresIn = null,
         When when = When.Always
     )
@@ -1060,10 +1080,25 @@ public sealed class RedisCache(
         }
 
         expiresIn = _NormalizeExpiration(expiresIn);
-        var redisValue = _ToRedisValue(value);
+        var redisValue = _ToFramedRedisValue(value, expiresIn);
 
         return await _database.StringSetAsync(key, redisValue, expiresIn, when).ConfigureAwait(false);
     }
+
+    private RedisValue _ToFramedRedisValue<T>(T? value, TimeSpan? expiresIn)
+    {
+        var expiresAt = _GetExpirationDateTime(expiresIn);
+        var valueSegment = value is null ? RedisValue.EmptyString : _ToRedisValue(value);
+
+        return RedisCacheEntryFrame.Encode(
+            valueSegment,
+            isNull: value is null,
+            logicalExpiresAt: expiresAt,
+            physicalExpiresAt: expiresAt
+        );
+    }
+
+    private static RedisValue _ToRedisValue(ReadOnlyMemory<byte> value) => value.ToArray();
 
     private async Task<int> _SetAllInternalAsync(KeyValuePair<RedisKey, RedisValue>[] pairs, TimeSpan? expiresIn)
     {
@@ -1164,6 +1199,17 @@ public sealed class RedisCache(
         }
 
         return (long)expiresIn.Value.TotalMilliseconds;
+    }
+
+    private DateTime? _GetExpirationDateTime(TimeSpan? expiresIn)
+    {
+        if (!expiresIn.HasValue || expiresIn.Value == TimeSpan.MaxValue)
+        {
+            return null;
+        }
+
+        var expiresAt = timeProvider.GetUtcNow().UtcDateTime.SafeAdd(expiresIn.Value);
+        return expiresAt == DateTime.MaxValue ? null : expiresAt;
     }
 
     private const long _MaxUnixEpochMilliseconds = 253_402_300_799_999L; // 9999-12-31T23:59:59.999Z

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Collections.ObjectModel;
+using System.Text;
 using Headless.Checks;
 using Headless.Redis;
 using Headless.Serializer;
@@ -143,13 +144,14 @@ public sealed class RedisCache(
         // Validate keys and serialize values upfront
         var pairs = new KeyValuePair<RedisKey, RedisValue>[value.Count];
         var index = 0;
+        var now = timeProvider.GetUtcNow();
 
         foreach (var kvp in value)
         {
             Argument.IsNotNullOrEmpty(kvp.Key);
             pairs[index++] = new KeyValuePair<RedisKey, RedisValue>(
                 _GetKey(kvp.Key),
-                _ToFramedRedisValue(kvp.Value, expiration)
+                _ToFramedRedisValue(kvp.Value, expiration, now)
             );
         }
 
@@ -215,11 +217,12 @@ public sealed class RedisCache(
             return false;
         }
 
+        var now = timeProvider.GetUtcNow();
         var normalizedExpiration = _NormalizeExpiration(expiration);
-        var redisValue = _ToFramedRedisValue(value, normalizedExpiration);
+        var redisValue = _ToFramedRedisValue(value, normalizedExpiration, now);
         var expectedValue = _ToRedisValue(expected);
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, now);
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var redisResult = await scriptsLoader
@@ -260,7 +263,7 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var result = await scriptsLoader
@@ -297,7 +300,7 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var result = await scriptsLoader
@@ -334,7 +337,7 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var result = await scriptsLoader
@@ -371,7 +374,7 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var result = await scriptsLoader
@@ -408,7 +411,7 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var result = await scriptsLoader
@@ -445,7 +448,7 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration);
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
         var expiresArg = expiresMs ?? RedisValue.EmptyString;
 
         var result = await scriptsLoader
@@ -964,6 +967,12 @@ public sealed class RedisCache(
         return string.IsNullOrEmpty(_keyPrefix) ? key : string.Concat(_keyPrefix, key);
     }
 
+    /// <summary>Encodes a value to its bare wire bytes (the value codec) without any envelope framing.</summary>
+    /// <remarks>
+    /// This output must stay frame-free: the CAS scripts (<see cref="CacheRemoveIfEqualScriptDefinition"/>,
+    /// <see cref="CacheReplaceIfEqualScriptDefinition"/>) pass it as the bare <c>expected</c> operand and compare
+    /// it against the framed value's sliced value segment. Adding a header here would break that comparison.
+    /// </remarks>
     private RedisValue _ToRedisValue<T>(T? value)
     {
         if (value is null)
@@ -1017,7 +1026,7 @@ public sealed class RedisCache(
                     return CacheValue<T>.Null;
                 }
 
-                var framedValue = _FromRedisValue<T>(_ToRedisValue(frame.ValueSegment), treatNullSentinel: false);
+                var framedValue = _DeserializeValueSegment<T>(frame.ValueSegment);
                 return new CacheValue<T>(framedValue, true);
             }
 
@@ -1080,14 +1089,14 @@ public sealed class RedisCache(
         }
 
         expiresIn = _NormalizeExpiration(expiresIn);
-        var redisValue = _ToFramedRedisValue(value, expiresIn);
+        var redisValue = _ToFramedRedisValue(value, expiresIn, timeProvider.GetUtcNow());
 
         return await _database.StringSetAsync(key, redisValue, expiresIn, when).ConfigureAwait(false);
     }
 
-    private RedisValue _ToFramedRedisValue<T>(T? value, TimeSpan? expiresIn)
+    private RedisValue _ToFramedRedisValue<T>(T? value, TimeSpan? expiresIn, DateTimeOffset now)
     {
-        var expiresAt = _GetExpirationDateTime(expiresIn);
+        var expiresAt = _GetExpirationDateTime(expiresIn, now);
         var valueSegment = value is null ? RedisValue.EmptyString : _ToRedisValue(value);
 
         return RedisCacheEntryFrame.Encode(
@@ -1098,7 +1107,17 @@ public sealed class RedisCache(
         );
     }
 
-    private static RedisValue _ToRedisValue(ReadOnlyMemory<byte> value) => value.ToArray();
+    private T? _DeserializeValueSegment<T>(ReadOnlyMemory<byte> segment)
+    {
+        // Deserialize the framed value segment off the raw bytes; an empty non-null segment yields the
+        // empty value (e.g. "") rather than default, since the frame already proved the value is present.
+        if (typeof(T) == typeof(string))
+        {
+            return (T?)(object)Encoding.UTF8.GetString(segment.Span);
+        }
+
+        return serializer.Deserialize<T>(segment.ToArray());
+    }
 
     private async Task<int> _SetAllInternalAsync(KeyValuePair<RedisKey, RedisValue>[] pairs, TimeSpan? expiresIn)
     {
@@ -1184,14 +1203,14 @@ public sealed class RedisCache(
         return expiresAt == DateTime.MaxValue ? null : expiresIn;
     }
 
-    private long? _GetExpirationMilliseconds(TimeSpan? expiresIn)
+    private static long? _GetExpirationMilliseconds(TimeSpan? expiresIn, DateTimeOffset now)
     {
         if (!expiresIn.HasValue || expiresIn.Value == TimeSpan.MaxValue)
         {
             return null;
         }
 
-        var expiresAt = timeProvider.GetUtcNow().UtcDateTime.SafeAdd(expiresIn.Value);
+        var expiresAt = now.UtcDateTime.SafeAdd(expiresIn.Value);
 
         if (expiresAt == DateTime.MaxValue)
         {
@@ -1201,18 +1220,16 @@ public sealed class RedisCache(
         return (long)expiresIn.Value.TotalMilliseconds;
     }
 
-    private DateTime? _GetExpirationDateTime(TimeSpan? expiresIn)
+    private static DateTime? _GetExpirationDateTime(TimeSpan? expiresIn, DateTimeOffset now)
     {
         if (!expiresIn.HasValue || expiresIn.Value == TimeSpan.MaxValue)
         {
             return null;
         }
 
-        var expiresAt = timeProvider.GetUtcNow().UtcDateTime.SafeAdd(expiresIn.Value);
+        var expiresAt = now.UtcDateTime.SafeAdd(expiresIn.Value);
         return expiresAt == DateTime.MaxValue ? null : expiresAt;
     }
-
-    private const long _MaxUnixEpochMilliseconds = 253_402_300_799_999L; // 9999-12-31T23:59:59.999Z
 
     private async Task _SetListExpirationAsync(string key)
     {
@@ -1227,7 +1244,7 @@ public sealed class RedisCache(
 
         var highestExpirationInMs = (long)items.Single().Score;
 
-        if (highestExpirationInMs >= _MaxUnixEpochMilliseconds)
+        if (highestExpirationInMs >= RedisCacheEntryFrame.MaxUnixEpochMilliseconds)
         {
             await _database.KeyPersistAsync(key).ConfigureAwait(false);
             return;

--- a/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
+++ b/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
@@ -15,6 +15,11 @@ internal static class RedisCacheEntryFrame
     internal const byte HasLogicalExpiresAtFlag = 1 << 1;
     internal const byte HasPhysicalExpiresAtFlag = 1 << 2;
 
+    // Valid range accepted by DateTimeOffset.FromUnixTimeMilliseconds; out-of-range values mean the
+    // header bytes were never written by this codec, so the frame must read as a miss rather than throw.
+    internal const long MinUnixEpochMilliseconds = -62_135_596_800_000L; // 0001-01-01T00:00:00.000Z
+    internal const long MaxUnixEpochMilliseconds = 253_402_300_799_999L; // 9999-12-31T23:59:59.999Z
+
     public static byte[] Encode(
         RedisValue value,
         bool isNull,
@@ -62,18 +67,32 @@ internal static class RedisCacheEntryFrame
 
         var bytes = _ToBytes(value);
 
-        if (bytes.Length < HeaderLength || bytes[0] != Magic || bytes[1] != Version)
+        if (bytes.Length < HeaderLength || bytes[0] != Magic)
         {
             return DecodedFrame.Unframed;
         }
 
+        // The magic byte marks a frame this codec wrote; an unrecognized version is a real corruption
+        // or a forward-incompatible writer, so fail loud instead of silently treating it as a raw value.
+        if (bytes[1] != Version)
+        {
+            throw new NotSupportedException($"Unsupported cache frame version 0x{bytes[1]:X2}");
+        }
+
         var flags = bytes[2];
-        var logicalExpiresAt = (flags & HasLogicalExpiresAtFlag) is 0
-            ? (DateTime?)null
-            : _FromUnixTimeMilliseconds(BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(3, sizeof(long))));
-        var physicalExpiresAt = (flags & HasPhysicalExpiresAtFlag) is 0
-            ? (DateTime?)null
-            : _FromUnixTimeMilliseconds(BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(11, sizeof(long))));
+
+        var hasLogical = (flags & HasLogicalExpiresAtFlag) is not 0;
+        var hasPhysical = (flags & HasPhysicalExpiresAtFlag) is not 0;
+        var logicalMs = hasLogical ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(3, sizeof(long))) : 0L;
+        var physicalMs = hasPhysical ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(11, sizeof(long))) : 0L;
+
+        if ((hasLogical && _IsOutOfRange(logicalMs)) || (hasPhysical && _IsOutOfRange(physicalMs)))
+        {
+            return DecodedFrame.Unframed;
+        }
+
+        var logicalExpiresAt = hasLogical ? _FromUnixTimeMilliseconds(logicalMs) : (DateTime?)null;
+        var physicalExpiresAt = hasPhysical ? _FromUnixTimeMilliseconds(physicalMs) : (DateTime?)null;
 
         return new DecodedFrame(
             IsFramed: true,
@@ -108,6 +127,9 @@ internal static class RedisCacheEntryFrame
 
     private static DateTime _FromUnixTimeMilliseconds(long value) =>
         DateTimeOffset.FromUnixTimeMilliseconds(value).UtcDateTime;
+
+    private static bool _IsOutOfRange(long value) =>
+        value is < MinUnixEpochMilliseconds or > MaxUnixEpochMilliseconds;
 
     internal readonly record struct DecodedFrame(
         bool IsFramed,

--- a/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
+++ b/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Buffers.Binary;
+using StackExchange.Redis;
+
+namespace Headless.Caching;
+
+internal static class RedisCacheEntryFrame
+{
+    public const int HeaderLength = 19;
+
+    internal const byte Magic = 0xFF;
+    internal const byte Version = 0x01;
+    internal const byte NullFlag = 1 << 0;
+    internal const byte HasLogicalExpiresAtFlag = 1 << 1;
+    internal const byte HasPhysicalExpiresAtFlag = 1 << 2;
+
+    public static byte[] Encode(
+        RedisValue value,
+        bool isNull,
+        DateTime? logicalExpiresAt,
+        DateTime? physicalExpiresAt
+    )
+    {
+        var valueBytes = isNull ? [] : _ToBytes(value);
+        var buffer = new byte[HeaderLength + valueBytes.Length];
+        buffer[0] = Magic;
+        buffer[1] = Version;
+
+        var flags = isNull ? NullFlag : (byte)0;
+
+        if (logicalExpiresAt.HasValue)
+        {
+            flags |= HasLogicalExpiresAtFlag;
+            BinaryPrimitives.WriteInt64LittleEndian(
+                buffer.AsSpan(3, sizeof(long)),
+                _ToUnixTimeMilliseconds(logicalExpiresAt.Value)
+            );
+        }
+
+        if (physicalExpiresAt.HasValue)
+        {
+            flags |= HasPhysicalExpiresAtFlag;
+            BinaryPrimitives.WriteInt64LittleEndian(
+                buffer.AsSpan(11, sizeof(long)),
+                _ToUnixTimeMilliseconds(physicalExpiresAt.Value)
+            );
+        }
+
+        buffer[2] = flags;
+        valueBytes.CopyTo(buffer.AsSpan(HeaderLength));
+
+        return buffer;
+    }
+
+    public static DecodedFrame Decode(RedisValue value)
+    {
+        if (!value.HasValue)
+        {
+            return DecodedFrame.Unframed;
+        }
+
+        var bytes = _ToBytes(value);
+
+        if (bytes.Length < HeaderLength || bytes[0] != Magic || bytes[1] != Version)
+        {
+            return DecodedFrame.Unframed;
+        }
+
+        var flags = bytes[2];
+        var logicalExpiresAt = (flags & HasLogicalExpiresAtFlag) is 0
+            ? (DateTime?)null
+            : _FromUnixTimeMilliseconds(BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(3, sizeof(long))));
+        var physicalExpiresAt = (flags & HasPhysicalExpiresAtFlag) is 0
+            ? (DateTime?)null
+            : _FromUnixTimeMilliseconds(BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(11, sizeof(long))));
+
+        return new DecodedFrame(
+            IsFramed: true,
+            IsNull: (flags & NullFlag) is not 0,
+            LogicalExpiresAt: logicalExpiresAt,
+            PhysicalExpiresAt: physicalExpiresAt,
+            ValueSegment: bytes.AsMemory(HeaderLength)
+        );
+    }
+
+    private static byte[] _ToBytes(RedisValue value)
+    {
+        if (!value.HasValue)
+        {
+            return [];
+        }
+
+        return (byte[])value!;
+    }
+
+    private static long _ToUnixTimeMilliseconds(DateTime value)
+    {
+        var utc = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+
+        return new DateTimeOffset(utc).ToUnixTimeMilliseconds();
+    }
+
+    private static DateTime _FromUnixTimeMilliseconds(long value) =>
+        DateTimeOffset.FromUnixTimeMilliseconds(value).UtcDateTime;
+
+    internal readonly record struct DecodedFrame(
+        bool IsFramed,
+        bool IsNull,
+        DateTime? LogicalExpiresAt,
+        DateTime? PhysicalExpiresAt,
+        ReadOnlyMemory<byte> ValueSegment
+    )
+    {
+        public static DecodedFrame Unframed { get; } = new(
+            IsFramed: false,
+            IsNull: false,
+            LogicalExpiresAt: null,
+            PhysicalExpiresAt: null,
+            ValueSegment: ReadOnlyMemory<byte>.Empty
+        );
+    }
+}

--- a/src/Headless.Caching.Redis/RedisCacheScriptsInitializer.cs
+++ b/src/Headless.Caching.Redis/RedisCacheScriptsInitializer.cs
@@ -13,8 +13,8 @@ internal sealed class RedisCacheScriptsInitializer(
     private static readonly IReadOnlyList<RedisScriptDefinition> _Definitions =
     [
         IncrementWithExpireScriptDefinition.Instance,
-        RemoveIfEqualScriptDefinition.Instance,
-        ReplaceIfEqualScriptDefinition.Instance,
+        CacheRemoveIfEqualScriptDefinition.Instance,
+        CacheReplaceIfEqualScriptDefinition.Instance,
         SetIfHigherScriptDefinition.Instance,
         SetIfLowerScriptDefinition.Instance,
     ];

--- a/tests/Headless.Caching.Memory.Tests.Unit/Headless.Caching.Memory.Tests.Unit.csproj
+++ b/tests/Headless.Caching.Memory.Tests.Unit/Headless.Caching.Memory.Tests.Unit.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Headless.Caching.Tests.Harness\Headless.Caching.Tests.Harness.csproj" />
     <ProjectReference Include="..\..\src\Headless.Caching.Memory\Headless.Caching.Memory.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
   </ItemGroup>

--- a/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheConformanceTests.cs
+++ b/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheConformanceTests.cs
@@ -28,6 +28,9 @@ public sealed class InMemoryCacheConformanceTests : CacheConformanceTestsBase
         base.should_round_trip_null_and_null_sentinel_string();
 
     [Fact]
+    public override Task should_round_trip_empty_string_value() => base.should_round_trip_empty_string_value();
+
+    [Fact]
     public override Task should_expire_values_after_duration() => base.should_expire_values_after_duration();
 
     [Fact]

--- a/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheConformanceTests.cs
+++ b/tests/Headless.Caching.Memory.Tests.Unit/InMemoryCacheConformanceTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests;
+
+public sealed class InMemoryCacheConformanceTests : CacheConformanceTestsBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    protected override ICache CreateCache(string keyPrefix)
+    {
+        return new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+    }
+
+    protected override ValueTask AdvancePastExpirationAsync(TimeSpan expiration)
+    {
+        _timeProvider.Advance(expiration + TimeSpan.FromMilliseconds(50));
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public override Task should_round_trip_object_and_string_values() => base.should_round_trip_object_and_string_values();
+
+    [Fact]
+    public override Task should_round_trip_null_and_null_sentinel_string() =>
+        base.should_round_trip_null_and_null_sentinel_string();
+
+    [Fact]
+    public override Task should_expire_values_after_duration() => base.should_expire_values_after_duration();
+
+    [Fact]
+    public override Task should_get_all_values_including_null_members() =>
+        base.should_get_all_values_including_null_members();
+
+    [Fact]
+    public override Task should_increment_and_read_back_number() => base.should_increment_and_read_back_number();
+
+    [Fact]
+    public override Task should_compare_and_swap_on_matching_values_only() =>
+        base.should_compare_and_swap_on_matching_values_only();
+
+    [Fact]
+    public override Task should_insert_only_when_missing_and_replace_only_when_present() =>
+        base.should_insert_only_when_missing_and_replace_only_when_present();
+}

--- a/tests/Headless.Caching.Redis.Tests.Integration/Headless.Caching.Redis.Tests.Integration.csproj
+++ b/tests/Headless.Caching.Redis.Tests.Integration/Headless.Caching.Redis.Tests.Integration.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Headless.Caching.Tests.Harness\Headless.Caching.Tests.Harness.csproj" />
     <ProjectReference Include="..\..\src\Headless.Caching.Redis\Headless.Caching.Redis.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Redis;
+using Headless.Serializer;
+using Microsoft.Extensions.Logging;
+
+namespace Tests;
+
+[Collection(nameof(RedisCacheFixture))]
+public sealed class RedisCacheConformanceTests(RedisCacheFixture fixture) : CacheConformanceTestsBase
+{
+    protected override ICache CreateCache(string keyPrefix)
+    {
+        var options = new RedisCacheOptions
+        {
+            ConnectionMultiplexer = fixture.ConnectionMultiplexer,
+            KeyPrefix = $"{keyPrefix}:",
+        };
+
+        var logger = LoggerFactory.CreateLogger<RedisCache>();
+        return new RedisCache(new SystemJsonSerializer(), TimeProvider.System, options, fixture.ScriptsLoader, logger);
+    }
+
+    protected override async ValueTask ResetAsync()
+    {
+        await fixture.ConnectionMultiplexer.FlushAllAsync();
+    }
+
+    protected override async ValueTask AdvancePastExpirationAsync(TimeSpan expiration)
+    {
+        await TimeProvider.System.Delay(expiration + TimeSpan.FromMilliseconds(250), AbortToken);
+    }
+
+    [Fact]
+    public override Task should_round_trip_object_and_string_values() => base.should_round_trip_object_and_string_values();
+
+    [Fact]
+    public override Task should_round_trip_null_and_null_sentinel_string() =>
+        base.should_round_trip_null_and_null_sentinel_string();
+
+    [Fact]
+    public override Task should_expire_values_after_duration() => base.should_expire_values_after_duration();
+
+    [Fact]
+    public override Task should_get_all_values_including_null_members() =>
+        base.should_get_all_values_including_null_members();
+
+    [Fact]
+    public override Task should_increment_and_read_back_number() => base.should_increment_and_read_back_number();
+
+    [Fact]
+    public override Task should_compare_and_swap_on_matching_values_only() =>
+        base.should_compare_and_swap_on_matching_values_only();
+
+    [Fact]
+    public override Task should_insert_only_when_missing_and_replace_only_when_present() =>
+        base.should_insert_only_when_missing_and_replace_only_when_present();
+}

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
@@ -40,6 +40,9 @@ public sealed class RedisCacheConformanceTests(RedisCacheFixture fixture) : Cach
         base.should_round_trip_null_and_null_sentinel_string();
 
     [Fact]
+    public override Task should_round_trip_empty_string_value() => base.should_round_trip_empty_string_value();
+
+    [Fact]
     public override Task should_expire_values_after_duration() => base.should_expire_values_after_duration();
 
     [Fact]

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
@@ -94,6 +94,32 @@ public sealed class RedisCacheEntryFrameTests
         BinaryPrimitives.ReadInt64LittleEndian(encoded.AsSpan(3, sizeof(long))).Should().Be(expected);
     }
 
+    [Fact]
+    public void should_encode_physical_expiration_as_little_endian_unix_milliseconds()
+    {
+        var logical = new DateTime(2026, 06, 03, 12, 34, 56, 789, DateTimeKind.Utc);
+        var physical = logical.AddMinutes(7);
+        var expectedPhysical = new DateTimeOffset(physical).ToUnixTimeMilliseconds();
+
+        var encoded = _Encode("value", isNull: false, logical, physical);
+        var decoded = _Decode(encoded);
+
+        BinaryPrimitives.ReadInt64LittleEndian(encoded.AsSpan(11, sizeof(long))).Should().Be(expectedPhysical);
+        decoded.PhysicalExpiresAt.Should().Be(physical);
+    }
+
+    [Fact]
+    public void should_throw_for_unsupported_frame_version()
+    {
+        var bytes = new byte[_HeaderLength];
+        bytes[0] = 0xFF;
+        bytes[1] = 0x02;
+
+        var act = () => _Decode(_RedisValue(bytes));
+
+        act.Should().Throw<TargetInvocationException>().WithInnerException<NotSupportedException>();
+    }
+
     private static byte[] _Encode(
         RedisValue value,
         bool isNull,

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Text;
+using StackExchange.Redis;
+
+namespace Tests;
+
+public sealed class RedisCacheEntryFrameTests
+{
+    private const int _HeaderLength = 19;
+    private static readonly Type _FrameType =
+        Type.GetType("Headless.Caching.RedisCacheEntryFrame, Headless.Caching.Redis", throwOnError: true)!;
+
+    private static readonly MethodInfo _EncodeMethod = _FrameType.GetMethod(
+        "Encode",
+        BindingFlags.Public | BindingFlags.Static
+    )!;
+
+    private static readonly MethodInfo _DecodeMethod = _FrameType.GetMethod(
+        "Decode",
+        BindingFlags.Public | BindingFlags.Static
+    )!;
+
+    [Fact]
+    public void should_round_trip_value_and_expiration_metadata()
+    {
+        var value = _RedisValue(Encoding.UTF8.GetBytes("value"));
+        var logical = new DateTime(2026, 06, 03, 12, 00, 00, DateTimeKind.Utc);
+        var physical = logical.AddMinutes(5);
+
+        var encoded = _Encode(value, isNull: false, logical, physical);
+        var decoded = _Decode(encoded);
+
+        decoded.IsFramed.Should().BeTrue();
+        decoded.IsNull.Should().BeFalse();
+        decoded.LogicalExpiresAt.Should().Be(logical);
+        decoded.PhysicalExpiresAt.Should().Be(physical);
+        decoded.ValueSegment.ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
+    }
+
+    [Fact]
+    public void should_encode_null_as_flag_with_empty_value_segment()
+    {
+        var encoded = _Encode(RedisValue.EmptyString, isNull: true, logicalExpiresAt: null, physicalExpiresAt: null);
+        var decoded = _Decode(encoded);
+
+        decoded.IsFramed.Should().BeTrue();
+        decoded.IsNull.Should().BeTrue();
+        decoded.ValueSegment.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void should_round_trip_no_expiry_without_expiration_flags()
+    {
+        var encoded = _Encode("value", isNull: false, logicalExpiresAt: null, physicalExpiresAt: null);
+        var decoded = _Decode(encoded);
+
+        encoded[2].Should().Be(0);
+        decoded.LogicalExpiresAt.Should().BeNull();
+        decoded.PhysicalExpiresAt.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0x01, 0x02, 0x03 })]
+    [InlineData(new byte[] { 0xFF, 0x02, 0x00, 0x00 })]
+    public void should_discriminate_unframed_values(byte[] value)
+    {
+        var decoded = _Decode(_RedisValue(value));
+
+        decoded.IsFramed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_round_trip_empty_non_null_value_distinctly_from_null()
+    {
+        var encoded = _Encode(RedisValue.EmptyString, isNull: false, logicalExpiresAt: null, physicalExpiresAt: null);
+        var decoded = _Decode(encoded);
+
+        decoded.IsFramed.Should().BeTrue();
+        decoded.IsNull.Should().BeFalse();
+        decoded.ValueSegment.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void should_encode_expiration_as_little_endian_unix_milliseconds()
+    {
+        var instant = new DateTime(2026, 06, 03, 12, 34, 56, 789, DateTimeKind.Utc);
+        var expected = new DateTimeOffset(instant).ToUnixTimeMilliseconds();
+
+        var encoded = _Encode("value", isNull: false, instant, physicalExpiresAt: null);
+
+        BinaryPrimitives.ReadInt64LittleEndian(encoded.AsSpan(3, sizeof(long))).Should().Be(expected);
+    }
+
+    private static byte[] _Encode(
+        RedisValue value,
+        bool isNull,
+        DateTime? logicalExpiresAt,
+        DateTime? physicalExpiresAt
+    ) =>
+        (byte[])_EncodeMethod.Invoke(null, [value, isNull, logicalExpiresAt, physicalExpiresAt])!;
+
+    private static RedisValue _RedisValue(byte[] value) => value;
+
+    private static DecodedFrame _Decode(RedisValue value)
+    {
+        var decoded = _DecodeMethod.Invoke(null, [value])!;
+        var type = decoded.GetType();
+
+        return new DecodedFrame(
+            (bool)type.GetProperty("IsFramed")!.GetValue(decoded)!,
+            (bool)type.GetProperty("IsNull")!.GetValue(decoded)!,
+            (DateTime?)type.GetProperty("LogicalExpiresAt")!.GetValue(decoded),
+            (DateTime?)type.GetProperty("PhysicalExpiresAt")!.GetValue(decoded),
+            (ReadOnlyMemory<byte>)type.GetProperty("ValueSegment")!.GetValue(decoded)!
+        );
+    }
+
+    private readonly record struct DecodedFrame(
+        bool IsFramed,
+        bool IsNull,
+        DateTime? LogicalExpiresAt,
+        DateTime? PhysicalExpiresAt,
+        ReadOnlyMemory<byte> ValueSegment
+    );
+}

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Text;
+using StackExchange.Redis;
+
+namespace Tests;
+
+public sealed class RedisEnvelopeFormatTests(RedisCacheFixture fixture) : RedisCacheTestBase(fixture)
+{
+    private const int _HeaderLength = 19;
+    private const byte _Magic = 0xFF;
+    private const byte _Version = 0x01;
+    private const byte _NullFlag = 1 << 0;
+    private const byte _HasPhysicalExpiresAtFlag = 1 << 2;
+
+    [Fact]
+    public async Task should_store_scalar_value_as_framed_payload_with_magic_prefix()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var value = Faker.Lorem.Word();
+
+        await cache.UpsertAsync(key, value, TimeSpan.FromMinutes(5), AbortToken);
+
+        var stored = await _GetRawBytesAsync(key);
+        stored[0].Should().Be(_Magic);
+        stored[1].Should().Be(_Version);
+        stored.AsSpan(_HeaderLength).ToArray().Should().Equal(Encoding.UTF8.GetBytes(value));
+    }
+
+    [Fact]
+    public async Task should_map_physical_expiration_to_redis_ttl()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var duration = TimeSpan.FromMinutes(5);
+
+        await cache.UpsertAsync(key, "value", duration, AbortToken);
+
+        var ttl = await _Database().KeyTimeToLiveAsync(key);
+        ttl.Should().NotBeNull();
+        ttl!.Value.Should().BeCloseTo(duration, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task should_store_null_as_frame_flag_with_empty_value_segment()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.UpsertAsync<string?>(key, null, TimeSpan.FromMinutes(5), AbortToken);
+
+        var stored = await _GetRawBytesAsync(key);
+        (stored[2] & _NullFlag).Should().Be(_NullFlag);
+        stored.Length.Should().Be(_HeaderLength);
+
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+        cached.HasValue.Should().BeTrue();
+        cached.IsNull.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_round_trip_literal_null_sentinel_string_as_value()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.UpsertAsync(key, "@@NULL", TimeSpan.FromMinutes(5), AbortToken);
+
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+        cached.Value.Should().Be("@@NULL");
+    }
+
+    [Fact]
+    public async Task should_keep_legacy_raw_null_sentinel_readable_as_null()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await _Database().StringSetAsync(key, "@@NULL");
+
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+
+        cached.HasValue.Should().BeTrue();
+        cached.IsNull.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_store_no_expiration_frame_without_physical_expiration_flag_or_ttl()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.UpsertAsync(key, "value", expiration: null, AbortToken);
+
+        var stored = await _GetRawBytesAsync(key);
+        (stored[2] & _HasPhysicalExpiresAtFlag).Should().Be(0);
+        var ttl = await _Database().KeyTimeToLiveAsync(key);
+        ttl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_keep_increment_counter_raw_and_unframed()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.IncrementAsync(key, 5L, TimeSpan.FromMinutes(5), AbortToken);
+
+        var stored = await _GetRawBytesAsync(key);
+        stored.Should().Equal(Encoding.UTF8.GetBytes("5"));
+    }
+
+    private IDatabase _Database() => Fixture.ConnectionMultiplexer.GetDatabase();
+
+    private async Task<byte[]> _GetRawBytesAsync(string key)
+    {
+        var value = await _Database().StringGetAsync(key);
+        value.HasValue.Should().BeTrue();
+        return (byte[])value!;
+    }
+}

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Buffers.Binary;
 using System.Text;
 using StackExchange.Redis;
 
@@ -102,6 +103,53 @@ public sealed class RedisEnvelopeFormatTests(RedisCacheFixture fixture) : RedisC
         (stored[2] & _HasPhysicalExpiresAtFlag).Should().Be(0);
         var ttl = await _Database().KeyTimeToLiveAsync(key);
         ttl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_store_upsert_all_members_as_framed_payloads()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var stringKey = Faker.Random.AlphaNumeric(10);
+        var nullKey = Faker.Random.AlphaNumeric(10);
+        var stringValue = Faker.Lorem.Word();
+        var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [stringKey] = stringValue,
+            [nullKey] = null,
+        };
+
+        await cache.UpsertAllAsync(values, TimeSpan.FromMinutes(5), AbortToken);
+
+        var storedString = await _GetRawBytesAsync(stringKey);
+        storedString[0].Should().Be(_Magic);
+        storedString[1].Should().Be(_Version);
+        storedString.AsSpan(_HeaderLength).ToArray().Should().Equal(Encoding.UTF8.GetBytes(stringValue));
+
+        var storedNull = await _GetRawBytesAsync(nullKey);
+        storedNull[0].Should().Be(_Magic);
+        storedNull[1].Should().Be(_Version);
+        (storedNull[2] & _NullFlag).Should().Be(_NullFlag);
+    }
+
+    [Fact]
+    public async Task should_encode_logical_expiration_header_as_now_plus_duration()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var duration = TimeSpan.FromMinutes(5);
+        var before = DateTimeOffset.UtcNow;
+
+        await cache.UpsertAsync(key, "value", duration, AbortToken);
+
+        var after = DateTimeOffset.UtcNow;
+        var stored = await _GetRawBytesAsync(key);
+        var logicalMs = BinaryPrimitives.ReadInt64LittleEndian(stored.AsSpan(3, sizeof(long)));
+        var logical = DateTimeOffset.FromUnixTimeMilliseconds(logicalMs);
+
+        logical.Should().BeOnOrAfter(before + duration - TimeSpan.FromSeconds(5));
+        logical.Should().BeOnOrBefore(after + duration + TimeSpan.FromSeconds(5));
     }
 
     [Fact]

--- a/tests/Headless.Caching.Redis.Tests.Integration/RemoveTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RemoveTests.cs
@@ -77,6 +77,42 @@ public sealed class RemoveTests(RedisCacheFixture fixture) : RedisCacheTestBase(
     }
 
     [Fact]
+    public async Task should_remove_if_equal_when_expected_is_null_and_stored_frame_is_null()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.UpsertAsync<string?>(key, null, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.RemoveIfEqualAsync<string?>(key, null, AbortToken);
+
+        // then
+        result.Should().BeTrue();
+        var exists = await cache.ExistsAsync(key, AbortToken);
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_not_remove_if_equal_when_expected_is_null_and_stored_frame_is_not_null()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.UpsertAsync(key, "value", TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.RemoveIfEqualAsync<string?>(key, null, AbortToken);
+
+        // then
+        result.Should().BeFalse();
+        var exists = await cache.ExistsAsync(key, AbortToken);
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task should_remove_all_keys()
     {
         // given

--- a/tests/Headless.Caching.Redis.Tests.Integration/RemoveTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RemoveTests.cs
@@ -113,6 +113,24 @@ public sealed class RemoveTests(RedisCacheFixture fixture) : RedisCacheTestBase(
     }
 
     [Fact]
+    public async Task should_remove_if_equal_on_raw_unframed_counter_value()
+    {
+        // given — counters are stored raw/unframed, exercising the Lua else branch
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.IncrementAsync(key, 5L, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.RemoveIfEqualAsync(key, 5L, AbortToken);
+
+        // then
+        result.Should().BeTrue();
+        var exists = await cache.ExistsAsync(key, AbortToken);
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task should_remove_all_keys()
     {
         // given

--- a/tests/Headless.Caching.Redis.Tests.Integration/TryReplaceTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/TryReplaceTests.cs
@@ -111,4 +111,40 @@ public sealed class TryReplaceTests(RedisCacheFixture fixture) : RedisCacheTestB
         // then
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task should_replace_if_equal_when_expected_is_null_and_stored_frame_is_null()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.UpsertAsync<string?>(key, null, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.TryReplaceIfEqualAsync<string?>(key, null, "value", TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().BeTrue();
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+        cached.Value.Should().Be("value");
+    }
+
+    [Fact]
+    public async Task should_not_replace_if_equal_when_expected_is_null_and_stored_frame_is_not_null()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.UpsertAsync(key, "value", TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.TryReplaceIfEqualAsync<string?>(key, null, "new-value", TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().BeFalse();
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+        cached.Value.Should().Be("value");
+    }
 }

--- a/tests/Headless.Caching.Redis.Tests.Integration/TryReplaceTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/TryReplaceTests.cs
@@ -131,6 +131,49 @@ public sealed class TryReplaceTests(RedisCacheFixture fixture) : RedisCacheTestB
     }
 
     [Fact]
+    public async Task should_replace_if_equal_on_raw_unframed_counter_value()
+    {
+        // given — counters are stored raw/unframed, exercising the Lua else branch
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.IncrementAsync(key, 5L, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.TryReplaceIfEqualAsync(key, 5L, 10L, TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().BeTrue();
+        var cached = await cache.GetAsync<long>(key, AbortToken);
+        cached.Value.Should().Be(10L);
+    }
+
+    [Fact]
+    public async Task should_replace_if_equal_comparing_value_segment_only_when_headers_differ()
+    {
+        // given — re-upserting the same value rewrites the physical timestamp in the frame header,
+        // so a whole-blob compare would fail; only a value-segment comparison succeeds.
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var value = Faker.Lorem.Sentence();
+        var newValue = Faker.Lorem.Sentence();
+        await cache.UpsertAsync(key, value, TimeSpan.FromMinutes(5), AbortToken);
+
+        // Re-upsert the identical value at a later instant so the header bytes (physical timestamp) drift
+        await Task.Delay(TimeSpan.FromMilliseconds(50), AbortToken);
+        await cache.UpsertAsync(key, value, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.TryReplaceIfEqualAsync(key, value, newValue, TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().BeTrue();
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+        cached.Value.Should().Be(newValue);
+    }
+
+    [Fact]
     public async Task should_not_replace_if_equal_when_expected_is_null_and_stored_frame_is_not_null()
     {
         // given

--- a/tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs
+++ b/tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+public abstract class CacheConformanceTestsBase : TestBase
+{
+    protected abstract ICache CreateCache(string keyPrefix);
+
+    protected virtual ValueTask ResetAsync() => ValueTask.CompletedTask;
+
+    protected virtual ValueTask AdvancePastExpirationAsync(TimeSpan expiration) => ValueTask.CompletedTask;
+
+    public virtual async Task should_round_trip_object_and_string_values()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var objectKey = Faker.Random.AlphaNumeric(10);
+        var stringKey = Faker.Random.AlphaNumeric(10);
+        var value = new CacheConformanceObject(Faker.Random.Guid(), Faker.Name.FullName());
+        var stringValue = Faker.Lorem.Sentence();
+
+        await cache.UpsertAsync(objectKey, value, TimeSpan.FromMinutes(5), AbortToken);
+        await cache.UpsertAsync(stringKey, stringValue, TimeSpan.FromMinutes(5), AbortToken);
+
+        var cachedObject = await cache.GetAsync<CacheConformanceObject>(objectKey, AbortToken);
+        var cachedString = await cache.GetAsync<string>(stringKey, AbortToken);
+
+        cachedObject.HasValue.Should().BeTrue();
+        cachedObject.Value.Should().Be(value);
+        cachedString.HasValue.Should().BeTrue();
+        cachedString.Value.Should().Be(stringValue);
+    }
+
+    public virtual async Task should_round_trip_null_and_null_sentinel_string()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var nullKey = Faker.Random.AlphaNumeric(10);
+        var sentinelKey = Faker.Random.AlphaNumeric(10);
+
+        await cache.UpsertAsync<string?>(nullKey, null, TimeSpan.FromMinutes(5), AbortToken);
+        await cache.UpsertAsync(sentinelKey, "@@NULL", TimeSpan.FromMinutes(5), AbortToken);
+
+        var nullValue = await cache.GetAsync<string>(nullKey, AbortToken);
+        var sentinelValue = await cache.GetAsync<string>(sentinelKey, AbortToken);
+
+        nullValue.HasValue.Should().BeTrue();
+        nullValue.IsNull.Should().BeTrue();
+        sentinelValue.HasValue.Should().BeTrue();
+        sentinelValue.Value.Should().Be("@@NULL");
+    }
+
+    public virtual async Task should_expire_values_after_duration()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var expiration = TimeSpan.FromMilliseconds(250);
+
+        await cache.UpsertAsync(key, "value", expiration, AbortToken);
+
+        var beforeExpiry = await cache.GetAsync<string>(key, AbortToken);
+        await AdvancePastExpirationAsync(expiration);
+        var afterExpiry = await cache.GetAsync<string>(key, AbortToken);
+
+        beforeExpiry.HasValue.Should().BeTrue();
+        afterExpiry.HasValue.Should().BeFalse();
+    }
+
+    public virtual async Task should_get_all_values_including_null_members()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var firstKey = Faker.Random.AlphaNumeric(10);
+        var nullKey = Faker.Random.AlphaNumeric(10);
+        var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [firstKey] = "value",
+            [nullKey] = null,
+        };
+
+        var written = await cache.UpsertAllAsync(values, TimeSpan.FromMinutes(5), AbortToken);
+        var cached = await cache.GetAllAsync<string>(values.Keys, AbortToken);
+
+        written.Should().Be(values.Count);
+        cached[firstKey].Value.Should().Be("value");
+        cached[nullKey].HasValue.Should().BeTrue();
+        cached[nullKey].IsNull.Should().BeTrue();
+    }
+
+    public virtual async Task should_increment_and_read_back_number()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.IncrementAsync(key, 2L, TimeSpan.FromMinutes(5), AbortToken);
+        var result = await cache.IncrementAsync(key, 3L, TimeSpan.FromMinutes(5), AbortToken);
+        var cached = await cache.GetAsync<long>(key, AbortToken);
+
+        result.Should().Be(5);
+        cached.HasValue.Should().BeTrue();
+        cached.Value.Should().Be(5);
+    }
+
+    public virtual async Task should_compare_and_swap_on_matching_values_only()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var replaceKey = Faker.Random.AlphaNumeric(10);
+        var removeKey = Faker.Random.AlphaNumeric(10);
+
+        await cache.UpsertAsync(replaceKey, "first", TimeSpan.FromMinutes(5), AbortToken);
+        await cache.UpsertAsync(removeKey, "remove", TimeSpan.FromMinutes(5), AbortToken);
+
+        var replaceMiss = await cache.TryReplaceIfEqualAsync(
+            replaceKey,
+            "wrong",
+            "second",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
+        var replaceHit = await cache.TryReplaceIfEqualAsync(
+            replaceKey,
+            "first",
+            "second",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
+        var removeMiss = await cache.RemoveIfEqualAsync(removeKey, "wrong", AbortToken);
+        var removeHit = await cache.RemoveIfEqualAsync(removeKey, "remove", AbortToken);
+
+        var replaced = await cache.GetAsync<string>(replaceKey, AbortToken);
+        var removed = await cache.GetAsync<string>(removeKey, AbortToken);
+
+        replaceMiss.Should().BeFalse();
+        replaceHit.Should().BeTrue();
+        replaced.Value.Should().Be("second");
+        removeMiss.Should().BeFalse();
+        removeHit.Should().BeTrue();
+        removed.HasValue.Should().BeFalse();
+    }
+
+    public virtual async Task should_insert_only_when_missing_and_replace_only_when_present()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var missingKey = Faker.Random.AlphaNumeric(10);
+
+        var inserted = await cache.TryInsertAsync(key, "first", TimeSpan.FromMinutes(5), AbortToken);
+        var duplicateInsert = await cache.TryInsertAsync(key, "second", TimeSpan.FromMinutes(5), AbortToken);
+        var replaceMissing = await cache.TryReplaceAsync(missingKey, "missing", TimeSpan.FromMinutes(5), AbortToken);
+        var replaceExisting = await cache.TryReplaceAsync(key, "second", TimeSpan.FromMinutes(5), AbortToken);
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+
+        inserted.Should().BeTrue();
+        duplicateInsert.Should().BeFalse();
+        replaceMissing.Should().BeFalse();
+        replaceExisting.Should().BeTrue();
+        cached.Value.Should().Be("second");
+    }
+
+    protected sealed record CacheConformanceObject(Guid Id, string Name);
+}

--- a/tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs
+++ b/tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs
@@ -53,6 +53,21 @@ public abstract class CacheConformanceTestsBase : TestBase
         sentinelValue.Value.Should().Be("@@NULL");
     }
 
+    public virtual async Task should_round_trip_empty_string_value()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.UpsertAsync(key, "", TimeSpan.FromMinutes(5), AbortToken);
+
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+
+        cached.HasValue.Should().BeTrue();
+        cached.IsNull.Should().BeFalse();
+        cached.Value.Should().Be("");
+    }
+
     public virtual async Task should_expire_values_after_duration()
     {
         await ResetAsync();

--- a/tests/Headless.Caching.Tests.Harness/Headless.Caching.Tests.Harness.csproj
+++ b/tests/Headless.Caching.Tests.Harness/Headless.Caching.Tests.Harness.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Headless.NET.Sdk.Test">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <IsTestProject>false</IsTestProject>
+    <IsTestableProject>false</IsTestableProject>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Headless.Caching.Abstractions\Headless.Caching.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Redis scalar cache entries now carry the same metadata envelope that Memory gained in #389: a versioned binary header preserves logical expiration, physical expiration, and null state while the Redis key TTL continues to enforce physical expiry. The literal `"@@NULL"` can now be cached normally through Redis cache APIs; raw legacy sentinel keys still read as null. Compare-and-swap operations now compare against the value segment of framed entries, so timestamp/header changes do not break `TryReplaceIfEqualAsync` or `RemoveIfEqualAsync`.

## Design Notes

- The scalar frame is a 19-byte header (`0xFF 0x01`, flags, logical/physical Unix milliseconds, little-endian) followed by the raw value segment. Atomic counters stay raw Redis values so Redis can keep native arithmetic semantics.
- Cache-specific Lua scripts handle framed CAS without changing shared Redis script definitions used by other packages.
- `Headless.Caching.Tests.Harness` now owns portable Memory + Redis cache semantics; Redis-only byte layout and TTL checks remain in integration tests.

## Test Plan

- `make test-project TEST_PROJECT=tests/Headless.Caching.Redis.Tests.Integration/Headless.Caching.Redis.Tests.Integration.csproj` passed, 106 tests.
- `make test-project TEST_PROJECT=tests/Headless.Caching.Memory.Tests.Unit/Headless.Caching.Memory.Tests.Unit.csproj` passed, 136 tests.
- `make format` passed, formatted 0 files.
- `make build` passed, 0 warnings/errors.

## Post-Deploy Monitoring & Validation

- Validation window: first downstream dogfood run and the first 24 hours after consuming a package containing this change.
- Healthy signals: no `RedisCacheLog.LogDeserializationFailed` events, `RedisCacheScriptsInitializer` completes, Redis `GET`/`SET`/CAS cache flows behave normally, and Redis script errors or `NOSCRIPT` retries do not increase.
- Failure signals: deserialization failures on Redis scalar cache reads, Lua errors from cache CAS scripts, matching `RemoveIfEqual`/`TryReplaceIfEqual` calls returning false unexpectedly, or consumers assuming Redis string values are plain UTF-8 payloads.
- Mitigation: revert this PR/package version and flush the affected Redis cache namespace before serving traffic with the previous reader, because older Redis cache code cannot parse the new framed scalar payloads.
