### PR TITLE
perf(coordination): targeted single-node liveness via ReadNodeLivenessAsync SPI (#418)

### DIFF
--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,6 +1,7 @@
 # CI restores NuGet packages into the workspace (.nuget/packages via NUGET_PACKAGES in ci.yml);
 # third-party package content must never gate formatting.
 .nuget/
+.worktrees/
 artifacts/
 
 # CSharpier's XML check disagrees on this hand-maintained file between local (macOS) and CI (Linux)

--- a/docs/llms/coordination.md
+++ b/docs/llms/coordination.md
@@ -98,7 +98,9 @@ The store is the temporal authority. PostgreSQL uses `clock_timestamp()`, SQL Se
 
 ### Liveness States
 
-`Alive` means the store-clock heartbeat age is below `SuspicionThreshold`. `Suspected` is a soft signal between `SuspicionThreshold` and `DeadThreshold`. `Dead` means the hard threshold passed or the node left gracefully. `GetLiveNodesAsync()` returns Alive identities only; `GetLivenessSnapshotAsync()` returns full state.
+`Alive` means the store-clock heartbeat age is below `SuspicionThreshold`. `Suspected` is a soft signal between `SuspicionThreshold` and `DeadThreshold`. `Dead` means the hard threshold passed or the node left gracefully. `GetLiveNodesAsync()` returns Alive identities only; `GetLivenessSnapshotAsync()` returns full state. `IsAliveAsync(identity)` checks a single node — it is a targeted O(1) read (one guarded single-row query / small Lua), not a full cluster snapshot, so per-request liveness checks do not scale with cluster size. It returns the same answer the snapshot would for that identity: current-generation-only, store-clock classified, and retention-bounded (a node at or past the retention window reads as absent, i.e. not alive).
+
+Provider SPI note: a custom `IMembershipStore` must implement `ReadNodeLivenessAsync(identity)` returning `NodeLivenessState?` — the targeted, read-only (no prune, no backfill) counterpart to `ReadLivenessAsync`, where `null` means the identity is absent from the current-generation view.
 
 ### Operational Read Model
 

--- a/docs/plans/2026-06-15-001-perf-coordination-targeted-node-liveness-plan.md
+++ b/docs/plans/2026-06-15-001-perf-coordination-targeted-node-liveness-plan.md
@@ -1,0 +1,231 @@
+---
+title: "perf(coordination): targeted single-node liveness via ReadNodeLivenessAsync SPI"
+date: 2026-06-15
+type: perf
+origin: https://github.com/xshaheen/headless-framework/issues/418
+depth: standard
+tags: [coordination, membership, liveness, performance, spi, api-decision]
+---
+
+# perf(coordination): targeted single-node liveness via ReadNodeLivenessAsync SPI
+
+## Summary
+
+Add a targeted single-node liveness method to the `IMembershipStore` provider SPI so a per-request consumer can ask "what state is *this* node in?" with one guarded single-row query instead of a full cluster-wide snapshot read plus LINQ filter. The relational providers gain a single-row SELECT, Redis a small read-only Lua, the in-memory fake an equivalent, and `MembershipService.IsAliveAsync` is rewired to delegate. A cross-provider conformance test pins parity with the existing snapshot path.
+
+---
+
+## Problem Frame
+
+`MembershipService.IsAliveAsync` (`src/Headless.Coordination.Core/MembershipService.cs`) and `GetLiveNodesAsync` both call `GetLivenessSnapshotAsync`, which calls `store.ReadLivenessAsync` — a full liveness projection over every known node in the cluster, classified and ordered, then filtered in C# (`snapshots.Any(s => s.Identity == identity && s.State == Alive)`). A per-request consumer that calls `IsAliveAsync` to validate a stamped `node@incarnation` before acting therefore triggers O(nodes · rps) full reads. On the relational providers the snapshot read also runs a best-effort full-table prune; on Redis it runs an opportunistic prune plus generation-mirror backfill — none of which a single-node liveness check needs.
+
+This was surfaced by code review of #416 and routed to follow-up (#418) because the fix touches the provider SPI plus all three providers plus the fake plus service wiring — too invasive to land inside that review's fixer pass. There is no upstream brainstorm document; scope was confirmed interactively.
+
+---
+
+## Requirements
+
+- R1. The membership store SPI exposes a targeted method returning the classified liveness state of a single `NodeIdentity` without reading other nodes.
+- R2. The targeted check returns exactly what the existing snapshot path would conclude for that identity: current-generation membership only, the same Alive/Suspected/Dead classification, the same store-clock authority, and — critically — the same retention boundary. The snapshot read produces "absent" by pruning rows older than `DeadThreshold + DeadRetentionWindow`; the targeted check must reproduce that view (see KTD3).
+- R3. An identity resolves to "absent" (`null`) — distinct from any present state — in all the cases the snapshot path omits it: incarnation is not the current generation (stale, superseded, never registered), **or** the liveness row's age is at or beyond the retention boundary (`DeadThreshold + DeadRetentionWindow`; Redis: the operational prune window) even if no prune has physically deleted it yet.
+- R4. `MembershipService.IsAliveAsync` derives its boolean from the targeted method and no longer issues a full snapshot read.
+- R5. The targeted path performs no full-table prune and no generation-mirror backfill; it stays a bounded single-row/single-member operation.
+- R6. All three providers (PostgreSql, SqlServer, Redis) and the in-memory fake implement the new method; cross-provider conformance proves identical observable behavior.
+- R7. `GetLiveNodesAsync` and `GetLivenessSnapshotAsync` behavior is unchanged.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Return shape: `ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(NodeIdentity, CancellationToken)`.** `null` means the identity is not a current-generation member (absent / stale / superseded); a non-null value is the store-classified state. This is a richer SPI than the issue's tentative `bool IsAliveAsync` — chosen so the single round-trip is reusable by future consumers that need Suspected-vs-Dead, with the service deriving `IsAlive == (state is NodeLivenessState.Alive)`. The public `INodeMembership.IsAliveAsync` consumer contract keeps its `bool` shape and existing semantics.
+- KTD2. **Parity is the contract, not an optimization detail (R2/R3).** The targeted query must mirror the snapshot path's invariants: it filters the liveness row to the **current generation** (`incarnation == current_incarnation`), it classifies with the **store clock** using the same `SuspicionThreshold` / `DeadThreshold` / `left_at` rules, and it applies the same **retention boundary** so that a row at or beyond `DeadThreshold + DeadRetentionWindow` reads as absent (`null`), not `Dead` (see KTD3). A stale or absent incarnation yields no row → `null`, matching the snapshot path which never surfaces non-current incarnations.
+- KTD3. **Read-only targeted path; no prune, no backfill — retention enforced as a classification cutoff, not a delete (R5).** The snapshot read produces "absent" *by deleting* rows whose age is at or beyond `DeadThreshold + DeadRetentionWindow` and then classifying the survivors (Dead is classified at `DeadThreshold`). The targeted path must not write, so it cannot delete — but it must still produce the same view. Therefore it applies the retention window as an **outermost read-only cutoff in the classification expression**: when `age >= DeadThreshold + DeadRetentionWindow` (Redis: `age >=` the operational prune window) it returns `null` (absent), and only otherwise does it classify `Dead`/`Suspected`/`Alive`. This reproduces the snapshot's post-prune view exactly while remaining write-free. (Note: the naive "skip the prune and just classify" approach is *unsound* — it would return `Dead` for a retention-expired-but-unpruned row where the snapshot returns absent, breaking the `Dead`-vs-absent distinction the richer SPI exists to serve. Because relational providers prune only on the snapshot read path, and the whole point of this change is that `IsAliveAsync` stops reading the snapshot, such rows can persist unpruned indefinitely — the divergence is structural, not theoretical.) Generation-mirror backfill (Redis) is still skipped; cleanup cadence remains owned by the snapshot read path and the Redis cleanup service.
+- KTD4. **Relational shape:** a single-row `SELECT` joining the liveness table to the generation table on `current_incarnation = incarnation`, returning the classified state for the one `(cluster, node, incarnation)` tuple. Reuse the store-clock function and threshold params from `ReadCurrentLivenessCoreAsync`, with the `CASE` extended so the retention boundary (`DeadThreshold + DeadRetentionWindow`) maps to a sentinel that materializes as `null` (absent). No transaction, no locking hints — it is a plain read.
+- KTD5. **Redis shape:** a new read-only `RedisMembershipReadNodeLivenessScriptDefinition` that reads the single `:known` member payload, resolves the current generation **the same way the read script does — mirror-first (`hget :known __gen:<node>`), falling back to `get gen:<node>`** — and classifies against `SuspicionThreshold` / `DeadThreshold` plus the operational prune window with server `TIME`. A member at or beyond the prune window returns the absent sentinel (`null`), matching the read script which deletes-and-omits such members. It performs no `hdel` / `zrem` / `hset`. Registered in `CoordinationRedisScriptsInitializer`. (Resolving generation mirror-first rather than `gen:`-only keeps the targeted path byte-for-byte aligned with the snapshot's generation view; reading `gen:` only would diverge if the `gen:` key were lost under eviction while the mirror survived.)
+- KTD6. **Build coupling is cross-cutting.** Adding a method to `public interface IMembershipStore` (and an `abstract` core to `DatabaseMembershipStoreBase`) breaks compilation of every implementer until each is updated. Intermediate commits in this PR may be red; the PR builds green at its tip. Sequence U1 → U2 → U3 → U4 accordingly.
+- KTD7. **Mandatory abstract method, not a C# default-interface fallback.** An alternative is a default interface method on `IMembershipStore` whose body derives state from the existing snapshot read, letting custom provider authors stay compilable without implementing the optimization. Rejected: this is a *performance* method, and a snapshot-derived default would silently hand custom providers the exact O(nodes) behavior this change exists to eliminate — a latent footgun rather than a safe default. Forcing implementation makes provider authors consciously address the hot path, and it keeps the SPI consistent with its existing all-mandatory shape. The build-coupling and drift costs (KTD6, Risks) are accepted in exchange. Greenfield + CLAUDE.md's "prefer breaking changes over compat layers" reinforces this.
+
+---
+
+## High-Level Technical Design
+
+Every provider implements the same classification decision — this is the parity contract (R2/R3) each `ReadNodeLivenessCoreAsync` / Lua must satisfy:
+
+```mermaid
+flowchart TB
+  A["ReadNodeLivenessAsync(identity)"] --> B{"row for (cluster, node, incarnation)
+  exists AND incarnation == current generation?"}
+  B -->|no| N["return null (absent / stale / superseded)"]
+  B -->|yes| R{"age >= DeadThreshold + DeadRetentionWindow?
+  (Redis: age >= operational prune window)"}
+  R -->|yes| N2["return null (retention-expired — snapshot would have pruned it)"]
+  R -->|no| C{"left_at set? (Redis: leave backdates last_beat past DeadThreshold)"}
+  C -->|yes| D["Dead"]
+  C -->|no| E{"age = storeClock - last_beat"}
+  E -->|"age >= DeadThreshold"| D
+  E -->|"age >= SuspicionThreshold"| F["Suspected"]
+  E -->|"else"| G["Alive"]
+```
+
+Service derivation after the rewire:
+
+```mermaid
+flowchart LR
+  H["MembershipService.IsAliveAsync(identity)"] --> I["state = store.ReadNodeLivenessAsync(identity)"]
+  I --> J["return state is NodeLivenessState.Alive"]
+```
+
+---
+
+## Implementation Units
+
+### U1. SPI contract, base wrapper, fake store, and service rewire
+
+- **Goal:** Introduce `ReadNodeLivenessAsync` on the SPI, the relational base wrapper + abstract core, the fake implementation, and rewire the service to delegate.
+- **Requirements:** R1, R2 (contract), R4, R7.
+- **Dependencies:** none.
+- **Files:**
+  - `src/Headless.Coordination.Core/IMembershipStore.cs` — add `ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(NodeIdentity identity, CancellationToken cancellationToken = default)` with XML-doc stating: the current-generation-only + store-clock + retention-boundary parity contract; that `null` means "absent from the current-generation snapshot view" and deliberately collapses the absence sub-states (never-registered / stale / superseded / retention-expired) — if a future consumer needs to distinguish them, that is an additive extension point, not modeled here.
+  - `src/Headless.Coordination.Core.Database/DatabaseMembershipStoreBase.cs` — add the public `ReadNodeLivenessAsync` (cancellation guard, delegate to a new `protected abstract ReadNodeLivenessCoreAsync(string clusterName, NodeIdentity, CancellationToken)`), mirroring the existing wrapper/core split.
+  - `src/Headless.Coordination.Core/MembershipService.cs` — rewire `IsAliveAsync` to `var state = await store.ReadNodeLivenessAsync(identity, ct); return state is NodeLivenessState.Alive;` (keep the cancellation check); leave `GetLiveNodesAsync` / `GetLivenessSnapshotAsync` untouched.
+  - `tests/Headless.Coordination.Core.Tests.Unit/FakeMembershipStore.cs` — implement `ReadNodeLivenessAsync` from a settable `Dictionary<NodeIdentity, NodeLivenessState?> NodeStates` (default empty → `null`), plus a `ReadNodeLivenessCalls` counter and a `ThrowOnReadNodeLiveness` toggle to mirror the existing fake's controllability.
+  - `tests/Headless.Coordination.Core.Tests.Unit/MembershipServiceTests.cs` (the existing service test file) — add `IsAliveAsync` tests driving the new path (the file currently has no `IsAliveAsync` coverage).
+- **Approach:** The base remains the cluster-scoping/operation-order owner; the new abstract core receives `clusterName` exactly like the other `*CoreAsync` members. `NullNodeMembership` is unaffected — it implements `INodeMembership`, not `IMembershipStore`, and already returns `false` from `IsAliveAsync`.
+- **Patterns to follow:** the wrapper/abstract-core split already in `DatabaseMembershipStoreBase` (`ReadLivenessAsync` → `ReadCurrentLivenessCoreAsync`); the fake's existing settable-field + call-counter style.
+- **Execution note:** This unit changes `IMembershipStore` and adds an abstract member to the base, so the relational and Redis provider projects will not compile until U2–U4. Expected; the PR is green at its tip.
+- **Test suite design:** Unit-level, in `Headless.Coordination.Core.Tests.Unit`, using `FakeMembershipStore`. The behavioral parity across real backends is owned by the conformance test in U5, not here.
+- **Test scenarios:**
+  - `IsAliveAsync` returns `true` when the fake's `ReadNodeLivenessAsync` yields `Alive` for the identity.
+  - `IsAliveAsync` returns `false` when the fake yields `Suspected`.
+  - `IsAliveAsync` returns `false` when the fake yields `Dead`.
+  - `IsAliveAsync` returns `false` when the fake yields `null` (absent).
+  - `IsAliveAsync` increments `ReadNodeLivenessCalls` and does **not** increment `ReadLivenessCalls` (proves the full-read path is no longer used — covers R4).
+  - `IsAliveAsync` throws `OperationCanceledException` when called with an already-cancelled token (cancellation-guard parity with the other service methods).
+- **Verification:** `Headless.Coordination.Core.Tests.Unit` compiles and the updated/added service tests pass; `ReadLivenessCalls` assertion proves the rewire.
+
+### U2. PostgreSql targeted single-row state query
+
+- **Goal:** Implement `ReadNodeLivenessCoreAsync` for PostgreSql as a single-row guarded read.
+- **Requirements:** R1, R2, R3, R5, R6.
+- **Dependencies:** U1.
+- **Files:**
+  - `src/Headless.Coordination.PostgreSql/PostgreSqlMembershipStore.cs` — add `ReadNodeLivenessCoreAsync`: a single connection, no transaction, a `SELECT` joining `coordination_liveness` to `coordination_node_generation` on `current_incarnation = incarnation` and filtered by `cluster_name`, `node_id`, `incarnation`, returning the classified `state` text via the same `clock_timestamp()` and threshold params used in `ReadCurrentLivenessCoreAsync`, with the `CASE` extended so `last_beat <= clock_timestamp() - @RetentionThreshold` yields no state (absent). No descriptor join is needed (state only). Map no row / retention-expired → `null`; otherwise `Enum.Parse<NodeLivenessState>`.
+  - `tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipNativeTests.cs` — add provider-native assertions for the SQL-level behavior.
+- **Approach:** Reuse the existing parameter set (`ClusterName`, `NodeId`, `Incarnation`, threshold + state-name params) plus a `@RetentionThreshold` = `DeadThreshold + DeadRetentionWindow` matching `_PruneExpiredRowsAsync`. Explicitly do **not** call `_PruneExpiredRowsAsync` (KTD3) — instead the retention boundary is enforced as the outermost read-only branch of the `CASE`, returning the absent sentinel rather than `Dead`. Read-only, so a plain `ExecuteReaderAsync`/`ExecuteScalarAsync` on the projected state column.
+- **Patterns to follow:** `ReadCurrentLivenessCoreAsync` SQL shape and parameter binding; the `#pragma warning disable CA2100` envelope already in the file.
+- **Test suite design:** Provider-native integration test (real Postgres via Testcontainers) for SQL-specific behavior that the conformance suite does not exercise (e.g., explicit stale-incarnation row → `null`). Cross-provider parity stays in U5.
+- **Test scenarios:**
+  - Registered, freshly-beaten node → `Alive`.
+  - Node aged past `SuspicionThreshold` but below `DeadThreshold` → `Suspected`.
+  - Node aged past `DeadThreshold` → `Dead`.
+  - Gracefully-left node (`left_at` set) → `Dead`.
+  - Identity with a stale incarnation while a newer generation is current → `null` (R3).
+  - Identity for a node id that was never registered → `null`.
+  - **Retention-expired-but-unpruned → `null`, not `Dead`:** age the row past `DeadThreshold + DeadRetentionWindow` and call `ReadNodeLivenessCoreAsync` *before* any snapshot read (so no prune has physically run); assert `null` (R2/R3, the parity-critical case — proves the classification cutoff, not the delete, produces absence).
+  - The call issues no DELETE (prune) — assert row counts are unchanged after the call, including for the retention-expired case above (R5).
+- **Verification:** `Headless.Coordination.PostgreSql.Tests.Integration` builds and the new native tests pass against the Testcontainers Postgres.
+
+### U3. SqlServer targeted single-row state query
+
+- **Goal:** Implement `ReadNodeLivenessCoreAsync` for SqlServer as a single-row guarded read.
+- **Requirements:** R1, R2, R3, R5, R6.
+- **Dependencies:** U1.
+- **Files:**
+  - `src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs` — add `ReadNodeLivenessCoreAsync`: a `SELECT` joining `liveness` to `generation` on `current_incarnation = incarnation`, filtered by cluster/node/incarnation, returning the `CASE`-classified state using `DATEDIFF_BIG(millisecond, ...)` + `SYSUTCDATETIME()` and the millisecond threshold params, matching `ReadCurrentLivenessCoreAsync`, with the `CASE` extended so age `>= @RetentionThresholdMs` (= `DeadThreshold + DeadRetentionWindow`) yields the absent sentinel. No row / retention-expired → `null`.
+  - `tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs` — add provider-native assertions.
+- **Approach:** Plain read — **do not** wrap in the `SERIALIZABLE` transaction or the deadlock-retry pipeline used by the write paths, and **do not** call `_PruneExpiredRowsAsync` (KTD3); the retention boundary is enforced as the outermost read-only `CASE` branch using `@RetentionThresholdMs` (the same value `_PruneExpiredRowsAsync` uses). This is a non-locking single-row classification read.
+- **Patterns to follow:** `ReadCurrentLivenessCoreAsync` SQL + `_ToMilliseconds` threshold params; `_Qualified` for schema-qualified table names; the `CA2100` envelope.
+- **Test suite design:** Provider-native integration test (Testcontainers SqlServer) for SQL-specific behavior; parity in U5.
+- **Test scenarios:** same matrix as U2 (Alive / Suspected / Dead-by-age / Dead-by-leave / stale-incarnation → null / never-registered → null / **retention-expired-but-unpruned read-first → null** / no prune side-effect), against SqlServer semantics.
+- **Verification:** `Headless.Coordination.SqlServer.Tests.Integration` builds and the new native tests pass against the Testcontainers SqlServer.
+
+### U4. Redis targeted state Lua
+
+- **Goal:** Implement a read-only single-member state lookup for Redis.
+- **Requirements:** R1, R2, R3, R5, R6.
+- **Dependencies:** U1.
+- **Files:**
+  - `src/Headless.Coordination.Redis/Scripts/RedisMembershipReadNodeLivenessScriptDefinition.cs` — new read-only script + `ReadNodeLivenessParams` record: read the single `:known` member payload for `node@incarnation`; resolve the node's current generation **mirror-first (`hget @knownKey __gen:<nodeId>`), falling back to `get @genKeyPrefix .. nodeId`** — identical to how `RedisMembershipReadScriptDefinition` resolves it; confirm `current == incarnation`; parse `last_beat_ms`; classify against `softMs` (Suspicion) / `hardMs` (Dead) with server `TIME`, returning the absent sentinel when `ageMs >= pruneMs` (the operational prune window — matches the read script's delete-and-omit). Return a nil/sentinel when the member is absent, not current-generation, or retention-expired. **No** `hdel` / `zrem` / `hset`.
+  - `src/Headless.Coordination.Redis/RedisMembershipStore.cs` — add `ReadNodeLivenessAsync` invoking the new script, mapping the result (state string or absent sentinel) to `NodeLivenessState?`.
+  - `src/Headless.Coordination.Redis/CoordinationRedisScriptsInitializer.cs` — register `RedisMembershipReadNodeLivenessScriptDefinition.Instance` in `_Definitions`.
+  - `tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipLuaTests.cs` — add Lua-level assertions.
+- **Approach:** Mirror `RedisMembershipReadScriptDefinition` exactly on the two parity-sensitive points — generation resolution (mirror-first, `gen:` fallback) and the prune-window boundary (`_OperationalPruneMilliseconds`, i.e. `max(DeadThreshold + DeadRetentionWindow, RedisKnownNodeRetention)`) — reduced to a single member. Note Redis has no `left_at`: graceful leave backdates `last_beat` past `hardMs`, so Dead-by-leave falls out of the age classification with no special case. Because the script does no writes, it does not require routing to a writable primary the way `ReadLivenessAsync` does — but keep it on the default `IDatabase` for simplicity unless replica routing is already configured. Reuse `RedisMembershipStore`'s existing key/param helpers (`_KnownKey`, `_GenKeyPrefix`, `_GenerationFieldPrefix`, `_OperationalPruneMilliseconds`, `_ToMilliseconds`, identity `ToString()`).
+- **Patterns to follow:** `RedisMembershipReadScriptDefinition` (classification, generation resolution, `__gen:` mirror handling) reduced to a single member; `RedisScriptDefinition` + `[StructLayout(LayoutKind.Auto)]` param-record convention; the heartbeat-script param style.
+- **Test suite design:** Provider-native integration test (Testcontainers Redis) for Lua-specific behavior — especially that the script performs no pruning writes (R5) and that the `__gen:` mirror vs `gen:` key resolution gives the same answer the snapshot read would. Parity in U5.
+- **Test scenarios:**
+  - Registered, freshly-beaten member → `Alive`.
+  - Member aged into the Suspicion band → `Suspected`.
+  - Member aged past Dead → `Dead`.
+  - Gracefully-left member → `Dead`.
+  - Stale incarnation while a newer generation is current → `null` (R3).
+  - Never-registered member → `null`.
+  - Retention-expired-but-unpruned member (`ageMs >= pruneMs`) read *before* any snapshot/cleanup tick → `null`, not `Dead` (parity-critical — proves the prune-window cutoff in the script).
+  - After the call, the `:known` hash and `:live` zset are byte-for-byte unchanged for an expired-but-unpruned member (proves no prune/backfill writes — R5).
+- **Verification:** `Headless.Coordination.Redis.Tests.Integration` builds; the script loads via the initializer; new Lua tests pass against the Testcontainers Redis.
+
+### U5. Cross-provider conformance for targeted state
+
+- **Goal:** Pin identical observable behavior across all three providers, including parity with the snapshot path.
+- **Requirements:** R2, R3, R6, R7.
+- **Dependencies:** U2, U3, U4.
+- **Files:**
+  - `tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs` — add `virtual` conformance scenarios that resolve `IMembershipStore` from the node's `Services` (as `should_reject_stale_and_impossible_heartbeats_with_generation_guard` already does) and call `ReadNodeLivenessAsync` directly, plus scenarios driving `INodeMembership.IsAliveAsync` end-to-end.
+  - `tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipConformanceTests.cs` — add `[Fact] public override` overrides for the new scenarios.
+  - `tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipConformanceTests.cs` — same overrides.
+  - `tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipConformanceTests.cs` — same overrides.
+- **Approach:** Mirror the existing harness style (`_Cluster()` isolation, `fixture.CreateNodeAsync`, `AbortToken`, the timing constants `SuspicionThreshold` / `DeadButRetainedWait`). The headline parity test reads the full snapshot and the targeted state for the same identity and asserts they agree.
+- **Patterns to follow:** the existing `MembershipConformanceTests<TFixture>` virtual-method + per-provider `override` wiring; the timing-constant helpers in `CoordinationFixtureExtensions`.
+- **Test suite design:** Cross-provider conformance in the harness, overridden in each of the three leaf integration projects — the established mechanism for "same observable behavior must hold for each provider." No new harness infrastructure is required.
+- **Test scenarios:**
+  - `ReadNodeLivenessAsync` returns `Alive` for a freshly-registered node before any extra heartbeat.
+  - `ReadNodeLivenessAsync` returns `Suspected` for a node aged into the suspicion band (`SuspicionThreshold` ≤ age < `DeadThreshold`) — pins cross-provider parity for the middle state, which the per-provider native tests cover individually but the harness must also assert uniformly (R2).
+  - `ReadNodeLivenessAsync` returns `Dead` for a node past the dead-but-retained window (mirrors `should_return_dead_snapshot_before_retention_prune`).
+  - `ReadNodeLivenessAsync` returns `null` for a superseded prior incarnation while the current incarnation returns `Alive` (R3, mirrors `should_filter_operational_reads_to_current_generation`).
+  - `ReadNodeLivenessAsync` returns `Dead` after graceful leave.
+  - **Retention parity (order-sensitive):** for an identity aged past `DeadThreshold + DeadRetentionWindow`, call `ReadNodeLivenessAsync` **first** and assert `null` — *before* any `GetLivenessSnapshotAsync` call, because the snapshot read prunes the row as a side effect and would mask the divergence. This is the scenario that catches the original "skip-the-prune returns Dead where snapshot returns absent" gap (R2/R3).
+  - **Full-state parity:** for an identity inside the retention window, `ReadNodeLivenessAsync(identity)` equals `(await GetLivenessSnapshotAsync()).FirstOrDefault(s => s.Identity == identity)?.State` — i.e. agreement across all three states and `null`-iff-absent, not just the `Alive` case (R2/R7).
+  - `IsAliveAsync` end-to-end returns `true` for a live current node and `false` for a Suspected current node, a Dead node, and a superseded incarnation.
+- **Verification:** all three leaf integration projects build and the new conformance overrides pass against their Testcontainers backends.
+
+### U6. Documentation sync
+
+- **Goal:** Reflect the SPI addition and the consumer-visible performance characteristic in the agent-facing docs.
+- **Requirements:** R1, R4 (consumer-visible behavior).
+- **Dependencies:** U1.
+- **Files:**
+  - `docs/llms/coordination.md` — note that `IsAliveAsync` is a targeted single-node check (O(1), not a cluster snapshot), and that the provider SPI requires `ReadNodeLivenessAsync` with the current-generation + store-clock parity contract.
+  - `src/Headless.Coordination.Core/README.md` — keep in lockstep with the llms doc per the authoring rule; add the SPI method to any membership-engine description.
+  - `src/Headless.Coordination.Abstractions/README.md` — only if it enumerates the SPI surface; otherwise leave untouched.
+- **Approach:** Follow `docs/authoring/AUTHORING.md` drift checks; the two surfaces (`docs/llms/coordination.md` and the package README) must stay paired. Docs explain the concept (targeted vs snapshot, why the targeted path skips prune), not just the signature.
+- **Test suite design:** none — documentation only.
+- **Test scenarios:** Test expectation: none -- documentation-only unit.
+- **Verification:** `docs/llms/coordination.md` and the Core README describe `ReadNodeLivenessAsync` and the faster `IsAliveAsync`; no stale claim that `IsAliveAsync` reads the full snapshot.
+
+---
+
+## Scope Boundaries
+
+- In scope: the `IMembershipStore` SPI addition, the relational base + Postgres + SqlServer + Redis + fake implementations, the `MembershipService.IsAliveAsync` rewire, cross-provider conformance, and the doc sync.
+- Out of scope — `INodeMembership` consumer contract shape: it already exposes `IsAliveAsync` returning `bool`; only its internals change. No public consumer-facing signature changes.
+- Out of scope — any caching/memoization of liveness results: the targeted query is the optimization; a cache layer is a separate concern with its own staleness trade-offs.
+
+### Deferred to Follow-Up Work
+
+- Sibling issue #417 (Redis O(N) snapshot `GET`s on the full read path) is a distinct optimization of `ReadLivenessAsync`, not the targeted single-node path; it is not addressed here.
+
+---
+
+## Risks & Dependencies
+
+- Classification drift between the targeted query and the snapshot path would silently violate parity (R2) — most dangerously on the retention boundary, where the snapshot produces absence by *deleting* and the targeted path must produce it by *classifying* (KTD3). Mitigation: every provider reuses its existing threshold/`CASE`/Lua classification and adds the retention cutoff using the same value its prune predicate uses; the U5 retention-parity scenario reads the targeted path *first* (before the snapshot's destructive prune) so the divergence is observable rather than masked.
+- Cross-cutting build breakage from the interface change (KTD6). Mitigation: sequence U1 → U2 → U3 → U4 and treat the PR as green-at-tip; reviewers should expect intermediate red commits.
+- Redis generation-resolution divergence: if the targeted Lua resolved generation differently from the read script, the two paths could disagree. (There is *no* post-generation-bump race to defend against — the allocate and heartbeat scripts write `gen:` and the `__gen:` mirror atomically in one script, so the mirror is never stale-but-present.) The real divergence is under Redis key eviction: reading `gen:` only would return `null` if the `gen:` key were evicted while the `:known` mirror survived, whereas the snapshot resolves mirror-first. Mitigation: resolve generation mirror-first with `gen:` fallback, byte-for-byte identical to `RedisMembershipReadScriptDefinition` (KTD5), removing the divergence entirely.
+
+---
+
+## Sources & Research
+
+- Origin issue: https://github.com/xshaheen/headless-framework/issues/418
+- `docs/solutions/architecture-patterns/coordination-register-establishes-durable-liveness.md` — the incarnation-guard + store-clock + per-provider classification model this targeted query must honor; lists #418 as planned follow-up.
+- `docs/solutions/design-patterns/redis-zset-semaphore-prune-count-separation.md` — Redis prune/count separation, relevant to keeping the targeted Lua write-free.
+- Existing implementations mirrored by this work: `DatabaseMembershipStoreBase` (wrapper/core split), `PostgreSqlMembershipStore.ReadCurrentLivenessCoreAsync`, `SqlServerMembershipStore.ReadCurrentLivenessCoreAsync`, `RedisMembershipReadScriptDefinition`, `MembershipConformanceTests<TFixture>`.

--- a/src/Headless.Coordination.Core.Database/DatabaseMembershipStoreBase.cs
+++ b/src/Headless.Coordination.Core.Database/DatabaseMembershipStoreBase.cs
@@ -64,6 +64,16 @@ internal abstract class DatabaseMembershipStoreBase(CoordinationOptions options,
         return snapshots.OrderBy(static snapshot => snapshot.Identity.ToString(), StringComparer.Ordinal).ToArray();
     }
 
+    public ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(
+        NodeIdentity identity,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ReadNodeLivenessCoreAsync(ClusterName, identity, cancellationToken);
+    }
+
     /// <summary>Allocates the next durable incarnation for <paramref name="nodeId"/>.</summary>
     protected abstract ValueTask<NodeIncarnation> AllocateIncarnationCoreAsync(
         string clusterName,
@@ -105,6 +115,19 @@ internal abstract class DatabaseMembershipStoreBase(CoordinationOptions options,
     /// </summary>
     protected abstract ValueTask<IReadOnlyList<NodeLivenessSnapshot>> ReadCurrentLivenessCoreAsync(
         string clusterName,
+        CancellationToken cancellationToken
+    );
+
+    /// <summary>
+    /// Reads the current-generation liveness state for a single identity, or <see langword="null"/> when the
+    /// identity is absent from the current-generation snapshot view (not current, or at/beyond the retention
+    /// window). Implementations must classify with the store clock identically to
+    /// <see cref="ReadCurrentLivenessCoreAsync"/> and apply the retention boundary as a read-only cutoff —
+    /// no pruning, no backfill.
+    /// </summary>
+    protected abstract ValueTask<NodeLivenessState?> ReadNodeLivenessCoreAsync(
+        string clusterName,
+        NodeIdentity identity,
         CancellationToken cancellationToken
     );
 

--- a/src/Headless.Coordination.Core.Database/DatabaseMembershipStoreBase.cs
+++ b/src/Headless.Coordination.Core.Database/DatabaseMembershipStoreBase.cs
@@ -71,7 +71,7 @@ internal abstract class DatabaseMembershipStoreBase(CoordinationOptions options,
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        return ReadNodeLivenessCoreAsync(ClusterName, identity, cancellationToken);
+        return ReadCurrentNodeLivenessCoreAsync(ClusterName, identity, cancellationToken);
     }
 
     /// <summary>Allocates the next durable incarnation for <paramref name="nodeId"/>.</summary>
@@ -125,7 +125,7 @@ internal abstract class DatabaseMembershipStoreBase(CoordinationOptions options,
     /// <see cref="ReadCurrentLivenessCoreAsync"/> and apply the retention boundary as a read-only cutoff —
     /// no pruning, no backfill.
     /// </summary>
-    protected abstract ValueTask<NodeLivenessState?> ReadNodeLivenessCoreAsync(
+    protected abstract ValueTask<NodeLivenessState?> ReadCurrentNodeLivenessCoreAsync(
         string clusterName,
         NodeIdentity identity,
         CancellationToken cancellationToken

--- a/src/Headless.Coordination.Core/IMembershipStore.cs
+++ b/src/Headless.Coordination.Core/IMembershipStore.cs
@@ -26,4 +26,24 @@ public interface IMembershipStore
     /// event ordering and snapshot output. Provider conformance tests must assert this ordering.
     /// </remarks>
     ValueTask<IReadOnlyList<NodeLivenessSnapshot>> ReadLivenessAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the liveness state of a single <paramref name="identity"/> without reading any other node — the
+    /// targeted, bounded counterpart to <see cref="ReadLivenessAsync"/> for per-request liveness checks.
+    /// </summary>
+    /// <remarks>
+    /// The result MUST equal what <see cref="ReadLivenessAsync"/> would conclude for the same identity at the
+    /// same instant: it is current-generation-only (a stale, superseded, or never-registered incarnation is
+    /// not surfaced), it classifies with the store clock using the same suspicion/dead thresholds, and it
+    /// honors the same retention boundary — a row at or beyond the retention window reads as absent, matching
+    /// the snapshot read which produces absence by pruning. A return of <see langword="null"/> means the
+    /// identity is absent from the current-generation snapshot view; it deliberately collapses the absence
+    /// sub-states (never-registered / stale / superseded / retention-expired). Distinguishing those is an
+    /// additive extension point, not modeled here. Implementations MUST be read-only — no pruning, no
+    /// generation-mirror backfill — so the call stays a bounded single-row/single-member operation.
+    /// </remarks>
+    ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(
+        NodeIdentity identity,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Headless.Coordination.Core/MembershipService.cs
+++ b/src/Headless.Coordination.Core/MembershipService.cs
@@ -82,9 +82,12 @@ internal sealed class MembershipService(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var snapshots = await GetLivenessSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        // Targeted single-node read instead of a full cluster snapshot + filter: a node is alive only when its
+        // current-generation liveness classifies as Alive. Absent (null) and any non-Alive state map to false,
+        // exactly matching the prior snapshot-based predicate.
+        var state = await store.ReadNodeLivenessAsync(identity, cancellationToken).ConfigureAwait(false);
 
-        return snapshots.Any(snapshot => snapshot.Identity == identity && snapshot.State == NodeLivenessState.Alive);
+        return state is NodeLivenessState.Alive;
     }
 
     public async ValueTask<IReadOnlyList<NodeIdentity>> GetLiveNodesAsync(CancellationToken cancellationToken = default)

--- a/src/Headless.Coordination.Core/README.md
+++ b/src/Headless.Coordination.Core/README.md
@@ -37,6 +37,10 @@ services.AddCoordinationCore<MyMembershipStore>(options =>
 
 Applications normally use a provider package and call `AddHeadlessCoordination(setup => setup.Use...)`; `AddCoordinationCore<TStore>` is the lower-level hook for provider authors and custom stores.
 
+## Provider SPI
+
+Custom `IMembershipStore` implementations must provide `ReadNodeLivenessAsync(NodeIdentity, CancellationToken) -> NodeLivenessState?` alongside the cluster-wide `ReadLivenessAsync`. It returns the classified state of a single identity, or `null` when that identity is absent from the current-generation view. The contract: it MUST equal what `ReadLivenessAsync` would conclude for that identity — current-generation-only, store-clock classified, and retention-bounded so a row at/beyond the retention window reads as `null`, not `Dead` — and it MUST be read-only (no pruning, no generation-mirror backfill) so `IsAliveAsync` stays a bounded single-row read. There is no default implementation; this method is a required part of the SPI, so existing custom stores must add it.
+
 ## Configuration
 
 Set `HeartbeatInterval < SuspicionThreshold < DeadThreshold`; `DeadRetentionWindow` must be at least two heartbeat intervals.

--- a/src/Headless.Coordination.Core/README.md
+++ b/src/Headless.Coordination.Core/README.md
@@ -9,6 +9,7 @@ Provides registration, heartbeat, event derivation, fail-stop self-loss, and ord
 ## Key Features
 
 - An internal membership service implements `INodeMembership` (consumers resolve `INodeMembership`).
+- `IsAliveAsync(identity)` is a targeted single-node check backed by the store SPI's `ReadNodeLivenessAsync` — one guarded single-row query (or small Lua), not a full cluster snapshot, so per-request liveness checks stay O(1) instead of scaling with cluster size. It returns the same result the snapshot would for that identity (current-generation-only, store-clock classified, retention-bounded).
 - Background heartbeat service derives lifecycle events from authoritative snapshots, leaves gracefully on host shutdown under a bounded timeout, and stops beating once local membership is lost.
 - Bounded per-subscriber event channels isolate slow consumers from heartbeats.
 - Default node-id provider resolves configured id, Kubernetes pod identity, hostname, then generated id.

--- a/src/Headless.Coordination.PostgreSql/PostgreSqlMembershipStore.cs
+++ b/src/Headless.Coordination.PostgreSql/PostgreSqlMembershipStore.cs
@@ -256,7 +256,7 @@ internal sealed class PostgreSqlMembershipStore(
         return snapshots;
     }
 
-    protected override async ValueTask<NodeLivenessState?> ReadNodeLivenessCoreAsync(
+    protected override async ValueTask<NodeLivenessState?> ReadCurrentNodeLivenessCoreAsync(
         string clusterName,
         NodeIdentity identity,
         CancellationToken cancellationToken

--- a/src/Headless.Coordination.PostgreSql/PostgreSqlMembershipStore.cs
+++ b/src/Headless.Coordination.PostgreSql/PostgreSqlMembershipStore.cs
@@ -256,6 +256,53 @@ internal sealed class PostgreSqlMembershipStore(
         return snapshots;
     }
 
+    protected override async ValueTask<NodeLivenessState?> ReadNodeLivenessCoreAsync(
+        string clusterName,
+        NodeIdentity identity,
+        CancellationToken cancellationToken
+    )
+    {
+        // Targeted single-row read: join to the generation authority so a non-current incarnation yields no
+        // row (absent -> null), classify with the store clock identically to ReadCurrentLivenessCoreAsync, and
+        // exclude retention-expired rows in the WHERE so they read as absent (null) exactly as the snapshot's
+        // prune would remove them. Read-only: no prune, no descriptor join (state only).
+        const string sql = $"""
+            SELECT
+                CASE
+                    WHEN l.{PostgreSqlMembershipSchema.Liveness.LeftAt} IS NOT NULL THEN @DeadState
+                    WHEN l.{PostgreSqlMembershipSchema.Liveness.LastBeat} <= clock_timestamp() - @DeadThreshold THEN @DeadState
+                    WHEN l.{PostgreSqlMembershipSchema.Liveness.LastBeat} <= clock_timestamp() - @SuspicionThreshold THEN @SuspectedState
+                    ELSE @AliveState
+                END AS state
+            FROM {PostgreSqlMembershipSchema.Liveness.Table} l
+            JOIN {PostgreSqlMembershipSchema.Generation.Table} g
+              ON g.{PostgreSqlMembershipSchema.ClusterName} = l.{PostgreSqlMembershipSchema.ClusterName}
+             AND g.{PostgreSqlMembershipSchema.NodeId} = l.{PostgreSqlMembershipSchema.NodeId}
+             AND g.{PostgreSqlMembershipSchema.Generation.CurrentIncarnation} = l.{PostgreSqlMembershipSchema.Incarnation}
+            WHERE l.{PostgreSqlMembershipSchema.ClusterName} = @ClusterName
+              AND l.{PostgreSqlMembershipSchema.NodeId} = @NodeId
+              AND l.{PostgreSqlMembershipSchema.Incarnation} = @Incarnation
+              AND l.{PostgreSqlMembershipSchema.Liveness.LastBeat} > clock_timestamp() - @RetentionThreshold;
+            """;
+
+        await using var connection = providerOptions.Value.CreateConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = _CreateCommand(connection, sql);
+        command.Parameters.AddWithValue("ClusterName", clusterName);
+        command.Parameters.AddWithValue("NodeId", identity.NodeId.Value);
+        command.Parameters.AddWithValue("Incarnation", identity.Incarnation.Value);
+        command.Parameters.AddWithValue("DeadThreshold", DeadThreshold);
+        command.Parameters.AddWithValue("SuspicionThreshold", SuspicionThreshold);
+        command.Parameters.AddWithValue("RetentionThreshold", DeadThreshold + DeadRetentionWindow);
+        command.Parameters.AddWithValue("AliveState", nameof(NodeLivenessState.Alive));
+        command.Parameters.AddWithValue("SuspectedState", nameof(NodeLivenessState.Suspected));
+        command.Parameters.AddWithValue("DeadState", nameof(NodeLivenessState.Dead));
+
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+
+        return result is string stateText ? Enum.Parse<NodeLivenessState>(stateText) : null;
+    }
+
     private async ValueTask _PruneExpiredRowsAsync(
         NpgsqlConnection connection,
         string clusterName,

--- a/src/Headless.Coordination.Redis/CoordinationRedisScriptsInitializer.cs
+++ b/src/Headless.Coordination.Redis/CoordinationRedisScriptsInitializer.cs
@@ -15,6 +15,7 @@ internal sealed class CoordinationRedisScriptsInitializer(
         RedisMembershipAllocateIncarnationScriptDefinition.Instance,
         RedisMembershipHeartbeatScriptDefinition.Instance,
         RedisMembershipReadScriptDefinition.Instance,
+        RedisMembershipReadNodeLivenessScriptDefinition.Instance,
         RedisMembershipLeaveScriptDefinition.Instance,
         RedisMembershipCleanupScriptDefinition.Instance,
     ];

--- a/src/Headless.Coordination.Redis/RedisMembershipStore.cs
+++ b/src/Headless.Coordination.Redis/RedisMembershipStore.cs
@@ -164,6 +164,41 @@ internal sealed class RedisMembershipStore(
         return _ParseSnapshots((RedisResult[]?)result);
     }
 
+    // Targeted single-member read. Unlike ReadLivenessAsync this performs no writes (no prune, no mirror
+    // backfill), so it does not require a writable primary — but it is left on the default database for
+    // simplicity. Resolves generation mirror-first with gen: fallback and applies the operational prune
+    // window as a read-only absent cutoff, matching the snapshot's delete-and-omit.
+    public async ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(
+        NodeIdentity identity,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var result = await scriptsLoader
+            .EvaluateAsync(
+                Db,
+                RedisMembershipReadNodeLivenessScriptDefinition.Instance,
+                new ReadNodeLivenessParams(
+                    _KnownKey(),
+                    _GenKey(identity.NodeId),
+                    _GenerationField(identity.NodeId),
+                    identity.ToString(),
+                    identity.Incarnation.Value,
+                    _ToMilliseconds(Options.SuspicionThreshold),
+                    _ToMilliseconds(Options.DeadThreshold),
+                    _OperationalPruneMilliseconds(),
+                    nameof(NodeLivenessState.Alive),
+                    nameof(NodeLivenessState.Suspected),
+                    nameof(NodeLivenessState.Dead)
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return result.IsNull ? null : Enum.Parse<NodeLivenessState>((string)result!);
+    }
+
     internal async ValueTask CleanupAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Headless.Coordination.Redis/Scripts/RedisMembershipReadNodeLivenessScriptDefinition.cs
+++ b/src/Headless.Coordination.Redis/Scripts/RedisMembershipReadNodeLivenessScriptDefinition.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Runtime.InteropServices;
+using Headless.Redis;
+using StackExchange.Redis;
+
+namespace Headless.Coordination.Redis;
+
+/// <summary>
+/// Classifies a single coordination member with Redis server time — the targeted, read-only counterpart to
+/// <see cref="RedisMembershipReadScriptDefinition"/>. Returns the state string, or nil when the member is
+/// absent, not current-generation, or retention-expired. Performs no writes (no prune, no mirror backfill).
+/// </summary>
+internal sealed class RedisMembershipReadNodeLivenessScriptDefinition : RedisScriptDefinition
+{
+    public static RedisMembershipReadNodeLivenessScriptDefinition Instance { get; } = new();
+
+    private RedisMembershipReadNodeLivenessScriptDefinition()
+        : base(
+            """
+            local payloadText = redis.call('hget', @knownKey, @member)
+            if payloadText == false then
+              return nil
+            end
+
+            -- Resolve the node's current generation mirror-first (matching the read script), gen: key fallback.
+            -- The mirror is a bare decimal written by tostring(incarnation); reading it avoids a second key when present.
+            local current = redis.call('hget', @knownKey, @generationField)
+            if current == false then
+              current = redis.call('get', @genKey)
+            end
+
+            if current == false or tonumber(current) ~= tonumber(@incarnation) then
+              return nil
+            end
+
+            local nowSecMicro = redis.call('TIME')
+            local nowMs = (tonumber(nowSecMicro[1]) * 1000) + math.floor(tonumber(nowSecMicro[2]) / 1000)
+            local payload = cjson.decode(payloadText)
+            local ageMs = nowMs - tonumber(payload['last_beat_ms'])
+
+            -- Retention boundary as a read-only cutoff: the read script deletes-and-omits such members, so the
+            -- targeted path reports absence (nil) rather than Dead to stay parity-equal without writing.
+            if ageMs >= tonumber(@pruneMs) then
+              return nil
+            end
+
+            if ageMs >= tonumber(@hardMs) then
+              return @deadState
+            elseif ageMs >= tonumber(@softMs) then
+              return @suspectedState
+            end
+
+            return @aliveState
+            """
+        ) { }
+}
+
+#pragma warning disable IDE1006 // camelCase mirrors the Lua @param token names
+/// <summary>Parameters for <see cref="RedisMembershipReadNodeLivenessScriptDefinition"/>.</summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ReadNodeLivenessParams(
+    RedisKey knownKey,
+    RedisKey genKey,
+    string generationField,
+    string member,
+    long incarnation,
+    long softMs,
+    long hardMs,
+    long pruneMs,
+    string aliveState,
+    string suspectedState,
+    string deadState
+);
+#pragma warning restore IDE1006

--- a/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
+++ b/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
@@ -355,7 +355,7 @@ internal sealed class SqlServerMembershipStore(
         return snapshots;
     }
 
-    protected override async ValueTask<NodeLivenessState?> ReadNodeLivenessCoreAsync(
+    protected override async ValueTask<NodeLivenessState?> ReadCurrentNodeLivenessCoreAsync(
         string clusterName,
         NodeIdentity identity,
         CancellationToken cancellationToken

--- a/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
+++ b/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
@@ -355,6 +355,56 @@ internal sealed class SqlServerMembershipStore(
         return snapshots;
     }
 
+    protected override async ValueTask<NodeLivenessState?> ReadNodeLivenessCoreAsync(
+        string clusterName,
+        NodeIdentity identity,
+        CancellationToken cancellationToken
+    )
+    {
+        var generationTable = _Qualified(SqlServerMembershipSchema.Generation.Table);
+        var livenessTable = _Qualified(SqlServerMembershipSchema.Liveness.Table);
+
+        // Targeted single-row read: join to the generation authority so a non-current incarnation yields no
+        // row (absent -> null), classify with the store clock identically to ReadCurrentLivenessCoreAsync, and
+        // exclude retention-expired rows in the WHERE so they read as absent (null) exactly as the snapshot's
+        // prune would remove them. Plain read: no SERIALIZABLE transaction, no deadlock retry, no prune.
+        var sql = $$"""
+            SELECT
+                CASE
+                    WHEN l.[{{SqlServerMembershipSchema.Liveness.LeftAt}}] IS NOT NULL THEN @DeadState
+                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @DeadThresholdMs THEN @DeadState
+                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @SuspicionThresholdMs THEN @SuspectedState
+                    ELSE @AliveState
+                END AS [state]
+            FROM {{livenessTable}} l
+            JOIN {{generationTable}} g
+              ON g.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
+             AND g.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
+             AND g.[{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
+            WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+              AND l.[{{SqlServerMembershipSchema.NodeId}}] = @NodeId
+              AND l.[{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation
+              AND DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) < @RetentionThresholdMs;
+            """;
+
+        await using var connection = providerOptions.Value.CreateConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = _CreateCommand(connection, sql);
+        command.Parameters.AddWithValue("ClusterName", clusterName);
+        command.Parameters.AddWithValue("NodeId", identity.NodeId.Value);
+        command.Parameters.AddWithValue("Incarnation", identity.Incarnation.Value);
+        command.Parameters.AddWithValue("DeadThresholdMs", _ToMilliseconds(DeadThreshold));
+        command.Parameters.AddWithValue("SuspicionThresholdMs", _ToMilliseconds(SuspicionThreshold));
+        command.Parameters.AddWithValue("RetentionThresholdMs", _ToMilliseconds(DeadThreshold + DeadRetentionWindow));
+        command.Parameters.AddWithValue("AliveState", nameof(NodeLivenessState.Alive));
+        command.Parameters.AddWithValue("SuspectedState", nameof(NodeLivenessState.Suspected));
+        command.Parameters.AddWithValue("DeadState", nameof(NodeLivenessState.Dead));
+
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+
+        return result is string stateText ? Enum.Parse<NodeLivenessState>(stateText) : null;
+    }
+
     private async ValueTask _PruneExpiredRowsAsync(
         SqlConnection connection,
         string clusterName,

--- a/tests/Headless.Coordination.Core.Tests.Unit/FakeMembershipStore.cs
+++ b/tests/Headless.Coordination.Core.Tests.Unit/FakeMembershipStore.cs
@@ -16,6 +16,8 @@ internal sealed class FakeMembershipStore : IMembershipStore
 
     public bool ThrowOnRead { get; set; }
 
+    public bool ThrowOnReadNodeLiveness { get; set; }
+
     public bool ThrowOnLeave { get; set; }
 
     public bool BlockOnLeave { get; set; }
@@ -23,6 +25,10 @@ internal sealed class FakeMembershipStore : IMembershipStore
     public int AllocateIncarnationCalls { get; private set; }
 
     public int ReadLivenessCalls { get; private set; }
+
+    public int ReadNodeLivenessCalls { get; private set; }
+
+    public Dictionary<NodeIdentity, NodeLivenessState?> NodeStates { get; } = [];
 
     public List<NodeDescriptor> Descriptors { get; } = [];
 
@@ -101,6 +107,23 @@ internal sealed class FakeMembershipStore : IMembershipStore
                     .ToArray();
 
         return ValueTask.FromResult(snapshots);
+    }
+
+    public ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(
+        NodeIdentity identity,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ReadNodeLivenessCalls++;
+
+        if (ThrowOnReadNodeLiveness)
+        {
+            throw new InvalidOperationException("store unavailable");
+        }
+
+        // Absent identities (never configured) resolve to null, matching the SPI's absent contract.
+        return ValueTask.FromResult(NodeStates.GetValueOrDefault(identity));
     }
 
     public void EnqueueSnapshot(params NodeLivenessSnapshot[] snapshots)

--- a/tests/Headless.Coordination.Core.Tests.Unit/MembershipServiceTests.cs
+++ b/tests/Headless.Coordination.Core.Tests.Unit/MembershipServiceTests.cs
@@ -144,6 +144,75 @@ public sealed class MembershipServiceTests : TestBase
         store.Heartbeats.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData(NodeLivenessState.Alive, true)]
+    [InlineData(NodeLivenessState.Suspected, false)]
+    [InlineData(NodeLivenessState.Dead, false)]
+    public async Task should_map_targeted_node_liveness_state_to_is_alive(NodeLivenessState state, bool expected)
+    {
+        // given
+        var store = new FakeMembershipStore();
+        var identity = new NodeIdentity(new NodeId("node-a"), new NodeIncarnation(1));
+        store.NodeStates[identity] = state;
+        var sut = _CreateService(store);
+
+        // when
+        var alive = await sut.IsAliveAsync(identity, AbortToken);
+
+        // then
+        alive.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task should_treat_absent_targeted_node_as_not_alive()
+    {
+        // given
+        var store = new FakeMembershipStore();
+        var identity = new NodeIdentity(new NodeId("node-a"), new NodeIncarnation(1));
+        var sut = _CreateService(store);
+
+        // when — identity was never configured in the store, so it resolves to absent (null)
+        var alive = await sut.IsAliveAsync(identity, AbortToken);
+
+        // then
+        alive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_use_targeted_read_and_not_full_snapshot_for_is_alive()
+    {
+        // given
+        var store = new FakeMembershipStore();
+        var identity = new NodeIdentity(new NodeId("node-a"), new NodeIncarnation(1));
+        store.NodeStates[identity] = NodeLivenessState.Alive;
+        var sut = _CreateService(store);
+
+        // when
+        await sut.IsAliveAsync(identity, AbortToken);
+
+        // then — the targeted SPI method is used; the full cluster snapshot read is not
+        store.ReadNodeLivenessCalls.Should().Be(1);
+        store.ReadLivenessCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_throw_when_is_alive_called_with_cancelled_token()
+    {
+        // given
+        var store = new FakeMembershipStore();
+        var identity = new NodeIdentity(new NodeId("node-a"), new NodeIncarnation(1));
+        var sut = _CreateService(store);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // when
+        var act = async () => await sut.IsAliveAsync(identity, cts.Token);
+
+        // then
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        store.ReadNodeLivenessCalls.Should().Be(0);
+    }
+
     private static MembershipService _CreateService(
         FakeMembershipStore store,
         CoordinationOptions? options = null,

--- a/tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipConformanceTests.cs
+++ b/tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipConformanceTests.cs
@@ -58,4 +58,28 @@ public sealed class PostgreSqlMembershipConformanceTests(PostgreSqlMembershipFix
     [Fact]
     public override Task should_not_evict_current_incarnation_when_prior_incarnation_leaves() =>
         base.should_not_evict_current_incarnation_when_prior_incarnation_leaves();
+
+    [Fact]
+    public override Task should_read_targeted_node_liveness_across_states() =>
+        base.should_read_targeted_node_liveness_across_states();
+
+    [Fact]
+    public override Task should_read_dead_targeted_state_after_graceful_leave() =>
+        base.should_read_dead_targeted_state_after_graceful_leave();
+
+    [Fact]
+    public override Task should_read_null_targeted_state_for_superseded_incarnation() =>
+        base.should_read_null_targeted_state_for_superseded_incarnation();
+
+    [Fact]
+    public override Task should_read_null_without_pruning_for_retention_expired_node() =>
+        base.should_read_null_without_pruning_for_retention_expired_node();
+
+    [Fact]
+    public override Task should_agree_between_targeted_read_and_snapshot() =>
+        base.should_agree_between_targeted_read_and_snapshot();
+
+    [Fact]
+    public override Task should_derive_is_alive_from_targeted_read() =>
+        base.should_derive_is_alive_from_targeted_read();
 }

--- a/tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipNativeTests.cs
+++ b/tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipNativeTests.cs
@@ -188,6 +188,90 @@ public sealed class PostgreSqlMembershipNativeTests(PostgreSqlMembershipFixture 
         thrown.Which.InnerException.Should().NotBeNull();
     }
 
+    [Fact]
+    public async Task should_classify_targeted_node_liveness_across_states()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Alive immediately after register (durable liveness established without a loop tick).
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+
+        // Aged into the suspicion band -> Suspected.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Suspected);
+
+        // Aged past the dead threshold but still inside the retention window -> Dead.
+        await TimeProvider.System.Delay(
+            CoordinationFixtureExtensions.DeadButRetainedWait - CoordinationFixtureExtensions.SuspectedWait,
+            AbortToken
+        );
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    [Fact]
+    public async Task should_return_dead_for_targeted_read_after_graceful_leave()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        await store.LeaveAsync(identity, AbortToken);
+
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    [Fact]
+    public async Task should_return_null_for_targeted_read_of_stale_and_unregistered_identities()
+    {
+        var cluster = _Cluster();
+        await using var first = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var firstIdentity = await first.Membership.RegisterAsync(AbortToken);
+
+        await using var second = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var secondIdentity = await second.Membership.RegisterAsync(AbortToken);
+        var store = second.Services.GetRequiredService<IMembershipStore>();
+        var unregistered = new NodeIdentity(new NodeId("node-z"), new NodeIncarnation(1));
+
+        // Superseded prior incarnation is not current-generation -> absent (null).
+        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken)).Should().BeNull();
+        // Never-registered node -> absent (null).
+        (await store.ReadNodeLivenessAsync(unregistered, AbortToken)).Should().BeNull();
+        // The current incarnation is still alive.
+        (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+    }
+
+    [Fact]
+    public async Task should_return_null_without_pruning_for_retention_expired_targeted_read()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Age past the retention window, then read the targeted path FIRST — before any snapshot read could
+        // prune the row. The snapshot path produces absence by deleting; the targeted path must produce the same
+        // absence by classification (returning null) without writing.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.AfterPruneWait, AbortToken);
+
+        var state = await store.ReadNodeLivenessAsync(identity, AbortToken);
+
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
+        var livenessRows = await _CountClusterRowsAsync(
+            connection,
+            "SELECT count(*) FROM coordination_liveness WHERE cluster_name = @ClusterName;",
+            cluster
+        );
+
+        state.Should().BeNull();
+        // The retention-expired row must still be physically present: the targeted read classifies, it never prunes.
+        livenessRows.Should().Be(1);
+    }
+
     private static string _Cluster()
     {
         return "native-" + Guid.NewGuid().ToString("N");

--- a/tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipNativeTests.cs
+++ b/tests/Headless.Coordination.PostgreSql.Tests.Integration/PostgreSqlMembershipNativeTests.cs
@@ -197,7 +197,9 @@ public sealed class PostgreSqlMembershipNativeTests(PostgreSqlMembershipFixture 
         var store = node.Services.GetRequiredService<IMembershipStore>();
 
         // Alive immediately after register (durable liveness established without a loop tick).
-        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken))
+            .Should()
+            .Be(NodeLivenessState.Alive);
 
         // Aged into the suspicion band -> Suspected.
         await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
@@ -237,11 +239,17 @@ public sealed class PostgreSqlMembershipNativeTests(PostgreSqlMembershipFixture 
         var unregistered = new NodeIdentity(new NodeId("node-z"), new NodeIncarnation(1));
 
         // Superseded prior incarnation is not current-generation -> absent (null).
-        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken))
+            .Should()
+            .BeNull();
         // Never-registered node -> absent (null).
-        (await store.ReadNodeLivenessAsync(unregistered, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(unregistered, AbortToken))
+            .Should()
+            .BeNull();
         // The current incarnation is still alive.
-        (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+        (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken))
+            .Should()
+            .Be(NodeLivenessState.Alive);
     }
 
     [Fact]

--- a/tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipConformanceTests.cs
+++ b/tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipConformanceTests.cs
@@ -67,6 +67,30 @@ public sealed class RedisMembershipConformanceTests(RedisMembershipFixture fixtu
     public override Task should_not_evict_current_incarnation_when_prior_incarnation_leaves() =>
         base.should_not_evict_current_incarnation_when_prior_incarnation_leaves();
 
+    [Fact]
+    public override Task should_read_targeted_node_liveness_across_states() =>
+        base.should_read_targeted_node_liveness_across_states();
+
+    [Fact]
+    public override Task should_read_dead_targeted_state_after_graceful_leave() =>
+        base.should_read_dead_targeted_state_after_graceful_leave();
+
+    [Fact]
+    public override Task should_read_null_targeted_state_for_superseded_incarnation() =>
+        base.should_read_null_targeted_state_for_superseded_incarnation();
+
+    [Fact]
+    public override Task should_read_null_without_pruning_for_retention_expired_node() =>
+        base.should_read_null_without_pruning_for_retention_expired_node();
+
+    [Fact]
+    public override Task should_agree_between_targeted_read_and_snapshot() =>
+        base.should_agree_between_targeted_read_and_snapshot();
+
+    [Fact]
+    public override Task should_derive_is_alive_from_targeted_read() =>
+        base.should_derive_is_alive_from_targeted_read();
+
     /// <summary>
     /// Documents the intentional cross-provider divergence (plan KTD-16): at the provider-default
     /// <see cref="RedisCoordinationOptions.RedisKnownNodeRetention"/> (7 days), Redis keeps Dead/Left nodes

--- a/tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipLuaTests.cs
+++ b/tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipLuaTests.cs
@@ -201,6 +201,101 @@ public sealed class RedisMembershipLuaTests(RedisMembershipFixture fixture) : Te
         identity.Should().Be(new NodeIdentity(new NodeId("node-a"), new NodeIncarnation(1)));
     }
 
+    [Fact]
+    public async Task should_classify_targeted_node_liveness_across_states()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Alive immediately after register.
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+
+        // Aged into the suspicion band -> Suspected.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Suspected);
+
+        // Aged past the dead threshold but still inside the retention window -> Dead.
+        await TimeProvider.System.Delay(
+            CoordinationFixtureExtensions.DeadButRetainedWait - CoordinationFixtureExtensions.SuspectedWait,
+            AbortToken
+        );
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    [Fact]
+    public async Task should_return_dead_for_targeted_read_after_graceful_leave()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        await store.LeaveAsync(identity, AbortToken);
+
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    [Fact]
+    public async Task should_return_null_for_targeted_read_of_stale_and_unregistered_identities()
+    {
+        var cluster = _Cluster();
+        await using var first = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var firstIdentity = await first.Membership.RegisterAsync(AbortToken);
+
+        await using var second = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var secondIdentity = await second.Membership.RegisterAsync(AbortToken);
+        var store = second.Services.GetRequiredService<IMembershipStore>();
+        var unregistered = new NodeIdentity(new NodeId("node-z"), new NodeIncarnation(1));
+
+        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(unregistered, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+    }
+
+    [Fact]
+    public async Task should_resolve_generation_via_gen_key_without_backfilling_mirror_on_targeted_read()
+    {
+        var cluster = _Cluster();
+        var db = fixture.ConnectionMultiplexer.GetDatabase();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+        var knownKey = _KnownKey(cluster);
+        var generationField = _GenerationField(identity.NodeId);
+
+        // Drop the generation mirror: the targeted read must fall back to the authoritative gen: key.
+        _ = await db.HashDeleteAsync(knownKey, generationField);
+
+        var state = await store.ReadNodeLivenessAsync(identity, AbortToken);
+
+        state.Should().Be(NodeLivenessState.Alive);
+        // Unlike the snapshot read, the targeted read is write-free: it must NOT repair the mirror.
+        (await db.HashExistsAsync(knownKey, generationField)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_return_null_without_pruning_for_retention_expired_targeted_read()
+    {
+        var cluster = _Cluster();
+        var db = fixture.ConnectionMultiplexer.GetDatabase();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+        var knownKey = _KnownKey(cluster);
+
+        // Age past the operational prune window, then read the targeted path FIRST — before any snapshot or
+        // cleanup tick could delete the member. The targeted path reports absence (null) without writing.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.AfterPruneWait, AbortToken);
+
+        var state = await store.ReadNodeLivenessAsync(identity, AbortToken);
+
+        state.Should().BeNull();
+        // The retention-expired member must still be present in :known: the targeted read classifies, never prunes.
+        (await db.HashExistsAsync(knownKey, identity.ToString())).Should().BeTrue();
+    }
+
     private static string _Cluster()
     {
         return "native-" + Guid.NewGuid().ToString("N");

--- a/tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipLuaTests.cs
+++ b/tests/Headless.Coordination.Redis.Tests.Integration/RedisMembershipLuaTests.cs
@@ -210,7 +210,9 @@ public sealed class RedisMembershipLuaTests(RedisMembershipFixture fixture) : Te
         var store = node.Services.GetRequiredService<IMembershipStore>();
 
         // Alive immediately after register.
-        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken))
+            .Should()
+            .Be(NodeLivenessState.Alive);
 
         // Aged into the suspicion band -> Suspected.
         await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
@@ -272,7 +274,9 @@ public sealed class RedisMembershipLuaTests(RedisMembershipFixture fixture) : Te
 
         state.Should().Be(NodeLivenessState.Alive);
         // Unlike the snapshot read, the targeted read is write-free: it must NOT repair the mirror.
-        (await db.HashExistsAsync(knownKey, generationField)).Should().BeFalse();
+        (await db.HashExistsAsync(knownKey, generationField))
+            .Should()
+            .BeFalse();
     }
 
     [Fact]
@@ -293,7 +297,9 @@ public sealed class RedisMembershipLuaTests(RedisMembershipFixture fixture) : Te
 
         state.Should().BeNull();
         // The retention-expired member must still be present in :known: the targeted read classifies, never prunes.
-        (await db.HashExistsAsync(knownKey, identity.ToString())).Should().BeTrue();
+        (await db.HashExistsAsync(knownKey, identity.ToString()))
+            .Should()
+            .BeTrue();
     }
 
     private static string _Cluster()

--- a/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipConformanceTests.cs
+++ b/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipConformanceTests.cs
@@ -58,4 +58,28 @@ public sealed class SqlServerMembershipConformanceTests(SqlServerMembershipFixtu
     [Fact]
     public override Task should_not_evict_current_incarnation_when_prior_incarnation_leaves() =>
         base.should_not_evict_current_incarnation_when_prior_incarnation_leaves();
+
+    [Fact]
+    public override Task should_read_targeted_node_liveness_across_states() =>
+        base.should_read_targeted_node_liveness_across_states();
+
+    [Fact]
+    public override Task should_read_dead_targeted_state_after_graceful_leave() =>
+        base.should_read_dead_targeted_state_after_graceful_leave();
+
+    [Fact]
+    public override Task should_read_null_targeted_state_for_superseded_incarnation() =>
+        base.should_read_null_targeted_state_for_superseded_incarnation();
+
+    [Fact]
+    public override Task should_read_null_without_pruning_for_retention_expired_node() =>
+        base.should_read_null_without_pruning_for_retention_expired_node();
+
+    [Fact]
+    public override Task should_agree_between_targeted_read_and_snapshot() =>
+        base.should_agree_between_targeted_read_and_snapshot();
+
+    [Fact]
+    public override Task should_derive_is_alive_from_targeted_read() =>
+        base.should_derive_is_alive_from_targeted_read();
 }

--- a/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs
+++ b/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs
@@ -169,7 +169,9 @@ public sealed class SqlServerMembershipNativeTests(SqlServerMembershipFixture fi
         var store = node.Services.GetRequiredService<IMembershipStore>();
 
         // Alive immediately after register (durable liveness established without a loop tick).
-        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken))
+            .Should()
+            .Be(NodeLivenessState.Alive);
 
         // Aged into the suspicion band -> Suspected.
         await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);

--- a/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs
+++ b/tests/Headless.Coordination.SqlServer.Tests.Integration/SqlServerMembershipNativeTests.cs
@@ -160,9 +160,94 @@ public sealed class SqlServerMembershipNativeTests(SqlServerMembershipFixture fi
         }
     }
 
+    [Fact]
+    public async Task should_classify_targeted_node_liveness_across_states()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Alive immediately after register (durable liveness established without a loop tick).
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+
+        // Aged into the suspicion band -> Suspected.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Suspected);
+
+        // Aged past the dead threshold but still inside the retention window -> Dead.
+        await TimeProvider.System.Delay(
+            CoordinationFixtureExtensions.DeadButRetainedWait - CoordinationFixtureExtensions.SuspectedWait,
+            AbortToken
+        );
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    [Fact]
+    public async Task should_return_dead_for_targeted_read_after_graceful_leave()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        await store.LeaveAsync(identity, AbortToken);
+
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    [Fact]
+    public async Task should_return_null_for_targeted_read_of_stale_and_unregistered_identities()
+    {
+        var cluster = _Cluster();
+        await using var first = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var firstIdentity = await first.Membership.RegisterAsync(AbortToken);
+
+        await using var second = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var secondIdentity = await second.Membership.RegisterAsync(AbortToken);
+        var store = second.Services.GetRequiredService<IMembershipStore>();
+        var unregistered = new NodeIdentity(new NodeId("node-z"), new NodeIncarnation(1));
+
+        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(unregistered, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+    }
+
+    [Fact]
+    public async Task should_return_null_without_pruning_for_retention_expired_targeted_read()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Age past the retention window, then read the targeted path FIRST — before any snapshot read could
+        // prune the row. The targeted path must produce absence by classification (null) without writing.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.AfterPruneWait, AbortToken);
+
+        var state = await store.ReadNodeLivenessAsync(identity, AbortToken);
+        var livenessRows = await _CountClusterLivenessRowsAsync(cluster);
+
+        state.Should().BeNull();
+        // The retention-expired row must still be physically present: the targeted read classifies, never prunes.
+        livenessRows.Should().Be(1);
+    }
+
     private static string _Cluster()
     {
         return "native-" + Guid.NewGuid().ToString("N");
+    }
+
+    private async Task<int> _CountClusterLivenessRowsAsync(string cluster)
+    {
+        const string sql = "SELECT count(*) FROM dbo.CoordinationLiveness WHERE ClusterName = @ClusterName;";
+
+        await using var connection = new SqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
+        await using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("ClusterName", cluster);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(AbortToken), CultureInfo.InvariantCulture);
     }
 
     private async Task _DropSchemaAsync()

--- a/tests/Headless.Coordination.Tests.Harness/CoordinationFixtureBase.cs
+++ b/tests/Headless.Coordination.Tests.Harness/CoordinationFixtureBase.cs
@@ -29,6 +29,10 @@ public static class CoordinationFixtureExtensions
     // Time at which a dead node's retained state is fully pruned (DeadThreshold + DeadRetentionWindow).
     public static TimeSpan PruneThreshold => DeadThreshold + DeadRetentionWindow;
 
+    // Comfortably inside the suspicion band (between SuspicionThreshold and DeadThreshold) for "node is suspected"
+    // assertions.
+    public static TimeSpan SuspectedWait => (SuspicionThreshold + DeadThreshold) / 2;
+
     // Comfortably inside the dead-but-retained window (between DeadThreshold and PruneThreshold) for "node is dead
     // but its retained state still exists" assertions.
     public static TimeSpan DeadButRetainedWait => (DeadThreshold + PruneThreshold) / 2;

--- a/tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs
+++ b/tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs
@@ -277,6 +277,109 @@ public abstract class MembershipConformanceTests<TFixture>(TFixture fixture) : T
         snapshot.Should().ContainSingle(x => x.Identity == secondIdentity && x.State == NodeLivenessState.Alive);
     }
 
+    public virtual async Task should_read_targeted_node_liveness_across_states()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Alive immediately after register.
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+
+        // Aged into the suspicion band -> Suspected.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Suspected);
+
+        // Aged past the dead threshold but still inside the retention window -> Dead.
+        await TimeProvider.System.Delay(
+            CoordinationFixtureExtensions.DeadButRetainedWait - CoordinationFixtureExtensions.SuspectedWait,
+            AbortToken
+        );
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    public virtual async Task should_read_dead_targeted_state_after_graceful_leave()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        await node.Membership.LeaveAsync(AbortToken);
+
+        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Dead);
+    }
+
+    public virtual async Task should_read_null_targeted_state_for_superseded_incarnation()
+    {
+        var cluster = _Cluster();
+        await using var first = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var firstIdentity = await first.Membership.RegisterAsync(AbortToken);
+
+        await using var second = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var secondIdentity = await second.Membership.RegisterAsync(AbortToken);
+        var store = second.Services.GetRequiredService<IMembershipStore>();
+
+        secondIdentity.Incarnation.Value.Should().BeGreaterThan(firstIdentity.Incarnation.Value);
+        // The superseded prior incarnation is not current-generation -> absent (null).
+        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+    }
+
+    public virtual async Task should_read_null_without_pruning_for_retention_expired_node()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+
+        // Age past the retention window, then read the TARGETED path first — before any snapshot read, whose
+        // prune side effect would delete the row and mask a divergence. The targeted path must reproduce the
+        // snapshot's post-prune "absent" view by returning null, never by classifying the row as Dead.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.AfterPruneWait, AbortToken);
+
+        var targeted = await store.ReadNodeLivenessAsync(identity, AbortToken);
+
+        targeted.Should().BeNull();
+        // The snapshot (read after) agrees the node is absent — and only now is the row eligible to be pruned.
+        var snapshot = await node.Membership.GetLivenessSnapshotAsync(AbortToken);
+        snapshot.Should().NotContain(x => x.Identity == identity);
+    }
+
+    public virtual async Task should_agree_between_targeted_read_and_snapshot()
+    {
+        var cluster = _Cluster();
+        await using var node = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var identity = await node.Membership.RegisterAsync(AbortToken);
+        var store = node.Services.GetRequiredService<IMembershipStore>();
+        var unregistered = new NodeIdentity(new NodeId("node-z"), new NodeIncarnation(1));
+
+        // Within the retention window the targeted read must equal the snapshot's per-identity state across all
+        // states, and null exactly when the identity is absent from the snapshot.
+        var snapshot = await node.Membership.GetLivenessSnapshotAsync(AbortToken);
+        var present = await store.ReadNodeLivenessAsync(identity, AbortToken);
+        var absent = await store.ReadNodeLivenessAsync(unregistered, AbortToken);
+
+        present.Should().Be(snapshot.FirstOrDefault(x => x.Identity == identity)?.State);
+        absent.Should().Be(snapshot.FirstOrDefault(x => x.Identity == unregistered)?.State);
+        absent.Should().BeNull();
+    }
+
+    public virtual async Task should_derive_is_alive_from_targeted_read()
+    {
+        var cluster = _Cluster();
+        await using var first = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var firstIdentity = await first.Membership.RegisterAsync(AbortToken);
+
+        await using var second = await fixture.CreateNodeAsync(cluster, "node-a", AbortToken);
+        var secondIdentity = await second.Membership.RegisterAsync(AbortToken);
+
+        // The current incarnation is alive; the superseded prior incarnation is not.
+        (await second.Membership.IsAliveAsync(secondIdentity, AbortToken)).Should().BeTrue();
+        (await second.Membership.IsAliveAsync(firstIdentity, AbortToken)).Should().BeFalse();
+    }
+
     private static string _Cluster()
     {
         return "conformance-" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);

--- a/tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs
+++ b/tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs
@@ -285,7 +285,9 @@ public abstract class MembershipConformanceTests<TFixture>(TFixture fixture) : T
         var store = node.Services.GetRequiredService<IMembershipStore>();
 
         // Alive immediately after register.
-        (await store.ReadNodeLivenessAsync(identity, AbortToken)).Should().Be(NodeLivenessState.Alive);
+        (await store.ReadNodeLivenessAsync(identity, AbortToken))
+            .Should()
+            .Be(NodeLivenessState.Alive);
 
         // Aged into the suspicion band -> Suspected.
         await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
@@ -323,7 +325,9 @@ public abstract class MembershipConformanceTests<TFixture>(TFixture fixture) : T
 
         secondIdentity.Incarnation.Value.Should().BeGreaterThan(firstIdentity.Incarnation.Value);
         // The superseded prior incarnation is not current-generation -> absent (null).
-        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken)).Should().BeNull();
+        (await store.ReadNodeLivenessAsync(firstIdentity, AbortToken))
+            .Should()
+            .BeNull();
         (await store.ReadNodeLivenessAsync(secondIdentity, AbortToken)).Should().Be(NodeLivenessState.Alive);
     }
 
@@ -400,7 +404,9 @@ public abstract class MembershipConformanceTests<TFixture>(TFixture fixture) : T
         var secondIdentity = await second.Membership.RegisterAsync(AbortToken);
 
         // The current incarnation is alive; the superseded prior incarnation is not.
-        (await second.Membership.IsAliveAsync(secondIdentity, AbortToken)).Should().BeTrue();
+        (await second.Membership.IsAliveAsync(secondIdentity, AbortToken))
+            .Should()
+            .BeTrue();
         (await second.Membership.IsAliveAsync(firstIdentity, AbortToken)).Should().BeFalse();
 
         // IsAliveAsync maps every non-Alive targeted state to false, not just absence. As the current-generation

--- a/tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs
+++ b/tests/Headless.Coordination.Tests.Harness/MembershipConformanceTests.cs
@@ -355,15 +355,39 @@ public abstract class MembershipConformanceTests<TFixture>(TFixture fixture) : T
         var store = node.Services.GetRequiredService<IMembershipStore>();
         var unregistered = new NodeIdentity(new NodeId("node-z"), new NodeIncarnation(1));
 
-        // Within the retention window the targeted read must equal the snapshot's per-identity state across all
-        // states, and null exactly when the identity is absent from the snapshot.
-        var snapshot = await node.Membership.GetLivenessSnapshotAsync(AbortToken);
-        var present = await store.ReadNodeLivenessAsync(identity, AbortToken);
+        // Within the retention window the targeted read must equal the snapshot's per-identity state across every
+        // classification — Alive, Suspected, and Dead-but-retained — and null exactly when the identity is absent
+        // from the snapshot. Each band stays inside the retention window, so the snapshot read's prune never
+        // deletes the row and masks a divergence; advancing the store clock walks the same row through all three
+        // states. Pinning each band to its expected literal stops the agreement assertion from passing vacuously
+        // when both paths classify the same wrong state.
+
+        // Alive immediately after register, plus the absent identity.
+        var aliveSnapshot = await node.Membership.GetLivenessSnapshotAsync(AbortToken);
+        var alive = await store.ReadNodeLivenessAsync(identity, AbortToken);
         var absent = await store.ReadNodeLivenessAsync(unregistered, AbortToken);
 
-        present.Should().Be(snapshot.FirstOrDefault(x => x.Identity == identity)?.State);
-        absent.Should().Be(snapshot.FirstOrDefault(x => x.Identity == unregistered)?.State);
+        alive.Should().Be(aliveSnapshot.FirstOrDefault(x => x.Identity == identity)?.State);
+        alive.Should().Be(NodeLivenessState.Alive);
+        absent.Should().Be(aliveSnapshot.FirstOrDefault(x => x.Identity == unregistered)?.State);
         absent.Should().BeNull();
+
+        // Suspected.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
+        var suspectedSnapshot = await node.Membership.GetLivenessSnapshotAsync(AbortToken);
+        var suspected = await store.ReadNodeLivenessAsync(identity, AbortToken);
+        suspected.Should().Be(suspectedSnapshot.FirstOrDefault(x => x.Identity == identity)?.State);
+        suspected.Should().Be(NodeLivenessState.Suspected);
+
+        // Dead, still inside the retention window.
+        await TimeProvider.System.Delay(
+            CoordinationFixtureExtensions.DeadButRetainedWait - CoordinationFixtureExtensions.SuspectedWait,
+            AbortToken
+        );
+        var deadSnapshot = await node.Membership.GetLivenessSnapshotAsync(AbortToken);
+        var dead = await store.ReadNodeLivenessAsync(identity, AbortToken);
+        dead.Should().Be(deadSnapshot.FirstOrDefault(x => x.Identity == identity)?.State);
+        dead.Should().Be(NodeLivenessState.Dead);
     }
 
     public virtual async Task should_derive_is_alive_from_targeted_read()
@@ -378,6 +402,18 @@ public abstract class MembershipConformanceTests<TFixture>(TFixture fixture) : T
         // The current incarnation is alive; the superseded prior incarnation is not.
         (await second.Membership.IsAliveAsync(secondIdentity, AbortToken)).Should().BeTrue();
         (await second.Membership.IsAliveAsync(firstIdentity, AbortToken)).Should().BeFalse();
+
+        // IsAliveAsync maps every non-Alive targeted state to false, not just absence. As the current-generation
+        // node ages out of the alive band its targeted state becomes Suspected, then Dead — both derive false
+        // (only Alive is true), so this pins the R4 derivation beyond the superseded/absent case above.
+        await TimeProvider.System.Delay(CoordinationFixtureExtensions.SuspectedWait, AbortToken);
+        (await second.Membership.IsAliveAsync(secondIdentity, AbortToken)).Should().BeFalse();
+
+        await TimeProvider.System.Delay(
+            CoordinationFixtureExtensions.DeadButRetainedWait - CoordinationFixtureExtensions.SuspectedWait,
+            AbortToken
+        );
+        (await second.Membership.IsAliveAsync(secondIdentity, AbortToken)).Should().BeFalse();
     }
 
     private static string _Cluster()


### PR DESCRIPTION
## What

Adds a targeted single-node liveness method to the `IMembershipStore` provider SPI so per-request liveness checks stop triggering full cluster-wide snapshot reads.

`MembershipService.IsAliveAsync` previously called `ReadLivenessAsync` (a full liveness projection over every node + LINQ filter) on every call — O(nodes·rps) for a per-request consumer. It now delegates to a new `ReadNodeLivenessAsync(NodeIdentity)` that does one guarded single-row query (Postgres/SqlServer) or a small read-only Lua (Redis).

Closes #418.

## SPI shape

`ValueTask<NodeLivenessState?> ReadNodeLivenessAsync(NodeIdentity, CancellationToken)` — richer than the issue's tentative `bool`, so the single round-trip is reusable by future Suspected-vs-Dead consumers. `null` = absent from the current-generation view; the service derives `IsAlive == (state is Alive)`. Method named to mirror its cluster-wide parent `ReadLivenessAsync`.

## Parity is the contract

The targeted read returns exactly what the snapshot would conclude for that identity: current-generation-only, store-clock classified, and **retention-bounded**. The subtle part (caught in review before code was written): the snapshot read produces "absent" by *pruning* (deleting) rows past `DeadThreshold + DeadRetentionWindow`, then classifying survivors. A naive write-free targeted read would have returned `Dead` for a retention-expired-but-unpruned row where the snapshot returns absent — breaking the `Dead`-vs-absent distinction the richer return exists to serve. Fixed by applying the retention boundary as a **read-only classification cutoff** (`age >= retention → null`), reproducing the post-prune view without writing. The targeted path does no prune and no Redis mirror backfill, so it stays O(1).

## Changes

- `IMembershipStore` SPI + `DatabaseMembershipStoreBase` wrapper/abstract core; `MembershipService.IsAliveAsync` rewire; fake-store impl + unit tests.
- Postgres + SqlServer single-row guarded queries (plain reads — no transaction/retry/prune).
- Redis read-only `RedisMembershipReadNodeLivenessScriptDefinition` (generation resolved mirror-first with `gen:` fallback, matching the snapshot read), registered in the scripts initializer.
- Cross-provider conformance pinning the state matrix, full-state targeted-vs-snapshot parity, `IsAliveAsync` derivation, and the order-sensitive retention case (targeted read first asserts `null` before the snapshot's prune can mask it).
- Docs: `docs/llms/coordination.md` + Core README.

## Testing

- Core unit tests pass locally (34/34), including the new `IsAliveAsync` coverage (asserts the targeted read is used, not the full snapshot).
- Full solution rebuild is green under warnings-as-errors (pre-push hook).
- Provider native + cross-provider conformance integration tests are authored; they require Docker/Testcontainers and run in CI (the local environment had no Docker daemon).

Plan: `docs/plans/2026-06-15-001-perf-coordination-targeted-node-liveness-plan.md`
