### PR TITLE
feat(caching): add sliding expiration

### DIFF
--- a/docs/llms/caching.md
+++ b/docs/llms/caching.md
@@ -83,6 +83,8 @@ Use `CacheValue<T>` return type — check `.HasValue` before accessing `.Value`.
 - For hybrid caching, register memory cache as non-default (`AddInMemoryCache(isDefault: false)`), then register Redis cache, then call `AddHybridCache()`. The hybrid cache becomes the default `ICache`.
 - Always check `CacheValue<T>.HasValue` before accessing `.Value` — cache misses return `HasValue = false`, not null.
 - `GetOrAddAsync` takes `CacheEntryOptions`. Passing a `TimeSpan` still works through implicit conversion when only duration is needed.
+- Set `CacheEntryOptions.SlidingExpiration` when a factory-backed entry should expire after an idle window while still respecting `Duration` as the absolute cap. Value reads re-arm; metadata reads such as `GetExpirationAsync` do not.
+- Do not combine sliding expiration and fail-safe in the same `CacheEntryOptions`; the coordinator rejects that combination.
 - Enable fail-safe per factory-backed entry with `CacheEntryOptions.IsFailSafeEnabled = true`. When the factory throws and a logically-expired value is still physically retained, `GetOrAddAsync` serves that value and returns `CacheValue<T>.IsStale = true`.
 - Fail-safe retention is bounded by `max(Duration, FailSafeMaxDuration)` from entry creation. `FailSafeThrottleDuration` restamps logical expiration to avoid hammering a failing factory, but never extends physical retention.
 - Normal value reads (`GetAsync`, `GetAllAsync`, `GetByPrefixAsync`, `GetSetAsync`, `ExistsAsync`) use logical expiration. A fail-safe reserve is only consumed by `GetOrAddAsync`.
@@ -92,10 +94,10 @@ Use `CacheValue<T>` return type — check `.HasValue` before accessing `.Value`.
 - StackExchange.Redis does not support `CancellationToken` — timeouts are configured via `ConfigurationOptions.SyncTimeout` and `AsyncTimeout`. Cancellation is checked at the start of operations only.
 - For Redis, SCAN-based operations (`RemoveByPrefixAsync`, `GetAllKeysByPrefixAsync`) are cancellable during iteration; single-key and batch operations complete atomically once started.
 - Redis scalar entries use a versioned binary envelope. Do not parse Redis string bytes as the application payload directly; strip the envelope first unless the key is a raw counter.
-- Redis key TTL follows physical expiration, not logical expiration, when fail-safe is enabled.
+- Redis key TTL follows physical expiration when fail-safe is enabled and follows the sliding idle deadline when sliding expiration is enabled.
 - Use `options.KeyPrefix` to namespace cache keys per application or module.
 - Memory cache supports `CloneValues = true` for value isolation between callers — useful when cached objects are mutated after retrieval.
-- Hybrid cache `DefaultLocalExpiration` controls L1 TTL independently of L2. Set to shorter durations than L2 for freshness.
+- Hybrid cache `DefaultLocalExpiration` controls L1 TTL independently of L2. Set to shorter durations than L2 for freshness; sliding factory entries still use the L2 physical cap as the absolute duration authority.
 
 ---
 
@@ -119,11 +121,13 @@ Provides a provider-agnostic caching API, enabling seamless switching between me
 - `IRemoteCache` - Marker interface for remote implementations
 - `ICache<T>` - Strongly-typed cache wrapper
 - `CacheValue<T>` - Cache result with `HasValue` semantics and an `IsStale` flag when fail-safe serves a stale value.
-- `CacheEntryOptions` - Factory-backed entry options: `Duration`, `IsFailSafeEnabled`, `FailSafeMaxDuration`, and `FailSafeThrottleDuration`.
+- `CacheEntryOptions` - Factory-backed entry options: `Duration`, `SlidingExpiration`, `IsFailSafeEnabled`, `FailSafeMaxDuration`, and `FailSafeThrottleDuration`.
 
 ## Design Notes
 
 `GetOrAddAsync` accepts `CacheEntryOptions` so factory-backed cache entries have a stable extension point for fail-safe, factory timeout, refresh, and tagging features. A `TimeSpan` converts implicitly to `CacheEntryOptions`, so positional duration-only call sites keep their shorthand while explicit options are available when a caller wants to name the duration. This is a greenfield public API break for named arguments: callers using `expiration: ...` on `GetOrAddAsync` must rename that argument to `options: ...`.
+
+`SlidingExpiration` is an optional idle window for factory-backed entries. `Duration` remains the absolute cap from entry creation, and value-returning reads re-arm the logical deadline to `min(now + SlidingExpiration, createdAt + Duration)`. Metadata reads do not re-arm. Sliding expiration and fail-safe are rejected together in this version.
 
 Fail-safe is opt-in and only applies to `GetOrAddAsync`. Direct writes keep the `TimeSpan?` API and write logical expiration equal to physical expiration. A stale value served by fail-safe returns `CacheValue<T>.IsStale = true` only for the activating call; reads during the throttle window are logical hits and return `IsStale = false`.
 
@@ -202,14 +206,14 @@ Centralizes the `GetOrAddAsync` state machine so memory, Redis, and hybrid provi
 
 - `FactoryCacheCoordinator` - shared factory orchestration engine.
 - `IFactoryCacheStore` - provider primitive for metadata-aware entry reads and writes.
-- `CacheStoreEntry<T>` - logical and physical expiration snapshot used by the coordinator.
+- `CacheStoreEntry<T>` - logical, physical, and optional sliding expiration snapshot used by the coordinator.
 - `CacheStoreEntryExtensions` - shared `IsFresh`/`IsPhysicallyPresent` predicates so every provider and the coordinator agree on the expiration boundary (an entry is expired at the exact tick, `expiresAt <= now`).
 - `FactoryCacheCoordinator.IsCallerCancellation` - shared predicate provider composites use so caller cancellation propagates while an unrelated/downstream `OperationCanceledException` activates fail-safe consistently.
 - Fail-safe activation log when stale data is served.
 
 ### Design Notes
 
-Providers construct the coordinator directly with their `TimeProvider` and logger; the Core package has no DI setup. Store read failures are treated as misses, and fail-safe restamp writes are best-effort so a stale value can still be returned when the backing store is unhealthy. Cancellation is classified by token identity: the caller's own cancellation propagates and never activates fail-safe, while an `OperationCanceledException` from an unrelated or downstream token is treated as a failure that activates fail-safe.
+Providers construct the coordinator directly with their `TimeProvider` and logger; the Core package has no DI setup. Store read failures are treated as misses, fail-safe restamp writes are best-effort, and sliding re-arm writes are best-effort so a cached value can still be returned when the backing store is unhealthy. Cancellation is classified by token identity: the caller's own cancellation propagates and never activates fail-safe, while an `OperationCanceledException` from an unrelated or downstream token is treated as a failure that activates fail-safe. Sliding expiration and fail-safe are rejected together because one needs value reads to extend the logical deadline while the other needs logical expiration to expose a stale reserve.
 
 ### Installation
 
@@ -254,9 +258,9 @@ Provides high-performance in-memory caching using the unified `ICache` abstracti
 
 ## Design Notes
 
-Memory cache stores entries in an internal envelope with logical expiration and physical expiration. Direct writes set both timestamps equal. Fail-safe `GetOrAddAsync` can make physical expiration outlive logical expiration so a stale reserve stays in memory after normal value reads miss. Physical expiration still drives eviction, LRU maintenance, size compaction, `GetCountAsync`, and key listing. Logical expiration drives `GetAsync`, `GetAllAsync`, `GetByPrefixAsync`, `GetSetAsync`, `ExistsAsync`, and `GetExpirationAsync`.
+Memory cache stores entries in an internal envelope with logical expiration, physical expiration, and optional sliding expiration. Direct writes set logical and physical timestamps equal. Fail-safe `GetOrAddAsync` can make physical expiration outlive logical expiration so a stale reserve stays in memory after normal value reads miss. Sliding `GetOrAddAsync` keeps physical expiration as the absolute cap and re-arms logical expiration on value reads only; `GetExpirationAsync`, `ExistsAsync`, key listing, and count operations do not extend the idle window. Physical expiration still drives eviction, LRU maintenance, size compaction, `GetCountAsync`, and key listing. Logical expiration drives `GetAsync`, `GetAllAsync`, `GetByPrefixAsync`, `GetSetAsync`, `ExistsAsync`, and `GetExpirationAsync`.
 
-Long `FailSafeMaxDuration` values can retain more entries in process memory. Use `MaxItems`, `MaxMemorySize`, and LRU compaction to bound direct in-memory deployments.
+Long `FailSafeMaxDuration` values and long sliding absolute caps can retain more entries in process memory. Use `MaxItems`, `MaxMemorySize`, and LRU compaction to bound direct in-memory deployments.
 
 ## Installation
 
@@ -328,7 +332,7 @@ Provides distributed caching using Redis via the unified `ICache` abstraction, e
 
 ## Design Notes
 
-Scalar write operations (`UpsertAsync`, `TryInsertAsync`, `TryReplaceAsync`, `TryReplaceIfEqualAsync`, `UpsertAllAsync`) store entries as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is mapped to the Redis key TTL; when fail-safe is enabled, Redis retains the key until physical expiration even after logical expiration has passed. Logical expiration rides in the payload so normal value reads can miss while `GetOrAddAsync` still has a fail-safe reserve. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) bypass framing and write raw Redis-native numeric strings (see below).
+Scalar write operations (`UpsertAsync`, `TryInsertAsync`, `TryReplaceAsync`, `TryReplaceIfEqualAsync`, `UpsertAllAsync`) store entries as a versioned binary envelope: a 19-byte base header followed by an optional 8-byte sliding-expiration field and the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is mapped to the Redis key TTL when fail-safe is enabled, so Redis retains the key until physical expiration even after logical expiration has passed. Sliding expiration maps the key TTL to the idle deadline and keeps physical expiration in the envelope as the absolute cap. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) bypass framing and write raw Redis-native numeric strings (see below).
 
 The envelope byte layout is:
 
@@ -336,10 +340,11 @@ The envelope byte layout is:
 | --- | --- | --- |
 | 0 | Magic | `0xFF` — marks a framed entry |
 | 1 | Version | `0x01` — current envelope version |
-| 2 | Flags | bit0 = `isNull`, bit1 = `hasLogicalExpiresAt`, bit2 = `hasPhysicalExpiresAt` |
+| 2 | Flags | bit0 = `isNull`, bit1 = `hasLogicalExpiresAt`, bit2 = `hasPhysicalExpiresAt`, bit3 = `hasSlidingExpiration` |
 | 3–10 | LogicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit1 is set) |
 | 11–18 | PhysicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit2 is set) |
-| 19+ | ValueSegment | raw codec bytes; empty when `isNull` is set |
+| 19–26 | SlidingExpiration | `Int64` little-endian milliseconds (present only when bit3 is set) |
+| 19+ or 27+ | ValueSegment | raw codec bytes; offset is 27 when bit3 is set, otherwise 19; empty when `isNull` is set |
 
 Null scalar values are represented by a header flag with an empty value segment. The literal string `"@@NULL"` is now a normal cacheable string when written through Redis cache APIs. Raw legacy keys containing `"@@NULL"` still read as null. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) remain raw Redis-native numeric strings so Redis can perform native atomic arithmetic; their read path falls back to the raw value codec.
 
@@ -497,6 +502,8 @@ public sealed class ProductService(ICache cache, IProductRepository repository)
 | `KeyPrefix`              | `""`           | Prefix for all cache keys                        |
 | `DefaultLocalExpiration` | `5 minutes`    | Default L1 TTL (uses L2 TTL if null)             |
 | `InstanceId`             | Auto-generated | Unique ID for filtering self-originated messages |
+
+For factory-backed sliding entries, `DefaultLocalExpiration` caps the L1 copy only. Hybrid revalidates sliding L1 hits against L2 before re-arm so L2 keeps the original `Duration` as the absolute cap. If L2 is unavailable, a fresh L1 sliding value can still be returned, but the read is not re-armed.
 
 ## Exception Handling
 

--- a/docs/plans/2026-06-09-001-feat-cache-sliding-expiration-plan.md
+++ b/docs/plans/2026-06-09-001-feat-cache-sliding-expiration-plan.md
@@ -1,0 +1,378 @@
+---
+title: "feat: caching sliding expiration (core engine + Memory + Redis)"
+type: feat
+status: active
+date: 2026-06-09
+origin: "GitHub issue #377 (M3 of caching roadmap #369)"
+depth: deep
+---
+
+# feat: caching sliding expiration (core engine + Memory + Redis)
+
+## Summary
+
+Add a **sliding-expiration** capability to the caching engine: an entry can carry an idle window that read paths **re-arm** (push the eviction deadline to `now + SlidingExpiration`, capped by the entry's absolute `Duration`), so the entry survives while accessed and expires after an idle gap. Delivered across the engine primitive, the InMemory provider (re-stamp the in-process entry on read), the Redis provider (re-arm via native key TTL — no value rewrite, no new Lua), and the Hybrid composite, exercised through a new `CacheEntryOptions.SlidingExpiration` field on `GetOrAddAsync` and proven by a cross-provider conformance suite. This is the first M3 (standard-interop) item in roadmap #369 and the engine groundwork that #383 (the BCL `IDistributedCache` adapter) and ASP.NET Session will map `DistributedCacheEntryOptions.SlidingExpiration` onto.
+
+---
+
+## Problem Frame
+
+**Today:** Every cache entry has a fixed lifetime. The envelope (shipped in #371/#372) carries `LogicalExpiresAt` (freshness/stale boundary) and `PhysicalExpiresAt` (retention/eviction); fail-safe (#373) makes physical outlive logical. No path re-arms an entry's deadline on access — once written, an entry expires at a fixed instant regardless of how often it is read.
+
+**Desired:** A caller that opts into sliding (`CacheEntryOptions.SlidingExpiration = window`) gets an entry whose eviction deadline is pushed forward to `min(now + window, createdAt + Duration)` on each value-returning read. An idle entry (no reads for `window`) expires; a frequently-read entry survives up to the absolute ceiling `Duration`. The behavior is identical across InMemory, Redis, and Hybrid, and is the contract ASP.NET Session and the BCL `IDistributedCache` adapter depend on.
+
+**Why now:** #369's strategy is "engine first, interfaces last" — build the capability into the engine so the standard `IDistributedCache`/Session implementation (#383) ships already faithful. Sliding is the M3 prerequisite that #383 cannot be built without.
+
+**Design grounding (FusionCache):** The roadmap names FusionCache as the resilience playbook, but FusionCache **deliberately omits sliding expiration** (issue #48, closed; absent from `Options.md` and the codebase) — its author argues a heavily-read entry "keeps sliding and never updates itself" and steers users to fail-safe + soft timeouts instead. Headless diverges intentionally: it adds real sliding **for BCL/Session parity**, a use case fail-safe does not serve. Because Headless's `Duration` is required and positive, every sliding entry has a built-in absolute ceiling, which defuses the "never expires" objection at the root.
+
+---
+
+## High-Level Technical Design
+
+Two shapes warrant visualization: the **read-path re-arm state machine** (the new behavior) and the **envelope/TTL mapping** across providers (where the sliding deadline lives). Both are authoritative; prose governs on any disagreement.
+
+### Re-arm-on-read decision (applies to every value-returning read)
+
+```mermaid
+flowchart TD
+    Start([read key]) --> Found{entry found?}
+    Found -- no --> Miss[return NoValue]
+    Found -- yes --> Cap{now >= absolute cap<br/>PhysicalExpiresAt?}
+    Cap -- yes --> Evict[evict / miss]
+    Cap -- no --> Slide{entry has<br/>SlidingExpiration?}
+    Slide -- no --> Fresh{now < LogicalExpiresAt?}
+    Fresh -- yes --> Hit[return hit]
+    Fresh -- no --> Miss
+    Slide -- yes --> SlideFresh{now < current<br/>sliding deadline?}
+    SlideFresh -- no --> Miss
+    SlideFresh -- yes --> Rearm["new deadline =<br/>min(now + SlidingExpiration, cap)"]
+    Rearm --> Persist["persist re-arm<br/>(Memory: replace entry · Redis: KeyExpire)"]
+    Persist --> Hit
+```
+
+### Envelope / TTL mapping per provider
+
+```mermaid
+graph TD
+    Opt["CacheEntryOptions<br/>Duration (cap) · SlidingExpiration?"]
+    Env["Envelope fields<br/>LogicalExpiresAt = current sliding deadline<br/>PhysicalExpiresAt = absolute cap (createdAt + Duration)<br/>SlidingExpiration = idle window (NEW)"]
+    Mem["InMemory CacheEntry<br/>holds all three; eviction loop keys on PhysicalExpiresAt;<br/>read replaces entry with re-armed LogicalExpiresAt"]
+    Red["Redis frame (format bump)<br/>encodes SlidingExpiration + cap;<br/>key TTL = current sliding deadline; read = KeyExpire(min(window, cap-now))"]
+    Opt --> Env
+    Env --> Mem
+    Env --> Red
+```
+
+For a sliding entry the invariant `LogicalExpiresAt <= PhysicalExpiresAt` is preserved (the sliding deadline is always at or before the absolute cap), so the existing `IsFresh`/`IsPhysicallyPresent` predicates and the fail-safe envelope semantics remain coherent.
+
+---
+
+## Key Technical Decisions
+
+### KTD-1 — `SlidingExpiration` is a per-entry option on the factory path only — *settled (user call)*
+Add `CacheEntryOptions.SlidingExpiration` (`TimeSpan?`, default `null` = off). Sliding entries are created through `GetOrAddAsync` (the factory path) and the engine store primitive; the public direct-write `ICache` methods (`UpsertAsync`/`TryInsertAsync`/`TryReplaceAsync`, which take a bare `TimeSpan?`) are **unchanged**. **Rationale:** keeps the power-user `ICache` surface stable; the BCL `IDistributedCache` adapter (#383) owns the mapping from `DistributedCacheEntryOptions.SlidingExpiration` onto the engine's sliding-aware set primitive — building a public direct-write sliding API now would front-run that adapter's design. *Alternative considered:* add options-bearing `Upsert` overloads now — deferred to #383.
+
+### KTD-2 — Sliding and fail-safe are mutually exclusive on a single entry **in this version** — *settled for v1; composition is a future option, not impossible*
+If `SlidingExpiration` is set **and** `IsFailSafeEnabled` is `true`, the coordinator rejects the call (`ArgumentException`/`ArgumentOutOfRangeException`) at the same validation gate that already enforces `Argument.IsPositive(options.Duration)`. The rejection message and docs frame this as **"unsupported in this version"**, not "logically invalid" — the combination is coherent and may be added later. **Rationale (v1):** FusionCache treats sliding and fail-safe as competing answers to the same "keep serving while the source is slow/unavailable" problem; there is no current Headless use case for combining them, and rejecting avoids ambiguous stale-vs-idle semantics in the first cut. Fail-safe is the factory-backed resilience answer (`GetOrAddAsync` power users); sliding is the idle-eviction answer (BCL/Session parity). **Consequence:** the v1 re-arm logic never has to reason about a stale reserve, and `LogicalExpiresAt <= PhysicalExpiresAt` stays a clean invariant.
+
+**Future composition (documented, deferred — see Scope Boundaries):** a coherent design exists — sliding re-arms the **logical** idle deadline; **physical** is the fail-safe reserve cap; fail-safe stale reuse activates only after the sliding logical deadline lapses, bounded by physical. It roughly doubles the re-arm × stale-reserve test matrix, so it is out of scope here, not foreclosed. *Alternative considered:* normalize-and-log (FusionCache's incoherent-options pattern) — rejected for v1 in favor of fail-fast, matching Headless's strict greenfield validation posture.
+
+### KTD-3 — `Duration` is the absolute cap; the sliding deadline rides `LogicalExpiresAt` — *settled*
+For a sliding entry: `PhysicalExpiresAt = createdAt + Duration` (the absolute ceiling, **never** moved by reads); `LogicalExpiresAt = min(lastAccess + SlidingExpiration, PhysicalExpiresAt)` (the current sliding deadline, re-armed on read). A read is a hit iff `now < LogicalExpiresAt`. **Rationale:** reuses the existing two-timestamp envelope with no inversion of the `logical <= physical` invariant, so fail-safe-disabled non-sliding entries (`logical == physical`) and sliding entries share the same `IsFresh`/`IsPhysicallyPresent` predicates. The required, positive `Duration` guarantees every sliding entry has a hard ceiling (the FusionCache "never expires" guard). **Normalization:** if `SlidingExpiration >= Duration` the `min()` makes sliding a no-op (the entry just lives `Duration`); this is allowed, not an error.
+
+### KTD-4 — One new envelope field: `SlidingExpiration` carried through the engine and both stores — *settled*
+`CacheStoreEntry<T>`, `IFactoryCacheStore.SetEntryAsync`, the InMemory `CacheEntry`, and the Redis frame each gain a `SlidingExpiration` (`TimeSpan?`) slot so each read can recompute the next deadline (`now + window`, capped). **Rationale:** re-arm needs the window value on every read, so it must be persisted with the entry — it cannot be derived from the two timestamps alone. `SetEntryAsync` gains a `slidingExpiration` parameter (the coordinator passes it on factory-backed writes; non-sliding writes pass `null`, preserving today's behavior).
+
+### KTD-5 — Re-arm happens in the read path as a side effect of a successful value-returning read — *settled*
+`GetAsync` (and the methods that delegate to it — `GetAllAsync`, `GetByPrefixAsync`, `GetSetAsync`) re-arm a sliding entry; `GetOrAddAsync`'s fresh-hit path re-arms via the same store primitive. Metadata/peek reads do **not** re-arm: `GetExpirationAsync`, `GetCountAsync`, `GetAllKeysByPrefixAsync`, and `ExistsAsync` are non-touching (mirrors BCL, where only `Get`/`Refresh` slide and key enumeration does not). **Rationale:** matches BCL `IDistributedCache` semantics (`Get`/`Refresh` re-arm); the re-arm computation (`min(now + window, cap)`) is trivial and lives in a **shared, reusable helper** (so a future `RefreshAsync` and the #383 BCL `IDistributedCache.Refresh` map onto the same re-arm), each provider supplying its own persist mechanism. *Alternative considered:* re-arm inside `IFactoryCacheStore.TryGetEntryAsync` so the coordinator gets it for free — rejected (a read-with-side-effect on a primitive named `TryGet` is surprising, and the coordinator calls it twice per `GetOrAddAsync`).
+
+**`GetExpirationAsync` returns the current sliding (logical) deadline, not the cap.** For a sliding entry, `GetExpirationAsync` reports the next observed expiration if no further value reads happen — i.e. the current sliding deadline — **without** re-arming. **InMemory:** read `LogicalExpiresAt` (kept current by re-arm). **Redis:** derive it from the live **key TTL** (`KeyTimeToLiveAsync`), **not** `frame.LogicalExpiresAt` — the embedded logical is stale after the first `KeyExpire` re-arm (KTD-6), so trusting it would return a wrong (too-early) value. Non-sliding entries keep today's behavior (logical remaining). This makes R6 ("metadata reads don't re-arm") true *and* the returned value correct.
+
+### KTD-9 — Re-arm is throttled to avoid write amplification; unconditional re-arm is benchmark-gated — *settled (lean: throttle)*
+Re-arming on **every** hot read causes write amplification in Redis (`KeyExpire` per read) and `ConcurrentDictionary` churn in InMemory. Default to a **lazy re-arm threshold**: re-arm only when the remaining lifetime has decayed past a fraction of the window — e.g. InMemory re-arms when `now - lastArm >= SlidingExpiration * RearmThreshold`; Redis issues `KeyExpire` only when current TTL `< SlidingExpiration * RearmThreshold` (lean: `RearmThreshold ≈ 0.5–0.75`). **Trade-off:** this trades exact-BCL precision (BCL `MemoryCache` re-arms on every access) for throughput — an entry may be evicted up to `window * RearmThreshold` earlier than a strict slide would allow. **Acceptance gate:** U4/U5 must include a hot-key read benchmark; do **not** ship unconditional re-arm without it. If the benchmark shows the throttle materially harms idle-eviction accuracy for a target workload, the threshold is tunable (or unconditional for that provider). The threshold is an internal implementation detail, not a public option, in v1.
+
+### KTD-6 — Redis re-arm is `KeyExpire`-only; Redis TTL is the sliding clock; no value rewrite, no new Lua — *settled*
+The Redis key TTL for a sliding entry is set to the current sliding deadline (`LogicalExpiresAt - now`). On a value-returning read, re-arm = `KeyExpireAsync(key, min(SlidingExpiration, cap - now))` — the value frame is **not** re-serialized or rewritten. The frame carries `SlidingExpiration` + the absolute cap (`PhysicalExpiresAt`) so each read recomputes the next TTL; eviction is delegated to Redis. **Rationale:** matches the BCL `Microsoft.Extensions.Caching.StackExchangeRedis` approach (store metadata in the value, re-arm via `EXPIRE`); avoids a per-read serialization cost and sidesteps the shared `ReplaceIfEqual`/`RemoveIfEqual` Lua scripts entirely (those live in `Headless.Redis` and are shared with `DistributedLocks.Redis` — must not be mutated). **Format bump:** the frame gains a `HasSlidingExpirationFlag` bit and an 8-byte field at a new offset; the `Version` byte stays `0x01` (a cleared flag means "no sliding" and the new bytes are not read), greenfield posture permits the format change.
+
+**Decode for sliding entries is logical-agnostic — key existence is truth (resolves the stale-embedded-logical hole):** because `KeyExpire` re-arms the live TTL **without** rewriting the frame, the frame's embedded `LogicalExpiresAt` goes stale the instant the first re-arm fires. Therefore, for a **sliding** frame (the `HasSlidingExpirationFlag` is set), the Redis read paths (`_RedisValueToCacheValue` and `_TryGetEntryAsync`) must **not** evaluate `frame.LogicalExpiresAt` — freshness is governed solely by key existence (Redis evicts the key at the re-armed sliding deadline) plus the absolute `PhysicalExpiresAt` cap as a hard ceiling. The embedded logical on a sliding frame is informational only. (Non-sliding frames keep checking both logical and physical exactly as today — this carve-out is gated on the sliding flag, so fail-safe/normal entries are unaffected.) This closes the contradiction where decode would otherwise report `NoValue` for a live, re-armed key once `now` passed the original embedded logical.
+
+**Best-effort:** a failed `KeyExpire` re-arm does not fail the read — the value is returned and the next read retries the re-arm (the slide is an optimization, not a correctness gate).
+
+### KTD-6b — TTL-from-logical is gated on `slidingExpiration != null`; fail-safe/normal writes keep TTL-from-physical — *settled*
+The shared `RedisCache.SetEntryAsync` today derives the Redis key TTL from `physicalExpiresAt - now`. The sliding change (TTL = `logical - now`, the nearer sliding deadline) applies **only** when `slidingExpiration is not null`. **Rationale:** fail-safe entries have `physical = max(Duration, FailSafeMaxDuration)` and `logical = Duration` — if the TTL-from-logical change applied unconditionally, the fail-safe physical reserve would silently collapse to the logical window, breaking #373. KTD-2 makes sliding⊕fail-safe exclusive, so the two TTL rules never apply to the same entry; the branch is `expiresIn = slidingExpiration is null ? (physical - now) : (logical - now)`.
+
+### KTD-7 — InMemory re-arm replaces the entry under `AddOrUpdate`; eviction loop is untouched — *settled*
+On a value-returning read of a sliding entry, `InMemoryCache` replaces the stored `CacheEntry` with one carrying the re-armed `LogicalExpiresAt` while **preserving `PhysicalExpiresAt` (the cap) and `SlidingExpiration` unchanged**, via `AddOrUpdate`/`TryUpdate`. **Rationale:** read-with-write is the standard sliding implementation (BCL `MemoryCache` does it).
+
+**Idle eviction is enforced two ways (resolves the lazy-vs-active memory-pressure gap):** (1) **on read** — a logically-expired sliding entry returns `NoValue` (correctness; already covered by the logical-governed reads); (2) **active reclamation** — the maintenance/eviction loop is extended to evict a sliding entry once `now >= LogicalExpiresAt` (the idle deadline), not only at `PhysicalExpiresAt` (the cap). Without (2), an idle 5-min-sliding entry under a 1-day cap would squat in memory for ~1 day. The eviction predicate becomes `now >= PhysicalExpiresAt || (SlidingExpiration is not null && now >= LogicalExpiresAt)`, removed with the value-equality `TryRemove(KeyValuePair)` overload (below). The expiration-tracking queue (`_TrackUpdate`/`_expirationQueue`) should enqueue the **logical** deadline for sliding entries so the loop wakes at the idle deadline, re-enqueued on each re-arm.
+
+**Do NOT reuse `WithExpiration` for re-arm.** `CacheEntry.WithExpiration(expiresAt)` sets **both** `LogicalExpiresAt` and `PhysicalExpiresAt` to the same value, which would move the absolute cap forward on every read and defeat R4. U4 adds a distinct clone-sharing helper — `WithLogicalExpiration(DateTime logicalExpiresAt)` — that threads `physicalExpiresAt` and `SlidingExpiration` through unchanged (the private clone-sharing constructor already accepts separate logical/physical; extend it to carry sliding). `WithExpiration` stays for the TTL-only refresh callers that legitimately move both.
+
+**Re-arm vs eviction concurrency invariant.** Re-arm publishes a **new** `CacheEntry` instance (new `InstanceNumber`) via `AddOrUpdate`. The maintenance evictor must use the value-equality `TryRemove(KeyValuePair<string, CacheEntry>(key, entry))` overload so a concurrent re-arm (different instance) causes the evict to no-op rather than drop a freshly-re-armed entry. **Any idle-evict-on-read path U4 adds must use the same value-equality remove, never the key-only `_RemoveExpiredKey`** (which would race-delete a concurrently re-armed entry). A lost re-arm race is otherwise benign (both writers only push the deadline forward). **LRU/clone:** re-arm touches LRU (`_TrackUpdate`) but reuses the cloned value reference.
+
+### KTD-8 — Hybrid re-arms both tiers; L1 stays bounded by `DefaultLocalExpiration` — *settled*
+`HybridCache`'s composite read re-arms L1 and L2 on a value-returning read. L2 (Redis) re-arms to the full sliding deadline; L1 (InMemory) re-arms bounded by `min(slidingDeadline, now + DefaultLocalExpiration)` so a long-lived sliding entry does not pin process memory beyond the local window — mirroring the L1/L2 bound established for fail-safe (#373). When L1's bound lapses, the composite read falls through to L2 and re-promotes. **Rationale:** preserves the existing two-tier memory-pressure ceiling; keeps sliding semantics authoritative in L2 (the shared tier).
+
+---
+
+## Output Structure
+
+This slice modifies existing files and adds one test file; no new package or directory hierarchy. The per-unit `**Files:**` lists are authoritative.
+
+---
+
+## Requirements
+
+From issue #377 (acceptance): *sliding entry survives while accessed, expires after idle window; conformance harness covers it; across Memory + Redis; prerequisite for faithful BCL `IDistributedCache`/Session.*
+
+### Capability
+
+- R1. A cache entry can carry a sliding idle window via `CacheEntryOptions.SlidingExpiration`, created through `GetOrAddAsync`.
+- R2. A value-returning read re-arms the entry's eviction deadline to `min(now + SlidingExpiration, createdAt + Duration)`.
+- R3. An entry read more frequently than its sliding window survives, up to the absolute ceiling `Duration`; an idle entry expires after the window.
+- R4. The absolute `Duration` is a hard ceiling that reads never extend.
+
+### Cross-provider parity
+
+- R5. R1–R4 hold identically across InMemory, Redis, and Hybrid, verified by a shared conformance suite.
+- R6. Metadata/peek reads (`ExistsAsync`, `GetExpirationAsync`, `GetCountAsync`, `GetAllKeysByPrefixAsync`) do not re-arm.
+- R10. `GetExpirationAsync` returns the current sliding (logical) deadline for a sliding entry — derived from the live key TTL on Redis, not the stale embedded logical (KTD-5).
+- R11. An idle sliding entry is actively reclaimed at its idle deadline, not held until the absolute cap (InMemory maintenance loop; KTD-7).
+
+### Coherence and compatibility
+
+- R7. Sliding and fail-safe are rejected when both set on one entry, framed as unsupported-in-this-version (KTD-2).
+- R8. Non-sliding entries (`SlidingExpiration == null`, the default) behave exactly as today across all providers and read methods; the Redis frame for a non-sliding entry is byte-identical to the pre-change layout (KTD-6/U3).
+- R9. Docs synced (`docs/llms/caching.md` + affected package READMEs).
+- R12. Re-arm is throttled (not issued on every hot read) and the hot-key read path is benchmarked before unconditional re-arm ships (KTD-9).
+
+---
+
+## Implementation Units
+
+### U1. `CacheEntryOptions.SlidingExpiration` field + coherence rules
+**Goal:** Add the per-entry opt-in surface and its normalization/guard semantics.
+**Requirements:** R1, R7, R8.
+**Dependencies:** none (Abstractions-only).
+**Files:**
+- `src/Headless.Caching.Abstractions/Contracts/CacheEntryOptions.cs` (modify — add `SlidingExpiration` `TimeSpan?` init property, default `null`; XML docs covering the cap relationship and the fail-safe mutual exclusion)
+- `tests/Headless.Caching.Abstractions.Tests.Unit/CacheEntryOptionsTests.cs` (extend)
+**Approach:** Keep the `readonly record struct` + implicit `TimeSpan` conversion (sets `Duration` only; sliding stays `null`, preserving R8). Store the raw value; the coordinator computes effective deadlines (KTD-3) and enforces the sliding⊕fail-safe guard (KTD-2) so all normalization lives in one place — the struct itself does not throw. Document that `SlidingExpiration >= Duration` degrades to a fixed `Duration` lifetime (no-op slide), and that sliding + fail-safe is rejected downstream.
+**Patterns to follow:** the existing fail-safe fields on `CacheEntryOptions` (same XML-doc style, same "raw value, coordinator normalizes" split).
+**Test suite design:** unit (pure value type), existing Abstractions unit project.
+**Test scenarios:**
+- Default options → `SlidingExpiration == null`.
+- Implicit `TimeSpan` conversion → `SlidingExpiration == null`, `Duration` set (R8 default preserved).
+- Setting `SlidingExpiration` round-trips the raw value unchanged (coherence applied downstream).
+- `Covers R8.` An options value with sliding unset is structurally identical to today (no new non-null defaults introduced).
+**Verification:** planned unit tests added and passing; `make test-project TEST_PROJECT=tests/Headless.Caching.Abstractions.Tests.Unit` green.
+
+### U2. Engine: thread `SlidingExpiration` through the envelope + coordinator (set on write, re-arm on hit, guard)
+**Goal:** Carry sliding through the engine primitive, set it on factory writes, re-arm on the fresh-hit path, and enforce the sliding⊕fail-safe guard.
+**Requirements:** R1, R2, R4, R7, R8.
+**Dependencies:** U1.
+**Files:**
+- `src/Headless.Caching.Core/CacheStoreEntry.cs` (modify — add `SlidingExpiration` `TimeSpan?` to the record struct + `NotFound`)
+- `src/Headless.Caching.Core/IFactoryCacheStore.cs` (modify — add `slidingExpiration` parameter to `SetEntryAsync`; document re-arm contract)
+- `src/Headless.Caching.Core/FactoryCacheCoordinator.cs` (modify — validation guard for sliding⊕fail-safe; compute logical/physical for a sliding write per KTD-3; re-arm the entry on the fresh-hit return path)
+- `tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs` (extend)
+- `tests/Headless.Caching.Core.Tests.Unit/FakeFactoryCacheStore.cs` (modify — record `SlidingExpiration` on set; expose re-arm observation)
+**Approach:** Add the guard `if (options.SlidingExpiration is { } slide) { Argument.IsPositive(slide); if (options.IsFailSafeEnabled) throw … }` alongside the existing `Argument.IsPositive(options.Duration)`. On factory success for a sliding entry: `physical = now + Duration` (cap), `logical = min(now + SlidingExpiration, physical)`; call `store.SetEntryAsync(..., slidingExpiration: options.SlidingExpiration, ...)`. Non-sliding paths are unchanged (sliding param `null`).
+
+**Re-arm on BOTH fresh-hit return sites.** `GetOrAddAsync` reads via `store.TryGetEntryAsync` (a peek, not `GetAsync`), so the coordinator must re-arm explicitly on each fresh-hit `return`: the **pre-lock** fresh hit (`FactoryCacheCoordinator.cs:51-54`) **and** the **under-lock** fresh hit (`:63-65`). The under-lock site is reachable — a concurrent writer can populate the entry between the pre-lock miss and lock acquisition — so it is a legitimate fresh return that must also re-arm, not dead code. Re-arm = best-effort `store.SetEntryAsync` with `logical = min(now + entry.SlidingExpiration, entry.PhysicalExpiresAt)`, physical + sliding unchanged; a failed re-arm still returns the hit. Two concurrent callers each re-arming once is benign (both push forward).
+**Execution note:** implement test-first — pure state-machine logic over the fake store.
+**Patterns to follow:** the existing fail-safe set/restamp computation in `FactoryCacheCoordinator`; `[LoggerMessage]` partial at file bottom if a re-arm-failure log is added.
+**Test suite design:** unit over `FakeFactoryCacheStore` + `FakeTimeProvider`, primary exhaustive coverage of the engine behavior; provider conformance (U7) re-proves end-to-end.
+**Test scenarios:**
+- `Covers R7.` Options with both `SlidingExpiration` and `IsFailSafeEnabled` → throws at the validation gate; factory not invoked.
+- `Covers R1.` Factory success with sliding set → `SetEntryAsync` called with `physical = now + Duration`, `logical = min(now + sliding, physical)`, `slidingExpiration` non-null.
+- `Covers R2.` Fresh-hit on a sliding entry re-arms: `SetEntryAsync` called with `logical = min(now + sliding, cap)`, physical unchanged; value returned `IsStale == false`.
+- `Covers R4.` Re-arm never pushes `logical` beyond `PhysicalExpiresAt` (set `now + sliding > cap` → re-armed logical clamps to cap).
+- `Covers R8.` Factory success with sliding `null` → `SetEntryAsync` called with `slidingExpiration: null`, `logical == physical == now + Duration` (today's behavior); fresh-hit does not re-arm.
+- `Covers R2.` Under-lock fresh-hit re-arms: simulate a concurrent populate (fake returns a miss pre-lock, a fresh sliding entry under-lock) → the under-lock return path also calls `SetEntryAsync` with the re-armed logical.
+- Re-arm write failure (fake faults `SetEntryAsync`) on the hit path → hit still returned (best-effort).
+**Verification:** planned unit tests added and passing; `make test-project TEST_PROJECT=tests/Headless.Caching.Core.Tests.Unit` green.
+
+### U3. Redis frame: encode/decode `SlidingExpiration`
+**Goal:** Extend the wire frame to carry the sliding window.
+**Requirements:** R1, R8.
+**Dependencies:** none (codec is self-contained; sequence before U5).
+**Files:**
+- `src/Headless.Caching.Redis/RedisCacheEntryFrame.cs` (modify — add `HasSlidingExpirationFlag = 1 << 3`, a **flag-conditional** 8-byte slot, a flag-derived payload offset, thread `slidingExpiration` through `Encode`/`Decode`/`DecodedFrame`)
+- `tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs` (extend — round-trip sliding; old-layout byte-compat; absence of the flag decodes `SlidingExpiration == null`)
+**Approach (the 8 sliding bytes are present ONLY when the flag is set — hard implementation note):** When `slidingExpiration` is non-null, set `HasSlidingExpirationFlag` and write 8 bytes (int64 ms) at offset 19, so the value payload starts at offset 27. When `slidingExpiration` is null, write **no** sliding bytes and the payload starts at offset 19 — **byte-identical to the pre-change frame**. The base header (logical at offset 3, physical at offset 11, `HeaderLength = 19`) is unchanged. **Decode must derive the payload offset from the flag, not a fixed `HeaderLength`:** `payloadOffset = (flags & HasSlidingExpirationFlag) != 0 ? 27 : 19`. If decode ever assumes a fixed 27-byte header, every old/non-sliding value's payload is read from the wrong offset and corrupts — this is the load-bearing correctness point of this unit. **Keep the `Version` byte at `0x01`** — `Decode` throws `NotSupportedException` on a version mismatch (`RedisCacheEntryFrame.cs:72-75`), so a version bump would make pre-change frames decode-throw (the flag-gated, zero-extra-bytes-when-absent layout is what makes `0x01` safe). Update `_IsOutOfRange` to cover the sliding field only when the flag is set. **Greenfield:** no migration required.
+**Patterns to follow:** the existing logical/physical flag+field encoding in `RedisCacheEntryFrame`; `_IsOutOfRange` validation.
+**Test suite design:** the frame is exercised by the Redis integration project's format tests (it is `internal`); cover encode/decode round-trips there.
+**Test scenarios:**
+- Encode with `SlidingExpiration` set → decode yields the same window; `HasSlidingExpirationFlag` set; payload at offset 27.
+- `Covers R8.` Encode with `slidingExpiration: null` → `HasSlidingExpirationFlag` cleared; **no sliding bytes written**; payload at offset 19; the encoded `byte[]` is identical to a pre-change frame for the same value/timestamps.
+- **Strict old-layout decode:** given a `byte[]` produced by the pre-change 19-byte-header encoder, decode reads the payload from offset 19 (not 27), returns the exact original value (no payload shift/corruption), and `SlidingExpiration == null`.
+- Out-of-range sliding bytes (flag set) → frame reads as unframed/miss (consistent with the existing timestamp guard).
+**Verification:** planned tests added and passing; `make test-project TEST_PROJECT=tests/Headless.Caching.Redis.Tests.Integration` green (Docker).
+
+### U4. `InMemoryCache`: store sliding, re-arm on read
+**Goal:** Persist the sliding window in the in-process entry and re-arm it on value-returning reads.
+**Requirements:** R1, R2, R3, R4, R6, R8.
+**Dependencies:** U2.
+**Files:**
+- `src/Headless.Caching.InMemory/InMemoryCache.cs` (modify — `CacheEntry` gains a `SlidingExpiration` slot; add a `WithLogicalExpiration(DateTime)` clone-sharing helper that preserves physical + sliding; `IFactoryCacheStore.SetEntryAsync` accepts + stores sliding; `IFactoryCacheStore.TryGetEntryAsync` surfaces it; `GetAsync` (and the delegating reads) re-arm sliding entries via value-equality `AddOrUpdate`; metadata reads left non-touching)
+- `tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs` (extend — memory-specific sliding cases)
+**Execution note:** turn the U7 conformance sliding scenarios green for the memory provider (authored failing in U7).
+**Approach:** Add `SlidingExpiration` to `CacheEntry` (carried through both public constructors and the private clone-sharing constructor). `SetEntryAsync` stores it. On a value-returning read of an entry with `SlidingExpiration` set and not past `PhysicalExpiresAt`: compute `newLogical = min(now + sliding, PhysicalExpiresAt)`, and if it advances the deadline, replace the entry via `AddOrUpdate` with the new **`WithLogicalExpiration(newLogical)`** helper — which keeps `PhysicalExpiresAt` (the cap) and `SlidingExpiration` unchanged (KTD-7; do **not** use `WithExpiration`, which moves both timestamps and would extend the cap). Re-arm is best-effort under the concurrent dictionary (a lost race just means another reader's re-arm wins — both push forward) and **throttled** per KTD-9 (re-arm only when `now - lastArm >= SlidingExpiration * RearmThreshold`) to avoid dictionary churn on hot keys. Extend the maintenance/eviction loop to evict sliding entries at their `LogicalExpiresAt` (idle deadline), not only `PhysicalExpiresAt` (KTD-7 active reclamation), and enqueue the logical deadline in the expiration queue (re-enqueued on re-arm). Any idle-evict path must use the value-equality `TryRemove(KeyValuePair)` overload, never key-only `_RemoveExpiredKey` (KTD-7 concurrency invariant). Metadata reads do not re-arm; `GetExpirationAsync` returns the current logical (sliding) deadline (KTD-5). `ExistsAsync`/`GetCountAsync`/`GetAllKeysByPrefixAsync` are non-touching.
+**Patterns to follow:** the `AddOrUpdate` flow in `_SetInternalAsync` and the value-equality evictor `TryRemove` (`InMemoryCache.cs` ~1965); the existing `WithExpiration` clone-sharing constructor (extend its private overload to carry sliding); `_TrackUpdate`; logical-governed read checks added for fail-safe.
+**Test suite design:** unit (memory provider, `FakeTimeProvider`); cross-provider parity owned by U7 — keep U4 to memory-specific concerns (eviction interplay, clone/LRU under re-arm, concurrent re-arm).
+**Test scenarios:**
+- `Covers R2.` Sliding entry, read within the window advances `LogicalExpiresAt` (assert via `TryGetEntryAsync` or `GetExpirationAsync` after a re-arming `GetAsync`).
+- `Covers R3.` Repeated reads each within the window keep the entry alive past the original sliding deadline; an idle gap > window → `GetAsync` miss.
+- `Covers R4.` Reads cannot extend past `createdAt + Duration`: after the cap, `GetAsync` miss even with continuous reads.
+- `Covers R4.` A re-arm leaves `PhysicalExpiresAt` (the cap) unchanged — read the entry's physical via `TryGetEntryAsync` before and after a re-arming `GetAsync` and assert it did not move (guards against the `WithExpiration` cap-extension bug).
+- `Covers R6.` `ExistsAsync`/`GetExpirationAsync` do not re-arm (deadline unchanged after a metadata read).
+- `Covers R10.` `GetExpirationAsync` on a sliding entry returns ≈ the current sliding remaining (logical deadline), not the absolute cap.
+- `Covers R11.` An idle sliding entry is removed by the maintenance loop at its idle (logical) deadline — assert `GetCountAsync`/memory size drops before the absolute cap, without an intervening read.
+- `Covers R12.` Hot-key reads do not re-arm on every read: with `RearmThreshold` set, N rapid reads within the threshold window produce far fewer than N store writes (assert bounded re-arm count via the test seam).
+- `Covers R8.` Non-sliding entry: read does not move the deadline; behavior identical to today.
+- Clone mode (`CloneValues=true`): a re-arm reuses the cloned value reference (no re-clone), returned value still a clone.
+- Concurrency: a re-arm racing the maintenance evictor does not drop the entry (value-equality `TryRemove` no-ops against the re-armed instance).
+**Verification:** planned unit tests added and passing; `make test-project-fast TEST_PROJECT=tests/Headless.Caching.InMemory.Tests.Unit` green; existing memory conformance unaffected.
+
+### U5. `RedisCache`: store sliding in frame, re-arm via `KeyExpire` on read
+**Goal:** Persist the window in the frame, drive eviction by key TTL, re-arm on value-returning reads without rewriting the value.
+**Requirements:** R1, R2, R3, R4, R6, R8.
+**Dependencies:** U2, U3.
+**Files:**
+- `src/Headless.Caching.Redis/RedisCache.cs` (modify — `IFactoryCacheStore.SetEntryAsync` encodes sliding + sets TTL to the sliding deadline; `_TryGetEntryAsync`/`_RedisValueToCacheValue` surface sliding and re-arm via `KeyExpireAsync`; metadata reads non-touching)
+- `tests/Headless.Caching.Redis.Tests.Integration/RedisCacheSlidingTests.cs` (create — TTL re-arm, idle expiry, cap ceiling)
+**Execution note:** turn the U7 conformance sliding scenarios green for the Redis provider (authored failing in U7).
+**Approach:** `SetEntryAsync`: encode `slidingExpiration` into the frame; derive the TTL with the **gated branch** `expiresIn = slidingExpiration is null ? (physical - now) : (logical - now)` (KTD-6b — non-sliding/fail-safe writes keep TTL-from-physical so the fail-safe reserve is not collapsed). On a value-returning read (`GetAsync` → `_RedisValueToCacheValue`, and the engine's `_TryGetEntryAsync`): when the frame has `SlidingExpiration` set, **skip the embedded-logical expiry check** — treat the entry as a hit while the key exists and `now < PhysicalExpiresAt` (cap), since the embedded logical is stale after the first re-arm (KTD-6); then re-arm `KeyExpireAsync(key, min(slidingExpiration, cap - now))` — best-effort, value not re-serialized. Non-sliding frames keep checking both logical and physical exactly as today (the carve-out is gated on the sliding flag). Use small real durations in tests (sliding 1s / cap 3s) to keep waits short. **No Lua** — `KeyExpireAsync` only. Metadata reads (`ExistsAsync`, `GetExpirationAsync`, key enumeration) do not call `KeyExpire`.
+**Patterns to follow:** `_SetInternalAsync`/`_ToFramedRedisValue`; `KeyExpireAsync` usage in `_SetListExpirationAsync`; the read decode path in `_RedisValueToCacheValue`; keyed-loader DI isolation (do not touch shared scripts).
+**Test suite design:** integration (Testcontainers Redis), existing Redis integration project; cross-provider parity owned by U7.
+**Test scenarios:**
+- `Covers R2.` Plant a sliding entry (TTL = window), read within the window → key TTL re-armed to the window (assert remaining TTL ≈ window after read).
+- `Covers R3.` Reads at sub-window intervals keep the key alive past the original window; an idle gap > window → key gone, `GetAsync` miss.
+- `Covers R3.` Re-armed key read after the *original* sliding window has elapsed (but TTL re-armed) → `GetAsync` returns the value, not `NoValue` (guards the stale-embedded-logical decode hole: decode must not reject on the frame's original logical).
+- `Covers R4.` Continuous reads cannot push the key past `createdAt + Duration` (cap): after the cap, `GetAsync` miss (the re-arm clamps TTL to `cap - now`, reaching ≤ 0).
+- `Covers R6.` `ExistsAsync`/`GetExpirationAsync` do not re-arm (TTL unchanged).
+- `Covers R10.` `GetExpirationAsync` after a re-arm returns the re-armed remaining (derived from key TTL), not the stale original embedded logical.
+- `Covers R12.` Throttle: N rapid reads within `SlidingExpiration * RearmThreshold` issue far fewer than N `KeyExpire` calls (assert via the test seam / a tracking `IDatabase` wrapper).
+- `Covers R8.` Non-sliding entry: TTL == `Duration`, reads do not re-arm; existing envelope-format behavior unchanged. Fail-safe entry (sliding null, physical > logical): TTL == physical window, **not** collapsed to logical (guards KTD-6b).
+**Verification:** planned integration tests added and passing; `make test-project TEST_PROJECT=tests/Headless.Caching.Redis.Tests.Integration` green (Docker).
+
+### U6. `HybridCache`: re-arm both tiers, bound L1
+**Goal:** Re-arm sliding across L1 and L2 on read while keeping L1 bounded by the local-expiration window.
+**Requirements:** R2, R3, R4, R5, R8.
+**Dependencies:** U4, U5.
+**Files:**
+- `src/Headless.Caching.Hybrid/HybridCache.cs` (modify — composite `SetEntryAsync` writes sliding to L2 (full deadline) and L1 (bounded by `DefaultLocalExpiration`); composite read re-arms both tiers; promote-from-L2 re-applies the L1 bound)
+- `tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSlidingTests.cs` (create)
+**Execution note:** if Hybrid is wired into the U7 conformance suite, turn those scenarios green here; otherwise author `HybridCacheSlidingTests` test-first against the composite.
+**Approach:** `SetEntryAsync` for a sliding entry: L2 gets the full `logical`/`physical`/`sliding`; L1 gets `l1Logical = min(logical, now + DefaultLocalExpiration)` and the same sliding window (so L1 re-arms within its bound). Composite read of a sliding hit re-arms L1 (bounded) and L2 (full); when L1's bound lapses, the read falls through to L2 and re-promotes with the bound. No backplane publish on a re-arm (sliding is a local TTL concern). Keep `HandleInvalidationAsync`/consumer untouched.
+**Patterns to follow:** the existing L1/L2 sequencing and the `min(…, DefaultLocalExpiration)` bound applied for fail-safe (#373); the non-fatal L2-write `try/catch`.
+**Test suite design:** unit (real `InMemoryCache` L1 + substitute/real L2, `FakeTimeProvider`/small durations), existing Hybrid unit project.
+**Test scenarios:**
+- `Covers R2.` Read of a sliding entry re-arms L1 and L2 deadlines.
+- `Covers R3.` Reads within the window keep the entry alive across tiers; idle gap > window → miss on both.
+- `Covers R4.` Cap ceiling holds across tiers.
+- L1 bound: a sliding deadline longer than `DefaultLocalExpiration` is capped in L1 but full in L2; after L1 lapses, the entry is served+re-promoted from L2.
+- `Covers R8.` Non-sliding entry: two-tier behavior identical to today.
+**Verification:** planned unit tests added and passing; `make test-project-fast TEST_PROJECT=tests/Headless.Caching.Hybrid.Tests.Unit` green; existing Hybrid tests unaffected.
+
+### U7. Cross-provider sliding conformance suite
+**Goal:** Prove identical sliding behavior across providers from one suite.
+**Requirements:** R5, R6, R8 (and R1–R4 per provider).
+**Dependencies:** U1, U2 (suite references only the public API + engine behavior). **Sequencing:** per the repo's harness-first rule, author this suite's sliding scenario methods **before U4–U6** as failing tests; each provider unit turns its slice green by supplying `CreateCache` + `AdvanceAsync`. Listed after the providers for reading order only.
+**Files:**
+- `tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs` (modify — add sliding conformance scenario methods using the existing `AdvanceAsync`/`ResetAsync`/`CreateCache` shape and a `_CreateSlidingOptions` helper mirroring `_CreateFailSafeOptions`)
+- `tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheConformanceTests.cs` (modify — inherit the new scenarios; `AdvanceAsync` via `FakeTimeProvider`)
+- `tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs` (modify — inherit the new scenarios; `AdvanceAsync` via small real delays)
+**Execution note:** harness-first — write the abstract sliding scenario methods (red) before the provider re-arm implementations exist.
+**Approach:** Add sliding scenarios that run against every provider using the existing `AdvanceAsync(TimeSpan)` time-advance seam. Keep the scenarios at the public-`ICache` level (`GetOrAddAsync` with `CacheEntryOptions.SlidingExpiration`, then `GetAsync` to re-arm, then `AdvanceAsync`).
+**Patterns to follow:** the existing fail-safe conformance methods + `_CreateFailSafeOptions` in `CacheConformanceTestsBase`.
+**Test suite design:** harness-owned conformance executed by Memory (unit) and Redis (integration) fixtures — the canonical same-behavior-per-backend guard.
+**Test scenarios (run per provider):**
+- `Covers R3.` Sliding entry read within the window before each advance survives past the original deadline; an idle advance > window → miss.
+- `Covers R2.` A read re-arms (read, advance < window, read again succeeds).
+- `Covers R4.` Continuous reads expire at the absolute cap.
+- `Covers R6.` `ExistsAsync` between reads does not re-arm.
+- `Covers R8.` Non-sliding default options → no re-arm on any provider.
+**Verification:** planned scenarios added and passing; `make test-unit` (memory) and `make test-integration` (redis) green; the same methods pass for both providers.
+
+### U8. Docs sync — `docs/llms/caching.md` + package READMEs
+**Goal:** Keep the agent-facing doc surfaces in lockstep with the new option and behavior.
+**Requirements:** R9.
+**Dependencies:** U1, U4, U5, U6 (final behavior settled).
+**Files:**
+- `docs/llms/caching.md` (modify — sliding concept, `SlidingExpiration` option + cap relationship, re-arm-on-read semantics + which reads re-arm (KTD-5), sliding⊕fail-safe exclusion (KTD-2), Redis TTL-as-clock note, per-provider notes, BCL/Session forward link to #383)
+- `src/Headless.Caching.Abstractions/README.md` (modify — `CacheEntryOptions.SlidingExpiration`)
+- `src/Headless.Caching.Core/README.md` (modify — engine re-arm contract + `SetEntryAsync` sliding parameter)
+- `src/Headless.Caching.InMemory/README.md`, `src/Headless.Caching.Redis/README.md`, `src/Headless.Caching.Hybrid/README.md` (modify — per-provider sliding behavior; Redis `KeyExpire` note; Hybrid L1 bound)
+**Approach:** Follow `docs/authoring/AUTHORING.md` (read first); docs explain concepts/trade-offs, not just API. Cover: the per-entry opt-in; `Duration` as the absolute cap; which reads re-arm vs which don't (KTD-5/R6); `GetExpirationAsync` returning the sliding deadline (Redis from key TTL — KTD-5/R10); the fail-safe exclusion framed as **unsupported-in-this-version** with the future-composition shape noted (KTD-2); the Redis TTL-as-clock + logical-agnostic-decode note (KTD-6); the throttled re-arm trade-off (KTD-9 — sliding precision vs write amplification); the InMemory active idle reclamation (KTD-7/R11); the Hybrid L1 bound; and the forward links that #383 maps the BCL `SlidingExpiration` and `Refresh` onto this.
+**Test suite design:** n/a (docs).
+**Test scenarios:** `Test expectation: none -- documentation only.`
+**Verification:** both surfaces updated and consistent; `AUTHORING.md` drift checks pass; sample snippets compile against the new API.
+
+---
+
+## Scope Boundaries
+
+### In scope
+- `CacheEntryOptions.SlidingExpiration` (factory path) + engine store primitive threading.
+- Re-arm-on-read across InMemory, Redis, Hybrid; absolute `Duration` ceiling.
+- Redis frame format bump (sliding field) + `KeyExpire`-based re-arm.
+- Cross-provider sliding conformance suite + docs sync.
+
+### Deferred to Follow-Up Work
+- Public direct-write sliding API on `ICache` (`Upsert` overloads) — owned by the BCL `IDistributedCache` adapter (#383), which maps `DistributedCacheEntryOptions.SlidingExpiration` onto the engine primitive.
+- **Public `RefreshAsync(key)` (re-arm without value materialization).** BCL `IDistributedCache.Refresh`/`RefreshAsync` is the explicit re-arm op and maps directly onto this slice's re-arm helper. This slice keeps re-arm a *read-path side effect* and does **not** add a public `RefreshAsync` to `ICache` (consistent with the factory-path-only write surface); the re-arm helper is factored to be reused, so #383 (or a follow-up) can expose `RefreshAsync` cheaply. Surface here as a known mapping, not built now.
+- BCL `IDistributedCache`/`HybridCache`/OutputCache adapters (#381/#382/#383) — the consumers of this capability.
+- A sliding × fail-safe composition — coherent but rejected in v1 (KTD-2): sliding re-arms logical, physical is the fail-safe reserve cap, stale reuse activates after the sliding logical deadline. No current use case; doubles the test matrix.
+- OpenTelemetry/event surfacing of re-arm activity (#384/#385).
+- A public/tunable re-arm threshold option (KTD-9 keeps `RearmThreshold` internal in v1).
+
+### Out of scope (not this product's direction here)
+- New Redis Lua / CAS scripts (KTD-6 avoids them; shared `ReplaceIfEqual`/`RemoveIfEqual` stay untouched).
+- Changing the eviction/maintenance loop's physical-expiry keying (sliding rides logical; the loop keeps keying on physical).
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Re-arm-on-read adds a write to the read path → contention/perf regression | Med | Med | Memory uses lock-free `AddOrUpdate` (re-arm races are benign — both push forward); Redis re-arm is a single best-effort `KeyExpire` (no value rewrite). Benchmark the read path under sliding in U4/U5; non-sliding reads skip re-arm entirely (R8). |
+| Redis frame format bump breaks decode of existing/non-sliding frames | Low | High | Flag-gated extension: cleared `HasSlidingExpirationFlag` means no sliding and the new bytes are not read; U3 explicitly tests pre-change-layout decode. Greenfield → no deployed data to migrate. |
+| Re-arm failure (e.g. Redis `KeyExpire` fails) silently shortens the window | Low | Low | Best-effort; the value is still returned and the next read retries the re-arm. Documented (KTD-6). |
+| Hybrid L1 pins memory for long sliding windows | Low | Med | L1 bounded by `DefaultLocalExpiration` (KTD-8), reusing the fail-safe bound; L2 holds the authoritative deadline. |
+| Sliding entry "never updates" (the FusionCache objection) | Low | Low | Hard ceiling at `Duration` (KTD-3) guarantees eventual eviction/refresh regardless of read frequency. |
+| Re-arm-on-`GetAsync` surprises consumers expecting a side-effect-free read | Low | Med | Greenfield posture; documented in U8 as the BCL-faithful behavior; only sliding entries (opt-in) are affected, and only value-returning reads (R6 keeps metadata reads pure). |
+
+**External dependencies:** none new. Builds on shipped #371/#372 (envelope) and #373 (engine). Docker required for Redis integration tests (U5, U7).
+
+---
+
+## Acceptance Examples
+
+- AE1 (R3): Entry created via `GetOrAddAsync` with `SlidingExpiration = 5m`, `Duration = 1h`. Read at T+4m, T+8m, T+12m (each within 5m of the prior) → all hits, the entry survives well past the original 5m deadline.
+- AE2 (R3): Same entry, last read at T+12m, next read at T+18m (6m idle > 5m window) → miss; the factory runs again.
+- AE3 (R4): Same entry read continuously every 1m → expires at T+1h (the absolute `Duration` cap), regardless of read frequency.
+- AE4 (R6): Between two reads, `ExistsAsync` is called → it returns `true` but does **not** push the deadline; the entry still expires on the original idle schedule.
+- AE5 (R7): `GetOrAddAsync` with both `SlidingExpiration = 5m` and `IsFailSafeEnabled = true` → throws at the validation gate; no entry written.
+- AE6 (R8): Default options (no sliding) → reads never move the deadline; behavior identical to today across all providers.
+
+---
+
+## Open Questions
+
+1. **Memory re-arm granularity** — only persist a re-arm when it advances the deadline by a meaningful delta, to avoid churning the concurrent dictionary on bursty reads? *(Lean: re-arm unconditionally for correctness in v1; add a min-delta throttle only if U4 benchmarks show churn.)*
+
+*(Resolved during planning — Redis `Version` byte stays `0x01`, KTD-6/U3; both `GetOrAddAsync` fresh-hit sites re-arm, including the reachable under-lock site, U2/KTD-5.)*
+
+---
+
+## Sources & Research
+
+- **Issue #377** (acceptance) and **roadmap #369** (M3 standard-interop sequencing; engine-first thesis). Dependencies **#371/#372** (envelope + Redis frame) and **#373** (engine) all shipped; downstream consumer **#383** (BCL `IDistributedCache` adapter).
+- **FusionCache (verified, load-bearing for KTD-2):** FusionCache deliberately has **no** sliding expiration — issue [#48 "Sliding Expiration"](https://github.com/ZiggyCreatures/FusionCache/issues/48) (closed), absent from `docs/Options.md`, no `SlidingExpiration` in the codebase. The author steers users to fail-safe + soft timeouts as the alternative, arguing sliding leads to entries that "keep sliding and never update." This grounds KTD-2 (sliding and fail-safe are alternatives, not composable) and KTD-3 (the required `Duration` cap defuses the "never expires" objection). FusionCache normalizes incoherent options with a log rather than throwing — considered and rejected for KTD-2 in favor of fail-fast.
+- **BCL parity targets:** `Microsoft.Extensions.Caching.StackExchangeRedis` (store metadata in the value, re-arm via `EXPIRE`) grounds KTD-6; `MemoryCache`'s read-with-write sliding grounds KTD-7; `DistributedCacheEntryOptions.SlidingExpiration` is the contract #383 maps onto.
+- **Sibling plan:** `docs/plans/2026-06-04-001-feat-cache-fail-safe-plan.md` (the engine + envelope this builds on; the L1/L2 bound reused in KTD-8).
+- **Code anchors:** engine `src/Headless.Caching.Core/FactoryCacheCoordinator.cs` (fresh-hit returns), `CacheStoreEntry.cs`/`IFactoryCacheStore.cs`; InMemory `src/Headless.Caching.InMemory/InMemoryCache.cs` (`CacheEntry` ~2056, `WithExpiration` ~2169, value-equality evictor ~1965, `GetAsync` ~1096); Redis `src/Headless.Caching.Redis/RedisCache.cs` (`_RedisValueToCacheValue` ~1017, `_TryGetEntryAsync` ~1162, `SetEntryAsync` ~1134) + `RedisCacheEntryFrame.cs` (offsets 3/11, `HeaderLength` 19); harness `tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs`.
+- **Plan hardened by an adversarial review pass** (substituted for the auth-blocked Antigravity reviewer): caught the `WithExpiration` cap-extension bug (B1→KTD-7/U4), the Redis stale-embedded-logical decode hole (B2a→KTD-6), the fail-safe TTL-collapse risk (B2b→KTD-6b), and the under-lock re-arm reachability (M1→U2).

--- a/src/Headless.Caching.Abstractions/Contracts/CacheEntryOptions.cs
+++ b/src/Headless.Caching.Abstractions/Contracts/CacheEntryOptions.cs
@@ -10,7 +10,8 @@ namespace Headless.Caching;
 /// This type is the extension point for factory-backed cache behaviors. <see cref="Duration"/>
 /// controls logical freshness. When fail-safe is enabled, the factory coordinator keeps the entry
 /// physically resident for <c>max(Duration, FailSafeMaxDuration)</c> so <c>GetOrAddAsync</c> can serve
-/// the last-known-good value after a factory failure.
+/// the last-known-good value after a factory failure. When <see cref="SlidingExpiration"/> is set,
+/// <see cref="Duration"/> remains the absolute ceiling while successful value reads re-arm the idle deadline.
 /// </remarks>
 [PublicAPI]
 public readonly record struct CacheEntryOptions
@@ -33,6 +34,14 @@ public readonly record struct CacheEntryOptions
     /// rejected with an <see cref="ArgumentOutOfRangeException"/> when the entry is created.
     /// </summary>
     public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// Gets the optional idle window for sliding expiration. When set, value-returning reads push the logical
+    /// expiration to <c>min(now + SlidingExpiration, createdAt + Duration)</c>; values greater than or equal to
+    /// <see cref="Duration"/> therefore behave like a fixed duration. Sliding expiration and fail-safe are not
+    /// supported together in this version and are rejected by the factory coordinator.
+    /// </summary>
+    public TimeSpan? SlidingExpiration { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether factory-backed cache operations can serve the physically-retained

--- a/src/Headless.Caching.Abstractions/README.md
+++ b/src/Headless.Caching.Abstractions/README.md
@@ -18,11 +18,13 @@ Provides a provider-agnostic caching API, enabling seamless switching between me
 - `IRemoteCache` - Marker interface for remote implementations
 - `ICache<T>` - Strongly-typed cache wrapper
 - `CacheValue<T>` - Cache result with `HasValue` semantics and an `IsStale` flag when fail-safe serves a stale value.
-- `CacheEntryOptions` - Factory-backed entry options: `Duration`, `IsFailSafeEnabled`, `FailSafeMaxDuration`, and `FailSafeThrottleDuration`.
+- `CacheEntryOptions` - Factory-backed entry options: `Duration`, `SlidingExpiration`, `IsFailSafeEnabled`, `FailSafeMaxDuration`, and `FailSafeThrottleDuration`.
 
 ## Design Notes
 
 `GetOrAddAsync` accepts `CacheEntryOptions` so factory-backed cache entries have a stable extension point for fail-safe, factory timeout, refresh, and tagging features. A `TimeSpan` converts implicitly to `CacheEntryOptions`, so positional duration-only call sites keep their shorthand while explicit options are available when a caller wants to name the duration. This is a greenfield public API break for named arguments: callers using `expiration: ...` on `GetOrAddAsync` must rename that argument to `options: ...`.
+
+`SlidingExpiration` is an optional idle window for factory-backed entries. `Duration` remains the absolute cap from entry creation, and value-returning reads re-arm the logical deadline to `min(now + SlidingExpiration, createdAt + Duration)`. Metadata reads do not re-arm. Sliding expiration and fail-safe are rejected together in this version.
 
 Fail-safe is opt-in and only applies to `GetOrAddAsync`. Direct writes keep the `TimeSpan?` API and write logical expiration equal to physical expiration. A stale value served by fail-safe returns `CacheValue<T>.IsStale = true` only for the activating call; reads during the throttle window are logical hits and return `IsStale = false`.
 

--- a/src/Headless.Caching.Core/CacheStoreEntry.cs
+++ b/src/Headless.Caching.Core/CacheStoreEntry.cs
@@ -10,13 +10,15 @@ namespace Headless.Caching;
 /// <param name="Value">The cached value.</param>
 /// <param name="LogicalExpiresAt">The timestamp after which normal reads treat the entry as stale.</param>
 /// <param name="PhysicalExpiresAt">The timestamp after which the entry is no longer retained.</param>
+/// <param name="SlidingExpiration">The optional idle window used to re-arm logical expiration on value reads.</param>
 [PublicAPI]
 public readonly record struct CacheStoreEntry<T>(
     bool Found,
     bool IsNull,
     T? Value,
     DateTime? LogicalExpiresAt,
-    DateTime? PhysicalExpiresAt
+    DateTime? PhysicalExpiresAt,
+    TimeSpan? SlidingExpiration
 )
 {
     /// <summary>Gets an entry representing a store miss.</summary>
@@ -25,7 +27,8 @@ public readonly record struct CacheStoreEntry<T>(
         IsNull: false,
         Value: default,
         LogicalExpiresAt: null,
-        PhysicalExpiresAt: null
+        PhysicalExpiresAt: null,
+        SlidingExpiration: null
     );
 }
 

--- a/src/Headless.Caching.Core/FactoryCacheCoordinator.cs
+++ b/src/Headless.Caching.Core/FactoryCacheCoordinator.cs
@@ -41,13 +41,15 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
         {
             Argument.IsPositive(configuredSlidingExpiration);
 
-            if (options.IsFailSafeEnabled)
-            {
-                throw new ArgumentException(
-                    "Sliding expiration and fail-safe are not supported together in this version.",
-                    nameof(options)
-                );
-            }
+            // Redis encodes the idle window as whole milliseconds; a sub-millisecond span floors to 0 and the
+            // frame then decodes as unframed (silent value loss), while in-memory would keep it natively. Reject
+            // it at the single sliding write choke point so every provider behaves identically.
+            Argument.IsGreaterThanOrEqualTo(configuredSlidingExpiration, TimeSpan.FromMilliseconds(1));
+
+            Ensure.False(
+                options.IsFailSafeEnabled,
+                "Sliding expiration and fail-safe are not supported together in this version."
+            );
         }
 
         if (options.IsFailSafeEnabled)
@@ -191,25 +193,22 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
             return;
         }
 
-        var logicalExpiresAt = _Min(now.Add(slidingExpiration), physicalExpiresAt);
-
-        if (entry.LogicalExpiresAt.HasValue && entry.LogicalExpiresAt.Value >= logicalExpiresAt)
+        // Nothing left to extend once the physical cap has passed.
+        if (physicalExpiresAt <= now)
         {
             return;
         }
 
         try
         {
+            // Delegate to the provider's metadata-only, throttled primitive instead of rewriting the whole value.
+            // The throttle and the "only extend" / physical-cap rules live in the store, which is the only layer
+            // that cheaply knows the entry's true remaining lifetime (Redis key TTL / in-memory logical deadline);
+            // after a metadata-only re-arm the coordinator's embedded logical is no longer authoritative, so the
+            // decision cannot be made here. CancellationToken.None: a caller cancellation must not abort the
+            // best-effort re-arm of a value read that already succeeded.
             await store
-                .SetEntryAsync(
-                    key,
-                    entry.Value,
-                    entry.IsNull,
-                    logicalExpiresAt,
-                    physicalExpiresAt,
-                    slidingExpiration,
-                    CancellationToken.None
-                )
+                .TryRearmSlidingAsync(key, slidingExpiration, physicalExpiresAt, now, CancellationToken.None)
                 .ConfigureAwait(false);
         }
         catch (Exception exception)

--- a/src/Headless.Caching.Core/FactoryCacheCoordinator.cs
+++ b/src/Headless.Caching.Core/FactoryCacheCoordinator.cs
@@ -37,6 +37,19 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
         Argument.IsNotNull(factory);
         Argument.IsPositive(options.Duration);
 
+        if (options.SlidingExpiration is { } configuredSlidingExpiration)
+        {
+            Argument.IsPositive(configuredSlidingExpiration);
+
+            if (options.IsFailSafeEnabled)
+            {
+                throw new ArgumentException(
+                    "Sliding expiration and fail-safe are not supported together in this version.",
+                    nameof(options)
+                );
+            }
+        }
+
         if (options.IsFailSafeEnabled)
         {
             Argument.IsPositive(options.FailSafeMaxDuration);
@@ -50,6 +63,7 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
 
         if (entry.IsFresh(now))
         {
+            await _TryRearmSlidingEntryAsync(store, key, entry, now).ConfigureAwait(false);
             return _ToCacheValue(entry, isStale: false);
         }
 
@@ -62,6 +76,7 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
 
             if (entry.IsFresh(now))
             {
+                await _TryRearmSlidingEntryAsync(store, key, entry, now).ConfigureAwait(false);
                 return _ToCacheValue(entry, isStale: false);
             }
 
@@ -99,9 +114,23 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
                 ? _Max(options.Duration, options.FailSafeMaxDuration)
                 : options.Duration;
             var physicalExpiresAt = now.Add(physicalDuration);
+            var slidingExpiration = options.SlidingExpiration;
+
+            if (slidingExpiration.HasValue)
+            {
+                logicalExpiresAt = _Min(now.Add(slidingExpiration.Value), physicalExpiresAt);
+            }
 
             await store
-                .SetEntryAsync(key, value, isNull: value is null, logicalExpiresAt, physicalExpiresAt, cancellationToken)
+                .SetEntryAsync(
+                    key,
+                    value,
+                    isNull: value is null,
+                    logicalExpiresAt,
+                    physicalExpiresAt,
+                    slidingExpiration,
+                    cancellationToken
+                )
                 .ConfigureAwait(false);
 
             return new CacheValue<T>(value, hasValue: true);
@@ -138,6 +167,7 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
                     staleCandidate.IsNull,
                     logicalExpiresAt,
                     physicalExpiresAt,
+                    slidingExpiration: null,
                     CancellationToken.None
                 )
                 .ConfigureAwait(false);
@@ -146,6 +176,45 @@ public sealed class FactoryCacheCoordinator(TimeProvider timeProvider, ILogger? 
         {
             // Swallow all exceptions (including cancellation): the stale value must always be returned.
             _logger.LogFailSafeRestampFailed(exception, key);
+        }
+    }
+
+    private async ValueTask _TryRearmSlidingEntryAsync<T>(
+        IFactoryCacheStore store,
+        string key,
+        CacheStoreEntry<T> entry,
+        DateTime now
+    )
+    {
+        if (entry.SlidingExpiration is not { } slidingExpiration || entry.PhysicalExpiresAt is not { } physicalExpiresAt)
+        {
+            return;
+        }
+
+        var logicalExpiresAt = _Min(now.Add(slidingExpiration), physicalExpiresAt);
+
+        if (entry.LogicalExpiresAt.HasValue && entry.LogicalExpiresAt.Value >= logicalExpiresAt)
+        {
+            return;
+        }
+
+        try
+        {
+            await store
+                .SetEntryAsync(
+                    key,
+                    entry.Value,
+                    entry.IsNull,
+                    logicalExpiresAt,
+                    physicalExpiresAt,
+                    slidingExpiration,
+                    CancellationToken.None
+                )
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogSlidingExpirationRearmFailed(exception, key);
         }
     }
 
@@ -245,4 +314,12 @@ internal static partial class FactoryCacheCoordinatorLog
         Message = "Cache store read failed for key {Key}; treating it as a cache miss."
     )]
     public static partial void LogCacheStoreReadFailed(this ILogger logger, Exception exception, string key);
+
+    [LoggerMessage(
+        EventId = 4,
+        EventName = "CacheSlidingExpirationRearmFailed",
+        Level = LogLevel.Debug,
+        Message = "Cache sliding-expiration re-arm failed for key {Key}; the cached value will still be returned."
+    )]
+    public static partial void LogSlidingExpirationRearmFailed(this ILogger logger, Exception exception, string key);
 }

--- a/src/Headless.Caching.Core/IFactoryCacheStore.cs
+++ b/src/Headless.Caching.Core/IFactoryCacheStore.cs
@@ -38,4 +38,33 @@ public interface IFactoryCacheStore
         TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     );
+
+    /// <summary>
+    /// Re-arms a sliding entry's logical expiration on a fresh read, extending it by the idle window without
+    /// rewriting the stored value.
+    /// </summary>
+    /// <remarks>
+    /// This is a metadata-only TTL bump, not a value write: implementations must extend the existing entry in
+    /// place (Redis <c>KeyExpire</c>, in-memory logical-expiration swap) rather than re-encode and re-store the
+    /// payload. Implementations must (a) only ever extend, never shorten, the entry's lifetime, (b) cap the new
+    /// logical deadline at <paramref name="physicalExpiresAt"/>, (c) throttle so a hot key is not re-armed on
+    /// every read (re-arm only once roughly half the idle window has elapsed), and (d) treat the call as
+    /// best-effort — a re-arm failure must not surface to the caller, because the value read already succeeded.
+    /// It is a no-op when the entry is missing or already past its physical cap.
+    /// </remarks>
+    /// <param name="key">The cache key.</param>
+    /// <param name="slidingExpiration">The idle window to extend logical expiration by.</param>
+    /// <param name="physicalExpiresAt">The physical (retention) cap the re-armed logical deadline must not exceed.</param>
+    /// <param name="now">
+    /// The reference UTC time for the re-arm, supplied by the caller so it matches the freshness check that
+    /// preceded it. Implementations use it to compute the new logical deadline and the throttle decision.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    ValueTask TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/Headless.Caching.Core/IFactoryCacheStore.cs
+++ b/src/Headless.Caching.Core/IFactoryCacheStore.cs
@@ -27,6 +27,7 @@ public interface IFactoryCacheStore
     /// <param name="isNull">Whether the stored value is the cache null sentinel.</param>
     /// <param name="logicalExpiresAt">The logical expiration timestamp.</param>
     /// <param name="physicalExpiresAt">The physical expiration timestamp.</param>
+    /// <param name="slidingExpiration">The optional idle window used to re-arm logical expiration.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     ValueTask SetEntryAsync<T>(
         string key,
@@ -34,6 +35,7 @@ public interface IFactoryCacheStore
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     );
 }

--- a/src/Headless.Caching.Core/README.md
+++ b/src/Headless.Caching.Core/README.md
@@ -10,14 +10,14 @@ Centralizes the `GetOrAddAsync` state machine so memory, Redis, and hybrid provi
 
 - `FactoryCacheCoordinator` - shared factory orchestration engine.
 - `IFactoryCacheStore` - provider primitive for metadata-aware entry reads and writes.
-- `CacheStoreEntry<T>` - logical and physical expiration snapshot used by the coordinator.
+- `CacheStoreEntry<T>` - logical, physical, and optional sliding expiration snapshot used by the coordinator.
 - `CacheStoreEntryExtensions` - shared `IsFresh`/`IsPhysicallyPresent` predicates so every provider and the coordinator agree on the expiration boundary (an entry is expired at the exact tick, `expiresAt <= now`).
 - `FactoryCacheCoordinator.IsCallerCancellation` - shared predicate provider composites use so caller cancellation propagates while an unrelated/downstream `OperationCanceledException` activates fail-safe consistently.
 - Fail-safe activation log when stale data is served.
 
 ## Design Notes
 
-Providers construct the coordinator directly with their `TimeProvider` and logger; the Core package has no DI setup. Store read failures are treated as misses, and fail-safe restamp writes are best-effort so a stale value can still be returned when the backing store is unhealthy. Cancellation is classified by token identity: the caller's own cancellation propagates and never activates fail-safe, while an `OperationCanceledException` from an unrelated or downstream token is treated as a failure that activates fail-safe.
+Providers construct the coordinator directly with their `TimeProvider` and logger; the Core package has no DI setup. Store read failures are treated as misses, fail-safe restamp writes are best-effort, and sliding re-arm writes are best-effort so a cached value can still be returned when the backing store is unhealthy. Cancellation is classified by token identity: the caller's own cancellation propagates and never activates fail-safe, while an `OperationCanceledException` from an unrelated or downstream token is treated as a failure that activates fail-safe. Sliding expiration and fail-safe are rejected together because one needs value reads to extend the logical deadline while the other needs logical expiration to expose a stale reserve.
 
 ## Installation
 

--- a/src/Headless.Caching.Hybrid/HybridCache.cs
+++ b/src/Headless.Caching.Hybrid/HybridCache.cs
@@ -1024,6 +1024,7 @@ public sealed class HybridCache(
 
         var now = _GetUtcNow();
         CacheStoreEntry<T>? l1StaleCandidate = null;
+        var l1SlidingHit = false;
 
         if (LocalCache is IFactoryCacheStore l1Store)
         {
@@ -1033,10 +1034,18 @@ public sealed class HybridCache(
             {
                 _logger.LogLocalCacheHit(key);
                 Interlocked.Increment(ref _localCacheHits);
-                return l1Entry;
-            }
 
-            if (l1Entry.IsPhysicallyPresent(now))
+                if (!l1Entry.SlidingExpiration.HasValue)
+                {
+                    return l1Entry;
+                }
+
+                // Sliding entries need the L2 physical cap for safe re-arm. A local entry may be physically
+                // capped by DefaultLocalExpiration, so use it only as a no-rearm fallback if L2 is unavailable.
+                l1SlidingHit = true;
+                l1StaleCandidate = l1Entry with { SlidingExpiration = null };
+            }
+            else if (l1Entry.IsPhysicallyPresent(now))
             {
                 l1StaleCandidate = l1Entry;
             }
@@ -1054,12 +1063,16 @@ public sealed class HybridCache(
                     IsNull: l1Value.IsNull,
                     Value: l1Value.Value,
                     LogicalExpiresAt: null,
-                    PhysicalExpiresAt: null
+                    PhysicalExpiresAt: null,
+                    SlidingExpiration: null
                 );
             }
         }
 
-        _logger.LogLocalCacheMiss(key);
+        if (!l1SlidingHit)
+        {
+            _logger.LogLocalCacheMiss(key);
+        }
 
         if (l2Cache is not IFactoryCacheStore l2Store)
         {
@@ -1096,6 +1109,7 @@ public sealed class HybridCache(
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     )
         where T : default
@@ -1109,7 +1123,15 @@ public sealed class HybridCache(
             try
             {
                 await l2Store
-                    .SetEntryAsync(key, value, isNull, logicalExpiresAt, physicalExpiresAt, cancellationToken)
+                    .SetEntryAsync(
+                        key,
+                        value,
+                        isNull,
+                        logicalExpiresAt,
+                        physicalExpiresAt,
+                        slidingExpiration,
+                        cancellationToken
+                    )
                     .ConfigureAwait(false);
             }
             catch (Exception exception) when (!FactoryCacheCoordinator.IsCallerCancellation(exception, cancellationToken))
@@ -1119,7 +1141,7 @@ public sealed class HybridCache(
         }
         else
         {
-            var expiresIn = physicalExpiresAt.Subtract(_GetUtcNow());
+            var expiresIn = (slidingExpiration is null ? physicalExpiresAt : logicalExpiresAt).Subtract(_GetUtcNow());
 
             try
             {
@@ -1140,7 +1162,8 @@ public sealed class HybridCache(
                 IsNull: isNull,
                 Value: isNull ? default : value,
                 LogicalExpiresAt: logicalExpiresAt,
-                PhysicalExpiresAt: physicalExpiresAt
+                PhysicalExpiresAt: physicalExpiresAt,
+                SlidingExpiration: slidingExpiration
             );
 
             await _SetLocalEntryAsync(l1Store, key, entry, cancellationToken).ConfigureAwait(false);
@@ -1184,7 +1207,15 @@ public sealed class HybridCache(
             }
 
             await l1Store
-                .SetEntryAsync(key, entry.Value, entry.IsNull, localCeiling.Value, localCeiling.Value, cancellationToken)
+                .SetEntryAsync(
+                    key,
+                    entry.Value,
+                    entry.IsNull,
+                    localCeiling.Value,
+                    localCeiling.Value,
+                    slidingExpiration: null,
+                    cancellationToken
+                )
                 .ConfigureAwait(false);
 
             return;
@@ -1194,7 +1225,15 @@ public sealed class HybridCache(
         var physicalExpiresAt = localCeiling.HasValue ? _Min(entry.PhysicalExpiresAt.Value, localCeiling.Value) : entry.PhysicalExpiresAt.Value;
 
         await l1Store
-            .SetEntryAsync(key, entry.Value, entry.IsNull, logicalExpiresAt, physicalExpiresAt, cancellationToken)
+            .SetEntryAsync(
+                key,
+                entry.Value,
+                entry.IsNull,
+                logicalExpiresAt,
+                physicalExpiresAt,
+                entry.SlidingExpiration,
+                cancellationToken
+            )
             .ConfigureAwait(false);
     }
 

--- a/src/Headless.Caching.Hybrid/HybridCache.cs
+++ b/src/Headless.Caching.Hybrid/HybridCache.cs
@@ -1181,6 +1181,43 @@ public sealed class HybridCache(
         }
     }
 
+    async ValueTask IFactoryCacheStore.TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        _ThrowIfDisposed();
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Re-arm both tiers (KTD-8). L2 carries the authoritative physical cap; L1's own re-arm bounds the new
+        // logical deadline by its locally-capped entry metadata, so passing the L2 cap is safe. L2 is best-effort
+        // (a remote hiccup must not fail the read); L1 is in-process and effectively infallible.
+        if (l2Cache is IFactoryCacheStore l2Store)
+        {
+            try
+            {
+                await l2Store
+                    .TryRearmSlidingAsync(key, slidingExpiration, physicalExpiresAt, now, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception) when (!FactoryCacheCoordinator.IsCallerCancellation(exception, cancellationToken))
+            {
+                _logger.LogFailedToWriteToL2Cache(exception, key);
+            }
+        }
+
+        if (LocalCache is IFactoryCacheStore l1Store)
+        {
+            await l1Store
+                .TryRearmSlidingAsync(key, slidingExpiration, physicalExpiresAt, now, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
     private async ValueTask _SetLocalEntryAsync<T>(
         IFactoryCacheStore l1Store,
         string key,

--- a/src/Headless.Caching.Hybrid/README.md
+++ b/src/Headless.Caching.Hybrid/README.md
@@ -90,6 +90,8 @@ public sealed class ProductService(ICache cache, IProductRepository repository)
 | `DefaultLocalExpiration` | `5 minutes` | Default L1 TTL (uses L2 TTL if null) |
 | `InstanceId` | Auto-generated | Unique ID for filtering self-originated messages |
 
+For factory-backed sliding entries, `DefaultLocalExpiration` caps the L1 copy only. Hybrid revalidates sliding L1 hits against L2 before re-arm so L2 keeps the original `Duration` as the absolute cap. If L2 is unavailable, a fresh L1 sliding value can still be returned, but the read is not re-armed.
+
 ## Exception Handling
 
 | Scenario | Behavior |

--- a/src/Headless.Caching.InMemory/InMemoryCache.cs
+++ b/src/Headless.Caching.InMemory/InMemoryCache.cs
@@ -14,6 +14,8 @@ namespace Headless.Caching;
 /// <summary>In-memory cache implementation with LRU eviction, expiration, and list/set operations.</summary>
 public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposable
 {
+    private const double _SlidingRearmThreshold = 0.5d;
+
     private readonly ConcurrentDictionary<string, CacheEntry> _memory = new(StringComparer.Ordinal);
     private readonly PriorityQueue<string, long> _expirationQueue = new();
     private readonly Lock _expirationLock = new();
@@ -1108,18 +1110,25 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
 
         if (existingEntry.IsExpired)
         {
-            _RemoveExpiredKey(key);
+            _TryRemoveExpiredEntry(key, existingEntry);
             return new ValueTask<CacheValue<T>>(CacheValue<T>.NoValue);
         }
 
         if (existingEntry.IsLogicallyExpired)
         {
+            if (existingEntry.SlidingExpiration.HasValue)
+            {
+                _TryRemoveExpiredEntry(key, existingEntry);
+            }
+
             return new ValueTask<CacheValue<T>>(CacheValue<T>.NoValue);
         }
 
         try
         {
             var value = existingEntry.GetValue<T>();
+            _TryRearmSlidingEntry(key, existingEntry);
+
             return new ValueTask<CacheValue<T>>(new CacheValue<T>(value, hasValue: true));
         }
         catch (Exception ex) when (!_shouldThrowOnSerializationError)
@@ -1606,7 +1615,8 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
                 IsNull: value is null,
                 Value: value,
                 LogicalExpiresAt: existingEntry.LogicalExpiresAt,
-                PhysicalExpiresAt: existingEntry.PhysicalExpiresAt
+                PhysicalExpiresAt: existingEntry.PhysicalExpiresAt,
+                SlidingExpiration: existingEntry.SlidingExpiration
             )
         );
     }
@@ -1617,6 +1627,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     )
         where T : default
@@ -1637,6 +1648,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
             isNull ? default : value,
             logicalExpiresAt,
             physicalExpiresAt,
+            slidingExpiration,
             _timeProvider,
             _shouldClone,
             _shouldThrowOnSerializationError,
@@ -1688,6 +1700,56 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         if (_memory.TryRemove(key, out var removedEntry))
         {
             Interlocked.Add(ref _currentMemorySize, -removedEntry.Size);
+        }
+    }
+
+    private void _TryRemoveExpiredEntry(string key, CacheEntry entry)
+    {
+        if (_memory.TryRemove(new KeyValuePair<string, CacheEntry>(key, entry)))
+        {
+            Interlocked.Add(ref _currentMemorySize, -entry.Size);
+        }
+    }
+
+    private void _TryRearmSlidingEntry(string key, CacheEntry entry)
+    {
+        if (
+            entry.SlidingExpiration is not { } slidingExpiration
+            || entry.LogicalExpiresAt is not { } logicalExpiresAt
+            || entry.PhysicalExpiresAt is not { } physicalExpiresAt
+        )
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        if (physicalExpiresAt <= now)
+        {
+            return;
+        }
+
+        var remaining = logicalExpiresAt - now;
+        var rearmThreshold = TimeSpan.FromTicks((long)(slidingExpiration.Ticks * _SlidingRearmThreshold));
+
+        if (remaining > rearmThreshold)
+        {
+            return;
+        }
+
+        var rearmedLogicalExpiresAt = _Min(now.Add(slidingExpiration), physicalExpiresAt);
+
+        if (rearmedLogicalExpiresAt <= logicalExpiresAt)
+        {
+            return;
+        }
+
+        var rearmedEntry = entry.WithLogicalExpiration(rearmedLogicalExpiresAt);
+
+        if (_memory.TryUpdate(key, rearmedEntry, entry))
+        {
+            _TrackUpdate(key, rearmedEntry.TrackedExpiresAt);
+            _ = _StartMaintenanceAsync();
         }
     }
 
@@ -1750,7 +1812,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
 
         if (wasUpdated)
         {
-            _TrackUpdate(key, entry.PhysicalExpiresAt);
+            _TrackUpdate(key, entry.TrackedExpiresAt);
         }
 
         await _StartMaintenanceAsync(ShouldCompact).ConfigureAwait(false);
@@ -1960,7 +2022,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
 
                     if (key is not null && _memory.TryGetValue(key, out var entry))
                     {
-                        if (entry.PhysicalExpiresAt.HasValue && entry.PhysicalExpiresAt.Value.Ticks <= expiresAtTicks)
+                        if (entry.ShouldRemoveAt(expiresAtTicks))
                         {
                             if (_memory.TryRemove(new KeyValuePair<string, CacheEntry>(key, entry)))
                             {
@@ -2074,6 +2136,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
                 value,
                 logicalExpiresAt: expiresAt,
                 physicalExpiresAt: expiresAt,
+                slidingExpiration: null,
                 timeProvider,
                 shouldClone,
                 shouldThrowOnSerializationError,
@@ -2084,6 +2147,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
             object? value,
             DateTime? logicalExpiresAt,
             DateTime? physicalExpiresAt,
+            TimeSpan? slidingExpiration,
             TimeProvider timeProvider,
             bool shouldClone,
             bool shouldThrowOnSerializationError = true,
@@ -2101,6 +2165,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
             _lastAccessTicks = utcNow.Ticks;
             LogicalExpiresAt = logicalExpiresAt;
             PhysicalExpiresAt = physicalExpiresAt;
+            SlidingExpiration = slidingExpiration;
             LastFactoryError = lastFactoryError;
             Tags = tags is { Count: > 0 } ? tags.ToFrozenSet(StringComparer.Ordinal) : null;
             Size = size;
@@ -2109,7 +2174,12 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
 
         /// <summary>Private constructor used by <see cref="WithExpiration"/> to share the already-cloned
         /// value without re-cloning.</summary>
-        private CacheEntry(CacheEntry prototype, DateTime? logicalExpiresAt, DateTime? physicalExpiresAt)
+        private CacheEntry(
+            CacheEntry prototype,
+            DateTime? logicalExpiresAt,
+            DateTime? physicalExpiresAt,
+            TimeSpan? slidingExpiration
+        )
         {
             _timeProvider = prototype._timeProvider;
             _shouldClone = prototype._shouldClone;
@@ -2118,6 +2188,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
             _lastAccessTicks = _timeProvider.GetUtcNow().Ticks;
             LogicalExpiresAt = logicalExpiresAt;
             PhysicalExpiresAt = physicalExpiresAt;
+            SlidingExpiration = slidingExpiration;
             LastFactoryError = prototype.LastFactoryError;
             Tags = prototype.Tags;
             Size = prototype.Size;
@@ -2129,6 +2200,10 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         internal DateTime? LogicalExpiresAt { get; }
 
         internal DateTime? PhysicalExpiresAt { get; }
+
+        internal TimeSpan? SlidingExpiration { get; }
+
+        internal DateTime? TrackedExpiresAt => SlidingExpiration.HasValue ? LogicalExpiresAt : PhysicalExpiresAt;
 
         internal LastFactoryError? LastFactoryError { get; }
 
@@ -2142,6 +2217,18 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
 
         internal bool IsLogicallyExpired =>
             LogicalExpiresAt.HasValue && LogicalExpiresAt <= _timeProvider.GetUtcNow().UtcDateTime;
+
+        internal bool ShouldRemoveAt(long expiresAtTicks)
+        {
+            if (PhysicalExpiresAt.HasValue && PhysicalExpiresAt.Value.Ticks <= expiresAtTicks)
+            {
+                return true;
+            }
+
+            return SlidingExpiration.HasValue
+                && LogicalExpiresAt.HasValue
+                && LogicalExpiresAt.Value.Ticks <= expiresAtTicks;
+        }
 
         internal long LastAccessTicks => Interlocked.Read(ref _lastAccessTicks);
 
@@ -2167,7 +2254,11 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         /// <summary>Returns a new entry that shares this entry's value but has a different
         /// expiration. Used by writers that only need to refresh the TTL.</summary>
         internal CacheEntry WithExpiration(DateTime? expiresAt) =>
-            new(this, logicalExpiresAt: expiresAt, physicalExpiresAt: expiresAt);
+            new(this, logicalExpiresAt: expiresAt, physicalExpiresAt: expiresAt, slidingExpiration: null);
+
+        /// <summary>Returns a new entry that shares this entry's value but only moves logical expiration.</summary>
+        internal CacheEntry WithLogicalExpiration(DateTime logicalExpiresAt) =>
+            new(this, logicalExpiresAt, PhysicalExpiresAt, SlidingExpiration);
 
         public T? GetValue<T>() => _ConvertValue<T>(ReadValue());
 
@@ -2310,6 +2401,8 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
 
         return hasInfinite ? null : max;
     }
+
+    private static DateTime _Min(DateTime left, DateTime right) => left <= right ? left : right;
 
     #endregion
 }

--- a/src/Headless.Caching.InMemory/InMemoryCache.cs
+++ b/src/Headless.Caching.InMemory/InMemoryCache.cs
@@ -14,8 +14,6 @@ namespace Headless.Caching;
 /// <summary>In-memory cache implementation with LRU eviction, expiration, and list/set operations.</summary>
 public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposable
 {
-    private const double _SlidingRearmThreshold = 0.5d;
-
     private readonly ConcurrentDictionary<string, CacheEntry> _memory = new(StringComparer.Ordinal);
     private readonly PriorityQueue<string, long> _expirationQueue = new();
     private readonly Lock _expirationLock = new();
@@ -1127,7 +1125,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         try
         {
             var value = existingEntry.GetValue<T>();
-            _TryRearmSlidingEntry(key, existingEntry);
+            _TryRearmSlidingEntry(key, existingEntry, _timeProvider.GetUtcNow().UtcDateTime);
 
             return new ValueTask<CacheValue<T>>(new CacheValue<T>(value, hasValue: true));
         }
@@ -1658,6 +1656,32 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         await _SetInternalAsync(key, entry).ConfigureAwait(false);
     }
 
+    ValueTask IFactoryCacheStore.TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        _ThrowIfDisposed();
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        key = _GetKey(key);
+
+        // The live entry carries the authoritative sliding/physical/logical metadata, so re-arm against it
+        // directly. _TryRearmSlidingEntry applies the same throttle + value-equality TryUpdate the direct
+        // GetAsync path uses; the slidingExpiration/physicalExpiresAt parameters are needed only by stores
+        // (Redis) whose metadata is not co-located with the value.
+        if (_memory.TryGetValue(key, out var existingEntry))
+        {
+            _TryRearmSlidingEntry(key, existingEntry, now);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
     private void _ThrowIfDisposed()
     {
         Ensure.NotDisposed(Volatile.Read(ref _isDisposed) != 0, this);
@@ -1711,7 +1735,7 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
         }
     }
 
-    private void _TryRearmSlidingEntry(string key, CacheEntry entry)
+    private void _TryRearmSlidingEntry(string key, CacheEntry entry, DateTime now)
     {
         if (
             entry.SlidingExpiration is not { } slidingExpiration
@@ -1722,15 +1746,14 @@ public sealed class InMemoryCache : IInMemoryCache, IFactoryCacheStore, IDisposa
             return;
         }
 
-        var now = _timeProvider.GetUtcNow().UtcDateTime;
-
         if (physicalExpiresAt <= now)
         {
             return;
         }
 
         var remaining = logicalExpiresAt - now;
-        var rearmThreshold = TimeSpan.FromTicks((long)(slidingExpiration.Ticks * _SlidingRearmThreshold));
+        // Re-arm once roughly half the idle window has elapsed. Exact integer halving (no lossy double cast).
+        var rearmThreshold = TimeSpan.FromTicks(slidingExpiration.Ticks / 2);
 
         if (remaining > rearmThreshold)
         {

--- a/src/Headless.Caching.InMemory/README.md
+++ b/src/Headless.Caching.InMemory/README.md
@@ -17,9 +17,9 @@ Provides high-performance in-memory caching using the unified `ICache` abstracti
 
 ## Design Notes
 
-Memory cache stores entries in an internal envelope with logical expiration and physical expiration. Direct writes set both timestamps equal. Fail-safe `GetOrAddAsync` can make physical expiration outlive logical expiration so a stale reserve stays in memory after normal value reads miss. Physical expiration still drives eviction, LRU maintenance, size compaction, `GetCountAsync`, and key listing. Logical expiration drives `GetAsync`, `GetAllAsync`, `GetByPrefixAsync`, `GetSetAsync`, `ExistsAsync`, and `GetExpirationAsync`.
+Memory cache stores entries in an internal envelope with logical expiration, physical expiration, and optional sliding expiration. Direct writes set logical and physical timestamps equal. Fail-safe `GetOrAddAsync` can make physical expiration outlive logical expiration so a stale reserve stays in memory after normal value reads miss. Sliding `GetOrAddAsync` keeps physical expiration as the absolute cap and re-arms logical expiration on value reads only; `GetExpirationAsync`, `ExistsAsync`, key listing, and count operations do not extend the idle window. Physical expiration still drives eviction, LRU maintenance, size compaction, `GetCountAsync`, and key listing. Logical expiration drives `GetAsync`, `GetAllAsync`, `GetByPrefixAsync`, `GetSetAsync`, `ExistsAsync`, and `GetExpirationAsync`.
 
-Long `FailSafeMaxDuration` values can retain more entries in process memory. Use `MaxItems`, `MaxMemorySize`, and LRU compaction to bound direct in-memory deployments.
+Long `FailSafeMaxDuration` values and long sliding absolute caps can retain more entries in process memory. Use `MaxItems`, `MaxMemorySize`, and LRU compaction to bound direct in-memory deployments.
 
 ## Installation
 

--- a/src/Headless.Caching.Redis/README.md
+++ b/src/Headless.Caching.Redis/README.md
@@ -18,7 +18,7 @@ Provides distributed caching using Redis via the unified `ICache` abstraction, e
 
 ## Design Notes
 
-Scalar write operations (`UpsertAsync`, `TryInsertAsync`, `TryReplaceAsync`, `TryReplaceIfEqualAsync`, `UpsertAllAsync`) store entries as a versioned binary envelope: a 19-byte header followed by the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is mapped to the Redis key TTL; when fail-safe is enabled, Redis retains the key until physical expiration even after logical expiration has passed. Logical expiration rides in the payload so normal value reads can miss while `GetOrAddAsync` still has a fail-safe reserve. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) bypass framing and write raw Redis-native numeric strings (see below).
+Scalar write operations (`UpsertAsync`, `TryInsertAsync`, `TryReplaceAsync`, `TryReplaceIfEqualAsync`, `UpsertAllAsync`) store entries as a versioned binary envelope: a 19-byte base header followed by an optional 8-byte sliding-expiration field and the raw value segment produced by the cache value codec. The header starts with magic/version bytes `0xFF 0x01`, then flags, then logical and physical expiration timestamps encoded as little-endian Unix milliseconds. Physical expiration is mapped to the Redis key TTL when fail-safe is enabled, so Redis retains the key until physical expiration even after logical expiration has passed. Sliding expiration maps the key TTL to the idle deadline and keeps physical expiration in the envelope as the absolute cap. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) bypass framing and write raw Redis-native numeric strings (see below).
 
 The envelope byte layout is:
 
@@ -26,10 +26,11 @@ The envelope byte layout is:
 | --- | --- | --- |
 | 0 | Magic | `0xFF` — marks a framed entry |
 | 1 | Version | `0x01` — current envelope version |
-| 2 | Flags | bit0 = `isNull`, bit1 = `hasLogicalExpiresAt`, bit2 = `hasPhysicalExpiresAt` |
+| 2 | Flags | bit0 = `isNull`, bit1 = `hasLogicalExpiresAt`, bit2 = `hasPhysicalExpiresAt`, bit3 = `hasSlidingExpiration` |
 | 3–10 | LogicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit1 is set) |
 | 11–18 | PhysicalExpiresAt | `Int64` little-endian Unix milliseconds (present only when bit2 is set) |
-| 19+ | ValueSegment | raw codec bytes; empty when `isNull` is set |
+| 19–26 | SlidingExpiration | `Int64` little-endian milliseconds (present only when bit3 is set) |
+| 19+ or 27+ | ValueSegment | raw codec bytes; offset is 27 when bit3 is set, otherwise 19; empty when `isNull` is set |
 
 Null scalar values are represented by a header flag with an empty value segment. The literal string `"@@NULL"` is now a normal cacheable string when written through Redis cache APIs. Raw legacy keys containing `"@@NULL"` still read as null. Atomic counters (`Increment`, `SetIfHigher`, `SetIfLower`) remain raw Redis-native numeric strings so Redis can perform native atomic arithmetic; their read path falls back to the raw value codec.
 

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -37,6 +37,7 @@ public sealed class RedisCache(
     /// <summary>Legacy null sentinel retained only for raw pre-envelope payloads and collection entries.</summary>
     private static readonly RedisValue _NullValue = "@@NULL";
     private const int _BatchSize = 250;
+    private const double _SlidingRearmThreshold = 0.5d;
 
     private readonly ILogger _logger = logger ?? NullLogger<RedisCache>.Instance;
     private readonly string _keyPrefix = options.KeyPrefix ?? "";
@@ -511,7 +512,7 @@ public sealed class RedisCache(
         cancellationToken.ThrowIfCancellationRequested();
 
         var redisValue = await _database.StringGetAsync(_GetKey(key), options.ReadMode).ConfigureAwait(false);
-        return _RedisValueToCacheValue<T>(redisValue);
+        return await _RedisValueToCacheValueAsync<T>(_GetKey(key), redisValue).ConfigureAwait(false);
     }
 
     public async ValueTask<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(
@@ -553,7 +554,8 @@ public sealed class RedisCache(
 
                 for (var i = 0; i < pairs.Length; i++)
                 {
-                    result[pairs[i].Original] = _RedisValueToCacheValue<T>(values[i]);
+                    result[pairs[i].Original] = await _RedisValueToCacheValueAsync<T>(pairs[i].Redis, values[i])
+                        .ConfigureAwait(false);
                 }
             }
 
@@ -566,7 +568,8 @@ public sealed class RedisCache(
 
             for (var i = 0; i < originalKeys.Count; i++)
             {
-                result[originalKeys[i]] = _RedisValueToCacheValue<T>(values[i]);
+                result[originalKeys[i]] = await _RedisValueToCacheValueAsync<T>(redisKeys[i], values[i])
+                    .ConfigureAwait(false);
             }
 
             return result.AsReadOnly();
@@ -707,6 +710,16 @@ public sealed class RedisCache(
         }
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
+
+        if (_IsExpired(frame.PhysicalExpiresAt, now))
+        {
+            return null;
+        }
+
+        if (frame.SlidingExpiration.HasValue)
+        {
+            return await _database.KeyTimeToLiveAsync(_GetKey(key)).ConfigureAwait(false);
+        }
 
         if (_IsExpired(frame.LogicalExpiresAt, now))
         {
@@ -1014,7 +1027,7 @@ public sealed class RedisCache(
         return serializer.Deserialize<T>((byte[])redisValue!);
     }
 
-    private CacheValue<T> _RedisValueToCacheValue<T>(RedisValue redisValue)
+    private async ValueTask<CacheValue<T>> _RedisValueToCacheValueAsync<T>(RedisKey redisKey, RedisValue redisValue)
     {
         if (!redisValue.HasValue)
         {
@@ -1029,10 +1042,15 @@ public sealed class RedisCache(
             {
                 var now = timeProvider.GetUtcNow().UtcDateTime;
 
-                if (_IsExpired(frame.PhysicalExpiresAt, now) || _IsExpired(frame.LogicalExpiresAt, now))
+                if (
+                    _IsExpired(frame.PhysicalExpiresAt, now)
+                    || (!frame.SlidingExpiration.HasValue && _IsExpired(frame.LogicalExpiresAt, now))
+                )
                 {
                     return CacheValue<T>.NoValue;
                 }
+
+                await _TryRearmSlidingEntryAsync(redisKey, frame, now).ConfigureAwait(false);
 
                 if (frame.IsNull)
                 {
@@ -1116,7 +1134,8 @@ public sealed class RedisCache(
             valueSegment,
             isNull: value is null,
             logicalExpiresAt: expiresAt,
-            physicalExpiresAt: expiresAt
+            physicalExpiresAt: expiresAt,
+            slidingExpiration: null
         );
     }
 
@@ -1137,6 +1156,7 @@ public sealed class RedisCache(
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     )
         where T : default
@@ -1144,7 +1164,8 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var expiresIn = physicalExpiresAt.Subtract(timeProvider.GetUtcNow().UtcDateTime);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var expiresIn = (slidingExpiration is null ? physicalExpiresAt : logicalExpiresAt).Subtract(now);
         var redisKey = _GetKey(key);
 
         if (expiresIn <= TimeSpan.Zero)
@@ -1154,7 +1175,13 @@ public sealed class RedisCache(
         }
 
         var valueSegment = isNull ? RedisValue.EmptyString : _ToRedisValue(value);
-        var redisValue = RedisCacheEntryFrame.Encode(valueSegment, isNull, logicalExpiresAt, physicalExpiresAt);
+        var redisValue = RedisCacheEntryFrame.Encode(
+            valueSegment,
+            isNull,
+            logicalExpiresAt,
+            physicalExpiresAt,
+            slidingExpiration
+        );
 
         await _database.StringSetAsync(redisKey, redisValue, expiresIn).ConfigureAwait(false);
     }
@@ -1185,7 +1212,8 @@ public sealed class RedisCache(
                 IsNull: frame.IsNull,
                 Value: value,
                 LogicalExpiresAt: frame.LogicalExpiresAt,
-                PhysicalExpiresAt: frame.PhysicalExpiresAt
+                PhysicalExpiresAt: frame.PhysicalExpiresAt,
+                SlidingExpiration: frame.SlidingExpiration
             );
         }
 
@@ -1196,7 +1224,8 @@ public sealed class RedisCache(
                 IsNull: true,
                 Value: default,
                 LogicalExpiresAt: null,
-                PhysicalExpiresAt: null
+                PhysicalExpiresAt: null,
+                SlidingExpiration: null
             );
         }
 
@@ -1205,7 +1234,8 @@ public sealed class RedisCache(
             IsNull: false,
             Value: _FromRedisValue<T>(redisValue),
             LogicalExpiresAt: null,
-            PhysicalExpiresAt: null
+            PhysicalExpiresAt: null,
+            SlidingExpiration: null
         );
     }
 
@@ -1224,10 +1254,50 @@ public sealed class RedisCache(
         }
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        return !_IsExpired(frame.PhysicalExpiresAt, now) && !_IsExpired(frame.LogicalExpiresAt, now);
+        return !_IsExpired(frame.PhysicalExpiresAt, now)
+            && (frame.SlidingExpiration.HasValue || !_IsExpired(frame.LogicalExpiresAt, now));
+    }
+
+    private async ValueTask _TryRearmSlidingEntryAsync(RedisKey redisKey, RedisCacheEntryFrame.DecodedFrame frame, DateTime now)
+    {
+        if (frame.SlidingExpiration is not { } slidingExpiration || frame.PhysicalExpiresAt is not { } physicalExpiresAt)
+        {
+            return;
+        }
+
+        var remainingToCap = physicalExpiresAt - now;
+
+        if (remainingToCap <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        var ttl = await _database.KeyTimeToLiveAsync(redisKey).ConfigureAwait(false);
+        var rearmThreshold = TimeSpan.FromTicks((long)(slidingExpiration.Ticks * _SlidingRearmThreshold));
+
+        if (ttl.HasValue && ttl.Value > rearmThreshold)
+        {
+            return;
+        }
+
+        var expiresIn = _Min(slidingExpiration, remainingToCap);
+
+        try
+        {
+            await _database.KeyExpireAsync(redisKey, expiresIn).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogSlidingExpirationRearmFailed(exception, redisKey.ToString());
+            }
+        }
     }
 
     private static bool _IsExpired(DateTime? expiresAt, DateTime now) => expiresAt.HasValue && expiresAt.Value <= now;
+
+    private static TimeSpan _Min(TimeSpan left, TimeSpan right) => left <= right ? left : right;
 
     private T? _DeserializeValueSegment<T>(ReadOnlyMemory<byte> segment)
     {
@@ -1506,4 +1576,12 @@ internal static partial class RedisCacheLog
         Message = "Removed {ExpiredValues} expired values for key: {Key}"
     )]
     public static partial void LogExpiredValuesRemoved(this ILogger logger, long expiredValues, string key);
+
+    [LoggerMessage(
+        EventId = 6,
+        EventName = "SlidingExpirationRearmFailed",
+        Level = LogLevel.Debug,
+        Message = "Unable to re-arm sliding expiration for cache key {Key}; the value will still be returned."
+    )]
+    public static partial void LogSlidingExpirationRearmFailed(this ILogger logger, Exception exception, string key);
 }

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -37,7 +37,6 @@ public sealed class RedisCache(
     /// <summary>Legacy null sentinel retained only for raw pre-envelope payloads and collection entries.</summary>
     private static readonly RedisValue _NullValue = "@@NULL";
     private const int _BatchSize = 250;
-    private const double _SlidingRearmThreshold = 0.5d;
 
     private readonly ILogger _logger = logger ?? NullLogger<RedisCache>.Instance;
     private readonly string _keyPrefix = options.KeyPrefix ?? "";
@@ -554,7 +553,11 @@ public sealed class RedisCache(
 
                 for (var i = 0; i < pairs.Length; i++)
                 {
-                    result[pairs[i].Original] = await _RedisValueToCacheValueAsync<T>(pairs[i].Redis, values[i])
+                    result[pairs[i].Original] = await _RedisValueToCacheValueAsync<T>(
+                            pairs[i].Redis,
+                            values[i],
+                            rearm: false
+                        )
                         .ConfigureAwait(false);
                 }
             }
@@ -568,7 +571,7 @@ public sealed class RedisCache(
 
             for (var i = 0; i < originalKeys.Count; i++)
             {
-                result[originalKeys[i]] = await _RedisValueToCacheValueAsync<T>(redisKeys[i], values[i])
+                result[originalKeys[i]] = await _RedisValueToCacheValueAsync<T>(redisKeys[i], values[i], rearm: false)
                     .ConfigureAwait(false);
             }
 
@@ -1027,7 +1030,11 @@ public sealed class RedisCache(
         return serializer.Deserialize<T>((byte[])redisValue!);
     }
 
-    private async ValueTask<CacheValue<T>> _RedisValueToCacheValueAsync<T>(RedisKey redisKey, RedisValue redisValue)
+    private async ValueTask<CacheValue<T>> _RedisValueToCacheValueAsync<T>(
+        RedisKey redisKey,
+        RedisValue redisValue,
+        bool rearm = true
+    )
     {
         if (!redisValue.HasValue)
         {
@@ -1050,7 +1057,13 @@ public sealed class RedisCache(
                     return CacheValue<T>.NoValue;
                 }
 
-                await _TryRearmSlidingEntryAsync(redisKey, frame, now).ConfigureAwait(false);
+                // Bulk reads (GetAllAsync) skip re-arm: re-arming here issues one KeyTimeToLive + KeyExpire per
+                // sliding key, turning a single batched StringGet into N sequential round trips. Single-key reads
+                // still re-arm so idle-window semantics hold on the hot path.
+                if (rearm)
+                {
+                    await _TryRearmSlidingEntryAsync(redisKey, frame, now).ConfigureAwait(false);
+                }
 
                 if (frame.IsNull)
                 {
@@ -1186,6 +1199,23 @@ public sealed class RedisCache(
         await _database.StringSetAsync(redisKey, redisValue, expiresIn).ConfigureAwait(false);
     }
 
+    async ValueTask IFactoryCacheStore.TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        Argument.IsNotNullOrEmpty(key);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // No embedded logical lower bound on this path (the coordinator drops it for sliding entries, since it
+        // goes stale after a metadata-only re-arm), so the throttle reads the live key TTL.
+        await _RearmSlidingTtlAsync(_GetKey(key), slidingExpiration, physicalExpiresAt, now, embeddedLogicalExpiresAt: null)
+            .ConfigureAwait(false);
+    }
+
     private async ValueTask<CacheStoreEntry<T>> _TryGetEntryAsync<T>(string key)
     {
         var redisValue = await _database.StringGetAsync(_GetKey(key), options.ReadMode).ConfigureAwait(false);
@@ -1211,7 +1241,12 @@ public sealed class RedisCache(
                 Found: true,
                 IsNull: frame.IsNull,
                 Value: value,
-                LogicalExpiresAt: frame.LogicalExpiresAt,
+                // For sliding entries the embedded logical timestamp goes stale after a metadata-only re-arm
+                // (KeyExpire bumps the key TTL but does not rewrite the frame), so reporting it would make the
+                // coordinator treat a live, recently-touched key as logically expired and spuriously re-run the
+                // factory. Drop it and let freshness rely on key existence + the physical cap, mirroring the
+                // other sliding read paths (_RedisValueToCacheValueAsync, _RedisValueIsLogicallyPresent).
+                LogicalExpiresAt: frame.SlidingExpiration.HasValue ? null : frame.LogicalExpiresAt,
                 PhysicalExpiresAt: frame.PhysicalExpiresAt,
                 SlidingExpiration: frame.SlidingExpiration
             );
@@ -1258,13 +1293,27 @@ public sealed class RedisCache(
             && (frame.SlidingExpiration.HasValue || !_IsExpired(frame.LogicalExpiresAt, now));
     }
 
-    private async ValueTask _TryRearmSlidingEntryAsync(RedisKey redisKey, RedisCacheEntryFrame.DecodedFrame frame, DateTime now)
+    private ValueTask _TryRearmSlidingEntryAsync(RedisKey redisKey, RedisCacheEntryFrame.DecodedFrame frame, DateTime now)
     {
         if (frame.SlidingExpiration is not { } slidingExpiration || frame.PhysicalExpiresAt is not { } physicalExpiresAt)
         {
-            return;
+            return ValueTask.CompletedTask;
         }
 
+        // The frame's embedded logical is a lower bound on the live key TTL (a metadata-only re-arm only ever
+        // pushes the TTL out, never the frame), so the shared helper can use it to skip the KeyTimeToLive probe
+        // when at least half the window still remains.
+        return _RearmSlidingTtlAsync(redisKey, slidingExpiration, physicalExpiresAt, now, frame.LogicalExpiresAt);
+    }
+
+    private async ValueTask _RearmSlidingTtlAsync(
+        RedisKey redisKey,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        DateTime? embeddedLogicalExpiresAt
+    )
+    {
         var remainingToCap = physicalExpiresAt - now;
 
         if (remainingToCap <= TimeSpan.Zero)
@@ -1272,18 +1321,29 @@ public sealed class RedisCache(
             return;
         }
 
-        var ttl = await _database.KeyTimeToLiveAsync(redisKey).ConfigureAwait(false);
-        var rearmThreshold = TimeSpan.FromTicks((long)(slidingExpiration.Ticks * _SlidingRearmThreshold));
+        // Re-arm once roughly half the idle window has elapsed. Exact integer halving (no lossy double cast).
+        var rearmThreshold = TimeSpan.FromTicks(slidingExpiration.Ticks / 2);
 
-        if (ttl.HasValue && ttl.Value > rearmThreshold)
+        // Fast path: when the (lower-bound) embedded logical already proves more than half the window remains,
+        // the live TTL — which can only be larger — does too, so skip both the re-arm and its round trip.
+        if (embeddedLogicalExpiresAt is { } embeddedLogical && embeddedLogical - now > rearmThreshold)
         {
             return;
         }
 
-        var expiresIn = _Min(slidingExpiration, remainingToCap);
-
         try
         {
+            // The TTL probe is part of the best-effort re-arm: keep it inside the catch so a transient Redis
+            // error during the probe degrades to "skip the re-arm" instead of failing a value read that the
+            // caller has already satisfied.
+            var ttl = await _database.KeyTimeToLiveAsync(redisKey).ConfigureAwait(false);
+
+            if (ttl.HasValue && ttl.Value > rearmThreshold)
+            {
+                return;
+            }
+
+            var expiresIn = _Min(slidingExpiration, remainingToCap);
             await _database.KeyExpireAsync(redisKey, expiresIn).ConfigureAwait(false);
         }
         catch (Exception exception)

--- a/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
+++ b/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
@@ -14,16 +14,25 @@ internal static class RedisCacheEntryFrame
     internal const byte NullFlag = 1 << 0;
     internal const byte HasLogicalExpiresAtFlag = 1 << 1;
     internal const byte HasPhysicalExpiresAtFlag = 1 << 2;
+    internal const byte HasSlidingExpirationFlag = 1 << 3;
 
     // Valid range accepted by DateTimeOffset.FromUnixTimeMilliseconds; out-of-range values mean the
     // header bytes were never written by this codec, so the frame must read as a miss rather than throw.
     internal const long MinUnixEpochMilliseconds = -62_135_596_800_000L; // 0001-01-01T00:00:00.000Z
     internal const long MaxUnixEpochMilliseconds = 253_402_300_799_999L; // 9999-12-31T23:59:59.999Z
 
-    public static byte[] Encode(RedisValue value, bool isNull, DateTime? logicalExpiresAt, DateTime? physicalExpiresAt)
+    public static byte[] Encode(
+        RedisValue value,
+        bool isNull,
+        DateTime? logicalExpiresAt,
+        DateTime? physicalExpiresAt,
+        TimeSpan? slidingExpiration
+    )
     {
         var valueBytes = isNull ? [] : _ToBytes(value);
-        var buffer = new byte[HeaderLength + valueBytes.Length];
+        var hasSlidingExpiration = slidingExpiration.HasValue;
+        var payloadOffset = hasSlidingExpiration ? HeaderLength + sizeof(long) : HeaderLength;
+        var buffer = new byte[payloadOffset + valueBytes.Length];
         buffer[0] = Magic;
         buffer[1] = Version;
 
@@ -47,8 +56,18 @@ internal static class RedisCacheEntryFrame
             );
         }
 
+        if (hasSlidingExpiration)
+        {
+            flags |= HasSlidingExpirationFlag;
+            var slidingExpirationValue = slidingExpiration.GetValueOrDefault();
+            BinaryPrimitives.WriteInt64LittleEndian(
+                buffer.AsSpan(HeaderLength, sizeof(long)),
+                (long)slidingExpirationValue.TotalMilliseconds
+            );
+        }
+
         buffer[2] = flags;
-        valueBytes.CopyTo(buffer.AsSpan(HeaderLength));
+        valueBytes.CopyTo(buffer.AsSpan(payloadOffset));
 
         return buffer;
     }
@@ -78,23 +97,40 @@ internal static class RedisCacheEntryFrame
 
         var hasLogical = (flags & HasLogicalExpiresAtFlag) is not 0;
         var hasPhysical = (flags & HasPhysicalExpiresAtFlag) is not 0;
+        var hasSliding = (flags & HasSlidingExpirationFlag) is not 0;
+        var payloadOffset = hasSliding ? HeaderLength + sizeof(long) : HeaderLength;
+
+        if (bytes.Length < payloadOffset)
+        {
+            return DecodedFrame.Unframed;
+        }
+
         var logicalMs = hasLogical ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(3, sizeof(long))) : 0L;
         var physicalMs = hasPhysical ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(11, sizeof(long))) : 0L;
+        var slidingMs = hasSliding
+            ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(HeaderLength, sizeof(long)))
+            : 0L;
 
-        if ((hasLogical && _IsOutOfRange(logicalMs)) || (hasPhysical && _IsOutOfRange(physicalMs)))
+        if (
+            (hasLogical && _IsOutOfRange(logicalMs))
+            || (hasPhysical && _IsOutOfRange(physicalMs))
+            || (hasSliding && slidingMs <= 0)
+        )
         {
             return DecodedFrame.Unframed;
         }
 
         var logicalExpiresAt = hasLogical ? _FromUnixTimeMilliseconds(logicalMs) : (DateTime?)null;
         var physicalExpiresAt = hasPhysical ? _FromUnixTimeMilliseconds(physicalMs) : (DateTime?)null;
+        var slidingExpiration = hasSliding ? TimeSpan.FromMilliseconds(slidingMs) : (TimeSpan?)null;
 
         return new DecodedFrame(
             IsFramed: true,
             IsNull: (flags & NullFlag) is not 0,
             LogicalExpiresAt: logicalExpiresAt,
             PhysicalExpiresAt: physicalExpiresAt,
-            ValueSegment: bytes.AsMemory(HeaderLength)
+            SlidingExpiration: slidingExpiration,
+            ValueSegment: bytes.AsMemory(payloadOffset)
         );
     }
 
@@ -130,6 +166,7 @@ internal static class RedisCacheEntryFrame
         bool IsNull,
         DateTime? LogicalExpiresAt,
         DateTime? PhysicalExpiresAt,
+        TimeSpan? SlidingExpiration,
         ReadOnlyMemory<byte> ValueSegment
     )
     {
@@ -139,6 +176,7 @@ internal static class RedisCacheEntryFrame
                 IsNull: false,
                 LogicalExpiresAt: null,
                 PhysicalExpiresAt: null,
+                SlidingExpiration: null,
                 ValueSegment: ReadOnlyMemory<byte>.Empty
             );
     }

--- a/tests/Headless.Caching.Abstractions.Tests.Unit/CacheEntryOptionsTests.cs
+++ b/tests/Headless.Caching.Abstractions.Tests.Unit/CacheEntryOptionsTests.cs
@@ -17,6 +17,7 @@ public sealed class CacheEntryOptionsTests
 
         // then
         options.Duration.Should().Be(duration);
+        options.SlidingExpiration.Should().BeNull();
         options.IsFailSafeEnabled.Should().BeFalse();
         options.FailSafeMaxDuration.Should().Be(CacheEntryOptions.DefaultFailSafeMaxDuration);
         options.FailSafeThrottleDuration.Should().Be(CacheEntryOptions.DefaultFailSafeThrottleDuration);
@@ -58,6 +59,7 @@ public sealed class CacheEntryOptionsTests
         options.IsFailSafeEnabled.Should().BeFalse();
         options.FailSafeMaxDuration.Should().Be(TimeSpan.FromDays(1));
         options.FailSafeThrottleDuration.Should().Be(TimeSpan.FromSeconds(30));
+        options.SlidingExpiration.Should().BeNull();
     }
 
     [Fact]
@@ -82,6 +84,23 @@ public sealed class CacheEntryOptionsTests
         options.IsFailSafeEnabled.Should().BeTrue();
         options.FailSafeMaxDuration.Should().Be(maxDuration);
         options.FailSafeThrottleDuration.Should().Be(throttleDuration);
+    }
+
+    [Fact]
+    public void should_round_trip_sliding_expiration()
+    {
+        // given
+        var slidingExpiration = TimeSpan.FromMinutes(2);
+
+        // when
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMinutes(10),
+            SlidingExpiration = slidingExpiration,
+        };
+
+        // then
+        options.SlidingExpiration.Should().Be(slidingExpiration);
     }
 
     private static CacheEntryOptions _CreateOptions(CacheEntryOptions options) => options;

--- a/tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs
+++ b/tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs
@@ -53,6 +53,43 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
     }
 
     [Fact]
+    public async Task should_rearm_fresh_sliding_hit_without_invoking_factory()
+    {
+        // given
+        var key = Faker.Random.AlphaNumeric(8);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var slidingExpiration = TimeSpan.FromSeconds(1);
+        var physicalExpiresAt = now.AddSeconds(5);
+        _store.SetEntry(key, "cached", now.AddMilliseconds(100), physicalExpiresAt, slidingExpiration);
+        var factoryCalls = 0;
+
+        // when
+        var result = await _CreateCoordinator()
+            .GetOrAddAsync<string>(
+                _store,
+                key,
+                _ =>
+                {
+                    factoryCalls++;
+                    return ValueTask.FromResult<string?>("new");
+                },
+                _CreateOptions(slidingExpiration: slidingExpiration),
+                AbortToken
+            );
+
+        // then
+        var entry = _store.GetEntry(key);
+        result.Value.Should().Be("cached");
+        result.IsStale.Should().BeFalse();
+        factoryCalls.Should().Be(0);
+        _store.SetEntryCalls.Should().Be(1);
+        entry.Should().NotBeNull();
+        entry!.LogicalExpiresAt.Should().Be(now.Add(slidingExpiration));
+        entry.PhysicalExpiresAt.Should().Be(physicalExpiresAt);
+        entry.SlidingExpiration.Should().Be(slidingExpiration);
+    }
+
+    [Fact]
     public async Task should_serve_stale_when_factory_throws_within_physical_window()
     {
         // given
@@ -291,6 +328,132 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
         entry.Should().NotBeNull();
         entry!.LogicalExpiresAt.Should().Be(now.Add(duration));
         entry.PhysicalExpiresAt.Should().Be(now.Add(failSafeMaxDuration));
+        entry.SlidingExpiration.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_set_sliding_logical_expiration_on_factory_success()
+    {
+        // given
+        var key = Faker.Random.AlphaNumeric(8);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var duration = TimeSpan.FromSeconds(5);
+        var slidingExpiration = TimeSpan.FromSeconds(1);
+
+        // when
+        var result = await _CreateCoordinator()
+            .GetOrAddAsync<string>(
+                _store,
+                key,
+                _ => ValueTask.FromResult<string?>("fresh"),
+                _CreateOptions(duration: duration, slidingExpiration: slidingExpiration),
+                AbortToken
+            );
+
+        // then
+        var entry = _store.GetEntry(key);
+        result.Value.Should().Be("fresh");
+        result.IsStale.Should().BeFalse();
+        entry.Should().NotBeNull();
+        entry!.LogicalExpiresAt.Should().Be(now.Add(slidingExpiration));
+        entry.PhysicalExpiresAt.Should().Be(now.Add(duration));
+        entry.SlidingExpiration.Should().Be(slidingExpiration);
+    }
+
+    [Fact]
+    public async Task should_clamp_sliding_logical_expiration_to_physical_cap_on_factory_success()
+    {
+        // given
+        var key = Faker.Random.AlphaNumeric(8);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var duration = TimeSpan.FromSeconds(2);
+        var slidingExpiration = TimeSpan.FromSeconds(5);
+
+        // when
+        await _CreateCoordinator()
+            .GetOrAddAsync<string>(
+                _store,
+                key,
+                _ => ValueTask.FromResult<string?>("fresh"),
+                _CreateOptions(duration: duration, slidingExpiration: slidingExpiration),
+                AbortToken
+            );
+
+        // then
+        var entry = _store.GetEntry(key);
+        entry.Should().NotBeNull();
+        entry!.LogicalExpiresAt.Should().Be(now.Add(duration));
+        entry.PhysicalExpiresAt.Should().Be(now.Add(duration));
+        entry.SlidingExpiration.Should().Be(slidingExpiration);
+    }
+
+    [Fact]
+    public async Task should_rearm_under_lock_sliding_fresh_hit()
+    {
+        // given
+        var key = Faker.Random.AlphaNumeric(8);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var slidingExpiration = TimeSpan.FromSeconds(1);
+        var physicalExpiresAt = now.AddSeconds(5);
+        var factoryCalls = 0;
+        _store.TryGetEntryOverride = (_, calls) =>
+            calls == 2
+                ? new FakeFactoryCacheStore.Entry(
+                    Value: "concurrent",
+                    IsNull: false,
+                    LogicalExpiresAt: now.AddMilliseconds(100),
+                    PhysicalExpiresAt: physicalExpiresAt,
+                    SlidingExpiration: slidingExpiration
+                )
+                : null;
+
+        // when
+        var result = await _CreateCoordinator()
+            .GetOrAddAsync<string>(
+                _store,
+                key,
+                _ =>
+                {
+                    factoryCalls++;
+                    return ValueTask.FromResult<string?>("new");
+                },
+                _CreateOptions(slidingExpiration: slidingExpiration),
+                AbortToken
+            );
+
+        // then
+        var entry = _store.GetEntry(key);
+        result.Value.Should().Be("concurrent");
+        factoryCalls.Should().Be(0);
+        _store.SetEntryCalls.Should().Be(1);
+        entry.Should().NotBeNull();
+        entry!.LogicalExpiresAt.Should().Be(now.Add(slidingExpiration));
+        entry.PhysicalExpiresAt.Should().Be(physicalExpiresAt);
+    }
+
+    [Fact]
+    public async Task should_return_fresh_sliding_hit_when_rearm_write_fails()
+    {
+        // given
+        var key = Faker.Random.AlphaNumeric(8);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var slidingExpiration = TimeSpan.FromSeconds(1);
+        _store.SetEntry(key, "cached", now.AddMilliseconds(100), now.AddSeconds(5), slidingExpiration);
+        _store.SetEntryFault = () => new InvalidOperationException("store write failed");
+
+        // when
+        var result = await _CreateCoordinator()
+            .GetOrAddAsync<string>(
+                _store,
+                key,
+                _ => ValueTask.FromResult<string?>("new"),
+                _CreateOptions(slidingExpiration: slidingExpiration),
+                AbortToken
+            );
+
+        // then
+        result.Value.Should().Be("cached");
+        result.IsStale.Should().BeFalse();
     }
 
     [Fact]
@@ -361,6 +524,34 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
 
         // then
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("factory failed");
+    }
+
+    [Fact]
+    public async Task should_reject_sliding_expiration_with_failsafe_enabled()
+    {
+        // given
+        var key = Faker.Random.AlphaNumeric(8);
+        var factoryCalls = 0;
+
+        // when
+        var act = async () =>
+            await _CreateCoordinator()
+                .GetOrAddAsync<string>(
+                    _store,
+                    key,
+                    _ =>
+                    {
+                        factoryCalls++;
+                        return ValueTask.FromResult<string?>("fresh");
+                    },
+                    _CreateOptions(isFailSafeEnabled: true, slidingExpiration: TimeSpan.FromSeconds(1)),
+                    AbortToken
+                );
+
+        // then
+        await act.Should().ThrowAsync<ArgumentException>().WithParameterName("options");
+        factoryCalls.Should().Be(0);
+        _store.SetEntryCalls.Should().Be(0);
     }
 
     [Fact]
@@ -507,11 +698,13 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
         TimeSpan? duration = null,
         bool isFailSafeEnabled = false,
         TimeSpan? maxDuration = null,
-        TimeSpan? throttleDuration = null
+        TimeSpan? throttleDuration = null,
+        TimeSpan? slidingExpiration = null
     ) =>
         new()
         {
             Duration = duration ?? TimeSpan.FromSeconds(5),
+            SlidingExpiration = slidingExpiration,
             IsFailSafeEnabled = isFailSafeEnabled,
             FailSafeMaxDuration = maxDuration ?? TimeSpan.FromMinutes(1),
             FailSafeThrottleDuration = throttleDuration ?? TimeSpan.FromSeconds(10),

--- a/tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs
+++ b/tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs
@@ -82,7 +82,9 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
         result.Value.Should().Be("cached");
         result.IsStale.Should().BeFalse();
         factoryCalls.Should().Be(0);
-        _store.SetEntryCalls.Should().Be(1);
+        // Re-arm is now a metadata-only TTL bump via TryRearmSlidingAsync, not a full SetEntry rewrite.
+        _store.RearmCalls.Should().Be(1);
+        _store.SetEntryCalls.Should().Be(0);
         entry.Should().NotBeNull();
         entry!.LogicalExpiresAt.Should().Be(now.Add(slidingExpiration));
         entry.PhysicalExpiresAt.Should().Be(physicalExpiresAt);
@@ -425,7 +427,8 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
         var entry = _store.GetEntry(key);
         result.Value.Should().Be("concurrent");
         factoryCalls.Should().Be(0);
-        _store.SetEntryCalls.Should().Be(1);
+        _store.RearmCalls.Should().Be(1);
+        _store.SetEntryCalls.Should().Be(0);
         entry.Should().NotBeNull();
         entry!.LogicalExpiresAt.Should().Be(now.Add(slidingExpiration));
         entry.PhysicalExpiresAt.Should().Be(physicalExpiresAt);
@@ -439,7 +442,7 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var slidingExpiration = TimeSpan.FromSeconds(1);
         _store.SetEntry(key, "cached", now.AddMilliseconds(100), now.AddSeconds(5), slidingExpiration);
-        _store.SetEntryFault = () => new InvalidOperationException("store write failed");
+        _store.RearmFault = () => new InvalidOperationException("store re-arm failed");
 
         // when
         var result = await _CreateCoordinator()
@@ -549,7 +552,9 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
                 );
 
         // then
-        await act.Should().ThrowAsync<ArgumentException>().WithParameterName("options");
+        // Sliding + fail-safe is an unsupported combination, guarded via Headless.Checks' Ensure.False
+        // (InvalidOperationException) rather than a hand-rolled ArgumentException.
+        await act.Should().ThrowAsync<InvalidOperationException>();
         factoryCalls.Should().Be(0);
         _store.SetEntryCalls.Should().Be(0);
     }

--- a/tests/Headless.Caching.Core.Tests.Unit/FakeFactoryCacheStore.cs
+++ b/tests/Headless.Caching.Core.Tests.Unit/FakeFactoryCacheStore.cs
@@ -17,6 +17,8 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
 
     public Func<Exception>? SetEntryFault { get; set; }
 
+    public Func<string, int, Entry?>? TryGetEntryOverride { get; set; }
+
     public Entry? GetEntry(string key)
     {
         lock (_lock)
@@ -25,7 +27,13 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
         }
     }
 
-    public void SetEntry<T>(string key, T? value, DateTime logicalExpiresAt, DateTime physicalExpiresAt)
+    public void SetEntry<T>(
+        string key,
+        T? value,
+        DateTime logicalExpiresAt,
+        DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration = null
+    )
     {
         lock (_lock)
         {
@@ -33,7 +41,8 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
                 Value: value,
                 IsNull: value is null,
                 LogicalExpiresAt: logicalExpiresAt,
-                PhysicalExpiresAt: physicalExpiresAt
+                PhysicalExpiresAt: physicalExpiresAt,
+                SlidingExpiration: slidingExpiration
             );
         }
     }
@@ -48,8 +57,15 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
             throw TryGetEntryFault();
         }
 
+        var overrideEntry = TryGetEntryOverride?.Invoke(key, TryGetEntryCalls);
+
         lock (_lock)
         {
+            if (overrideEntry is not null)
+            {
+                _entries[key] = overrideEntry;
+            }
+
             if (!_entries.TryGetValue(key, out var entry))
             {
                 return new ValueTask<CacheStoreEntry<T>>(CacheStoreEntry<T>.NotFound);
@@ -61,7 +77,8 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
                     IsNull: entry.IsNull,
                     Value: (T?)entry.Value,
                     LogicalExpiresAt: entry.LogicalExpiresAt,
-                    PhysicalExpiresAt: entry.PhysicalExpiresAt
+                    PhysicalExpiresAt: entry.PhysicalExpiresAt,
+                    SlidingExpiration: entry.SlidingExpiration
                 )
             );
         }
@@ -73,6 +90,7 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     )
     {
@@ -90,12 +108,19 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
                 Value: value,
                 IsNull: isNull,
                 LogicalExpiresAt: logicalExpiresAt,
-                PhysicalExpiresAt: physicalExpiresAt
+                PhysicalExpiresAt: physicalExpiresAt,
+                SlidingExpiration: slidingExpiration
             );
         }
 
         return ValueTask.CompletedTask;
     }
 
-    internal sealed record Entry(object? Value, bool IsNull, DateTime LogicalExpiresAt, DateTime PhysicalExpiresAt);
+    internal sealed record Entry(
+        object? Value,
+        bool IsNull,
+        DateTime LogicalExpiresAt,
+        DateTime PhysicalExpiresAt,
+        TimeSpan? SlidingExpiration
+    );
 }

--- a/tests/Headless.Caching.Core.Tests.Unit/FakeFactoryCacheStore.cs
+++ b/tests/Headless.Caching.Core.Tests.Unit/FakeFactoryCacheStore.cs
@@ -13,9 +13,13 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
 
     public int SetEntryCalls { get; private set; }
 
+    public int RearmCalls { get; private set; }
+
     public Func<Exception>? TryGetEntryFault { get; set; }
 
     public Func<Exception>? SetEntryFault { get; set; }
+
+    public Func<Exception>? RearmFault { get; set; }
 
     public Func<string, int, Entry?>? TryGetEntryOverride { get; set; }
 
@@ -111,6 +115,61 @@ internal sealed class FakeFactoryCacheStore : IFactoryCacheStore
                 PhysicalExpiresAt: physicalExpiresAt,
                 SlidingExpiration: slidingExpiration
             );
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        RearmCalls++;
+
+        if (RearmFault is not null)
+        {
+            throw RearmFault();
+        }
+
+        lock (_lock)
+        {
+            // Models a metadata-only re-arm: extend the stored entry's logical deadline in place, keeping the
+            // value, physical cap, and sliding window. Mirrors the throttle the real stores apply (re-arm only
+            // once at least half the idle window has elapsed) so coordinator throttle behavior is observable.
+            if (
+                !_entries.TryGetValue(key, out var entry)
+                || entry.SlidingExpiration is null
+                || physicalExpiresAt <= now
+            )
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            var remaining = entry.LogicalExpiresAt - now;
+
+            if (remaining > TimeSpan.FromTicks(slidingExpiration.Ticks / 2))
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            var rearmed = now.Add(slidingExpiration);
+
+            if (rearmed > physicalExpiresAt)
+            {
+                rearmed = physicalExpiresAt;
+            }
+
+            if (rearmed <= entry.LogicalExpiresAt)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            _entries[key] = entry with { LogicalExpiresAt = rearmed };
         }
 
         return ValueTask.CompletedTask;

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheFailSafeTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheFailSafeTests.cs
@@ -69,6 +69,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
             isNull: false,
             logicallyExpiredAt,
             physicallyExpiredAt,
+            slidingExpiration: null,
             AbortToken
         );
 
@@ -112,6 +113,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
             isNull: false,
             logicallyExpiredAt,
             physicallyExpiredAt,
+            slidingExpiration: null,
             AbortToken
         );
 
@@ -166,6 +168,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
             isNull: false,
             logicallyExpiredAt,
             physicallyExpiredAt,
+            slidingExpiration: null,
             AbortToken
         );
 
@@ -213,6 +216,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
                 isNull: false,
                 logicalExpiresAt: now.AddMinutes(-1),
                 physicalExpiresAt: now.AddHours(1),
+                slidingExpiration: null,
                 AbortToken
             );
 
@@ -414,6 +418,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
             isNull: false,
             logicallyExpiredAt,
             physicallyExpiredAt,
+            slidingExpiration: null,
             AbortToken
         );
 
@@ -452,6 +457,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
                 isNull: false,
                 logicalExpiresAt: now.Add(logicalTtl),
                 physicalExpiresAt: now.AddHours(1),
+                slidingExpiration: null,
                 AbortToken
             );
 
@@ -495,6 +501,7 @@ public sealed class HybridCacheFailSafeTests : TestBase
             isNull: false,
             logicallyExpiredAt,
             physicallyExpiredAt,
+            slidingExpiration: null,
             AbortToken
         );
 

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSlidingTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSlidingTests.cs
@@ -94,6 +94,51 @@ public sealed class HybridCacheSlidingTests : TestBase
         l1Entry.SlidingExpiration.Should().Be(slidingExpiration);
     }
 
+    [Fact]
+    public async Task should_serve_sliding_l1_hit_when_l2_is_physically_expired()
+    {
+        // given - both tiers hold the sliding entry; L1's local ceiling outlives L2's absolute cap.
+        var localExpiration = TimeSpan.FromSeconds(5);
+        var duration = TimeSpan.FromSeconds(2);
+        var slidingExpiration = TimeSpan.FromMilliseconds(500);
+        var (cache, l1, l2) = _CreateCache(new HybridCacheOptions { DefaultLocalExpiration = localExpiration });
+        await using var _ = cache;
+
+        var key = Faker.Random.AlphaNumeric(10);
+        var value = Faker.Random.Int();
+        var options = new CacheEntryOptions { Duration = duration, SlidingExpiration = slidingExpiration };
+        await cache.GetOrAddAsync(key, _ => new ValueTask<int?>(value), options, AbortToken);
+
+        // Simulate L2 physical expiry while L1 stays fresh: drop the L2 copy. A subsequent read is a fresh
+        // sliding L1 hit that must fall through to the (now-empty) L2 and still serve the L1 value.
+        (await l2.RemoveAsync(key, AbortToken)).Should().BeTrue();
+
+        var factoryCalls = 0;
+
+        // when
+        var result = await cache.GetOrAddAsync(
+            key,
+            _ =>
+            {
+                factoryCalls++;
+                return new ValueTask<int?>(Faker.Random.Int());
+            },
+            options,
+            AbortToken
+        );
+
+        // then - the value comes from L1 without re-invoking the factory, and the fallthrough does not
+        // repopulate L2 (the served entry has its sliding metadata stripped, so no re-arm fires).
+        result.Value.Should().Be(value);
+        factoryCalls.Should().Be(0);
+
+        var l1Entry = await ((IFactoryCacheStore)l1).TryGetEntryAsync<int>(key, AbortToken);
+        var l2Entry = await ((IFactoryCacheStore)l2).TryGetEntryAsync<int>(key, AbortToken);
+        l1Entry.Found.Should().BeTrue();
+        l1Entry.Value.Should().Be(value);
+        l2Entry.Found.Should().BeFalse();
+    }
+
     private (HybridCache Cache, IInMemoryCache L1, IRemoteCache L2) _CreateCache(HybridCacheOptions options)
     {
         var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSlidingTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSlidingTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Messaging;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests;
+
+public sealed class HybridCacheSlidingTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    [Fact]
+    public async Task should_store_sliding_metadata_in_l2_and_bound_local_copy()
+    {
+        // given
+        var localExpiration = TimeSpan.FromMilliseconds(200);
+        var duration = TimeSpan.FromSeconds(2);
+        var slidingExpiration = TimeSpan.FromMilliseconds(800);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var (cache, l1, l2) = _CreateCache(new HybridCacheOptions { DefaultLocalExpiration = localExpiration });
+        await using var _ = cache;
+
+        var key = Faker.Random.AlphaNumeric(10);
+        var value = Faker.Random.Int();
+        var options = new CacheEntryOptions { Duration = duration, SlidingExpiration = slidingExpiration };
+
+        // when
+        var result = await cache.GetOrAddAsync(key, _ => new ValueTask<int?>(value), options, AbortToken);
+
+        // then
+        var l1Entry = await ((IFactoryCacheStore)l1).TryGetEntryAsync<int>(key, AbortToken);
+        var l2Entry = await ((IFactoryCacheStore)l2).TryGetEntryAsync<int>(key, AbortToken);
+
+        result.Value.Should().Be(value);
+        l2Entry.Value.Should().Be(value);
+        l2Entry.LogicalExpiresAt.Should().Be(now.Add(slidingExpiration));
+        l2Entry.PhysicalExpiresAt.Should().Be(now.Add(duration));
+        l2Entry.SlidingExpiration.Should().Be(slidingExpiration);
+
+        l1Entry.Value.Should().Be(value);
+        l1Entry.LogicalExpiresAt.Should().Be(now.Add(localExpiration));
+        l1Entry.PhysicalExpiresAt.Should().Be(now.Add(localExpiration));
+        l1Entry.SlidingExpiration.Should().Be(slidingExpiration);
+    }
+
+    [Fact]
+    public async Task should_rearm_sliding_l2_and_local_copy_without_shortening_l2_physical_cap()
+    {
+        // given
+        var localExpiration = TimeSpan.FromSeconds(1);
+        var duration = TimeSpan.FromSeconds(2);
+        var slidingExpiration = TimeSpan.FromMilliseconds(400);
+        var createdAt = _timeProvider.GetUtcNow().UtcDateTime;
+        var (cache, l1, l2) = _CreateCache(new HybridCacheOptions { DefaultLocalExpiration = localExpiration });
+        await using var _ = cache;
+
+        var key = Faker.Random.AlphaNumeric(10);
+        var value = Faker.Random.Int();
+        var options = new CacheEntryOptions { Duration = duration, SlidingExpiration = slidingExpiration };
+
+        await cache.GetOrAddAsync(key, _ => new ValueTask<int?>(value), options, AbortToken);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(300));
+        var rearmedAt = _timeProvider.GetUtcNow().UtcDateTime;
+        var factoryCalls = 0;
+
+        // when
+        var result = await cache.GetOrAddAsync(
+            key,
+            _ =>
+            {
+                factoryCalls++;
+                return new ValueTask<int?>(Faker.Random.Int());
+            },
+            options,
+            AbortToken
+        );
+
+        // then
+        var l1Entry = await ((IFactoryCacheStore)l1).TryGetEntryAsync<int>(key, AbortToken);
+        var l2Entry = await ((IFactoryCacheStore)l2).TryGetEntryAsync<int>(key, AbortToken);
+
+        result.Value.Should().Be(value);
+        factoryCalls.Should().Be(0);
+        l2Entry.Value.Should().Be(value);
+        l2Entry.LogicalExpiresAt.Should().Be(rearmedAt.Add(slidingExpiration));
+        l2Entry.PhysicalExpiresAt.Should().Be(createdAt.Add(duration));
+        l2Entry.SlidingExpiration.Should().Be(slidingExpiration);
+
+        l1Entry.Value.Should().Be(value);
+        l1Entry.LogicalExpiresAt.Should().Be(rearmedAt.Add(slidingExpiration));
+        l1Entry.PhysicalExpiresAt.Should().Be(rearmedAt.Add(localExpiration));
+        l1Entry.SlidingExpiration.Should().Be(slidingExpiration);
+    }
+
+    private (HybridCache Cache, IInMemoryCache L1, IRemoteCache L2) _CreateCache(HybridCacheOptions options)
+    {
+        var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });
+        var l2 = new InMemoryRemoteCacheAdapter(
+            new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true })
+        );
+        var publisher = Substitute.For<IBus>();
+        publisher
+            .PublishAsync(Arg.Any<CacheInvalidationMessage>(), Arg.Any<PublishOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        return (new HybridCache(l1, l2, publisher, options, timeProvider: _timeProvider), l1, l2);
+    }
+}

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheTests.cs
@@ -114,7 +114,15 @@ public sealed class HybridCacheTests : TestBase
         var freshValue = Faker.Random.Int(101, 200);
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         await ((IFactoryCacheStore)l1)
-            .SetEntryAsync(key, staleValue, isNull: false, now.AddMinutes(-1), now.AddMinutes(5), AbortToken);
+            .SetEntryAsync(
+                key,
+                staleValue,
+                isNull: false,
+                now.AddMinutes(-1),
+                now.AddMinutes(5),
+                slidingExpiration: null,
+                AbortToken
+            );
         await l2.UpsertAsync(key, freshValue, TimeSpan.FromMinutes(5), AbortToken);
         var factoryCalled = false;
 

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridTestDoubles.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridTestDoubles.cs
@@ -23,10 +23,11 @@ internal sealed class InMemoryRemoteCacheAdapter(InMemoryCache cache) : IRemoteC
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     ) =>
         ((IFactoryCacheStore)cache)
-            .SetEntryAsync(key, value, isNull, logicalExpiresAt, physicalExpiresAt, cancellationToken);
+            .SetEntryAsync(key, value, isNull, logicalExpiresAt, physicalExpiresAt, slidingExpiration, cancellationToken);
 
     public ValueTask<bool> UpsertAsync<T>(
         string key,
@@ -191,6 +192,7 @@ internal sealed class ThrowingReadRemoteCache(TimeProvider timeProvider) : IRemo
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     ) =>
         // No-op: writes are silently dropped (non-fatal in HybridCache.SetEntryAsync)
@@ -300,7 +302,8 @@ internal sealed class NullTimestampL2Adapter<TValue>(TValue value) : IRemoteCach
             IsNull: false,
             Value: typedValue,
             LogicalExpiresAt: null,
-            PhysicalExpiresAt: null
+            PhysicalExpiresAt: null,
+            SlidingExpiration: null
         );
         return new ValueTask<CacheStoreEntry<T>>(entry);
     }
@@ -311,6 +314,7 @@ internal sealed class NullTimestampL2Adapter<TValue>(TValue value) : IRemoteCach
         bool isNull,
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
+        TimeSpan? slidingExpiration,
         CancellationToken cancellationToken
     ) => ValueTask.CompletedTask;
 

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridTestDoubles.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridTestDoubles.cs
@@ -29,6 +29,16 @@ internal sealed class InMemoryRemoteCacheAdapter(InMemoryCache cache) : IRemoteC
         ((IFactoryCacheStore)cache)
             .SetEntryAsync(key, value, isNull, logicalExpiresAt, physicalExpiresAt, slidingExpiration, cancellationToken);
 
+    public ValueTask TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    ) =>
+        ((IFactoryCacheStore)cache)
+            .TryRearmSlidingAsync(key, slidingExpiration, physicalExpiresAt, now, cancellationToken);
+
     public ValueTask<bool> UpsertAsync<T>(
         string key,
         T? value,
@@ -198,6 +208,16 @@ internal sealed class ThrowingReadRemoteCache(TimeProvider timeProvider) : IRemo
         // No-op: writes are silently dropped (non-fatal in HybridCache.SetEntryAsync)
         ValueTask.CompletedTask;
 
+    public ValueTask TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
+        CancellationToken cancellationToken
+    ) =>
+        // No-op: best-effort re-arm on a down store is silently dropped.
+        ValueTask.CompletedTask;
+
     public ValueTask<CacheValue<T>> GetOrAddAsync<T>(
         string key,
         Func<CancellationToken, ValueTask<T?>> factory,
@@ -315,6 +335,14 @@ internal sealed class NullTimestampL2Adapter<TValue>(TValue value) : IRemoteCach
         DateTime logicalExpiresAt,
         DateTime physicalExpiresAt,
         TimeSpan? slidingExpiration,
+        CancellationToken cancellationToken
+    ) => ValueTask.CompletedTask;
+
+    public ValueTask TryRearmSlidingAsync(
+        string key,
+        TimeSpan slidingExpiration,
+        DateTime physicalExpiresAt,
+        DateTime now,
         CancellationToken cancellationToken
     ) => ValueTask.CompletedTask;
 

--- a/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheConformanceTests.cs
+++ b/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheConformanceTests.cs
@@ -78,4 +78,19 @@ public sealed class InMemoryCacheConformanceTests : CacheConformanceTestsBase
     [Fact]
     public override Task should_not_serve_stale_when_caller_cancels() =>
         base.should_not_serve_stale_when_caller_cancels();
+
+    [Fact]
+    public override Task should_keep_sliding_entry_alive_when_read_within_idle_window() =>
+        base.should_keep_sliding_entry_alive_when_read_within_idle_window();
+
+    [Fact]
+    public override Task should_expire_sliding_entry_at_absolute_duration_cap() =>
+        base.should_expire_sliding_entry_at_absolute_duration_cap();
+
+    [Fact]
+    public override Task should_not_rearm_sliding_entry_when_metadata_is_read() =>
+        base.should_not_rearm_sliding_entry_when_metadata_is_read();
+
+    [Fact]
+    public override Task should_not_rearm_non_sliding_entry() => base.should_not_rearm_non_sliding_entry();
 }

--- a/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCachePerformanceTests.cs
+++ b/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCachePerformanceTests.cs
@@ -77,4 +77,44 @@ public sealed class InMemoryCachePerformanceTests : TestBase
             .Should()
             .BeLessThan(50, "overhead increase should be negligible between 100k and 200k items");
     }
+
+    // KTD-9 acceptance gate: sliding re-arm must be throttled, never unconditional. A hot key read many times
+    // within the first half of its idle window must NOT be re-written on every read (which would hammer the
+    // store under load); the logical deadline only advances once at least half the window has elapsed.
+    [Fact]
+    public async Task sliding_rearm_is_throttled_on_a_hot_key_and_does_not_rewrite_on_every_read()
+    {
+        // given - a sliding entry whose idle window (1s) is well inside the absolute cap (30s)
+        using var cache = _CreateCache();
+        var store = (IFactoryCacheStore)cache;
+        var key = Faker.Random.AlphaNumeric(10);
+        var sliding = TimeSpan.FromSeconds(1);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var options = new CacheEntryOptions { Duration = TimeSpan.FromSeconds(30), SlidingExpiration = sliding };
+        await cache.GetOrAddAsync(key, _ => new ValueTask<string?>("value"), options, AbortToken);
+
+        // when - a burst of hot reads with no time advance (more than half the window still remains)
+        for (var i = 0; i < 1_000; i++)
+        {
+            (await cache.GetAsync<string>(key, AbortToken)).Value.Should().Be("value");
+        }
+
+        // then - the throttle suppressed every re-arm: the logical deadline is unchanged from the initial set.
+        // TryGetEntryAsync is a non-re-arming inspection read, so it does not perturb the measurement.
+        var afterBurst = await store.TryGetEntryAsync<string>(key, AbortToken);
+        afterBurst.LogicalExpiresAt.Should().Be(now.Add(sliding));
+
+        // and when - more than half the idle window elapses, the next read re-arms exactly once...
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(600));
+        var rearmAt = _timeProvider.GetUtcNow().UtcDateTime;
+        (await cache.GetAsync<string>(key, AbortToken)).Value.Should().Be("value");
+
+        var afterThreshold = await store.TryGetEntryAsync<string>(key, AbortToken);
+        afterThreshold.LogicalExpiresAt.Should().Be(rearmAt.Add(sliding));
+
+        // ...and an immediate follow-up read is throttled again (back above the half-window).
+        (await cache.GetAsync<string>(key, AbortToken)).Value.Should().Be("value");
+        var afterSecond = await store.TryGetEntryAsync<string>(key, AbortToken);
+        afterSecond.LogicalExpiresAt.Should().Be(rearmAt.Add(sliding));
+    }
 }

--- a/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs
+++ b/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs
@@ -34,6 +34,7 @@ public sealed class InMemoryCacheTests : TestBase
                 return new CacheEntryEnvelope(
                     _GetEntryProperty<DateTime?>(entry, "LogicalExpiresAt"),
                     _GetEntryProperty<DateTime?>(entry, "PhysicalExpiresAt"),
+                    _GetEntryProperty<TimeSpan?>(entry, "SlidingExpiration"),
                     _GetEntryProperty<object?>(entry, "LastFactoryError"),
                     _GetEntryProperty<IReadOnlySet<string>?>(entry, "Tags")
                 );
@@ -68,6 +69,7 @@ public sealed class InMemoryCacheTests : TestBase
                 typeof(object),
                 typeof(DateTime?),
                 typeof(DateTime?),
+                typeof(TimeSpan?),
                 typeof(TimeProvider),
                 typeof(bool),
                 typeof(bool),
@@ -85,6 +87,7 @@ public sealed class InMemoryCacheTests : TestBase
             value,
             logicalExpiresAt,
             physicalExpiresAt,
+            null,
             typeof(InMemoryCache)
                 .GetField("_timeProvider", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .GetValue(cache),
@@ -105,6 +108,19 @@ public sealed class InMemoryCacheTests : TestBase
         return field!.GetValue(cache)!;
     }
 
+    private static async Task _StartMaintenanceAsync(InMemoryCache cache)
+    {
+        var method = typeof(InMemoryCache).GetMethod(
+            "_StartMaintenanceAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        );
+        method.Should().NotBeNull();
+
+        var task = (Task)method!.Invoke(cache, [true])!;
+        await task;
+        await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
+    }
+
     private static T? _GetEntryProperty<T>(object entry, string propertyName)
     {
         var property = entry
@@ -120,6 +136,7 @@ public sealed class InMemoryCacheTests : TestBase
         var envelope = _GetEntryEnvelope(cache, key);
         envelope.LogicalExpiresAt.Should().Be(expectedExpiration);
         envelope.PhysicalExpiresAt.Should().Be(expectedExpiration);
+        envelope.SlidingExpiration.Should().BeNull();
         envelope.LastFactoryError.Should().BeNull();
         envelope.Tags.Should().BeNull();
     }
@@ -127,6 +144,7 @@ public sealed class InMemoryCacheTests : TestBase
     private sealed record CacheEntryEnvelope(
         DateTime? LogicalExpiresAt,
         DateTime? PhysicalExpiresAt,
+        TimeSpan? SlidingExpiration,
         object? LastFactoryError,
         IReadOnlySet<string>? Tags
     );
@@ -238,8 +256,130 @@ public sealed class InMemoryCacheTests : TestBase
         var envelope = _GetEntryEnvelope(cache, key);
         envelope.LogicalExpiresAt.Should().Be(now.Add(duration));
         envelope.PhysicalExpiresAt.Should().Be(now.Add(duration));
+        envelope.SlidingExpiration.Should().BeNull();
         envelope.LastFactoryError.Should().BeNull();
         envelope.Tags.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_store_sliding_expiration_for_factory_entry()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMinutes(10),
+            SlidingExpiration = TimeSpan.FromMinutes(2),
+        };
+
+        // when
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+
+        // then
+        var envelope = _GetEntryEnvelope(cache, key);
+        envelope.LogicalExpiresAt.Should().Be(now.Add(options.SlidingExpiration.Value));
+        envelope.PhysicalExpiresAt.Should().Be(now.Add(options.Duration));
+        envelope.SlidingExpiration.Should().Be(options.SlidingExpiration);
+    }
+
+    [Fact]
+    public async Task should_rearm_sliding_entry_on_value_read_without_moving_physical_cap()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromSeconds(10),
+            SlidingExpiration = TimeSpan.FromSeconds(2),
+        };
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        var before = _GetEntryEnvelope(cache, key);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(1300));
+
+        // when
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+
+        // then
+        var after = _GetEntryEnvelope(cache, key);
+        cached.Value.Should().Be("value");
+        after.LogicalExpiresAt.Should().Be(_timeProvider.GetUtcNow().UtcDateTime.Add(options.SlidingExpiration.Value));
+        after.PhysicalExpiresAt.Should().Be(before.PhysicalExpiresAt);
+        after.SlidingExpiration.Should().Be(options.SlidingExpiration);
+    }
+
+    [Fact]
+    public async Task should_not_rearm_sliding_entry_before_rearm_threshold()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromSeconds(10),
+            SlidingExpiration = TimeSpan.FromSeconds(2),
+        };
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        var before = _GetEntryEnvelope(cache, key);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(250));
+
+        // when
+        var cached = await cache.GetAsync<string>(key, AbortToken);
+
+        // then
+        var after = _GetEntryEnvelope(cache, key);
+        cached.Value.Should().Be("value");
+        after.LogicalExpiresAt.Should().Be(before.LogicalExpiresAt);
+    }
+
+    [Fact]
+    public async Task should_not_rearm_sliding_entry_on_metadata_read()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromSeconds(10),
+            SlidingExpiration = TimeSpan.FromSeconds(2),
+        };
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        var before = _GetEntryEnvelope(cache, key);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(1300));
+
+        // when
+        var exists = await cache.ExistsAsync(key, AbortToken);
+        var expiration = await cache.GetExpirationAsync(key, AbortToken);
+
+        // then
+        var after = _GetEntryEnvelope(cache, key);
+        exists.Should().BeTrue();
+        expiration.Should().BeCloseTo(TimeSpan.FromMilliseconds(700), TimeSpan.FromMilliseconds(1));
+        after.LogicalExpiresAt.Should().Be(before.LogicalExpiresAt);
+    }
+
+    [Fact]
+    public async Task should_remove_idle_sliding_entry_during_maintenance_before_physical_cap()
+    {
+        // given
+        using var cache = _CreateCache(new InMemoryCacheOptions { MaintenanceInterval = TimeSpan.FromMilliseconds(1) });
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMinutes(5),
+            SlidingExpiration = TimeSpan.FromMilliseconds(100),
+        };
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(150));
+
+        // when
+        await _StartMaintenanceAsync(cache);
+
+        // then
+        var count = await cache.GetCountAsync(cancellationToken: AbortToken);
+        count.Should().Be(0);
     }
 
     [Fact]
@@ -258,6 +398,7 @@ public sealed class InMemoryCacheTests : TestBase
         var envelope = _GetEntryEnvelope(cache, key);
         envelope.LogicalExpiresAt.Should().Be(now.Add(duration));
         envelope.PhysicalExpiresAt.Should().Be(now.Add(duration));
+        envelope.SlidingExpiration.Should().BeNull();
     }
 
     [Fact]
@@ -290,6 +431,7 @@ public sealed class InMemoryCacheTests : TestBase
         var envelope = _GetEntryEnvelope(cache, key);
         envelope.LogicalExpiresAt.Should().BeNull();
         envelope.PhysicalExpiresAt.Should().BeNull();
+        envelope.SlidingExpiration.Should().BeNull();
     }
 
     [Fact]
@@ -1897,6 +2039,7 @@ public sealed class InMemoryCacheTests : TestBase
                 isNull: false,
                 logicalExpiresAt: now.AddMinutes(-1),
                 physicalExpiresAt: now.AddMinutes(5),
+                slidingExpiration: null,
                 AbortToken
             );
 

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
@@ -89,4 +89,19 @@ public sealed class RedisCacheConformanceTests(RedisCacheFixture fixture) : Cach
     [Fact]
     public override Task should_not_serve_stale_when_caller_cancels() =>
         base.should_not_serve_stale_when_caller_cancels();
+
+    [Fact]
+    public override Task should_keep_sliding_entry_alive_when_read_within_idle_window() =>
+        base.should_keep_sliding_entry_alive_when_read_within_idle_window();
+
+    [Fact]
+    public override Task should_expire_sliding_entry_at_absolute_duration_cap() =>
+        base.should_expire_sliding_entry_at_absolute_duration_cap();
+
+    [Fact]
+    public override Task should_not_rearm_sliding_entry_when_metadata_is_read() =>
+        base.should_not_rearm_sliding_entry_when_metadata_is_read();
+
+    [Fact]
+    public override Task should_not_rearm_non_sliding_entry() => base.should_not_rearm_non_sliding_entry();
 }

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
@@ -10,6 +10,8 @@ namespace Tests;
 public sealed class RedisCacheEntryFrameTests
 {
     private const int _HeaderLength = 19;
+    private const int _SlidingHeaderLength = 27;
+    private const byte _HasSlidingExpirationFlag = 1 << 3;
     private static readonly Type _FrameType = Type.GetType(
         "Headless.Caching.RedisCacheEntryFrame, Headless.Caching.Redis",
         throwOnError: true
@@ -39,6 +41,7 @@ public sealed class RedisCacheEntryFrameTests
         decoded.IsNull.Should().BeFalse();
         decoded.LogicalExpiresAt.Should().Be(logical);
         decoded.PhysicalExpiresAt.Should().Be(physical);
+        decoded.SlidingExpiration.Should().BeNull();
         decoded.ValueSegment.ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
     }
 
@@ -62,6 +65,58 @@ public sealed class RedisCacheEntryFrameTests
         encoded[2].Should().Be(0);
         decoded.LogicalExpiresAt.Should().BeNull();
         decoded.PhysicalExpiresAt.Should().BeNull();
+        decoded.SlidingExpiration.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_round_trip_sliding_expiration_with_flag_conditional_payload_offset()
+    {
+        var value = _RedisValue(Encoding.UTF8.GetBytes("value"));
+        var logical = new DateTime(2026, 06, 03, 12, 00, 00, DateTimeKind.Utc);
+        var physical = logical.AddMinutes(5);
+        var sliding = TimeSpan.FromSeconds(30);
+
+        var encoded = _Encode(value, isNull: false, logical, physical, sliding);
+        var decoded = _Decode(encoded);
+
+        (encoded[2] & _HasSlidingExpirationFlag).Should().Be(_HasSlidingExpirationFlag);
+        BinaryPrimitives.ReadInt64LittleEndian(encoded.AsSpan(_HeaderLength, sizeof(long)))
+            .Should()
+            .Be((long)sliding.TotalMilliseconds);
+        decoded.SlidingExpiration.Should().Be(sliding);
+        decoded.ValueSegment.ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
+        encoded.AsSpan(_SlidingHeaderLength).ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
+    }
+
+    [Fact]
+    public void should_keep_non_sliding_frame_at_old_header_length()
+    {
+        var logical = new DateTime(2026, 06, 03, 12, 00, 00, DateTimeKind.Utc);
+        var physical = logical.AddMinutes(5);
+
+        var encoded = _Encode("value", isNull: false, logical, physical, slidingExpiration: null);
+        var decoded = _Decode(encoded);
+
+        (encoded[2] & _HasSlidingExpirationFlag).Should().Be(0);
+        encoded.Length.Should().Be(_HeaderLength + Encoding.UTF8.GetByteCount("value"));
+        encoded.AsSpan(_HeaderLength).ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
+        decoded.SlidingExpiration.Should().BeNull();
+        decoded.ValueSegment.ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
+    }
+
+    [Fact]
+    public void should_decode_old_layout_payload_from_header_length_nineteen()
+    {
+        var encoded = new byte[_HeaderLength + 5];
+        encoded[0] = 0xFF;
+        encoded[1] = 0x01;
+        Encoding.UTF8.GetBytes("value").CopyTo(encoded.AsSpan(_HeaderLength));
+
+        var decoded = _Decode(_RedisValue(encoded));
+
+        decoded.IsFramed.Should().BeTrue();
+        decoded.SlidingExpiration.Should().BeNull();
+        decoded.ValueSegment.ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
     }
 
     [Theory]
@@ -126,8 +181,9 @@ public sealed class RedisCacheEntryFrameTests
         RedisValue value,
         bool isNull,
         DateTime? logicalExpiresAt,
-        DateTime? physicalExpiresAt
-    ) => (byte[])_EncodeMethod.Invoke(null, [value, isNull, logicalExpiresAt, physicalExpiresAt])!;
+        DateTime? physicalExpiresAt,
+        TimeSpan? slidingExpiration = null
+    ) => (byte[])_EncodeMethod.Invoke(null, [value, isNull, logicalExpiresAt, physicalExpiresAt, slidingExpiration])!;
 
     private static RedisValue _RedisValue(byte[] value) => value;
 
@@ -141,6 +197,7 @@ public sealed class RedisCacheEntryFrameTests
             (bool)type.GetProperty("IsNull")!.GetValue(decoded)!,
             (DateTime?)type.GetProperty("LogicalExpiresAt")!.GetValue(decoded),
             (DateTime?)type.GetProperty("PhysicalExpiresAt")!.GetValue(decoded),
+            (TimeSpan?)type.GetProperty("SlidingExpiration")!.GetValue(decoded),
             (ReadOnlyMemory<byte>)type.GetProperty("ValueSegment")!.GetValue(decoded)!
         );
     }
@@ -150,6 +207,7 @@ public sealed class RedisCacheEntryFrameTests
         bool IsNull,
         DateTime? LogicalExpiresAt,
         DateTime? PhysicalExpiresAt,
+        TimeSpan? SlidingExpiration,
         ReadOnlyMemory<byte> ValueSegment
     );
 }

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheSlidingTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheSlidingTests.cs
@@ -85,4 +85,33 @@ public sealed class RedisCacheSlidingTests(RedisCacheFixture fixture) : RedisCac
 
         capped.HasValue.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task should_not_rearm_ttl_on_value_read_below_threshold()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(900),
+            SlidingExpiration = TimeSpan.FromMilliseconds(300),
+        };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+
+        // Read well within the first half of the 300ms window (re-arm threshold = 150ms), so the throttle must
+        // suppress the re-arm: the key's TTL keeps counting down rather than being bumped back toward 300ms.
+        await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(50), AbortToken);
+
+        var ttlBefore = await Fixture.ConnectionMultiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+        var read = await cache.GetAsync<string>(key, AbortToken);
+        var ttlAfter = await Fixture.ConnectionMultiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+
+        read.Value.Should().Be("value");
+        ttlBefore.Should().NotBeNull();
+        ttlAfter.Should().NotBeNull();
+        // A re-arm would push the TTL back up above ttlBefore; below the threshold it only ever decreases.
+        ttlAfter!.Value.Should().BeLessThanOrEqualTo(ttlBefore!.Value);
+    }
 }

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheSlidingTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheSlidingTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+
+namespace Tests;
+
+public sealed class RedisCacheSlidingTests(RedisCacheFixture fixture) : RedisCacheTestBase(fixture)
+{
+    [Fact]
+    public async Task should_rearm_ttl_on_value_read_and_keep_value_after_original_logical_deadline()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(900),
+            SlidingExpiration = TimeSpan.FromMilliseconds(300),
+        };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(225), AbortToken);
+
+        var firstRead = await cache.GetAsync<string>(key, AbortToken);
+        var ttlAfterRearm = await Fixture.ConnectionMultiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+
+        await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(150), AbortToken);
+        var afterOriginalLogicalDeadline = await cache.GetAsync<string>(key, AbortToken);
+
+        firstRead.Value.Should().Be("value");
+        ttlAfterRearm.Should().NotBeNull();
+        ttlAfterRearm!.Value.Should().BeCloseTo(options.SlidingExpiration.Value, TimeSpan.FromMilliseconds(150));
+        afterOriginalLogicalDeadline.Value.Should().Be("value");
+    }
+
+    [Fact]
+    public async Task should_not_rearm_ttl_on_metadata_read()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(900),
+            SlidingExpiration = TimeSpan.FromMilliseconds(300),
+        };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(225), AbortToken);
+
+        var ttlBefore = await Fixture.ConnectionMultiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+        var exists = await cache.ExistsAsync(key, AbortToken);
+        var expiration = await cache.GetExpirationAsync(key, AbortToken);
+        var ttlAfter = await Fixture.ConnectionMultiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+
+        exists.Should().BeTrue();
+        expiration.Should().NotBeNull();
+        ttlBefore.Should().NotBeNull();
+        ttlAfter.Should().NotBeNull();
+        ttlAfter!.Value.Should().BeLessThan(ttlBefore!.Value + TimeSpan.FromMilliseconds(50));
+    }
+
+    [Fact]
+    public async Task should_expire_at_absolute_duration_cap_even_with_repeated_reads()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMilliseconds(550),
+            SlidingExpiration = TimeSpan.FromMilliseconds(250),
+        };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(150), AbortToken);
+            (await cache.GetAsync<string>(key, AbortToken)).HasValue.Should().BeTrue();
+        }
+
+        await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(175), AbortToken);
+        var capped = await cache.GetAsync<string>(key, AbortToken);
+
+        capped.HasValue.Should().BeFalse();
+    }
+}

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisEnvelopeFormatTests.cs
@@ -14,6 +14,7 @@ public sealed class RedisEnvelopeFormatTests(RedisCacheFixture fixture) : RedisC
     private const byte _Version = 0x01;
     private const byte _NullFlag = 1 << 0;
     private const byte _HasPhysicalExpiresAtFlag = 1 << 2;
+    private const byte _HasSlidingExpirationFlag = 1 << 3;
 
     [Fact]
     public async Task should_store_scalar_value_as_framed_payload_with_magic_prefix()
@@ -65,6 +66,28 @@ public sealed class RedisEnvelopeFormatTests(RedisCacheFixture fixture) : RedisC
         var ttl = await _Database().KeyTimeToLiveAsync(key);
         ttl.Should().NotBeNull();
         ttl!.Value.Should().BeCloseTo(options.FailSafeMaxDuration, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task should_store_sliding_expiration_flag_and_map_redis_ttl_to_logical_deadline()
+    {
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromSeconds(30),
+            SlidingExpiration = TimeSpan.FromSeconds(5),
+        };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+
+        var stored = await _GetRawBytesAsync(key);
+        var ttl = await _Database().KeyTimeToLiveAsync(key);
+        (stored[2] & _HasSlidingExpirationFlag).Should().Be(_HasSlidingExpirationFlag);
+        stored.AsSpan(27).ToArray().Should().Equal(Encoding.UTF8.GetBytes("value"));
+        ttl.Should().NotBeNull();
+        ttl!.Value.Should().BeCloseTo(options.SlidingExpiration.Value, TimeSpan.FromSeconds(2));
     }
 
     [Fact]

--- a/tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs
+++ b/tests/Headless.Caching.Tests.Harness/CacheConformanceTestsBase.cs
@@ -333,6 +333,86 @@ public abstract class CacheConformanceTestsBase : TestBase
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    public virtual async Task should_keep_sliding_entry_alive_when_read_within_idle_window()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = _CreateSlidingOptions();
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        await AdvanceAsync(options.SlidingExpiration!.Value - TimeSpan.FromMilliseconds(25));
+
+        var firstRead = await cache.GetAsync<string>(key, AbortToken);
+
+        await AdvanceAsync(options.SlidingExpiration.Value - TimeSpan.FromMilliseconds(25));
+        var secondRead = await cache.GetAsync<string>(key, AbortToken);
+
+        await AdvanceAsync(options.SlidingExpiration.Value + TimeSpan.FromMilliseconds(75));
+        var idleRead = await cache.GetAsync<string>(key, AbortToken);
+
+        firstRead.Value.Should().Be("value");
+        secondRead.Value.Should().Be("value");
+        idleRead.HasValue.Should().BeFalse();
+    }
+
+    public virtual async Task should_expire_sliding_entry_at_absolute_duration_cap()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = _CreateSlidingOptions(duration: TimeSpan.FromMilliseconds(450), sliding: TimeSpan.FromMilliseconds(150));
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await AdvanceAsync(TimeSpan.FromMilliseconds(100));
+            (await cache.GetAsync<string>(key, AbortToken)).HasValue.Should().BeTrue();
+        }
+
+        await AdvanceAsync(TimeSpan.FromMilliseconds(180));
+        var capped = await cache.GetAsync<string>(key, AbortToken);
+
+        capped.HasValue.Should().BeFalse();
+    }
+
+    public virtual async Task should_not_rearm_sliding_entry_when_metadata_is_read()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = _CreateSlidingOptions(sliding: TimeSpan.FromMilliseconds(150));
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        await AdvanceAsync(TimeSpan.FromMilliseconds(100));
+
+        (await cache.ExistsAsync(key, AbortToken)).Should().BeTrue();
+
+        await AdvanceAsync(TimeSpan.FromMilliseconds(90));
+        var expired = await cache.GetAsync<string>(key, AbortToken);
+
+        expired.HasValue.Should().BeFalse();
+    }
+
+    public virtual async Task should_not_rearm_non_sliding_entry()
+    {
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var options = new CacheEntryOptions { Duration = TimeSpan.FromMilliseconds(180) };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+        await AdvanceAsync(TimeSpan.FromMilliseconds(120));
+
+        (await cache.GetAsync<string>(key, AbortToken)).HasValue.Should().BeTrue();
+
+        await AdvanceAsync(TimeSpan.FromMilliseconds(100));
+        var expired = await cache.GetAsync<string>(key, AbortToken);
+
+        expired.HasValue.Should().BeFalse();
+    }
+
     private static CacheEntryOptions _CreateFailSafeOptions(TimeSpan? throttleDuration = null) =>
         new()
         {
@@ -340,6 +420,13 @@ public abstract class CacheConformanceTestsBase : TestBase
             IsFailSafeEnabled = true,
             FailSafeMaxDuration = TimeSpan.FromMilliseconds(900),
             FailSafeThrottleDuration = throttleDuration ?? TimeSpan.FromMilliseconds(200),
+        };
+
+    private static CacheEntryOptions _CreateSlidingOptions(TimeSpan? duration = null, TimeSpan? sliding = null) =>
+        new()
+        {
+            Duration = duration ?? TimeSpan.FromMilliseconds(700),
+            SlidingExpiration = sliding ?? TimeSpan.FromMilliseconds(200),
         };
 
     protected sealed record CacheConformanceObject(Guid Id, string Name);


### PR DESCRIPTION
## Summary

Factory-backed cache entries can now use an idle sliding window without losing the original absolute duration cap. Reads that return values re-arm the logical deadline, while metadata reads leave the idle window untouched; fail-safe and sliding expiration are rejected together so stale-reserve semantics stay explicit.

Closes #377.

## Design Notes

| Area | Decision |
| --- | --- |
| Core coordinator | Threads `SlidingExpiration` through `CacheEntryOptions`, `CacheStoreEntry`, and `IFactoryCacheStore`; re-arm writes are best-effort so read success is not coupled to metadata refresh. |
| In-memory provider | Stores sliding metadata in the entry envelope and re-arms logical expiration only after the idle window crosses the 50% threshold. |
| Redis provider | Extends the binary frame with an optional sliding field while preserving the old non-sliding payload offset; Redis TTL tracks the idle deadline for sliding entries and the physical cap for fail-safe entries. |
| Hybrid provider | Revalidates sliding L1 hits against L2 before re-arm so a short local TTL cannot shorten the remote absolute cap. |

## Validation

- `make test-project TEST_PROJECT=tests/Headless.Caching.Abstractions.Tests.Unit`
- `make test-project TEST_PROJECT=tests/Headless.Caching.Core.Tests.Unit`
- `make test-project TEST_PROJECT=tests/Headless.Caching.InMemory.Tests.Unit`
- `make test-project TEST_PROJECT=tests/Headless.Caching.Hybrid.Tests.Unit`
- `make test-project TEST_PROJECT=tests/Headless.Caching.Redis.Tests.Integration`
- `make format`
- `make format-check`
- `make build`
