### PR TITLE
ci: route hooks and CI through Make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
     paths:
       - '.github/workflows/**'
+      - '.husky/**'
+      - 'Makefile'
       - 'src/**'
       - 'tests/**'
       - 'Directory.*'
@@ -15,6 +17,8 @@ on:
     branches: [ "main" ]
     paths:
       - '.github/workflows/**'
+      - '.husky/**'
+      - 'Makefile'
       - 'src/**'
       - 'tests/**'
       - 'Directory.*'
@@ -82,25 +86,8 @@ jobs:
         run: dotnet nuget update source github.com --username xshaheen --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --configfile nuget.config
         shell: bash
 
-      - name: "Restore"
-        run: dotnet restore headless-framework.slnx
-
-      - name: "Format check"
-        run: |
-          dotnet tool restore
-          dotnet csharpier check .
-        shell: bash
-
-      - name: "Build"
-        run: dotnet build headless-framework.slnx --configuration ${{ env.CONFIGURATION }} --no-restore --no-incremental -v:q -nologo /clp:ErrorsOnly
-
-      - name: "Pack"
-        run: |
-          set -euo pipefail
-          for csproj in src/*/*.csproj; do
-            dotnet pack "$csproj" --configuration "${CONFIGURATION}" --no-restore --no-build --include-symbols --output "${PACKAGES_DIR}"
-          done
-        shell: bash
+      - name: "Format, build, and pack"
+        run: make ci-build
 
       - name: "Publish Artifacts"
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
 
       - name: "Restore"
-        run: dotnet restore headless-framework.slnx
+        run: make restore
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -73,7 +73,7 @@ jobs:
           build-mode: manual
 
       - name: "Build"
-        run: dotnet build headless-framework.slnx --configuration Release --no-restore --no-incremental -v:q -nologo /clp:ErrorsOnly
+        run: make rebuild-no-restore
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,6 @@
 #!/bin/sh
-# Format staged C# files with CSharpier before commit.
 # Committed hook (no Husky.Net). `make hooks` / `make bootstrap` points
-# core.hooksPath here, so this runs in every clone and worktree.
+# core.hooksPath here; the Makefile owns hook behavior.
 set -eu
 
-files=$(git diff --cached --name-only --diff-filter=ACM -- '*.cs')
-[ -z "$files" ] && exit 0
-
-# shellcheck disable=SC2086 # intentional word-splitting; repo paths have no spaces
-dotnet csharpier format $files
-# shellcheck disable=SC2086
-git add -- $files
+exec make hook-pre-commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,15 +1,6 @@
 #!/bin/sh
-# Verify formatting and do a clean (non-incremental) build before push.
-#
-# Analyzers and warnings-as-errors only run when a project actually recompiles, so an
-# incremental build can silently mask a CI failure (e.g. MA0008). `make rebuild` reproduces
-# the CI build step (--no-incremental) locally; `make format-check` mirrors the CI format gate.
-#
-# Complements .husky/pre-commit (which auto-formats staged files on commit): commit-time
-# formats, push-time verifies + builds — no overlap. `make hooks` / `make bootstrap` points
-# core.hooksPath here, so this runs in every clone and worktree. Bypass with `git push --no-verify`.
+# Committed hook (no Husky.Net). `make hooks` / `make bootstrap` points
+# core.hooksPath here; the Makefile owns hook behavior.
 set -eu
 
-printf '\033[36m[pre-push]\033[0m format-check + clean build (~1-2 min; skip with --no-verify)...\n'
-make format-check
-make rebuild
+exec make hook-pre-push

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,20 @@ restore-project: ## Restore one project; preferred for focused project work.
 hooks: ## Point git at the committed hooks (per clone/worktree).
 	git config core.hooksPath .husky
 
+.PHONY: hook-pre-commit
+hook-pre-commit: ## Git hook: format staged C# files before commit.
+	@files=(); \
+	while IFS= read -r file; do files+=("$$file"); done < <(git diff --cached --name-only --diff-filter=ACM -- '*.cs'); \
+	if [ "$${#files[@]}" -eq 0 ]; then exit 0; fi; \
+	$(DOTNET) csharpier format "$${files[@]}"; \
+	git add -- "$${files[@]}"
+
+.PHONY: hook-pre-push
+hook-pre-push: ## Git hook: verify formatting and do a clean build before push.
+	@printf '\033[36m[pre-push]\033[0m format-check + clean build (~1-2 min; skip with --no-verify)...\n'
+	$(MAKE) format-check
+	$(MAKE) rebuild
+
 .PHONY: build
 build: restore ## Build the solution.
 	$(DOTNET) build "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-restore -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,14 @@ hook-pre-commit: ## Git hook: format staged C# files before commit.
 	git add -- "$${files[@]}"
 
 .PHONY: hook-pre-push
-hook-pre-push: ## Git hook: verify formatting and do a clean build before push.
+hook-pre-push: hook-pre-push-message format-check rebuild ## Git hook: verify formatting and do a clean build before push.
+
+.PHONY: hook-pre-push-message
+hook-pre-push-message:
 	@printf '\033[36m[pre-push]\033[0m format-check + clean build (~1-2 min; skip with --no-verify)...\n'
-	$(MAKE) format-check
-	$(MAKE) rebuild
+
+.PHONY: ci-build
+ci-build: format-check rebuild pack-built ## CI: check formatting, clean-build, then pack already-built projects.
 
 .PHONY: build
 build: restore ## Build the solution.
@@ -73,6 +77,10 @@ build: restore ## Build the solution.
 
 .PHONY: rebuild
 rebuild: restore ## Build the solution without incremental compilation.
+	$(DOTNET) build "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-restore --no-incremental -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
+
+.PHONY: rebuild-no-restore
+rebuild-no-restore: ## Build without restore or incremental compilation; use after an explicit restore.
 	$(DOTNET) build "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-restore --no-incremental -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
 
 .PHONY: build-project
@@ -183,6 +191,13 @@ coverage-open: coverage-html ## Generate report and open in browser.
 pack: restore ## Pack NuGet packages with symbols.
 	@mkdir -p "$(PACKAGES_DIR)"
 	$(DOTNET) pack "$(SOLUTION)" --configuration "$(CONFIGURATION)" --include-symbols --output "$(PACKAGES_DIR)" $(MSBUILD_ARGS)
+
+.PHONY: pack-built
+pack-built: ## Pack already-built source projects without restore/build; used by CI.
+	@mkdir -p "$(PACKAGES_DIR)"
+	@for csproj in src/*/*.csproj; do \
+		$(DOTNET) pack "$$csproj" --configuration "$(CONFIGURATION)" --no-restore --no-build --include-symbols --output "$(PACKAGES_DIR)"; \
+	done
 
 .PHONY: pack-sbom
 pack-sbom: restore ## Pack NuGet packages with symbols and GenerateSBOM=true.


### PR DESCRIPTION
## Summary

Validation behavior for local hooks and GitHub CI now has one source of truth in the Makefile. The Husky hooks call dedicated Make targets, the main CI workflow calls a single Make aggregate instead of duplicating restore/format/build/pack shell commands, and CodeQL reuses the same restore/build targets while preserving its required restore-before-init order.

## Details

- Hook entry points now delegate to `make hook-pre-commit` and `make hook-pre-push`.
- `make ci-build` runs format check, clean rebuild, and pack-from-built outputs with one tool restore and one package restore in the command graph.
- CI path filters now include `.husky/**` and `Makefile` so hook/build orchestration changes run validation.

## Validation

- `make -n hook-pre-push` showed one `dotnet tool restore`, one `dotnet restore`, and a clean no-incremental build.
- `make -n ci-build` showed one `dotnet tool restore`, one `dotnet restore`, a clean no-incremental build, and `dotnet pack --no-restore --no-build`.
- `make -n restore rebuild-no-restore` confirmed CodeQL's restore-then-no-restore-build path.
- `bash -n .husky/pre-commit && bash -n .husky/pre-push` passed.
- `shellcheck .husky/pre-commit .husky/pre-push` passed.
- Workflow YAML parsed successfully with Ruby YAML.
- `git diff --check` passed.
- Pre-push validation on the first push attempt passed: CSharpier checked 3493 files, restore was up to date, and the Release no-incremental build succeeded with 0 warnings and 0 errors. The first network push timed out connecting to GitHub after validation; the retry used `--no-verify` to avoid rerunning the already-passed hook for the same HEAD.

## Post-Deploy Monitoring & Validation

No production runtime monitoring required; this only changes local hook and GitHub Actions orchestration.

Watch the first PR run in GitHub Actions:

- Logs: `Build and pack` job output for `make ci-build`; CodeQL `Analyze` job output for `make restore` and `make rebuild-no-restore`.
- Healthy signal: format check, restore, no-incremental build, and pack steps complete; `packages-results` artifact uploads successfully; CodeQL reaches analysis.
- Failure signal: missing Make target, duplicate/incorrect restore assumptions, pack artifact upload failure, or CodeQL build failure.
- Mitigation: revert this PR or restore the previous inline workflow commands if Make target routing fails in CI.
- Validation window and owner: first PR CI run, owner is PR author.
