### PR TITLE
chore: add pre-push build/format guardrails + CI format gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
       - name: "Restore"
         run: dotnet restore headless-framework.slnx
 
+      - name: "Format check"
+        run: |
+          dotnet tool restore
+          dotnet csharpier check .
+        shell: bash
+
       - name: "Build"
         run: dotnet build headless-framework.slnx --configuration ${{ env.CONFIGURATION }} --no-restore --no-incremental -v:q -nologo /clp:ErrorsOnly
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Verify formatting and do a clean (non-incremental) build before push.
+#
+# Analyzers and warnings-as-errors only run when a project actually recompiles, so an
+# incremental build can silently mask a CI failure (e.g. MA0008). `make rebuild` reproduces
+# the CI build step (--no-incremental) locally; `make format-check` mirrors the CI format gate.
+#
+# Complements .husky/pre-commit (which auto-formats staged files on commit): commit-time
+# formats, push-time verifies + builds — no overlap. `make hooks` / `make bootstrap` points
+# core.hooksPath here, so this runs in every clone and worktree. Bypass with `git push --no-verify`.
+set -eu
+
+make format-check
+make rebuild

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,5 +10,6 @@
 # core.hooksPath here, so this runs in every clone and worktree. Bypass with `git push --no-verify`.
 set -eu
 
+printf '\033[36m[pre-push]\033[0m format-check + clean build (~1-2 min; skip with --no-verify)...\n'
 make format-check
 make rebuild


### PR DESCRIPTION
## Why

Analyzers and warnings-as-errors only run when a project actually **recompiles**, so an *incremental* build can silently mask a failure that CI then rejects. This bit us during review of #426: a struct change tripped `MA0008` (warnings-as-errors), but local incremental builds reported "0 errors" because the project wasn't recompiled — only a clean `--no-incremental` build surfaced it.

CI already builds with `--no-incremental`, so the gap is purely the **local feedback loop**: you discover the failure only after pushing and waiting for CI to go red.

## What

- **`.husky/pre-push`** — runs `make format-check` + `make rebuild` (`--no-incremental`) before every push, reproducing the CI build gate locally so warnings-as-errors / analyzer failures are caught before the push round-trip. Prints a one-line banner first (the build is ~1-2 min and otherwise near-silent). Bypass with `git push --no-verify`.
- **CI format gate** — added a `csharpier check` step to the build job. Formatting was previously enforced *only* by the git hooks; a `--no-verify` commit could land unformatted code on `main`. CI now backs it.

## How it activates

`.husky` is already this repo's `core.hooksPath` (wired by `make hooks` / `make bootstrap`), so once merged the hook runs in every clone and worktree — no per-machine setup.

## Complements, doesn't conflict with, `pre-commit`

`pre-commit` *formats* staged files on commit (CSharpier write + re-stage); `pre-push` *verifies* format + does the clean build on push. Different files, different events. If someone commits with `--no-verify`, the push-time `format-check` still catches the drift.

## Verification

The push of this branch dogfooded the hook itself: `make format-check` + `make rebuild` ran (full solution, ~47s, **0 warnings / 0 errors**) before the push was allowed through.

## Follow-up (not in this PR)

CI runs **build + pack only** — no workflow runs the test suite. With this PR, CI gates build + format, but tests remain entirely manual. A separate change should add a `test` job (scoped to `make test-unit`, no Docker). Flagged here for visibility; intentionally out of scope to keep this PR focused on the build/format guardrails.
