### PR TITLE
fix: harden postgres advisory savepoint detection

### DIFF
--- a/docs/plans/2026-06-09-001-fix-postgres-advisory-savepoint-probe-plan.md
+++ b/docs/plans/2026-06-09-001-fix-postgres-advisory-savepoint-probe-plan.md
@@ -1,0 +1,241 @@
+---
+title: "fix: Replace Postgres advisory savepoint transaction probe"
+type: fix
+status: completed
+date: 2026-06-09
+github_issue: 404
+---
+
+# fix: Replace Postgres advisory savepoint transaction probe
+
+## Summary
+
+Replace the side-effectful transaction probe in `PostgresAdvisoryLock` with a savepoint-first boundary check. The fix should preserve transaction-local timeout isolation for visible and invisible external transactions, while ensuring "no active transaction" is the only swallowed PostgreSQL state.
+
+The issue is not the savepoint itself. The issue is using `DatabaseConnection.BeginTransactionAsync(...)` as a detection mechanism: it can mutate wrapper state on success, and it catches provider `InvalidOperationException` too broadly on failure.
+
+## Problem Frame
+
+`src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs` currently decides whether acquisition should be protected by a savepoint through `_ShouldDefineSavePointAsync(...)`.
+
+The problematic branch is an externally-owned `NpgsqlConnection` whose active transaction is not tracked by `DatabaseConnection`:
+
+1. `connection.HasTransaction` is false.
+2. `_ShouldDefineSavePointAsync(...)` calls `connection.BeginTransactionAsync(CancellationToken.None)`.
+3. If Npgsql rejects the call, any `InvalidOperationException` is treated as "there must already be an active transaction".
+4. If the call succeeds, a transaction was created only to answer a question.
+
+That is fragile because the classifier is the exception shape from an operation that changes transaction state. It also makes future Npgsql failures easy to misclassify.
+
+Primary-source check against Npgsql v10.0.2 showed no public authoritative hidden-transaction property. `NpgsqlConnection.FullState` is connection state, while the useful transaction markers (`Connector.InTransaction`, `TransactionStatus`) are internal. Therefore the safer design is not "read hidden state"; it is "attempt the exact PostgreSQL boundary operation we actually need, and classify only its documented SQLSTATE".
+
+## Requirements
+
+### Probe Removal and Transaction Boundaries
+
+- R1. `PostgresAdvisoryLock` must not call `DatabaseConnection.BeginTransactionAsync(...)` to infer external transaction state.
+- R2. For Headless-tracked transactions (`connection.HasTransaction == true`), acquisition must still create a savepoint before mutating `SET LOCAL` timeout settings.
+- R3. For externally-owned `NpgsqlConnection` instances with an invisible active transaction, acquisition must still create a savepoint so timeout settings can be rolled back.
+- R4. For externally-owned `NpgsqlConnection` instances with no active transaction, acquisition must not attempt rollback-to-savepoint cleanup.
+- R5. Only PostgreSQL `NoActiveSqlTransaction` (`25P01`) may mean "no transaction"; failed transactions, busy connections, network/provider errors, and other SQLSTATEs must propagate.
+- R6. Existing session-scoped and transaction-scoped advisory-lock semantics must stay unchanged.
+
+### Testing and Documentation
+
+- R7. Add integration coverage for visible transaction, invisible external transaction, no transaction, and failed transaction paths.
+- R8. Do not change public docs unless the implementation changes public behavior. This fix is intended to be internal/provider-behavior hardening.
+- R9. The PR body should include `Fixes #404`.
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+    A["Acquire Postgres advisory lock"] --> B{"connection.HasTransaction?"}
+    B -->|yes| C["SAVEPOINT name"]
+    B -->|no| D{"connection.IsExternallyOwned?"}
+    D -->|no| E["No savepoint"]
+    D -->|yes| F["Try SAVEPOINT name"]
+    F -->|success| G["Savepoint defined"]
+    F -->|"PostgresException: 25P01"| E
+    F -->|"any other failure"| H["Propagate"]
+    C --> I["Run acquire SQL"]
+    G --> I
+    E --> I
+    I --> J{"savepoint defined and not successful xact-lock?"}
+    J -->|yes| K["ROLLBACK TO SAVEPOINT name"]
+    J -->|no| L["Return acquisition result"]
+    K --> L
+```
+
+The helper should make savepoint creation the transaction-boundary check:
+
+```csharp
+private static async ValueTask<bool> _TryDefineSavePointAsync(
+    DatabaseConnection connection,
+    string savePointName,
+    CancellationToken cancellationToken
+)
+```
+
+Expected behavior:
+
+- Internal provider-owned no-transaction path returns `false` without a server round trip.
+- Visible transaction path executes `SAVEPOINT`.
+- External no-visible-transaction path executes `SAVEPOINT`; it returns `false` only for `PostgresErrorCodes.NoActiveSqlTransaction`.
+- All other failures bubble.
+
+## Key Technical Decisions
+
+### KTD1. Use savepoint-first detection, not a synthetic transaction
+
+Because Npgsql does not expose a public read-only hidden transaction flag, using `BeginTransactionAsync(...)` as a probe creates exactly the side effect the issue asks to remove. `SAVEPOINT` is the boundary operation the provider actually needs, so classifying `SAVEPOINT` failure is both narrower and more directly tied to behavior.
+
+### KTD2. Preserve invisible external transaction timeout isolation
+
+A simpler implementation could return `connection.HasTransaction` and remove all hidden-transaction handling. That would be read-only, but it would leak `SET LOCAL lock_timeout` changes within invisible external transactions. The savepoint-first design preserves the existing isolation behavior without creating a transaction.
+
+### KTD3. Keep transaction-scoped lock selection tied to `connection.HasTransaction`
+
+`_UseTransactionScopedLock(...)` should remain based on Headless-tracked transactions. The invisible external transaction path should be protected for timeout cleanup, but this fix should not silently convert session-scoped lock acquisition into `pg_advisory_xact_lock`.
+
+### KTD4. Add a narrow provider test seam only where public APIs cannot reach the branch
+
+The normal provider behavior should stay covered through public DI/conformance tests. The issue-specific external-connection branch is internal to the database lock engine and Postgres strategy, so targeted integration tests may add `InternalsVisibleTo` for `Headless.DistributedLocks.Postgres.Tests.Integration`, matching existing provider precedent such as the SQL Server distributed-lock project.
+
+## Implementation Units
+
+### U1. Add failing/characterizing Postgres integration coverage
+
+Goal: lock down the transaction-boundary behavior before refactoring the probe.
+
+Requirements: R2, R3, R4, R5, R6, R7.
+
+Files:
+
+- `tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs`
+- `src/Headless.DistributedLocks.Postgres/Headless.DistributedLocks.Postgres.csproj` only if internal access is required
+
+Approach:
+
+- Prefer public/static Postgres APIs for transaction-scoped behavior already exposed by `PostgresDistributedLock`.
+- For the issue-specific branch, instantiate `PostgresAdvisoryLock` and `PostgresDatabaseConnection` directly only if no public path can exercise externally-owned connection behavior.
+- If internals are exposed, keep the exposure limited to the existing Postgres integration test assembly and document that it exists for provider-boundary behavior, not generic white-box unit testing.
+- Reuse the existing `PostgresDistributedLockFixture` and `TestBase.AbortToken`.
+
+Test scenarios:
+
+- Visible transaction: wrap an `NpgsqlTransaction`, acquire through the advisory strategy, and assert acquisition succeeds with transaction-scoped behavior unchanged.
+- Invisible external transaction: begin a transaction directly on `NpgsqlConnection`, wrap only the connection, set a sentinel `lock_timeout`, acquire through `PostgresAdvisoryLock`, then assert the sentinel is still visible inside the transaction after acquisition.
+- No transaction: wrap an open external `NpgsqlConnection` without a transaction and assert acquisition succeeds without trying to roll back to a savepoint.
+- Failed transaction: begin a transaction, intentionally force a SQL error so PostgreSQL enters failed-transaction state, wrap only the connection, attempt acquisition, and assert the non-`NoActiveSqlTransaction` `PostgresException` propagates.
+
+Verification:
+
+- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Postgres.Tests.Integration/Headless.DistributedLocks.Postgres.Tests.Integration.csproj`
+
+### U2. Replace `_ShouldDefineSavePointAsync(...)` with savepoint-first boundary handling
+
+Goal: remove the transaction probe and classify only the PostgreSQL "no active transaction" SQLSTATE.
+
+Requirements: R1, R2, R3, R4, R5, R6.
+
+Files:
+
+- `src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs`
+
+Approach:
+
+- Replace the sequence:
+  - `needsSavePoint = await _ShouldDefineSavePointAsync(...)`
+  - conditional `SAVEPOINT`
+- With:
+  - `savePointDefined = await _TryDefineSavePointAsync(connection, savePointName, cancellationToken)`
+- Remove `_ShouldDefineSavePointAsync(...)`.
+- Add `_TryDefineSavePointAsync(...)` that:
+  - returns `false` for provider-owned connections without `HasTransaction`;
+  - creates a savepoint directly for `HasTransaction`;
+  - for externally-owned connections without visible transactions, attempts `SAVEPOINT` and catches only `PostgresException` where `SqlState == PostgresErrorCodes.NoActiveSqlTransaction`;
+  - lets every other exception propagate.
+- Keep rollback/timeout restore behavior keyed to the returned `savePointDefined` boolean.
+- Keep `_UseTransactionScopedLock(...)` unchanged.
+
+Verification:
+
+- `rg -n "BeginTransactionAsync|_ShouldDefineSavePointAsync" src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs` should not show either symbol.
+- Run the U1 integration tests.
+
+### U3. Tighten comments and issue traceability
+
+Goal: make the new branch readable without expanding public documentation.
+
+Requirements: R8, R9.
+
+Files:
+
+- `src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs`
+
+Approach:
+
+- Add a short comment only where it prevents future regressions: the external no-visible-transaction branch is intentionally using `SAVEPOINT` as the transaction boundary check because Npgsql's transaction state is not public.
+- Do not update `src/Headless.DistributedLocks.Postgres/README.md` or `docs/llms/...` unless the code change becomes consumer-visible.
+- Include `Fixes #404` in the PR body.
+
+Verification:
+
+- `make build-project PROJECT=src/Headless.DistributedLocks.Postgres/Headless.DistributedLocks.Postgres.csproj`
+- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Postgres.Tests.Integration/Headless.DistributedLocks.Postgres.Tests.Integration.csproj`
+
+## Testing Strategy
+
+Use Postgres integration tests as the primary validation surface. The behavior depends on PostgreSQL transaction state, savepoint semantics, and Npgsql exception mapping, so mock/unit tests would mostly assert an invented model.
+
+Minimum verification:
+
+- `make build-project PROJECT=src/Headless.DistributedLocks.Postgres/Headless.DistributedLocks.Postgres.csproj`
+- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Postgres.Tests.Integration/Headless.DistributedLocks.Postgres.Tests.Integration.csproj`
+- `git diff --check`
+
+Broader verification if the implementation touches shared database lock engine code:
+
+- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Core.Database.Tests.Unit/Headless.DistributedLocks.Core.Database.Tests.Unit.csproj`
+- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.SqlServer.Tests.Integration/Headless.DistributedLocks.SqlServer.Tests.Integration.csproj`
+
+## Scope Boundaries
+
+In scope:
+
+- `PostgresAdvisoryLock` transaction-boundary/savepoint decision.
+- Postgres provider integration tests for the affected paths.
+- Minimal comments explaining the new branch.
+
+Out of scope:
+
+- Public API changes.
+- Changes to `PostgresDistributedLock.AcquireWithTransactionAsync(...)` or `TryAcquireWithTransactionAsync(...)`.
+- Reflection into Npgsql internals.
+- New transaction isolation-level behavior.
+- Reworking the shared database lock engine unless tests prove the fix cannot stay Postgres-local.
+- README or LLM documentation updates unless public behavior changes.
+
+## Risks and Dependencies
+
+- Integration validation requires Docker/Testcontainers.
+- Hidden external transaction detection cannot be implemented as a pure read with public Npgsql v10.0.2 APIs.
+- The external no-visible-transaction path will issue one `SAVEPOINT` round trip to classify transaction state. Provider-owned no-transaction acquisitions should avoid that branch.
+- Failed transaction tests must assert SQLSTATE/class behavior, not English exception messages.
+- If future Npgsql versions expose a public transaction-state property, this logic can be simplified later.
+
+## Sources and Research
+
+- GitHub issue: `https://github.com/xshaheen/headless-framework/issues/404`
+- `src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs`
+- `src/Headless.DistributedLocks.Postgres/PostgresDatabaseConnection.cs`
+- `src/Headless.DistributedLocks.Core.Database/Internal/DatabaseConnection.cs`
+- `src/Headless.DistributedLocks.Core.Database/Internal/DedicatedConnectionOrTransactionDbDistributedLock.cs`
+- `tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs`
+- `src/Headless.DistributedLocks.SqlServer/Headless.DistributedLocks.SqlServer.csproj`
+- `docs/solutions/tooling-decisions/redlock-multi-instance-not-adopted-2026-05-19.md`
+- Npgsql v10.0.2 source via GitHub API:
+  - `src/Npgsql/NpgsqlConnection.cs`
+  - `src/Npgsql/Internal/NpgsqlConnector.cs`
+  - `src/Npgsql/PostgresErrorCodes.cs`

--- a/src/Headless.DistributedLocks.Core.Database/Headless.DistributedLocks.Core.Database.csproj
+++ b/src/Headless.DistributedLocks.Core.Database/Headless.DistributedLocks.Core.Database.csproj
@@ -7,6 +7,7 @@
     <InternalsVisibleTo Include="Headless.DistributedLocks.Postgres" />
     <InternalsVisibleTo Include="Headless.DistributedLocks.SqlServer" />
     <InternalsVisibleTo Include="Headless.DistributedLocks.Core.Database.Tests.Unit" />
+    <InternalsVisibleTo Include="Headless.DistributedLocks.Postgres.Tests.Integration" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nito.AsyncEx" />

--- a/src/Headless.DistributedLocks.Core.Database/Internal/DatabaseConnection.cs
+++ b/src/Headless.DistributedLocks.Core.Database/Internal/DatabaseConnection.cs
@@ -156,8 +156,6 @@ internal abstract class DatabaseConnection : IAsyncDisposable
         }
     }
 
-    public ValueTask DisposeTransactionAsync() => _DisposeTransactionAsync(isClosingOrDisposingConnection: false);
-
     private async ValueTask _DisposeTransactionAsync(bool isClosingOrDisposingConnection)
     {
         var transaction = _transaction;

--- a/src/Headless.DistributedLocks.Postgres/Headless.DistributedLocks.Postgres.csproj
+++ b/src/Headless.DistributedLocks.Postgres/Headless.DistributedLocks.Postgres.csproj
@@ -4,6 +4,9 @@
     <RootNamespace>Headless.DistributedLocks.Postgres</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Headless.DistributedLocks.Postgres.Tests.Integration" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Npgsql" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs
+++ b/src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs
@@ -87,7 +87,7 @@ internal sealed partial class PostgresAdvisoryLock : IDbSynchronizationStrategy<
         // The acquire command uses SET LOCAL to set statement/lock timeouts; inside a transaction those persist to the
         // end of the transaction, so we wrap in a savepoint we can roll back (except on a transaction-scoped success,
         // where rolling back would release the lock).
-        var savePointDefined = await _TryDefineSavePointAsync(connection, savePointName, cancellationToken)
+        var savePointDefined = await _DefineSavePointIfNeededAsync(connection, savePointName, cancellationToken)
             .ConfigureAwait(false);
 
         using var acquireCommand = _CreateAcquireCommand(connection, key, timeout);
@@ -302,13 +302,14 @@ internal sealed partial class PostgresAdvisoryLock : IDbSynchronizationStrategy<
         }
     }
 
-    private static async ValueTask<bool> _TryDefineSavePointAsync(
+    private static async ValueTask<bool> _DefineSavePointIfNeededAsync(
         DatabaseConnection connection,
         string savePointName,
         CancellationToken cancellationToken
     )
     {
-        // Internally-owned: a savepoint is only needed when a transaction has been opened.
+        // For internally-owned connections, HasTransaction is authoritative; without one,
+        // SET LOCAL cannot escape the acquire command.
         if (!connection.IsExternallyOwned && !connection.HasTransaction)
         {
             return false;
@@ -326,6 +327,7 @@ internal sealed partial class PostgresAdvisoryLock : IDbSynchronizationStrategy<
 
         // Npgsql does not expose a public read-only flag for an externally-owned connection's active transaction.
         // SAVEPOINT is the exact boundary we need, so classify only PostgreSQL's "no active transaction" state.
+        // Cancellation before this returns is clean: no savepoint or SET LOCAL state has been established yet.
         try
         {
             await setSavePointCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs
+++ b/src/Headless.DistributedLocks.Postgres/PostgresAdvisoryLock.cs
@@ -87,14 +87,8 @@ internal sealed partial class PostgresAdvisoryLock : IDbSynchronizationStrategy<
         // The acquire command uses SET LOCAL to set statement/lock timeouts; inside a transaction those persist to the
         // end of the transaction, so we wrap in a savepoint we can roll back (except on a transaction-scoped success,
         // where rolling back would release the lock).
-        var needsSavePoint = await _ShouldDefineSavePointAsync(connection).ConfigureAwait(false);
-
-        if (needsSavePoint)
-        {
-            using var setSavePointCommand = connection.CreateCommand();
-            setSavePointCommand.SetCommandText("SAVEPOINT " + savePointName);
-            await setSavePointCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
+        var savePointDefined = await _TryDefineSavePointAsync(connection, savePointName, cancellationToken)
+            .ConfigureAwait(false);
 
         using var acquireCommand = _CreateAcquireCommand(connection, key, timeout);
 
@@ -171,7 +165,7 @@ internal sealed partial class PostgresAdvisoryLock : IDbSynchronizationStrategy<
         async ValueTask _RollBackTransactionTimeoutVariablesIfNeededAsync(bool acquired)
         {
             if (
-                needsSavePoint
+                savePointDefined
                 // For a transaction-scoped success we can't roll back the savepoint (it would release the lock). Leaking
                 // the savepoint is fine: an internally-owned transaction cleans it up on disposal, and an externally-owned
                 // transaction must keep it or lose the lock.
@@ -308,36 +302,41 @@ internal sealed partial class PostgresAdvisoryLock : IDbSynchronizationStrategy<
         }
     }
 
-    private static async ValueTask<bool> _ShouldDefineSavePointAsync(DatabaseConnection connection)
+    private static async ValueTask<bool> _TryDefineSavePointAsync(
+        DatabaseConnection connection,
+        string savePointName,
+        CancellationToken cancellationToken
+    )
     {
         // Internally-owned: a savepoint is only needed when a transaction has been opened.
-        if (!connection.IsExternallyOwned)
+        if (!connection.IsExternallyOwned && !connection.HasTransaction)
         {
-            return connection.HasTransaction;
+            return false;
         }
 
-        // Externally-owned with a visible transaction came through the transactional API: needs a savepoint.
+        using var setSavePointCommand = connection.CreateCommand();
+        setSavePointCommand.SetCommandText("SAVEPOINT " + savePointName);
+
         if (connection.HasTransaction)
         {
+            await setSavePointCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
             return true;
         }
 
-        // Externally-owned with no visible transaction might still be inside one we can't see. The only way to detect it
-        // is to try to begin a new transaction.
+        // Npgsql does not expose a public read-only flag for an externally-owned connection's active transaction.
+        // SAVEPOINT is the exact boundary we need, so classify only PostgreSQL's "no active transaction" state.
         try
         {
-            await connection.BeginTransactionAsync(CancellationToken.None).ConfigureAwait(false);
+            await setSavePointCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (InvalidOperationException)
+        catch (PostgresException exception)
+            when (exception.SqlState == PostgresErrorCodes.NoActiveSqlTransaction)
         {
-            // Already in a transaction => needs a savepoint.
-            return true;
+            return false;
         }
 
-        await connection.DisposeTransactionAsync().ConfigureAwait(false);
-
-        // No transaction => no savepoint.
-        return false;
+        return true;
     }
 
     private static async ValueTask _RestoreTimeoutSettingsIfNeededAsync(

--- a/tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs
+++ b/tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs
@@ -9,6 +9,8 @@ namespace Tests;
 [Collection<PostgresDistributedLockFixture>]
 public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture fixture) : TestBase
 {
+    private const int _MonitoringCommandTimeoutSeconds = 30;
+
     [Fact]
     public async Task should_release_transaction_lock_when_transaction_commits()
     {
@@ -100,12 +102,185 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    [Fact]
+    public async Task should_restore_timeout_settings_when_strategy_uses_visible_transaction()
+    {
+        var resourceName = _CreateResourceName();
+
+        await using var connection = await _OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync(AbortToken);
+        await using var databaseConnection = new PostgresDatabaseConnection(
+            transaction,
+            TimeProvider.System,
+            _MonitoringCommandTimeoutSeconds
+        );
+
+        await _ExecuteAsync(connection, "SET LOCAL lock_timeout = 1234", AbortToken);
+        var expectedLockTimeout = await _CurrentSettingAsync(connection, "lock_timeout", AbortToken);
+
+        var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+
+        var cookie = await strategy.TryAcquireAsync(
+            databaseConnection,
+            resourceName,
+            TimeSpan.Zero,
+            AbortToken
+        );
+
+        cookie.Should().NotBeNull();
+        (await _CurrentSettingAsync(connection, "lock_timeout", AbortToken)).Should().Be(expectedLockTimeout);
+
+        await transaction.RollbackAsync(AbortToken);
+    }
+
+    [Fact]
+    public async Task should_restore_timeout_settings_when_strategy_uses_invisible_external_transaction()
+    {
+        var resourceName = _CreateResourceName();
+
+        await using var connection = await _OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync(AbortToken);
+        await using var databaseConnection = new PostgresDatabaseConnection(
+            connection,
+            TimeProvider.System,
+            _MonitoringCommandTimeoutSeconds
+        );
+
+        await _ExecuteAsync(connection, "SET LOCAL lock_timeout = 1234", AbortToken);
+        var expectedLockTimeout = await _CurrentSettingAsync(connection, "lock_timeout", AbortToken);
+
+        var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+        var cookie = await strategy.TryAcquireAsync(
+            databaseConnection,
+            resourceName,
+            TimeSpan.Zero,
+            AbortToken
+        );
+
+        try
+        {
+            cookie.Should().NotBeNull();
+            (await _CurrentSettingAsync(connection, "lock_timeout", AbortToken)).Should().Be(expectedLockTimeout);
+        }
+        finally
+        {
+            if (cookie is not null)
+            {
+                await strategy.ReleaseAsync(databaseConnection, resourceName, cookie);
+            }
+
+            await transaction.RollbackAsync(AbortToken);
+        }
+    }
+
+    [Fact]
+    public async Task should_acquire_when_strategy_uses_external_connection_without_transaction()
+    {
+        var resourceName = _CreateResourceName();
+
+        await using var connection = await _OpenAsync();
+        await using var databaseConnection = new PostgresDatabaseConnection(
+            connection,
+            TimeProvider.System,
+            _MonitoringCommandTimeoutSeconds
+        );
+
+        var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+        var cookie = await strategy.TryAcquireAsync(
+            databaseConnection,
+            resourceName,
+            TimeSpan.Zero,
+            AbortToken
+        );
+
+        try
+        {
+            cookie.Should().NotBeNull();
+        }
+        finally
+        {
+            if (cookie is not null)
+            {
+                await strategy.ReleaseAsync(databaseConnection, resourceName, cookie);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task should_propagate_failed_transaction_when_strategy_uses_invisible_external_transaction()
+    {
+        var resourceName = _CreateResourceName();
+
+        await using var connection = await _OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync(AbortToken);
+        await using var databaseConnection = new PostgresDatabaseConnection(
+            connection,
+            TimeProvider.System,
+            _MonitoringCommandTimeoutSeconds
+        );
+
+        await _CauseTransactionFailureAsync(connection);
+
+        var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+        var act = async () =>
+            await strategy.TryAcquireAsync(databaseConnection, resourceName, TimeSpan.Zero, AbortToken);
+
+        await act
+            .Should()
+            .ThrowAsync<PostgresException>()
+            .Where(x => x.SqlState == PostgresErrorCodes.InFailedSqlTransaction);
+
+        await transaction.DisposeAsync();
+    }
+
     private async Task<NpgsqlConnection> _OpenAsync()
     {
         var connection = new NpgsqlConnection(fixture.ConnectionString);
         await connection.OpenAsync(AbortToken);
 
         return connection;
+    }
+
+    private string _CreateResourceName() => "postgres-transaction-lock-tests:" + Faker.Random.Guid();
+
+    private static async Task<string> _CurrentSettingAsync(
+        NpgsqlConnection connection,
+        string settingName,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT current_setting('{settingName}')";
+
+        return (string)(await command.ExecuteScalarAsync(cancellationToken) ?? string.Empty);
+    }
+
+    private static async Task _ExecuteAsync(
+        NpgsqlConnection connection,
+        string commandText,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task _CauseTransactionFailureAsync(NpgsqlConnection connection)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1 / 0";
+
+        try
+        {
+            await command.ExecuteNonQueryAsync(AbortToken);
+        }
+        catch (PostgresException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException("The test setup query should have failed the active transaction.");
     }
 
     private async Task<long> _CountAdvisoryLocksAsync(PostgresAdvisoryLockKey key)

--- a/tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs
+++ b/tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Headless.DistributedLocks;
 using Headless.DistributedLocks.Postgres;
 using Headless.Testing.Tests;
@@ -265,6 +269,26 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
     }
 
     [Fact]
+    public async Task should_propagate_external_savepoint_failure_when_sqlstate_is_not_no_active_transaction()
+    {
+        await using var databaseConnection = new ThrowingSavePointDatabaseConnection();
+
+        var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+        var act = async () =>
+            await strategy.TryAcquireAsync(
+                databaseConnection,
+                _CreateResourceName(),
+                TimeSpan.Zero,
+                AbortToken
+            );
+
+        await act
+            .Should()
+            .ThrowAsync<PostgresException>()
+            .Where(x => x.SqlState == PostgresErrorCodes.InFailedSqlTransaction);
+    }
+
+    [Fact]
     public async Task should_propagate_failed_transaction_when_savepoint_definition_fails()
     {
         var resourceName = _CreateResourceName();
@@ -385,5 +409,195 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
         command.Parameters.AddWithValue("objSubId", (short)(key.HasSingleKey ? 1 : 2));
 
         return (long)(await command.ExecuteScalarAsync(AbortToken) ?? 0L);
+    }
+
+    private sealed class ThrowingSavePointDatabaseConnection()
+        : DatabaseConnection(new ThrowingSavePointDbConnection(), isExternallyOwned: true, TimeProvider.System)
+    {
+        public override bool ShouldPrepareCommands => false;
+
+        public override bool IsCommandCancellationException(Exception exception) => false;
+
+        public override Task SleepAsync(
+            TimeSpan sleepTime,
+            Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor,
+            CancellationToken cancellationToken
+        ) => throw new NotSupportedException();
+    }
+
+    private sealed class ThrowingSavePointDbConnection : DbConnection
+    {
+        [AllowNull]
+        public override string ConnectionString { get; set; } = string.Empty;
+
+        public override string Database => "fake";
+
+        public override string DataSource => "fake";
+
+        public override string ServerVersion => "fake";
+
+        public override ConnectionState State => ConnectionState.Open;
+
+        public override void ChangeDatabase(string databaseName) { }
+
+        public override void Close() { }
+
+        public override void Open() { }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+            throw new NotSupportedException();
+
+        protected override DbCommand CreateDbCommand() => new ThrowingSavePointDbCommand(this);
+    }
+
+    private sealed class ThrowingSavePointDbCommand(DbConnection connection) : DbCommand
+    {
+        private readonly FakeDbParameterCollection _parameters = new();
+
+        [AllowNull]
+        public override string CommandText { get; set; } = string.Empty;
+
+        public override int CommandTimeout { get; set; }
+
+        public override CommandType CommandType { get; set; }
+
+        public override bool DesignTimeVisible { get; set; }
+
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+
+        protected override DbConnection? DbConnection { get; set; } = connection;
+
+        protected override DbParameterCollection DbParameterCollection => _parameters;
+
+        protected override DbTransaction? DbTransaction { get; set; }
+
+        public override void Cancel() { }
+
+        public override int ExecuteNonQuery() => throw _CreateSavePointException();
+
+        public override object ExecuteScalar() => 0L;
+
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
+            CommandText?.StartsWith("SAVEPOINT ", StringComparison.Ordinal) == true
+                ? Task.FromException<int>(_CreateSavePointException())
+                : Task.FromResult(0);
+
+        public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<object?>(0L);
+
+        public override void Prepare() { }
+
+        protected override DbParameter CreateDbParameter() => new FakeDbParameter();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) =>
+            throw new NotSupportedException();
+
+        private static PostgresException _CreateSavePointException() =>
+            new(
+                "current transaction is aborted",
+                "ERROR",
+                "ERROR",
+                PostgresErrorCodes.InFailedSqlTransaction
+            );
+    }
+
+    private sealed class FakeDbParameter : DbParameter
+    {
+        public override DbType DbType { get; set; }
+
+        public override ParameterDirection Direction { get; set; } = ParameterDirection.Input;
+
+        public override bool IsNullable { get; set; }
+
+        [AllowNull]
+        public override string ParameterName { get; set; } = string.Empty;
+
+        [AllowNull]
+        public override string SourceColumn { get; set; } = string.Empty;
+
+        public override object? Value { get; set; }
+
+        public override bool SourceColumnNullMapping { get; set; }
+
+        public override int Size { get; set; }
+
+        public override void ResetDbType() { }
+    }
+
+    private sealed class FakeDbParameterCollection : DbParameterCollection
+    {
+        private readonly List<DbParameter> _parameters = [];
+
+        public override int Count => _parameters.Count;
+
+        public override object SyncRoot => ((ICollection)_parameters).SyncRoot;
+
+        public override int Add(object value)
+        {
+            _parameters.Add((DbParameter)value);
+
+            return _parameters.Count - 1;
+        }
+
+        public override void AddRange(Array values)
+        {
+            foreach (var value in values)
+            {
+                Add(value!);
+            }
+        }
+
+        public override void Clear() => _parameters.Clear();
+
+        public override bool Contains(object value) => _parameters.Contains((DbParameter)value);
+
+        public override bool Contains(string value) =>
+            _parameters.Exists(parameter => parameter.ParameterName == value);
+
+        public override void CopyTo(Array array, int index) =>
+            ((ICollection)_parameters).CopyTo(array, index);
+
+        public override IEnumerator GetEnumerator() => _parameters.GetEnumerator();
+
+        public override int IndexOf(object value) => _parameters.IndexOf((DbParameter)value);
+
+        public override int IndexOf(string parameterName) =>
+            _parameters.FindIndex(parameter => parameter.ParameterName == parameterName);
+
+        public override void Insert(int index, object value) => _parameters.Insert(index, (DbParameter)value);
+
+        public override void Remove(object value) => _parameters.Remove((DbParameter)value);
+
+        public override void RemoveAt(int index) => _parameters.RemoveAt(index);
+
+        public override void RemoveAt(string parameterName)
+        {
+            var index = IndexOf(parameterName);
+
+            if (index >= 0)
+            {
+                RemoveAt(index);
+            }
+        }
+
+        protected override DbParameter GetParameter(int index) => _parameters[index];
+
+        protected override DbParameter GetParameter(string parameterName) => _parameters[IndexOf(parameterName)];
+
+        protected override void SetParameter(int index, DbParameter value) => _parameters[index] = value;
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+            var index = IndexOf(parameterName);
+
+            if (index >= 0)
+            {
+                _parameters[index] = value;
+            }
+            else
+            {
+                _parameters.Add(value);
+            }
+        }
     }
 }

--- a/tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs
+++ b/tests/Headless.DistributedLocks.Postgres.Tests.Integration/PostgresTransactionLockTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.DistributedLocks;
 using Headless.DistributedLocks.Postgres;
 using Headless.Testing.Tests;
 using Npgsql;
@@ -207,6 +208,36 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
     }
 
     [Fact]
+    public async Task should_acquire_when_strategy_uses_internally_owned_transaction()
+    {
+        var resourceName = _CreateResourceName();
+        var key = PostgresAdvisoryLockKey.FromString(resourceName, allowHashing: true);
+
+        await using (var databaseConnection = new PostgresDatabaseConnection(
+            fixture.ConnectionString,
+            TimeProvider.System,
+            _MonitoringCommandTimeoutSeconds
+        ))
+        {
+            await databaseConnection.OpenAsync(AbortToken);
+            await databaseConnection.BeginTransactionAsync(AbortToken);
+
+            var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+            var cookie = await strategy.TryAcquireAsync(
+                databaseConnection,
+                resourceName,
+                TimeSpan.Zero,
+                AbortToken
+            );
+
+            cookie.Should().NotBeNull();
+            (await _CountAdvisoryLocksAsync(key)).Should().BeGreaterThan(0);
+        }
+
+        (await _CountAdvisoryLocksAsync(key)).Should().Be(0);
+    }
+
+    [Fact]
     public async Task should_propagate_failed_transaction_when_strategy_uses_invisible_external_transaction()
     {
         var resourceName = _CreateResourceName();
@@ -231,6 +262,30 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
             .Where(x => x.SqlState == PostgresErrorCodes.InFailedSqlTransaction);
 
         await transaction.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task should_propagate_failed_transaction_when_savepoint_definition_fails()
+    {
+        var resourceName = _CreateResourceName();
+
+        await using var databaseConnection = new PostgresDatabaseConnection(
+            fixture.ConnectionString,
+            TimeProvider.System,
+            _MonitoringCommandTimeoutSeconds
+        );
+        await databaseConnection.OpenAsync(AbortToken);
+        await databaseConnection.BeginTransactionAsync(AbortToken);
+        await _CauseTransactionFailureAsync(databaseConnection);
+
+        var strategy = new PostgresAdvisoryLock(isShared: false, TimeProvider.System);
+        var act = async () =>
+            await strategy.TryAcquireAsync(databaseConnection, resourceName, TimeSpan.Zero, AbortToken);
+
+        await act
+            .Should()
+            .ThrowAsync<PostgresException>()
+            .Where(x => x.SqlState == PostgresErrorCodes.InFailedSqlTransaction);
     }
 
     private async Task<NpgsqlConnection> _OpenAsync()
@@ -266,6 +321,17 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    private static async Task _ExecuteAsync(
+        DatabaseConnection connection,
+        string commandText,
+        CancellationToken cancellationToken
+    )
+    {
+        using var command = connection.CreateCommand();
+        command.SetCommandText(commandText);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     private async Task _CauseTransactionFailureAsync(NpgsqlConnection connection)
     {
         await using var command = connection.CreateCommand();
@@ -274,6 +340,20 @@ public sealed class PostgresTransactionLockTests(PostgresDistributedLockFixture 
         try
         {
             await command.ExecuteNonQueryAsync(AbortToken);
+        }
+        catch (PostgresException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException("The test setup query should have failed the active transaction.");
+    }
+
+    private async Task _CauseTransactionFailureAsync(DatabaseConnection connection)
+    {
+        try
+        {
+            await _ExecuteAsync(connection, "SELECT 1 / 0", AbortToken);
         }
         catch (PostgresException)
         {


### PR DESCRIPTION
## Summary

Postgres advisory-lock acquisition no longer probes transaction state by trying to open a synthetic transaction. Instead, the provider now uses the required `SAVEPOINT` operation as the boundary check and only treats PostgreSQL `NoActiveSqlTransaction` as the no-transaction case, so unrelated provider/transaction failures bubble normally.

This keeps timeout-setting cleanup for visible and invisible external transactions without relying on Npgsql internal transaction state or broad `InvalidOperationException` classification.

## Testing

- `make build-project PROJECT=src/Headless.DistributedLocks.Postgres/Headless.DistributedLocks.Postgres.csproj`
- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Postgres.Tests.Integration/Headless.DistributedLocks.Postgres.Tests.Integration.csproj` (59/59)
- `git diff --check`
- `make format-check` exited 0, but CSharpier reported `Checked 0 files`

Fixes #404
