### PR TITLE
fix(messaging-storage): hourly monitoring bugs + #414 guid test fallout

### DIFF
--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -336,11 +336,13 @@ public sealed class PostgreSqlMonitoringApi(
     {
         var sqlQuery = $"""
             WITH Aggr AS (
-                SELECT to_char("Added",'yyyy-MM-dd-HH') AS "Key",
+                -- HH24 (24-hour) matches the C# key built with DateTime.ToString("yyyy-MM-dd-HH"); Postgres 'HH'
+                -- is 12-hour, which silently mismatched buckets for hours 00 and 13-23.
+                SELECT to_char("Added",'yyyy-MM-dd-HH24') AS "Key",
                 COUNT("Id") AS "Count"
                 FROM {tableName}
                     WHERE "StatusName" = @StatusName AND "Added" >= @MinAdded AND "Added" <= @MaxAdded
-                GROUP BY to_char("Added", 'yyyy-MM-dd-HH')
+                GROUP BY to_char("Added", 'yyyy-MM-dd-HH24')
             )
             SELECT "Key","Count" from Aggr;
             """;

--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerMonitoringApi.cs
@@ -329,8 +329,10 @@ public sealed class SqlServerMonitoringApi(
         // Use CONVERT instead of FORMAT to avoid CLR dependency (Azure SQL Edge doesn't support CLR)
         var sqlQuery = $"""
             WITH Aggr AS (
+            -- COUNT (int) not COUNT_BIG: the reader maps [Count] via GetInt32 into a Dictionary<string,int>, and
+            -- a single-hour bucket can never overflow int. SqlClient.GetInt32 rejects a bigint column outright.
             SELECT CONVERT(CHAR(10), Added, 120) + '-' + RIGHT('0' + CAST(DATEPART(HOUR, Added) AS VARCHAR(2)), 2) AS [Key],
-                COUNT_BIG(Id) [Count]
+                COUNT(Id) [Count]
             FROM  {tableName}
             WHERE StatusName = @StatusName AND Added >= @MinAdded AND Added <= @MaxAdded
             GROUP BY CONVERT(CHAR(10), Added, 120) + '-' + RIGHT('0' + CAST(DATEPART(HOUR, Added) AS VARCHAR(2)), 2)

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlDeduplicationTest.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlDeduplicationTest.cs
@@ -1,4 +1,5 @@
 using Headless.Abstractions;
+using Headless.Core;
 using Headless.Messaging;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Messages;
@@ -25,6 +26,8 @@ public sealed class PostgreSqlDeduplicationTest(PostgreSqlTestFixture fixture) :
         services.AddSingleton<IStorageInitializer, PostgreSqlStorageInitializer>();
         services.AddSingleton<ISerializer, JsonUtf8Serializer>();
         services.AddSingleton(TimeProvider.System);
+        // PostgreSqlDataStorage resolves a keyed IGuidGenerator (SequentialGuidType.Version7) for native uuid PKs.
+        services.AddHeadlessGuidGenerator();
         services.AddSingleton<IDataStorage, PostgreSqlDataStorage>();
 
         var provider = services.BuildServiceProvider();

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
@@ -422,7 +422,7 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
         {
             "received" => $$"""
                 INSERT INTO {{qualifiedTable}} ("Id","Version","Name","Group","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId")
-                SELECT g, 'v1', 'plan-test', NULL, '{}', 0, 0, now(), NULL,
+                SELECT gen_random_uuid(), 'v1', 'plan-test', NULL, '{}', 0, 0, now(), NULL,
                        CASE WHEN g % 2 = 0 THEN now() - interval '1 minute' ELSE NULL END,
                        NULL, 'Failed', 'plan-' || g
                 FROM generate_series(1000, 1000 + {{seedRows - 1}}) g
@@ -430,7 +430,7 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
                 """,
             "published" => $$"""
                 INSERT INTO {{qualifiedTable}} ("Id","Version","Name","Content","IntentType","Retries","Added","ExpiresAt","NextRetryAt","LockedUntil","StatusName","MessageId")
-                SELECT g, 'v1', 'plan-test', '{}', 0, 0, now(), NULL,
+                SELECT gen_random_uuid(), 'v1', 'plan-test', '{}', 0, 0, now(), NULL,
                        CASE WHEN g % 2 = 0 THEN now() - interval '1 minute' ELSE NULL END,
                        NULL, 'Failed', 'plan-' || g
                 FROM generate_series(1000, 1000 + {{seedRows - 1}}) g


### PR DESCRIPTION
## Summary

Fixes real messaging-storage integration-test failures surfaced by a full-suite run, all fallout from the #414 storage→Guid migration. Two are product bugs, two are test bugs.

### Product fixes
- **`PostgreSqlMonitoringApi` hourly timeline (12h/24h bug).** The SQL bucket key used `to_char("Added",'yyyy-MM-dd-HH')` — Postgres `HH` is **12-hour** — while the C# key uses `DateTime.ToString("yyyy-MM-dd-HH")` — .NET `HH` is **24-hour**. Keys silently mismatched for hours `00` and `13–23`, so `HourlySucceededJobs`/`HourlyFailedJobs` returned all-zero buckets in the afternoon/evening. Changed the SQL to `HH24`. (Time-of-day flaky: passed in the morning, failed after noon.)
- **`SqlServerMonitoringApi` hourly timeline (Int64→Int32 cast).** The query used `COUNT_BIG(Id)` (bigint) but the reader maps `[Count]` via `GetInt32` into `Dictionary<string,int>`; `SqlClient.GetInt32` rejects a bigint column. Switched that one query to `COUNT(Id)` (a single-hour bucket can't overflow int).

### Test fixes
- **`PostgreSqlDeduplicationTest`** registered `IDataStorage` in DI but not the keyed `IGuidGenerator` that `PostgreSqlDataStorage` now requires (`SequentialGuidType.Version7` for native uuid PKs) → added `AddHeadlessGuidGenerator()`.
- **`PostgreSqlStorageTests` query-plan seed** inserted an integer (`generate_series`) into the now-`uuid` `Id` column → use `gen_random_uuid()` (the integer still drives row count / `MessageId`).

## Verification
- Postgres storage: **94/94** pass (was 6 failing).
- SqlServer storage: **86/86** pass (was 1 failing).

## Note — not included
The 5 `Headless.Orm.EntityFramework.Messaging.Tests.Integration` failures from the same full-suite run were **local stale-container artifacts**, not real bugs: a leftover pre-#414 `bigint` `messaging.published`/`received` table that the initializer's `CREATE TABLE IF NOT EXISTS` skipped (Ryuk wasn't reaping containers locally). On a pruned/clean environment all 5 pass unmodified, so no code change is warranted (CI runs clean). The 24 `Messaging.NatsPostgreSql` failures are a separate Testcontainers/Docker `OutOfMemoryException` while reading NATS container logs — infra, not code.
