### PR TITLE
test(distributed-locks): cover stale fencing-token rejection

### DIFF
--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs
@@ -125,6 +125,29 @@ public sealed class DistributedLockProviderTests : TestBase
     }
 
     [Fact]
+    public async Task should_allow_protected_resource_to_reject_stale_fencing_token()
+    {
+        // given
+        var provider = _CreateProvider();
+        var protectedResource = new FencedProtectedResource();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        await using var first = await provider.AcquireAsync(resource, cancellationToken: AbortToken);
+        var staleToken = first.FencingToken;
+        protectedResource.TryWrite(staleToken).Should().BeTrue();
+        await first.ReleaseAsync();
+
+        await using var second = await provider.AcquireAsync(resource, cancellationToken: AbortToken);
+        protectedResource.TryWrite(second.FencingToken).Should().BeTrue();
+
+        // when
+        var accepted = protectedResource.TryWrite(staleToken);
+
+        // then
+        accepted.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task should_keep_fencing_token_stable_on_renew()
     {
         // given
@@ -1392,4 +1415,21 @@ public sealed class DistributedLockProviderTests : TestBase
     }
 
     #endregion
+
+    private sealed class FencedProtectedResource
+    {
+        private long _lastSeenFence;
+
+        public bool TryWrite(long? fencingToken)
+        {
+            if (fencingToken is not { } token || token < _lastSeenFence)
+            {
+                return false;
+            }
+
+            _lastSeenFence = token;
+
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fencing-token coverage now includes the actual stale-write pattern from #364: a protected resource records the newest accepted token and rejects an older holder after a later acquisition succeeds.

This keeps `LockInfo.FencingToken` intentionally nullable for inspection paths; the acquire handle remains the authoritative place to read a live token.

Closes #364.

## Tests

- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Tests.Unit/Headless.DistributedLocks.Tests.Unit.csproj`
- `make test-project-fast TEST_PROJECT=tests/Headless.DistributedLocks.Redis.Tests.Integration/Headless.DistributedLocks.Redis.Tests.Integration.csproj`
- `make test-project-fast TEST_PROJECT=tests/Headless.DistributedLocks.Postgres.Tests.Integration/Headless.DistributedLocks.Postgres.Tests.Integration.csproj`
- `make test-project-fast TEST_PROJECT=tests/Headless.DistributedLocks.SqlServer.Tests.Integration/Headless.DistributedLocks.SqlServer.Tests.Integration.csproj`
- `dotnet csharpier check tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockProviderTests.cs`
- `git diff --check`
