### PR TITLE
fix(coordination): retry SQL Server membership deadlocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ This repo's abstraction-plus-provider pattern (`Headless.<Feature>.Abstractions`
 
 Use the [Makefile](Makefile) targets instead of raw `dotnet` invocations — they pin configuration, results directories, and parallelism consistently. `make help` lists everything; `make` alone prints it.
 
-- **Setup**: `make bootstrap` (restores tools + packages). `make tools`, `make restore` individually.
-- **Build**: `make build` (incremental, errors-only), `make rebuild` (no incremental), `make build-project PROJECT=src/.../X.csproj`.
+- **Setup**: run `make bootstrap` when initializing a fresh clone or new worktree; it restores tools, packages, and git hooks. Use `make tools` and `make restore` individually only when you need a narrower setup step. Use `make restore-project PROJECT=src/.../X.csproj` for a project-scoped restore.
+- **Build**: `make build` (incremental, errors-only), `make rebuild` (no incremental), `make build-project PROJECT=src/.../X.csproj`. Prefer `build-project` when the work is scoped to a specified project; it restores only the selected project graph before building and does not restore the full solution.
 - **Format**: `make format` (CSharpier write), `make format-check` (verify only).
 - **Test**: `make test` (build + run all). `make test-fast` / `make test-project-fast` skip restore/build when outputs exist. Scope with `make test-project TEST_PROJECT=…`, `test-class CLASS='*ClockTests'`, `test-method METHOD=…`, `test-namespace`, `test-trait`, `test-query`. Group runs: `test-unit`, `test-integration` (needs Docker).
 - **Coverage**: `make coverage` (Cobertura), `coverage-html`, `coverage-json` (Summary.json), `coverage-open`.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help: ## Show available commands.
 	@printf "  make pack CONFIGURATION=Release\n\n"
 
 .PHONY: bootstrap
-bootstrap: tools restore hooks ## Restore local tools, NuGet packages, and git hooks.
+bootstrap: tools restore hooks ## Initialize a clone/worktree: restore tools, packages, and git hooks.
 
 .PHONY: tools
 tools: ## Restore repo-pinned .NET tools.
@@ -43,6 +43,11 @@ tools: ## Restore repo-pinned .NET tools.
 .PHONY: restore
 restore: ## Restore NuGet packages.
 	$(DOTNET) restore "$(SOLUTION)"
+
+.PHONY: restore-project
+restore-project: ## Restore one project; preferred for focused project work.
+	@test -n "$(PROJECT)" || (echo "PROJECT is required. Example: make restore-project PROJECT=src/Headless.Api/Headless.Api.csproj" && exit 2)
+	$(DOTNET) restore "$(PROJECT)"
 
 .PHONY: hooks
 hooks: ## Point git at the committed hooks (per clone/worktree).
@@ -57,7 +62,7 @@ rebuild: restore ## Build the solution without incremental compilation.
 	$(DOTNET) build "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-restore --no-incremental -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
 
 .PHONY: build-project
-build-project: restore ## Build one project: make build-project PROJECT=src/.../*.csproj
+build-project: restore-project ## Build one project; preferred when working on a specified project.
 	@test -n "$(PROJECT)" || (echo "PROJECT is required. Example: make build-project PROJECT=src/Headless.Api/Headless.Api.csproj" && exit 2)
 	$(DOTNET) build "$(PROJECT)" --configuration "$(CONFIGURATION)" --no-restore -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
 

--- a/docs/llms/coordination.md
+++ b/docs/llms/coordination.md
@@ -403,11 +403,14 @@ Stores membership in SQL Server with guarded update/insert statements and server
 - Atomic incarnation allocation under `UPDLOCK, HOLDLOCK`.
 - Heartbeat guard rejects stale or impossible incarnations.
 - Liveness classification uses `SYSUTCDATETIME()`.
+- Guarded membership writes retry SQL Server deadlock victim error `1205` with a bounded jittered Polly policy.
 - DDL initialization uses `sp_getapplock`.
 
 ### Design Notes
 
 The provider intentionally avoids `MERGE`. Explicit locking keeps the generation guard and liveness row update readable and testable.
+
+Membership writes intentionally keep `SERIALIZABLE` transactions plus generation-first `UPDLOCK, HOLDLOCK` access. Under a large concurrent startup, SQL Server can still choose one writer as deadlock victim (`1205`); the provider retries the whole rolled-back transaction. This retry is SQL Server-specific and does not apply to PostgreSQL or Redis providers, whose membership write paths use different concurrency primitives.
 
 ### Installation
 

--- a/src/Headless.Coordination.SqlServer/Headless.Coordination.SqlServer.csproj
+++ b/src/Headless.Coordination.SqlServer/Headless.Coordination.SqlServer.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Polly.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Headless.Coordination.Core.Database\Headless.Coordination.Core.Database.csproj" />

--- a/src/Headless.Coordination.SqlServer/README.md
+++ b/src/Headless.Coordination.SqlServer/README.md
@@ -11,11 +11,14 @@ Provides an authoritative SQL Server membership provider for multi-instance apps
 - Atomic incarnation allocation under `UPDLOCK, HOLDLOCK`.
 - Equality heartbeat guard rejects stale and impossible incarnations.
 - Liveness classification uses `SYSUTCDATETIME()`.
+- Bounded jittered retry for SQL Server deadlock victim error `1205` during guarded membership writes.
 - DDL initialization uses `sp_getapplock`.
 
 ## Design Notes
 
 The provider intentionally avoids `MERGE`. Explicit locking keeps the generation guard and liveness row update readable and testable.
+
+Guarded membership writes intentionally keep `SERIALIZABLE` transactions plus generation-first `UPDLOCK, HOLDLOCK` access. Under a large concurrent startup, SQL Server can still choose one writer as deadlock victim (`1205`); the provider retries that rolled-back transaction with a short bounded jittered Polly policy. The retry is SQL Server-specific and does not lower isolation or serialize the hot path with `sp_getapplock`.
 
 ## Installation
 
@@ -50,6 +53,7 @@ Configure shared `CoordinationOptions` with `setup.Configure(...)`. Configure `C
 - `Headless.Coordination.Core.Database`
 - `Headless.Hosting`
 - `Microsoft.Data.SqlClient`
+- `Polly.Core`
 
 ## Side Effects
 

--- a/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
+++ b/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
@@ -4,7 +4,10 @@ using System.Data;
 using Headless.Serializer;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Retry;
 
 namespace Headless.Coordination.SqlServer;
 
@@ -12,9 +15,14 @@ namespace Headless.Coordination.SqlServer;
 internal sealed class SqlServerMembershipStore(
     IOptions<SqlServerCoordinationOptions> providerOptions,
     IOptions<CoordinationOptions> coordinationOptions,
-    [FromKeyedServices(CoordinationOptions.JsonSerializerServiceKey)] IJsonSerializer serializer
+    [FromKeyedServices(CoordinationOptions.JsonSerializerServiceKey)] IJsonSerializer serializer,
+    TimeProvider timeProvider,
+    ILogger<SqlServerMembershipStore> logger
 ) : DatabaseMembershipStoreBase(coordinationOptions.Value, serializer)
 {
+    private const int _MaxDeadlockRetryAttempts = 2;
+    private readonly ResiliencePipeline _deadlockRetryPipeline = _BuildDeadlockRetryPipeline(timeProvider, logger);
+
     protected override async ValueTask<NodeIncarnation> AllocateIncarnationCoreAsync(
         string clusterName,
         NodeId nodeId,
@@ -61,23 +69,29 @@ internal sealed class SqlServerMembershipStore(
             SELECT TOP (1) [value] FROM @allocated;
             """;
 
-        await using var connection = options.CreateConnection();
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = (SqlTransaction)
-            await connection
-                .BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
-                .ConfigureAwait(false);
-        await using var command = _CreateCommand(connection, sql, transaction);
-        command.Parameters.AddWithValue("ClusterName", clusterName);
-        command.Parameters.AddWithValue("NodeId", nodeId.Value);
+        return await _ExecuteWithDeadlockRetryAsync(
+                "AllocateIncarnation",
+                async ct =>
+                {
+                    await using var connection = options.CreateConnection();
+                    await connection.OpenAsync(ct).ConfigureAwait(false);
+                    await using var transaction = (SqlTransaction)
+                        await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
+                    await using var command = _CreateCommand(connection, sql, transaction);
+                    command.Parameters.AddWithValue("ClusterName", clusterName);
+                    command.Parameters.AddWithValue("NodeId", nodeId.Value);
 
-        var value = Convert.ToInt64(
-            await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false),
-            CultureInfo.InvariantCulture
-        );
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    var value = Convert.ToInt64(
+                        await command.ExecuteScalarAsync(ct).ConfigureAwait(false),
+                        CultureInfo.InvariantCulture
+                    );
+                    await transaction.CommitAsync(ct).ConfigureAwait(false);
 
-        return new NodeIncarnation(value);
+                    return new NodeIncarnation(value);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     protected override async ValueTask UpsertDescriptorCoreAsync(
@@ -160,23 +174,29 @@ internal sealed class SqlServerMembershipStore(
             END;
             """;
 
-        await using var connection = providerOptions.Value.CreateConnection();
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = (SqlTransaction)
-            await connection
-                .BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
-                .ConfigureAwait(false);
-        await using var command = _CreateCommand(connection, sql, transaction);
-        command.Parameters.AddWithValue("ClusterName", clusterName);
-        command.Parameters.AddWithValue("NodeId", descriptor.Identity.NodeId.Value);
-        command.Parameters.AddWithValue("Incarnation", descriptor.Identity.Incarnation.Value);
-        command.Parameters.AddWithValue("HostName", (object?)descriptor.HostName ?? DBNull.Value);
-        command.Parameters.AddWithValue("Endpoints", SerializeDictionary(descriptor.Endpoints));
-        command.Parameters.AddWithValue("Role", (object?)descriptor.Role ?? DBNull.Value);
-        command.Parameters.AddWithValue("Metadata", SerializeDictionary(descriptor.Metadata));
+        await _ExecuteWithDeadlockRetryAsync(
+                "UpsertDescriptor",
+                async ct =>
+                {
+                    await using var connection = providerOptions.Value.CreateConnection();
+                    await connection.OpenAsync(ct).ConfigureAwait(false);
+                    await using var transaction = (SqlTransaction)
+                        await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
+                    await using var command = _CreateCommand(connection, sql, transaction);
+                    command.Parameters.AddWithValue("ClusterName", clusterName);
+                    command.Parameters.AddWithValue("NodeId", descriptor.Identity.NodeId.Value);
+                    command.Parameters.AddWithValue("Incarnation", descriptor.Identity.Incarnation.Value);
+                    command.Parameters.AddWithValue("HostName", (object?)descriptor.HostName ?? DBNull.Value);
+                    command.Parameters.AddWithValue("Endpoints", SerializeDictionary(descriptor.Endpoints));
+                    command.Parameters.AddWithValue("Role", (object?)descriptor.Role ?? DBNull.Value);
+                    command.Parameters.AddWithValue("Metadata", SerializeDictionary(descriptor.Metadata));
 
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                    await transaction.CommitAsync(ct).ConfigureAwait(false);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     protected override async ValueTask<bool> HeartbeatCoreAsync(
@@ -230,22 +250,28 @@ internal sealed class SqlServerMembershipStore(
             SELECT CAST(1 AS bit);
             """;
 
-        await using var connection = providerOptions.Value.CreateConnection();
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = (SqlTransaction)
-            await connection
-                .BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
-                .ConfigureAwait(false);
-        await using var command = _CreateCommand(connection, sql, transaction);
-        command.Parameters.AddWithValue("ClusterName", clusterName);
-        command.Parameters.AddWithValue("NodeId", identity.NodeId.Value);
-        command.Parameters.AddWithValue("Incarnation", identity.Incarnation.Value);
+        return await _ExecuteWithDeadlockRetryAsync(
+                "Heartbeat",
+                async ct =>
+                {
+                    await using var connection = providerOptions.Value.CreateConnection();
+                    await connection.OpenAsync(ct).ConfigureAwait(false);
+                    await using var transaction = (SqlTransaction)
+                        await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
+                    await using var command = _CreateCommand(connection, sql, transaction);
+                    command.Parameters.AddWithValue("ClusterName", clusterName);
+                    command.Parameters.AddWithValue("NodeId", identity.NodeId.Value);
+                    command.Parameters.AddWithValue("Incarnation", identity.Incarnation.Value);
 
-        var accepted = (bool)(await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false))!;
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    var accepted = (bool)(await command.ExecuteScalarAsync(ct).ConfigureAwait(false))!;
+                    await transaction.CommitAsync(ct).ConfigureAwait(false);
 
-        // Retention pruning runs once per tick on the read path; the heartbeat path no longer prunes.
-        return accepted;
+                    // Retention pruning runs once per tick on the read path; the heartbeat path no longer prunes.
+                    return accepted;
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     protected override async ValueTask LeaveCoreAsync(
@@ -380,5 +406,113 @@ internal sealed class SqlServerMembershipStore(
     {
         return (long)Math.Ceiling(value.TotalMilliseconds);
     }
+
+    private async ValueTask _ExecuteWithDeadlockRetryAsync(
+        string operationName,
+        Func<CancellationToken, ValueTask> action,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await _deadlockRetryPipeline
+                .ExecuteAsync(static async (action, ct) => await action(ct), action, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (SqlException ex) when (_IsDeadlockVictim(ex))
+        {
+            logger.LogSqlServerMembershipDeadlock(operationName, ex);
+
+            throw;
+        }
+    }
+
+    private async ValueTask<TResult> _ExecuteWithDeadlockRetryAsync<TResult>(
+        string operationName,
+        Func<CancellationToken, ValueTask<TResult>> action,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            return await _deadlockRetryPipeline
+                .ExecuteAsync(
+                    static async (action, ct) => await action(ct).ConfigureAwait(false),
+                    action,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        catch (SqlException ex) when (_IsDeadlockVictim(ex))
+        {
+            logger.LogSqlServerMembershipDeadlock(operationName, ex);
+
+            throw;
+        }
+    }
+
+    private static ResiliencePipeline _BuildDeadlockRetryPipeline(TimeProvider timeProvider, ILogger logger)
+    {
+        return new ResiliencePipelineBuilder { TimeProvider = timeProvider }
+            .AddRetry(
+                new RetryStrategyOptions
+                {
+                    ShouldHandle = static args => new ValueTask<bool>(
+                        args.Outcome.Exception is SqlException ex && _IsDeadlockVictim(ex)
+                    ),
+                    MaxRetryAttempts = _MaxDeadlockRetryAttempts,
+                    BackoffType = DelayBackoffType.Exponential,
+                    Delay = TimeSpan.FromMilliseconds(50),
+                    MaxDelay = TimeSpan.FromMilliseconds(500),
+                    UseJitter = true,
+                    OnRetry = args =>
+                    {
+                        logger.LogSqlServerMembershipDeadlockRetry(
+                            args.AttemptNumber + 1,
+                            _MaxDeadlockRetryAttempts + 1,
+                            args.RetryDelay,
+                            args.Outcome.Exception
+                        );
+
+                        return default;
+                    },
+                }
+            )
+            .Build();
+    }
+
+    private static bool _IsDeadlockVictim(SqlException exception)
+    {
+        return exception.Number == 1205;
+    }
 }
 #pragma warning restore CA2100
+
+internal static partial class SqlServerMembershipStoreLoggerExtensions
+{
+    [LoggerMessage(
+        EventId = 1,
+        EventName = "SqlServerMembershipDeadlockRetry",
+        Level = LogLevel.Warning,
+        Message = "SQL Server coordination membership write hit deadlock victim error 1205; retrying attempt {AttemptNumber}/{MaxAttempts} after {Delay}."
+    )]
+    public static partial void LogSqlServerMembershipDeadlockRetry(
+        this ILogger logger,
+        int attemptNumber,
+        int maxAttempts,
+        TimeSpan delay,
+        Exception? exception
+    );
+
+    [LoggerMessage(
+        EventId = 2,
+        EventName = "SqlServerMembershipDeadlock",
+        Level = LogLevel.Error,
+        Message = "SQL Server coordination membership operation {OperationName} exhausted deadlock victim retries."
+    )]
+    public static partial void LogSqlServerMembershipDeadlock(
+        this ILogger logger,
+        string operationName,
+        Exception exception
+    );
+}

--- a/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs
+++ b/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs
@@ -123,6 +123,43 @@ public sealed class SqlServerMembershipNativeTests(SqlServerMembershipFixture fi
         currentIncarnation.Should().Be(secondIdentity.Incarnation.Value);
     }
 
+    [Fact]
+    public async Task should_tolerate_concurrent_registration_and_heartbeat_stampede()
+    {
+        var cluster = _Cluster();
+        var nodes = await Task.WhenAll(
+            Enumerable
+                .Range(0, 24)
+                .Select(index => fixture.CreateNodeAsync(cluster, $"node-{index % 4}", AbortToken).AsTask())
+        );
+
+        try
+        {
+            var identities = await Task.WhenAll(
+                nodes.Select(node => node.Membership.RegisterAsync(AbortToken).AsTask())
+            );
+            var currentPairs = nodes
+                .Zip(identities)
+                .GroupBy(static pair => pair.Second.NodeId)
+                .Select(static group => group.MaxBy(static pair => pair.Second.Incarnation.Value))
+                .ToArray();
+            var accepted = await Task.WhenAll(
+                currentPairs.Select(pair => pair.First.Membership.HeartbeatAsync(AbortToken).AsTask())
+            );
+            var live = await nodes[0].Membership.GetLiveNodesAsync(AbortToken);
+
+            accepted.Should().OnlyContain(x => x);
+            live.Should().BeEquivalentTo(currentPairs.Select(static pair => pair.Second));
+        }
+        finally
+        {
+            foreach (var node in nodes)
+            {
+                await node.DisposeAsync();
+            }
+        }
+    }
+
     private static string _Cluster()
     {
         return "native-" + Guid.NewGuid().ToString("N");


### PR DESCRIPTION
## Summary
SQL Server coordination membership writes now recover from deadlock victim error 1205 during concurrent startup without lowering SERIALIZABLE isolation or serializing the hot path. The provider retries the entire rolled-back membership transaction with a bounded jittered Polly policy, so incarnation allocation, registration, and heartbeat keep the generation guard intact.

PostgreSQL and Redis were checked and left unchanged: their concurrency primitives do not have the same SQL Server deadlock-victim failure mode.

Fixes #419

## Validation
- `make test-project TEST_PROJECT=tests/Headless.Coordination.SqlServer.Tests.Integration/Headless.Coordination.SqlServer.Tests.Integration.csproj` (18/18 passed)
- `dotnet csharpier check src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs`
- `git diff --check`
