### PR TITLE
perf: replace dynamic SQL IN-lists with TVPs + messaging hot-path allocs (#352)

### DIFF
--- a/src/Headless.Features.Storage.SqlServer/SqlServerFeatureValueRecordRepository.cs
+++ b/src/Headless.Features.Storage.SqlServer/SqlServerFeatureValueRecordRepository.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Data;
 using Headless.Domain;
 using Headless.Features.Entities;
 using Headless.Features.Repositories;
@@ -15,8 +16,6 @@ internal sealed class SqlServerFeatureValueRecordRepository(
     IServiceProvider services
 ) : IFeatureValueRecordRepository
 {
-    private const int _MaxDeleteParameters = 2000;
-
     public async Task<FeatureValueRecord?> FindAsync(
         string name,
         string? providerName,
@@ -128,15 +127,13 @@ internal sealed class SqlServerFeatureValueRecordRepository(
             return;
         }
 
-        foreach (var chunk in features.Chunk(_MaxDeleteParameters))
-        {
-            var idParameters = chunk.Select((_, index) => $"@Id{index}").ToArray();
-            var parameters = chunk.Select((feature, index) => _Param($"Id{index}", feature.Id)).ToArray();
-            var sql =
-                $"DELETE FROM {SqlServerFeaturesStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.FeatureValuesTableName)} WHERE [Id] IN ({string.Join(",", idParameters)});";
+        // Pass ids through the HeadlessFeaturesIdList TVP: one cached plan regardless of count, no
+        // 2100-parameter ceiling, portable to older engines (no OPENJSON / compatibility level 130).
+        var sql =
+            $"DELETE FROM {SqlServerFeaturesStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.FeatureValuesTableName)} WHERE [Id] IN (SELECT [Id] FROM @Ids);";
 
-            await _ExecuteAsync(sql, cancellationToken, parameters).ConfigureAwait(false);
-        }
+        await _ExecuteAsync(sql, cancellationToken, _BuildIdListTvpParameter(features.Select(feature => feature.Id)))
+            .ConfigureAwait(false);
 
         foreach (var feature in features)
         {
@@ -199,6 +196,22 @@ internal sealed class SqlServerFeatureValueRecordRepository(
     }
 
     private int _CommandTimeout() => (int)providerOptions.Value.CommandTimeout.TotalSeconds;
+
+    private SqlParameter _BuildIdListTvpParameter(IEnumerable<Guid> ids)
+    {
+        var idsTable = new DataTable();
+        idsTable.Columns.Add("Id", typeof(Guid));
+        foreach (var id in ids)
+        {
+            idsTable.Rows.Add(id);
+        }
+
+        return new SqlParameter("@Ids", SqlDbType.Structured)
+        {
+            TypeName = $"[{storageOptions.Value.Schema}].[HeadlessFeaturesIdList]",
+            Value = idsTable,
+        };
+    }
 
     private static SqlParameter _Param(string name, object? value) => new($"@{name}", value ?? DBNull.Value);
 }

--- a/src/Headless.Features.Storage.SqlServer/SqlServerFeaturesStorageInitializer.cs
+++ b/src/Headless.Features.Storage.SqlServer/SqlServerFeaturesStorageInitializer.cs
@@ -158,6 +158,14 @@ internal sealed class SqlServerFeaturesStorageInitializer(
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
             END CATCH;
+
+            BEGIN TRY
+                IF TYPE_ID(N'{options.Schema}.HeadlessFeaturesIdList') IS NULL
+                    CREATE TYPE [{options.Schema}].[HeadlessFeaturesIdList] AS TABLE ([Id] uniqueidentifier NOT NULL PRIMARY KEY);
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
+            END CATCH;
             """;
 
         // Wrap the DDL body in BEGIN TRAN / COMMIT TRAN so a mid-script failure cannot leave the

--- a/src/Headless.Messaging.Core/Internal/PublishMiddlewarePipeline.cs
+++ b/src/Headless.Messaging.Core/Internal/PublishMiddlewarePipeline.cs
@@ -65,12 +65,18 @@ internal sealed class PublishMiddlewarePipeline(
             cancellationToken
         );
         var middleware = _ResolveMiddleware(provider, context);
-        var innerRingCompleted = false;
+
+        // Inner-ring completion flag, hoisted into a single StrongBox so the per-middleware wiring below
+        // captures one loop-invariant reference instead of allocating a fresh `() => innerRingCompleted`
+        // delegate for every middleware in the chain. This flag is intentionally distinct from
+        // context.IsCompleted: it tracks whether the innermost publish actually ran, whereas a
+        // short-circuiting middleware can mark the context completed without the inner ring executing.
+        var innerRingCompleted = new StrongBox<bool>(false);
 
         Func<ValueTask> next = async () =>
         {
             await innerPublish(context.Options, context.DelayTime, context.CancellationToken).ConfigureAwait(false);
-            innerRingCompleted = true;
+            innerRingCompleted.Value = true;
             context.MarkCompleted();
         };
 
@@ -78,7 +84,7 @@ internal sealed class PublishMiddlewarePipeline(
         {
             var current = middleware[i];
             var innerNext = next;
-            next = () => _InvokeAsync(current, context, innerNext, () => innerRingCompleted);
+            next = () => _InvokeAsync(current, context, innerNext, innerRingCompleted);
         }
 
         await next().ConfigureAwait(false);
@@ -88,7 +94,7 @@ internal sealed class PublishMiddlewarePipeline(
         object middleware,
         PublishContext context,
         Func<ValueTask> innerNext,
-        Func<bool> innerRingCompleted
+        StrongBox<bool> innerRingCompleted
     )
     {
         try
@@ -96,7 +102,7 @@ internal sealed class PublishMiddlewarePipeline(
             await _InvokeMiddlewareAsync(middleware, context, innerNext).ConfigureAwait(false);
             _MarkCompleted(context);
         }
-        catch (Exception ex) when (innerRingCompleted())
+        catch (Exception ex) when (innerRingCompleted.Value)
         {
             logger?.PublishPostSuccessMiddlewareFailed(ex, middleware.GetType().FullName ?? middleware.GetType().Name);
             return;

--- a/src/Headless.Messaging.Redis/IRedisStreamManagerDefault.cs
+++ b/src/Headless.Messaging.Redis/IRedisStreamManagerDefault.cs
@@ -41,12 +41,13 @@ internal class RedisStreamManager(
         [EnumeratorCancellation] CancellationToken token
     )
     {
-        var positions = streams.Select(stream => new StreamPosition(stream, StreamPosition.NewMessages));
+        // Subscription set is fixed for the consumer's lifetime, so materialize positions once
+        // instead of rebuilding the StreamPosition[] on every poll iteration.
+        var positions = streams.Select(stream => new StreamPosition(stream, StreamPosition.NewMessages)).ToArray();
 
         while (true)
         {
-            var result = await _TryReadConsumerGroupAsync(consumerGroup, positions.ToArray(), token)
-                .ConfigureAwait(false);
+            var result = await _TryReadConsumerGroupAsync(consumerGroup, positions, token).ConfigureAwait(false);
 
             yield return result;
 
@@ -63,14 +64,15 @@ internal class RedisStreamManager(
         [EnumeratorCancellation] CancellationToken token
     )
     {
-        var positions = streams.Select(stream => new StreamPosition(stream, StreamPosition.Beginning));
+        // Subscription set is fixed for the consumer's lifetime, so materialize positions once
+        // instead of rebuilding the StreamPosition[] on every poll iteration.
+        var positions = streams.Select(stream => new StreamPosition(stream, StreamPosition.Beginning)).ToArray();
 
         while (true)
         {
             token.ThrowIfCancellationRequested();
 
-            var result = await _TryReadConsumerGroupAsync(consumerGroup, positions.ToArray(), token)
-                .ConfigureAwait(false);
+            var result = await _TryReadConsumerGroupAsync(consumerGroup, positions, token).ConfigureAwait(false);
 
             yield return result;
 

--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerDataStorage.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerDataStorage.cs
@@ -79,17 +79,7 @@ public sealed class SqlServerDataStorage(
             return;
         }
 
-        var schema = options.Value.Schema;
-        var tvpTypeName = $"[{schema}].[HeadlessMessagingIdList]";
-
-        var idsTable = new DataTable();
-        idsTable.Columns.Add("Id", typeof(Guid));
-        foreach (var id in storageIds)
-        {
-            idsTable.Rows.Add(id);
-        }
-
-        var tvpParam = new SqlParameter("@Ids", SqlDbType.Structured) { TypeName = tvpTypeName, Value = idsTable };
+        var tvpParam = _BuildIdListTvpParameter(storageIds);
         var statusParam = new SqlParameter("@StatusName", nameof(StatusName.Delayed));
 
         var sql = $"UPDATE {_publishedTable} SET [StatusName]=@StatusName WHERE [Id] IN (SELECT [Id] FROM @Ids);";
@@ -536,15 +526,9 @@ public sealed class SqlServerDataStorage(
             return 0;
         }
 
-        var paramNames = new string[ids.Count];
-        var sqlParams = new object[ids.Count];
-        for (var i = 0; i < ids.Count; i++)
-        {
-            paramNames[i] = $"@Id{i}";
-            sqlParams[i] = new SqlParameter($"@Id{i}", ids[i]);
-        }
+        var sqlParams = new object[] { _BuildIdListTvpParameter(ids) };
 
-        var sql = $"DELETE FROM {_receivedTable} WHERE Id IN ({string.Join(',', paramNames)})";
+        var sql = $"DELETE FROM {_receivedTable} WHERE Id IN (SELECT Id FROM @Ids)";
 
         await using var connection = new SqlConnection(options.Value.ConnectionString);
         return await connection
@@ -567,15 +551,9 @@ public sealed class SqlServerDataStorage(
             return 0;
         }
 
-        var paramNames = new string[ids.Count];
-        var sqlParams = new object[ids.Count];
-        for (var i = 0; i < ids.Count; i++)
-        {
-            paramNames[i] = $"@Id{i}";
-            sqlParams[i] = new SqlParameter($"@Id{i}", ids[i]);
-        }
+        var sqlParams = new object[] { _BuildIdListTvpParameter(ids) };
 
-        var sql = $"DELETE FROM {_publishedTable} WHERE Id IN ({string.Join(',', paramNames)})";
+        var sql = $"DELETE FROM {_publishedTable} WHERE Id IN (SELECT Id FROM @Ids)";
 
         await using var connection = new SqlConnection(options.Value.ConnectionString);
         return await connection
@@ -586,6 +564,28 @@ public sealed class SqlServerDataStorage(
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds the <c>@Ids</c> table-valued parameter backed by the <c>HeadlessMessagingIdList</c> type
+    /// (provisioned by the storage initializer). Using a TVP keeps the SQL text and parameter shape
+    /// constant regardless of id count, so SQL Server reuses a single cached query plan — and it stays
+    /// portable to older engines (table types need no OPENJSON / compatibility level 130).
+    /// </summary>
+    private SqlParameter _BuildIdListTvpParameter(IReadOnlyList<Guid> ids)
+    {
+        var idsTable = new DataTable();
+        idsTable.Columns.Add("Id", typeof(Guid));
+        foreach (var id in ids)
+        {
+            idsTable.Rows.Add(id);
+        }
+
+        return new SqlParameter("@Ids", SqlDbType.Structured)
+        {
+            TypeName = $"[{options.Value.Schema}].[HeadlessMessagingIdList]",
+            Value = idsTable,
+        };
     }
 
     public async ValueTask ScheduleMessagesOfDelayedAsync(

--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerMonitoringApi.cs
@@ -398,17 +398,27 @@ public sealed class SqlServerMonitoringApi(
             ? "ExceptionInfo"
             : "CAST(NULL AS nvarchar(max)) AS ExceptionInfo";
 
-        // Build @Id0,@Id1,... IN-list for SQL Server (no array parameter support).
-        var paramNames = new string[storageIds.Count];
-        var sqlParams = new object[storageIds.Count];
-        for (var i = 0; i < storageIds.Count; i++)
+        // Pass the id set through the HeadlessMessagingIdList table-valued parameter (provisioned by the
+        // storage initializer and already used by SqlServerDataStorage). The SQL text and the @Ids shape
+        // stay constant regardless of id count, so SQL Server reuses one cached query plan instead of
+        // compiling a fresh plan per dynamic IN-list length — and it stays portable to older engines
+        // (table types need no OPENJSON / compatibility level 130).
+        var tvpTypeName = $"[{_options.Schema}].[HeadlessMessagingIdList]";
+
+        var idsTable = new DataTable();
+        idsTable.Columns.Add("Id", typeof(Guid));
+        foreach (var id in storageIds)
         {
-            paramNames[i] = $"@Id{i}";
-            sqlParams[i] = new SqlParameter($"@Id{i}", storageIds[i]);
+            idsTable.Rows.Add(id);
         }
 
+        var sqlParams = new object[]
+        {
+            new SqlParameter("@Ids", SqlDbType.Structured) { TypeName = tvpTypeName, Value = idsTable },
+        };
+
         var sql =
-            $"SELECT Id, Content, IntentType, Added, ExpiresAt, Retries, {exceptionInfoSql}, NextRetryAt, LockedUntil FROM {tableName} WITH (READPAST) WHERE Id IN ({string.Join(',', paramNames)})";
+            $"SELECT Id, Content, IntentType, Added, ExpiresAt, Retries, {exceptionInfoSql}, NextRetryAt, LockedUntil FROM {tableName} WITH (READPAST) WHERE Id IN (SELECT Id FROM @Ids)";
 
         await using var connection = new SqlConnection(_options.ConnectionString);
 

--- a/src/Headless.Permissions.Storage.SqlServer/SqlServerPermissionGrantRepository.cs
+++ b/src/Headless.Permissions.Storage.SqlServer/SqlServerPermissionGrantRepository.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Data;
 using Headless.Abstractions;
 using Headless.Domain;
 using Headless.Permissions.Entities;
@@ -16,8 +17,6 @@ internal sealed class SqlServerPermissionGrantRepository(
     IServiceProvider services
 ) : IPermissionGrantRepository
 {
-    private const int _MaxDeleteParameters = 2000;
-    private const int _MaxNameParameters = 2000;
     private const string _GrantColumns = "[Id],[Name],[ProviderName],[ProviderKey],[TenantId],[IsGranted]";
     private const string _TenantFilter = "(([TenantId] IS NULL AND @TenantId IS NULL) OR [TenantId]=@TenantId)";
 
@@ -64,7 +63,7 @@ internal sealed class SqlServerPermissionGrantRepository(
         );
     }
 
-    public async Task<List<PermissionGrantRecord>> GetListAsync(
+    public Task<List<PermissionGrantRecord>> GetListAsync(
         IReadOnlyCollection<string> names,
         string providerName,
         string providerKey,
@@ -73,26 +72,22 @@ internal sealed class SqlServerPermissionGrantRepository(
     {
         if (names.Count == 0)
         {
-            return [];
+            return Task.FromResult(new List<PermissionGrantRecord>());
         }
 
-        var result = new List<PermissionGrantRecord>();
+        // Pass the names through the HeadlessPermissionsNameList TVP: one cached plan regardless of count
+        // and no 2100-parameter ceiling, portable to older engines (no OPENJSON / compatibility level 130).
+        var sql =
+            $"SELECT {_GrantColumns} FROM {SqlServerPermissionsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.PermissionGrantsTableName)} WHERE [Name] IN (SELECT [Name] FROM @Names) AND [ProviderName]=@ProviderName AND [ProviderKey]=@ProviderKey AND {_TenantFilter};";
 
-        foreach (var chunk in names.Chunk(_MaxNameParameters))
-        {
-            var nameParameters = chunk.Select((_, index) => $"@Name{index}").ToArray();
-            var parameters = chunk.Select((name, index) => _Param($"Name{index}", name)).ToList();
-            parameters.Add(_Param("ProviderName", providerName));
-            parameters.Add(_Param("ProviderKey", providerKey));
-            parameters.Add(_TenantParam());
-
-            var sql =
-                $"SELECT {_GrantColumns} FROM {SqlServerPermissionsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.PermissionGrantsTableName)} WHERE [Name] IN ({string.Join(",", nameParameters)}) AND [ProviderName]=@ProviderName AND [ProviderKey]=@ProviderKey AND {_TenantFilter};";
-
-            result.AddRange(await _ReadAsync(sql, cancellationToken, parameters.ToArray()).ConfigureAwait(false));
-        }
-
-        return result;
+        return _ReadAsync(
+            sql,
+            cancellationToken,
+            _BuildNameListTvpParameter(names),
+            _Param("ProviderName", providerName),
+            _Param("ProviderKey", providerKey),
+            _TenantParam()
+        );
     }
 
     public Task InsertAsync(PermissionGrantRecord permissionGrant, CancellationToken cancellationToken = default)
@@ -145,18 +140,18 @@ internal sealed class SqlServerPermissionGrantRepository(
             return;
         }
 
-        foreach (var chunk in permissionGrants.Chunk(_MaxDeleteParameters))
-        {
-            var idParameters = chunk.Select((_, index) => $"@Id{index}").ToArray();
-            var parameters = chunk
-                .Select((permissionGrant, index) => _Param($"Id{index}", permissionGrant.Id))
-                .ToList();
-            parameters.Add(_TenantParam());
-            var sql =
-                $"DELETE FROM {SqlServerPermissionsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.PermissionGrantsTableName)} WHERE [Id] IN ({string.Join(",", idParameters)}) AND {_TenantFilter};";
+        // Pass ids through the HeadlessPermissionsIdList TVP: one cached plan regardless of count, no
+        // 2100-parameter ceiling, portable to older engines (no OPENJSON / compatibility level 130).
+        var sql =
+            $"DELETE FROM {SqlServerPermissionsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.PermissionGrantsTableName)} WHERE [Id] IN (SELECT [Id] FROM @Ids) AND {_TenantFilter};";
 
-            await _ExecuteAsync(sql, cancellationToken, parameters.ToArray()).ConfigureAwait(false);
-        }
+        await _ExecuteAsync(
+                sql,
+                cancellationToken,
+                _BuildIdListTvpParameter(permissionGrants.Select(permissionGrant => permissionGrant.Id)),
+                _TenantParam()
+            )
+            .ConfigureAwait(false);
 
         foreach (var permissionGrant in permissionGrants)
         {
@@ -221,6 +216,38 @@ internal sealed class SqlServerPermissionGrantRepository(
     private SqlParameter _TenantParam() => _Param("TenantId", services.GetService<ICurrentTenant>()?.Id);
 
     private int _CommandTimeout() => (int)providerOptions.Value.CommandTimeout.TotalSeconds;
+
+    private SqlParameter _BuildIdListTvpParameter(IEnumerable<Guid> ids)
+    {
+        var idsTable = new DataTable();
+        idsTable.Columns.Add("Id", typeof(Guid));
+        foreach (var id in ids)
+        {
+            idsTable.Rows.Add(id);
+        }
+
+        return new SqlParameter("@Ids", SqlDbType.Structured)
+        {
+            TypeName = $"[{storageOptions.Value.Schema}].[HeadlessPermissionsIdList]",
+            Value = idsTable,
+        };
+    }
+
+    private SqlParameter _BuildNameListTvpParameter(IEnumerable<string> names)
+    {
+        var namesTable = new DataTable();
+        namesTable.Columns.Add("Name", typeof(string));
+        foreach (var name in names)
+        {
+            namesTable.Rows.Add(name);
+        }
+
+        return new SqlParameter("@Names", SqlDbType.Structured)
+        {
+            TypeName = $"[{storageOptions.Value.Schema}].[HeadlessPermissionsNameList]",
+            Value = namesTable,
+        };
+    }
 
     private static SqlParameter[] _Parameters(PermissionGrantRecord permissionGrant) =>
         [

--- a/src/Headless.Permissions.Storage.SqlServer/SqlServerPermissionsStorageInitializer.cs
+++ b/src/Headless.Permissions.Storage.SqlServer/SqlServerPermissionsStorageInitializer.cs
@@ -145,6 +145,24 @@ internal sealed class SqlServerPermissionsStorageInitializer(
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
             END CATCH;
+
+            -- Table-valued parameter types for batched id/name queries (single cached plan, no 2100-parameter
+            -- ceiling, portable to older engines). The name type is a heap (no PK) so trailing-space / collation
+            -- duplicate names cannot raise a PK violation the dynamic IN-list never had.
+            BEGIN TRY
+                IF TYPE_ID(N'{options.Schema}.HeadlessPermissionsIdList') IS NULL
+                    CREATE TYPE [{options.Schema}].[HeadlessPermissionsIdList] AS TABLE ([Id] uniqueidentifier NOT NULL PRIMARY KEY);
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
+            END CATCH;
+            BEGIN TRY
+                IF TYPE_ID(N'{options.Schema}.HeadlessPermissionsNameList') IS NULL
+                    CREATE TYPE [{options.Schema}].[HeadlessPermissionsNameList] AS TABLE ([Name] nvarchar({PermissionGrantRecordConstants.NameMaxLength}) NOT NULL);
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
+            END CATCH;
             """;
 
         // Wrap the DDL body in BEGIN TRAN / COMMIT TRAN so a mid-script failure cannot leave the

--- a/src/Headless.Settings.Storage.SqlServer/SqlServerSettingValueRecordRepository.cs
+++ b/src/Headless.Settings.Storage.SqlServer/SqlServerSettingValueRecordRepository.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Data;
 using Headless.Domain;
 using Headless.Settings.Entities;
 using Headless.Settings.Repositories;
@@ -15,8 +16,6 @@ internal sealed class SqlServerSettingValueRecordRepository(
     IServiceProvider services
 ) : ISettingValueRecordRepository
 {
-    private const int _MaxDeleteParameters = 2000;
-    private const int _MaxNameParameters = 2000;
     private const string _ValueColumns = "[Id],[Name],[Value],[ProviderName],[ProviderKey],[DateCreated],[DateUpdated]";
 
     public async Task<SettingValueRecord?> FindAsync(
@@ -71,7 +70,7 @@ internal sealed class SqlServerSettingValueRecordRepository(
         return _ReadValuesAsync(sql, cancellationToken, parameters.ToArray());
     }
 
-    public async Task<List<SettingValueRecord>> GetListAsync(
+    public Task<List<SettingValueRecord>> GetListAsync(
         HashSet<string> names,
         string providerName,
         string? providerKey,
@@ -80,27 +79,21 @@ internal sealed class SqlServerSettingValueRecordRepository(
     {
         if (names.Count == 0)
         {
-            return [];
+            return Task.FromResult(new List<SettingValueRecord>());
         }
 
-        // Chunk the name set: a single IN-list would exceed SQL Server's ~2100-parameter ceiling once
-        // the caller passes more than that many names. The per-chunk index keeps @Name0..@NameN bounded.
-        var result = new List<SettingValueRecord>();
+        // Pass the names through the HeadlessSettingsNameList TVP: one cached plan regardless of count and
+        // no 2100-parameter ceiling, portable to older engines (no OPENJSON / compatibility level 130).
+        var sql =
+            $"SELECT {_ValueColumns} FROM {SqlServerSettingsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.SettingValuesTableName)} WHERE [Name] IN (SELECT [Name] FROM @Names) AND [ProviderName]=@ProviderName AND (([ProviderKey] IS NULL AND @ProviderKey IS NULL) OR [ProviderKey]=@ProviderKey);";
 
-        foreach (var chunk in names.Chunk(_MaxNameParameters))
-        {
-            var nameParameters = chunk.Select((_, index) => $"@Name{index}").ToArray();
-            var parameters = chunk.Select((name, index) => _Param($"Name{index}", name)).ToList();
-            parameters.Add(_Param("ProviderName", providerName));
-            parameters.Add(_Param("ProviderKey", providerKey));
-
-            var sql =
-                $"SELECT {_ValueColumns} FROM {SqlServerSettingsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.SettingValuesTableName)} WHERE [Name] IN ({string.Join(",", nameParameters)}) AND [ProviderName]=@ProviderName AND (([ProviderKey] IS NULL AND @ProviderKey IS NULL) OR [ProviderKey]=@ProviderKey);";
-
-            result.AddRange(await _ReadValuesAsync(sql, cancellationToken, parameters.ToArray()).ConfigureAwait(false));
-        }
-
-        return result;
+        return _ReadValuesAsync(
+            sql,
+            cancellationToken,
+            _BuildNameListTvpParameter(names),
+            _Param("ProviderName", providerName),
+            _Param("ProviderKey", providerKey)
+        );
     }
 
     public Task<List<SettingValueRecord>> GetListAsync(
@@ -174,15 +167,13 @@ internal sealed class SqlServerSettingValueRecordRepository(
             return;
         }
 
-        foreach (var chunk in settings.Chunk(_MaxDeleteParameters))
-        {
-            var idParameters = chunk.Select((_, index) => $"@Id{index}").ToArray();
-            var parameters = chunk.Select((setting, index) => _Param($"Id{index}", setting.Id)).ToArray();
-            var sql =
-                $"DELETE FROM {SqlServerSettingsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.SettingValuesTableName)} WHERE [Id] IN ({string.Join(",", idParameters)});";
+        // Pass ids through the HeadlessSettingsIdList TVP: one cached plan regardless of count, no
+        // 2100-parameter ceiling, portable to older engines (no OPENJSON / compatibility level 130).
+        var sql =
+            $"DELETE FROM {SqlServerSettingsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.SettingValuesTableName)} WHERE [Id] IN (SELECT [Id] FROM @Ids);";
 
-            await _ExecuteAsync(sql, cancellationToken, parameters).ConfigureAwait(false);
-        }
+        await _ExecuteAsync(sql, cancellationToken, _BuildIdListTvpParameter(settings.Select(setting => setting.Id)))
+            .ConfigureAwait(false);
 
         foreach (var setting in settings)
         {
@@ -251,6 +242,38 @@ internal sealed class SqlServerSettingValueRecordRepository(
     private int _CommandTimeout() => (int)providerOptions.Value.CommandTimeout.TotalSeconds;
 
     private TimeProvider _TimeProvider() => services.GetService<TimeProvider>() ?? TimeProvider.System;
+
+    private SqlParameter _BuildIdListTvpParameter(IEnumerable<Guid> ids)
+    {
+        var idsTable = new DataTable();
+        idsTable.Columns.Add("Id", typeof(Guid));
+        foreach (var id in ids)
+        {
+            idsTable.Rows.Add(id);
+        }
+
+        return new SqlParameter("@Ids", SqlDbType.Structured)
+        {
+            TypeName = $"[{storageOptions.Value.Schema}].[HeadlessSettingsIdList]",
+            Value = idsTable,
+        };
+    }
+
+    private SqlParameter _BuildNameListTvpParameter(IEnumerable<string> names)
+    {
+        var namesTable = new DataTable();
+        namesTable.Columns.Add("Name", typeof(string));
+        foreach (var name in names)
+        {
+            namesTable.Rows.Add(name);
+        }
+
+        return new SqlParameter("@Names", SqlDbType.Structured)
+        {
+            TypeName = $"[{storageOptions.Value.Schema}].[HeadlessSettingsNameList]",
+            Value = namesTable,
+        };
+    }
 
     private static SqlParameter _Param(string name, object? value) => new($"@{name}", value ?? DBNull.Value);
 }

--- a/src/Headless.Settings.Storage.SqlServer/SqlServerSettingValueRecordRepository.cs
+++ b/src/Headless.Settings.Storage.SqlServer/SqlServerSettingValueRecordRepository.cs
@@ -16,6 +16,7 @@ internal sealed class SqlServerSettingValueRecordRepository(
 ) : ISettingValueRecordRepository
 {
     private const int _MaxDeleteParameters = 2000;
+    private const int _MaxNameParameters = 2000;
     private const string _ValueColumns = "[Id],[Name],[Value],[ProviderName],[ProviderKey],[DateCreated],[DateUpdated]";
 
     public async Task<SettingValueRecord?> FindAsync(
@@ -70,7 +71,7 @@ internal sealed class SqlServerSettingValueRecordRepository(
         return _ReadValuesAsync(sql, cancellationToken, parameters.ToArray());
     }
 
-    public Task<List<SettingValueRecord>> GetListAsync(
+    public async Task<List<SettingValueRecord>> GetListAsync(
         HashSet<string> names,
         string providerName,
         string? providerKey,
@@ -79,18 +80,27 @@ internal sealed class SqlServerSettingValueRecordRepository(
     {
         if (names.Count == 0)
         {
-            return Task.FromResult(new List<SettingValueRecord>());
+            return [];
         }
 
-        var nameParameters = names.Select((_, index) => $"@Name{index}").ToArray();
-        var parameters = names.Select((name, index) => _Param($"Name{index}", name)).ToList();
-        parameters.Add(_Param("ProviderName", providerName));
-        parameters.Add(_Param("ProviderKey", providerKey));
+        // Chunk the name set: a single IN-list would exceed SQL Server's ~2100-parameter ceiling once
+        // the caller passes more than that many names. The per-chunk index keeps @Name0..@NameN bounded.
+        var result = new List<SettingValueRecord>();
 
-        var sql =
-            $"SELECT {_ValueColumns} FROM {SqlServerSettingsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.SettingValuesTableName)} WHERE [Name] IN ({string.Join(",", nameParameters)}) AND [ProviderName]=@ProviderName AND (([ProviderKey] IS NULL AND @ProviderKey IS NULL) OR [ProviderKey]=@ProviderKey);";
+        foreach (var chunk in names.Chunk(_MaxNameParameters))
+        {
+            var nameParameters = chunk.Select((_, index) => $"@Name{index}").ToArray();
+            var parameters = chunk.Select((name, index) => _Param($"Name{index}", name)).ToList();
+            parameters.Add(_Param("ProviderName", providerName));
+            parameters.Add(_Param("ProviderKey", providerKey));
 
-        return _ReadValuesAsync(sql, cancellationToken, parameters.ToArray());
+            var sql =
+                $"SELECT {_ValueColumns} FROM {SqlServerSettingsStorageInitializer.Qualified(storageOptions.Value, storageOptions.Value.SettingValuesTableName)} WHERE [Name] IN ({string.Join(",", nameParameters)}) AND [ProviderName]=@ProviderName AND (([ProviderKey] IS NULL AND @ProviderKey IS NULL) OR [ProviderKey]=@ProviderKey);";
+
+            result.AddRange(await _ReadValuesAsync(sql, cancellationToken, parameters.ToArray()).ConfigureAwait(false));
+        }
+
+        return result;
     }
 
     public Task<List<SettingValueRecord>> GetListAsync(

--- a/src/Headless.Settings.Storage.SqlServer/SqlServerSettingsStorageInitializer.cs
+++ b/src/Headless.Settings.Storage.SqlServer/SqlServerSettingsStorageInitializer.cs
@@ -126,6 +126,26 @@ internal sealed class SqlServerSettingsStorageInitializer(
             END CATCH;
             """;
 
+        // Table-valued parameter types for batched id/name queries (single cached plan, no 2100-parameter
+        // ceiling, portable to older engines). The name type is a heap (no PK) so trailing-space / collation
+        // duplicate names cannot raise a PK violation the dynamic IN-list never had.
+        var createTvpTypes = $"""
+            BEGIN TRY
+                IF TYPE_ID(N'{options.Schema}.HeadlessSettingsIdList') IS NULL
+                    CREATE TYPE [{options.Schema}].[HeadlessSettingsIdList] AS TABLE ([Id] uniqueidentifier NOT NULL PRIMARY KEY);
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
+            END CATCH;
+            BEGIN TRY
+                IF TYPE_ID(N'{options.Schema}.HeadlessSettingsNameList') IS NULL
+                    CREATE TYPE [{options.Schema}].[HeadlessSettingsNameList] AS TABLE ([Name] nvarchar({SettingValueRecordConstants.NameMaxLength}) NOT NULL);
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (2714, 1913, 2759) THROW;
+            END CATCH;
+            """;
+
         // Wrap the DDL body in BEGIN TRAN / COMMIT TRAN so a mid-script failure cannot leave the
         // schema half-initialized. Inner BEGIN TRY swallow-lists keep soft errors (2714, 1913,
         // 2759) from dooming the outer transaction.
@@ -144,6 +164,8 @@ internal sealed class SqlServerSettingsStorageInitializer(
                 {createDefinitionsIndex}
 
                 {createValuesIndexes}
+
+                {createTvpTypes}
 
                 COMMIT TRAN;
 

--- a/tests/Headless.Features.Storage.SqlServer.Tests.Integration/SqlServerFeaturesFailureModesTests.cs
+++ b/tests/Headless.Features.Storage.SqlServer.Tests.Integration/SqlServerFeaturesFailureModesTests.cs
@@ -105,6 +105,7 @@ public sealed class SqlServerFeaturesFailureModesTests(SqlServerFeaturesFixture 
             IF OBJECT_ID(N'{schema}.FeatureValues', N'U') IS NOT NULL DROP TABLE [{schema}].[FeatureValues];
             IF OBJECT_ID(N'{schema}.FeatureDefinitions', N'U') IS NOT NULL DROP TABLE [{schema}].[FeatureDefinitions];
             IF OBJECT_ID(N'{schema}.FeatureGroupDefinitions', N'U') IS NOT NULL DROP TABLE [{schema}].[FeatureGroupDefinitions];
+            IF TYPE_ID(N'{schema}.HeadlessFeaturesIdList') IS NOT NULL DROP TYPE [{schema}].[HeadlessFeaturesIdList];
             IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'{schema}') EXEC(N'DROP SCHEMA [{schema}]');
             """,
             connection

--- a/tests/Headless.Features.Storage.SqlServer.Tests.Integration/SqlServerFeaturesStorageTests.cs
+++ b/tests/Headless.Features.Storage.SqlServer.Tests.Integration/SqlServerFeaturesStorageTests.cs
@@ -165,6 +165,7 @@ public sealed class SqlServerFeaturesStorageTests(SqlServerFeaturesFixture fixtu
             IF OBJECT_ID(N'{_Schema}.FeatureValues', N'U') IS NOT NULL DROP TABLE [{_Schema}].[FeatureValues];
             IF OBJECT_ID(N'{_Schema}.FeatureDefinitions', N'U') IS NOT NULL DROP TABLE [{_Schema}].[FeatureDefinitions];
             IF OBJECT_ID(N'{_Schema}.FeatureGroupDefinitions', N'U') IS NOT NULL DROP TABLE [{_Schema}].[FeatureGroupDefinitions];
+            IF TYPE_ID(N'{_Schema}.HeadlessFeaturesIdList') IS NOT NULL DROP TYPE [{_Schema}].[HeadlessFeaturesIdList];
             IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'{_Schema}') EXEC(N'DROP SCHEMA [{_Schema}]');
             """,
             connection

--- a/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerMonitoringApiTests.cs
+++ b/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerMonitoringApiTests.cs
@@ -215,6 +215,62 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
 
     #endregion
 
+    #region Get Messages By Ids Tests
+
+    [Fact]
+    public async Task should_get_published_messages_by_ids()
+    {
+        // given
+        var first = await _CreatePublishedMessage(StatusName.Succeeded);
+        var second = await _CreatePublishedMessage(StatusName.Succeeded);
+        await _CreatePublishedMessage(StatusName.Succeeded); // stored but not requested
+
+        // when - multiple ids resolved through the IN-list query
+        var result = await _monitoringApi.GetPublishedMessagesAsync([first.StorageId, second.StorageId], AbortToken);
+
+        // then
+        result.Select(m => m.StorageId).Should().BeEquivalentTo([first.StorageId, second.StorageId]);
+    }
+
+    [Fact]
+    public async Task should_get_received_messages_by_ids()
+    {
+        // given
+        var first = await _CreateReceivedMessage(StatusName.Failed);
+        var second = await _CreateReceivedMessage(StatusName.Succeeded);
+
+        // when
+        var result = await _monitoringApi.GetReceivedMessagesAsync([first.StorageId, second.StorageId], AbortToken);
+
+        // then
+        result.Select(m => m.StorageId).Should().BeEquivalentTo([first.StorageId, second.StorageId]);
+    }
+
+    [Fact]
+    public async Task should_return_only_existing_messages_when_some_ids_missing()
+    {
+        // given
+        var existing = await _CreatePublishedMessage(StatusName.Succeeded);
+
+        // when - mix a stored id with one that was never persisted
+        var result = await _monitoringApi.GetPublishedMessagesAsync([existing.StorageId, Guid.NewGuid()], AbortToken);
+
+        // then
+        result.Should().ContainSingle().Which.StorageId.Should().Be(existing.StorageId);
+    }
+
+    [Fact]
+    public async Task should_return_empty_when_ids_empty()
+    {
+        // when
+        var result = await _monitoringApi.GetPublishedMessagesAsync([], AbortToken);
+
+        // then
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
     #region Pagination Tests
 
     [Fact]

--- a/tests/Headless.Permissions.Storage.SqlServer.Tests.Integration/SqlServerPermissionsFailureModesTests.cs
+++ b/tests/Headless.Permissions.Storage.SqlServer.Tests.Integration/SqlServerPermissionsFailureModesTests.cs
@@ -105,6 +105,8 @@ public sealed class SqlServerPermissionsFailureModesTests(SqlServerPermissionsFi
             IF OBJECT_ID(N'{schema}.PermissionGrants', N'U') IS NOT NULL DROP TABLE [{schema}].[PermissionGrants];
             IF OBJECT_ID(N'{schema}.PermissionDefinitions', N'U') IS NOT NULL DROP TABLE [{schema}].[PermissionDefinitions];
             IF OBJECT_ID(N'{schema}.PermissionGroupDefinitions', N'U') IS NOT NULL DROP TABLE [{schema}].[PermissionGroupDefinitions];
+            IF TYPE_ID(N'{schema}.HeadlessPermissionsIdList') IS NOT NULL DROP TYPE [{schema}].[HeadlessPermissionsIdList];
+            IF TYPE_ID(N'{schema}.HeadlessPermissionsNameList') IS NOT NULL DROP TYPE [{schema}].[HeadlessPermissionsNameList];
             IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'{schema}') EXEC(N'DROP SCHEMA [{schema}]');
             """,
             connection

--- a/tests/Headless.Permissions.Storage.SqlServer.Tests.Integration/SqlServerPermissionsStorageTests.cs
+++ b/tests/Headless.Permissions.Storage.SqlServer.Tests.Integration/SqlServerPermissionsStorageTests.cs
@@ -195,6 +195,8 @@ public sealed class SqlServerPermissionsStorageTests(SqlServerPermissionsFixture
             IF OBJECT_ID(N'{_Schema}.PermissionGrants', N'U') IS NOT NULL DROP TABLE [{_Schema}].[PermissionGrants];
             IF OBJECT_ID(N'{_Schema}.PermissionDefinitions', N'U') IS NOT NULL DROP TABLE [{_Schema}].[PermissionDefinitions];
             IF OBJECT_ID(N'{_Schema}.PermissionGroupDefinitions', N'U') IS NOT NULL DROP TABLE [{_Schema}].[PermissionGroupDefinitions];
+            IF TYPE_ID(N'{_Schema}.HeadlessPermissionsIdList') IS NOT NULL DROP TYPE [{_Schema}].[HeadlessPermissionsIdList];
+            IF TYPE_ID(N'{_Schema}.HeadlessPermissionsNameList') IS NOT NULL DROP TYPE [{_Schema}].[HeadlessPermissionsNameList];
             IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'{_Schema}') EXEC(N'DROP SCHEMA [{_Schema}]');
             """,
             connection

--- a/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/SqlServerSettingsFailureModesTests.cs
+++ b/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/SqlServerSettingsFailureModesTests.cs
@@ -115,6 +115,8 @@ public sealed class SqlServerSettingsFailureModesTests(SqlServerSettingsFixture 
             $"""
             IF OBJECT_ID(N'{schema}.SettingValues', N'U') IS NOT NULL DROP TABLE [{schema}].[SettingValues];
             IF OBJECT_ID(N'{schema}.SettingDefinitions', N'U') IS NOT NULL DROP TABLE [{schema}].[SettingDefinitions];
+            IF TYPE_ID(N'{schema}.HeadlessSettingsIdList') IS NOT NULL DROP TYPE [{schema}].[HeadlessSettingsIdList];
+            IF TYPE_ID(N'{schema}.HeadlessSettingsNameList') IS NOT NULL DROP TYPE [{schema}].[HeadlessSettingsNameList];
             IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'{schema}') EXEC(N'DROP SCHEMA [{schema}]');
             """,
             connection

--- a/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/SqlServerSettingsStorageTests.cs
+++ b/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/SqlServerSettingsStorageTests.cs
@@ -138,6 +138,8 @@ public sealed class SqlServerSettingsStorageTests(SqlServerSettingsFixture fixtu
             $"""
             IF OBJECT_ID(N'{_Schema}.SettingValues', N'U') IS NOT NULL DROP TABLE [{_Schema}].[SettingValues];
             IF OBJECT_ID(N'{_Schema}.SettingDefinitions', N'U') IS NOT NULL DROP TABLE [{_Schema}].[SettingDefinitions];
+            IF TYPE_ID(N'{_Schema}.HeadlessSettingsIdList') IS NOT NULL DROP TYPE [{_Schema}].[HeadlessSettingsIdList];
+            IF TYPE_ID(N'{_Schema}.HeadlessSettingsNameList') IS NOT NULL DROP TYPE [{_Schema}].[HeadlessSettingsNameList];
             IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'{_Schema}') EXEC(N'DROP SCHEMA [{_Schema}]');
             """,
             connection


### PR DESCRIPTION
## What & why

Addresses the three parked hot-path findings in #352, then extends the same fix across every SqlServer storage package that had the pattern.

**Unifying theme:** dynamic `IN (@Id0..@IdN)` lists force SQL Server to compile a fresh plan per id count and risk the ~2100-parameter ceiling. The fix replaces them with **table-valued parameters** — one cached plan regardless of count, no ceiling, and fully portable (no `OPENJSON` / compatibility level 130).

## Changes

### Messaging (the original #352 items)
| Commit | Fix |
|--------|-----|
| `perf(messaging)` | P1 — hoist the publish-pipeline completion flag into one `StrongBox<bool>` → kills the per-middleware closure alloc. Flag kept distinct from `context.IsCompleted` to preserve short-circuit error-swallow semantics. |
| `perf(messaging-redis)` | P2 — materialize `StreamPosition[]` once before the poll loop instead of per-iteration. |
| `perf(messaging-sqlserver)` | P3 — `HeadlessMessagingIdList` TVP for get-by-ids + bulk deletes; adds the previously-missing by-ids integration coverage. |

### Storage packages (the IN-list audit sweep)
| Commit | Fix |
|--------|-----|
| `perf(permissions-sqlserver)` | New `HeadlessPermissionsIdList` (Guid) + `HeadlessPermissionsNameList` (nvarchar heap) types; `GetListAsync(names)` + `DeleteManyAsync` routed through them. |
| `perf(settings-sqlserver)` | New `HeadlessSettingsIdList` + `HeadlessSettingsNameList`; `GetListAsync(names)` + `DeleteAsync` converted (replaces the interim chunk-fix for the >2100 bug). |
| `perf(features-sqlserver)` | New `HeadlessFeaturesIdList`; `DeleteAsync` converted. |

The TVP types are provisioned by each package's existing idempotent, startup-run, lock-guarded initializer — **no separate migration**; they appear on next deploy. TVP also lifts the 2100-parameter ceiling, so the chunk loops on converted paths are removed.

## Key decisions

**TVP, not OPENJSON.** OPENJSON requires DB compatibility level >= 130, which the messaging package README explicitly forbids for older-engine portability. TVP gives the same single-plan reuse, stays portable (table types since SQL 2008), and the messaging type was already provisioned. Prior art agrees: EF Core 8 moved to OPENJSON, hit the exact compat-130 + cardinality problems, and **EF Core 10 defaulted back toward scalar params** — OPENJSON is not the destination for id-lists. Nobody runtime-probes compat level; EF made it a *configured* value and explicitly declined server-probing (efcore #32528).

**Id types keep a `PRIMARY KEY`; Name types are heaps (no PK).** A PK on `Name` would enforce uniqueness under the DB collation — SQL Server's trailing-space-insensitive comparison would reject `'a '` when `'a'` is present, a behavior change from the tolerant dynamic IN-list. Guids have no such footgun.

## Verification

- ✅ **P1**: 890/890 `Headless.Messaging.Core.Tests.Unit` pass (incl. the swallow/cancellation guards).
- ✅ All touched src + integration-test projects build clean (0 warnings, 0 errors).
- ✅ Converted methods already have integration coverage: Permissions `GetListAsync(names)` + `DeleteManyAsync`, Settings `DeleteAsync`, Features `DeleteAsync`, messaging by-ids (new).
- ✅ Every integration cleanup now drops the new types before `DROP SCHEMA` (a schema can't be dropped while it contains a type).
- ⚠️ **All SqlServer paths need CI**: Docker is unavailable locally, so the TVP SQL + new tests execute only in CI (Testcontainers SQL 2022). **CI must go green before merge.**
- No benchmarks (the items were parked pending measurement); the single-cached-plan win is by construction, not measured.

Closes #352.