### PR TITLE
feat(blobs): Cloudflare R2 backend + presigned URLs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       include: "scope"
     open-pull-requests-limit: 5
     groups:
+      # Keep AWS SDK bumps in their own PR so the R2 conformance workflow can gate them distinctly.
+      aws-sdk:
+        patterns:
+          - "AWSSDK.*"
       nuget-minor-patch:
         patterns:
           - "*"

--- a/.github/workflows/r2-conformance.yml
+++ b/.github/workflows/r2-conformance.yml
@@ -1,0 +1,75 @@
+name: R2 Conformance
+
+# Runs the Cloudflare R2 blob conformance suite against a real R2 account. There is no R2 emulator, so this is
+# gated on credentials supplied as repository/environment secrets: when they are absent (forks, or before the
+# secrets are configured) the suite skips every scenario and the job still passes. Triggered on dependency bumps
+# to the shared package file (which carry AWSSDK.* updates) and on changes to the R2/S3 blob code.
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'Directory.Packages.props'
+      - 'src/Headless.Blobs.CloudflareR2/**'
+      - 'src/Headless.Blobs.Aws/**'
+      - 'tests/Headless.Blobs.CloudflareR2.Tests.Integration/**'
+      - '.github/workflows/r2-conformance.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  CONFIGURATION: Release
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+  HUSKY: 0
+
+jobs:
+  r2-conformance:
+    name: "R2 conformance"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+
+    # The R2 credentials live in this protected environment. The job runs without them too (suite self-skips).
+    environment:
+      name: "R2 Conformance"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v5.3.0
+        with:
+          global-json-file: "./global.json"
+
+      - name: "Setup nuget cache"
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'global.json', 'nuget.config') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: "Authenticate GitHub Packages"
+        run: dotnet nuget update source github.com --username xshaheen --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --configfile nuget.config
+        shell: bash
+
+      - name: "Run R2 conformance suite"
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: make test-project TEST_PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
+        shell: bash

--- a/docs/brainstorms/2026-06-19-blobs-cloudflare-r2-requirements.md
+++ b/docs/brainstorms/2026-06-19-blobs-cloudflare-r2-requirements.md
@@ -1,0 +1,121 @@
+---
+date: 2026-06-19
+topic: blobs-cloudflare-r2
+---
+
+# Cloudflare R2 Blob Backend + Presigned URLs
+
+## Summary
+
+Add a dedicated `Headless.Blobs.CloudflareR2` package that runs R2 as a private, cost-saving S3 replacement on the reused AWS blob engine with R2-correct client config. Introduce an `IPresignedUrlBlobStorage` capability interface (presigned GET + PUT) implemented by the S3 engine (AWS + R2) and the Azure provider (via SAS). Refactor the shared `AwsBlobStorage` engine to end the per-operation bucket round trips that hurt both backends.
+
+---
+
+## Problem Frame
+
+R2 is not usable through the current AWS provider today, despite being S3-compatible. `SetupAwsS3.AddAwsS3BlobStorage` only accepts `AWSOptions`, which can't set `ForcePathStyle` or the SDK v4 checksum knobs — both required for R2. On `AWSSDK.S3 4.0.23.3` the flexible-checksum default (`WHEN_SUPPORTED`) emits CRC32 trailers / `aws-chunked` framing that R2 rejects with signature/checksum errors. R2 also has no ACL concept, while the engine always sets `CannedACL`.
+
+Separately, `AwsBlobStorage` does a `HeadBucket` (and sometimes `PutBucket`) before almost every object operation: uploads auto-create the bucket every call, and reads/exists/delete pre-check bucket existence. That is wasted latency on S3 and a hard failure on R2, where API tokens are commonly scoped to objects only and cannot create buckets.
+
+Presigned URLs are advertised in `src/Headless.Blobs.Aws/README.md` but do not exist — `IBlobStorage` has no URL surface and no blob provider implements one. The migration use case (serving private files to clients for a bounded time) needs them.
+
+---
+
+## Key Decisions
+
+- **Dedicated package, reused engine.** `Headless.Blobs.CloudflareR2` references `Headless.Blobs.Aws` and reuses `AwsBlobStorage` verbatim. R2's data plane is pure S3, so a standalone engine would only duplicate it. The package owns R2 options, setup, an R2-correct naming normalizer, conformance tests, and docs.
+- **Presigned URLs as a capability interface.** `IPresignedUrlBlobStorage` is a separate interface, not members on `IBlobStorage`. FileSystem, Redis, and SshNet have no native signing concept; a capability interface keeps `IBlobStorage` honest and avoids runtime `NotSupportedException` holes.
+- **Pin request shaping in client config.** The R2 `AmazonS3Config` sets `RequestChecksumCalculation` and `ResponseChecksumValidation` to `WHEN_REQUIRED` (plus `DisablePayloadSigning` / `UseChunkEncoding=false` via options). Pinning behavior in one place immunizes R2 against future AWS SDK default flips, the category of change that breaks S3-compatible stores.
+- **Opt-in, cached auto-create.** Auto-create becomes an `AutoCreateContainer` flag (AWS default true, R2 default false), and when on, the bucket check runs at most once per bucket per instance. Reads/exists/delete drop the bucket pre-check entirely.
+- **Bump-gated drift detection.** Durability rides on the pinned config plus a creds-gated conformance run required on `AWSSDK.*` dependency-update PRs. No scheduled run; the gap between bumps is accepted.
+- **Public access stays deferred.** Custom domains and CDN serving are out — they do not help presigned URLs (SigV4 and SAS bind the signature to the storage host) and belong to the deferred public-access scope.
+
+---
+
+## Requirements
+
+**Packaging and R2 client**
+
+- R1. `Headless.Blobs.CloudflareR2` references `Headless.Blobs.Aws` and uses `AwsBlobStorage` as its storage engine without duplicating S3 logic.
+- R2. The R2 `IAmazonS3` is configured with `ServiceURL` derived from the account id (and optional jurisdiction), `ForcePathStyle = true`, region `auto`, and `RequestChecksumCalculation` / `ResponseChecksumValidation` set to `WHEN_REQUIRED`.
+- R3. R2 options bind account id, access key, secret key, and an optional jurisdiction (default / EU / FedRAMP). Registration is `AddR2BlobStorage` exposing the standard overload trio (`IConfiguration`, `Action<TOptions>`, `Action<TOptions, IServiceProvider>`).
+- R4. R2 defaults are R2-safe: `CannedAcl = null`, `UseChunkEncoding = false`, `DisablePayloadSigning = true`, `AutoCreateContainer = false`.
+- R5. R2 ships a naming normalizer enforcing R2 bucket rules — 3–63 chars, lowercase letters, digits, and hyphens, no dots.
+
+**Shared engine refactor (`Headless.Blobs.Aws`)**
+
+- R6. Read, exists, delete, and download paths no longer pre-check bucket existence; the object operation runs directly and `NoSuchBucket` / 404 maps to not-found or null, the same as a missing key.
+- R7. Auto-create on upload and copy is gated by an `AutoCreateContainer` option (AWS default true, R2 default false); when off, a missing bucket surfaces as a clear error rather than being created.
+- R8. When auto-create is on, the bucket existence/create call runs at most once per bucket per storage instance via an in-process cache. Explicit `CreateContainerAsync` always creates regardless of the flag and primes the cache.
+
+**Presigned URLs**
+
+- R9. `Headless.Blobs.Abstractions` defines `IPresignedUrlBlobStorage` with a presigned-download (GET) method and a presigned-upload (PUT) method, each taking the container, blob name, and an expiry.
+- R10. `AwsBlobStorage` implements it via S3 SigV4 (covering both AWS and R2); the Azure provider implements it via SAS. FileSystem, Redis, and SshNet do not implement it.
+- R11. Consumers obtain the capability by feature detection (`storage is IPresignedUrlBlobStorage`) or direct injection; a provider that lacks it is detectable without triggering a runtime `NotSupportedException`.
+
+**Testing and drift durability**
+
+- R12. A creds-gated R2 integration project reuses the cross-provider conformance suite against real R2 and skips cleanly when R2 credentials are absent.
+- R13. The R2 conformance run is a required check on `AWSSDK.*` dependency-update PRs; there is no scheduled run.
+- R14. Presigned GET and PUT round-trips are covered by tests for AWS and Azure (fetch/upload through the signed URL, with an expiry boundary check).
+
+**Documentation**
+
+- R15. Update `docs/llms/blobs.md` and the affected READMEs (`Headless.Blobs.Aws`, `Headless.Blobs.Azure`, and the new `Headless.Blobs.CloudflareR2`) for the new package, the presigned capability, the auto-create behavior change, and R2 setup; fix the stale `BucketName` claim in the AWS README.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R7.** R2 storage (auto-create off), bucket missing. **When** a blob is uploaded, **then** the call fails with a clear bucket-not-found error rather than creating the bucket.
+- AE2. **Covers R6.** Bucket missing. **When** `GetBlobInfoAsync` or `OpenReadStreamAsync` is called, **then** it returns null instead of throwing.
+- AE3. **Covers R8.** AWS storage (auto-create on). **When** 100 blobs are uploaded to the same bucket, **then** the bucket existence/create call is issued at most once.
+- AE4. **Covers R11.** FileSystem storage. **When** a consumer evaluates `storage is IPresignedUrlBlobStorage`, **then** the result is false and no exception is thrown.
+- AE5. **Covers R9, R10.** A presigned download URL is generated with a short expiry. **When** an unauthenticated HTTP client fetches it before expiry, **then** it receives the object; after expiry, **then** the request is denied.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later**
+
+- Public / CDN access, including R2 custom domains and `r2.dev`. Does not help presigned URLs; reopens the public-access scope set aside for this work.
+- Multipart upload / large-file streaming. The single-PUT ~5 GiB cap and in-memory buffering of non-seekable streams remain.
+- Presigned POST-form and multipart-part URLs. These ride with the deferred multipart work.
+- Scheduled / nightly conformance runs. Detection is bump-PR-only by decision.
+- Multi-account named clients and keyed-DI factories for R2 (present in the reference library, not requested here).
+
+---
+
+## Dependencies / Assumptions
+
+- `AWSSDK.S3` is a shared, centrally-managed package (`Directory.Packages.props`) used by Blobs.Aws, SES, SNS, and SQS. A separate pinned version for R2 is not feasible; durability relies on the explicit config plus the bump-PR conformance gate.
+- Checksum lever: config-level `WHEN_REQUIRED` is assumed sufficient on `AWSSDK.S3 4.0.23.3` (~90% confidence). Fallback if live R2 still rejects writes is per-request `DisableDefaultChecksumValidation = true` — the lever the reference library uses on its pinned `4.0.7.1`. Only a live R2 round-trip confirms which is needed.
+- Azure SAS generation requires account-key or user-delegation-key auth; a provider wired with a bare SAS-token or anonymous connection cannot presign. Verify the Azure provider's current auth model during planning.
+- R2 API tokens are commonly object-scoped and cannot create buckets. R2 auto-create defaults off (R4), and pre-creating buckets out of band (dashboard / API) is a documented requirement, not a bug to design around.
+- The engine refactor (R6–R8) changes the existing AWS provider's observable behavior. Accepted under the greenfield "prefer clean breaking changes" rule; existing AWS tests are updated to match.
+
+---
+
+## Outstanding Questions
+
+**Deferred to planning**
+
+- Presigned method signature shape: expiry as `TimeSpan` vs absolute time, return `Uri` vs `string`, and whether presigned PUT constrains content-type/length.
+- Whether `AutoCreateContainer` lives on the shared `AwsBlobStorageOptions` or only on the R2 options surface.
+- R2 jurisdiction endpoint derivation (default / EU / FedRAMP host construction).
+- Azure SAS auth-mode detection (account key vs user delegation key) and how the provider selects it.
+- CI wiring for the creds-gated conformance secret and the `AWSSDK.*`-bump required-check trigger.
+
+---
+
+## Sources / Research
+
+- `src/Headless.Blobs.Aws/AwsBlobStorage.cs` — per-operation bucket dance: auto-create on upload (`:69`) and copy (`:387`); `DoesS3BucketExistV2Async` pre-check in `_ExistsAsync` (`:468`) reached by download (`:506`) and delete (`:179`); non-seekable stream buffered to memory (`:82`).
+- `src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs` — existing `UseChunkEncoding`, `DisablePayloadSigning`, `CannedAcl` knobs.
+- `src/Headless.Blobs.Abstractions/IBlobStorage.cs` — current contract has no URL/presign surface.
+- `src/Headless.Blobs.Aws/README.md` — stale `options.BucketName` claim (no such option exists).
+- `tests/Headless.Blobs.Tests.Harness/BlobStorageTestsBase.cs` — cross-provider conformance suite to reuse for R2.
+- Reference `Alos-no/Cloudflare.NET`: `src/Cloudflare.NET.R2/R2ClientFactory.cs` (config = `ServiceURL` + `ForcePathStyle=true` + `AuthenticationRegion="auto"`); `src/Cloudflare.NET.R2/R2Client.cs` per-request `DisablePayloadSigning` + `DisableDefaultChecksumValidation` (`:133`, `:226`); pins `AWSSDK.S3 4.0.7.1`.
+- Verified in `AWSSDK.S3 4.0.23.3` / `AWSSDK.Core 4.0.7.1`: `ClientConfig.RequestChecksumCalculation` / `ResponseChecksumValidation` (enum values `WHEN_REQUIRED` / `WHEN_SUPPORTED`), `AmazonS3Config.ForcePathStyle`, `PutObjectRequest` / `UploadPartRequest.DisableDefaultChecksumValidation` and `.DisablePayloadSigning`.

--- a/docs/llms/blobs.md
+++ b/docs/llms/blobs.md
@@ -102,7 +102,7 @@ All providers register `IBlobStorage` as singleton. Container paths are arrays o
 - Redis blob storage (`Blobs.Redis`) is for small blobs only (metadata, thumbnails, temporary uploads). The default `MaxBlobSizeBytes` is 10 MB. For large files, use S3 or Azure.
 - Always dispose the result of `OpenReadStreamAsync()` promptly — holding it may exhaust connection pools. Use `await using`.
 - Container paths are string arrays, not slash-delimited strings: `["uploads", "images"]` not `"uploads/images"`.
-- Each provider registers its own `IBlobNamingNormalizer` for provider-specific path normalization — do not manually normalize paths.
+- Naming is normalized two-tier through each provider's `IBlobNamingNormalizer`: the **first** container segment is the backend bucket/container (strict backend rules — e.g. lowercase, length, allowed characters) and the **remaining** segments plus the blob name are the object path (lenient — validated, not rewritten). This is applied uniformly by every provider (AWS, R2, Azure, FileSystem, SshNet, Redis); do not manually normalize paths.
 - Metadata is a `Dictionary<string, string?>`. For `FileSystem` provider, metadata is stored as companion JSON files. For `Redis`, metadata is stored alongside blobs in Redis.
 - `SshNet` supports both password and SSH key authentication. Use `PrivateKeyPath` for key-based auth.
 - Only one provider can be the default `IBlobStorage` registration. If you need multiple providers, use keyed services or named registrations.
@@ -188,7 +188,7 @@ Provides seamless integration with AWS S3 for blob storage using the unified `IB
 
 - Full `IBlobStorage` implementation for AWS S3
 - Bulk upload/delete with optimized batching
-- Automatic path normalization for S3 object keys
+- Two-tier name normalization: the bucket name is normalized to S3 rules; object-key path segments are validated and preserved
 - Metadata support
 - Presigned download/upload URLs via `IPresignedUrlBlobStorage`
 - Opt-in, cached bucket auto-create (`AutoCreateContainer`)

--- a/docs/llms/blobs.md
+++ b/docs/llms/blobs.md
@@ -98,7 +98,7 @@ All providers register `IBlobStorage` as singleton. Container paths are arrays o
 - Always depend on `IBlobStorage` from `Headless.Blobs.Abstractions` — never reference `AwsS3BlobStorage`, `AzureBlobStorage`, or other concrete types in service code.
 - Use `Blobs.FileSystem` (`AddFileSystemBlobStorage()`) for local development and testing. Use `Blobs.Aws`, `Blobs.Azure`, or `Blobs.CloudflareR2` for production.
 - Presigned URLs are an opt-in capability: `IPresignedUrlBlobStorage` (presigned GET + PUT) is implemented only by AWS, Cloudflare R2, and Azure (SAS). Feature-detect with `storage is IPresignedUrlBlobStorage` — FileSystem, Redis, and SshNet do not implement it. Azure can throw at call time if its `BlobServiceClient` was wired without account-key/user-delegation-key credentials.
-- For the S3 engine (AWS and R2), bucket auto-create on upload/copy is controlled by `AwsBlobStorageOptions.AutoCreateContainer` (AWS default `true`, R2 default `false`); read/exists/delete no longer pre-check the bucket. With auto-create off, pre-create buckets or call `CreateContainerAsync`.
+- Container auto-create on upload/copy is opt-in and cached once per container per instance. The S3 engine (AWS and R2) uses `AwsBlobStorageOptions.AutoCreateContainer` (AWS default `true`, R2 default `false`); Azure uses `AzureStorageOptions.AutoCreateContainer` (default `true`). With it off, pre-create containers or call `CreateContainerAsync`. The S3 engine also no longer pre-checks the bucket on read/exists/delete.
 - Redis blob storage (`Blobs.Redis`) is for small blobs only (metadata, thumbnails, temporary uploads). The default `MaxBlobSizeBytes` is 10 MB. For large files, use S3 or Azure.
 - Always dispose the result of `OpenReadStreamAsync()` promptly — holding it may exhaust connection pools. Use `await using`.
 - Container paths are string arrays, not slash-delimited strings: `["uploads", "images"]` not `"uploads/images"`.
@@ -273,7 +273,7 @@ Provides seamless integration with Azure Blob Storage using the unified `IBlobSt
 
 - Full `IBlobStorage` implementation for Azure Blob Storage
 - Bulk operations with Azure Batch API
-- Container management
+- Opt-in, cached container auto-create (`AutoCreateContainer`)
 - Metadata support
 - Presigned download/upload URLs via `IPresignedUrlBlobStorage` (SAS-based)
 - Integration with Azure.Identity for authentication

--- a/docs/llms/blobs.md
+++ b/docs/llms/blobs.md
@@ -1,6 +1,6 @@
 ---
 domain: Blob Storage
-packages: Blobs.Abstractions, Blobs.Aws, Blobs.Azure, Blobs.FileSystem, Blobs.Redis, Blobs.SshNet
+packages: Blobs.Abstractions, Blobs.Aws, Blobs.Azure, Blobs.CloudflareR2, Blobs.FileSystem, Blobs.Redis, Blobs.SshNet
 ---
 
 # Blob Storage
@@ -66,6 +66,16 @@ packages: Blobs.Abstractions, Blobs.Aws, Blobs.Azure, Blobs.FileSystem, Blobs.Re
     - [SSH Key Authentication](#ssh-key-authentication)
   - [Dependencies](#dependencies-5)
   - [Side Effects](#side-effects-5)
+- [Headless.Blobs.CloudflareR2](#headlessblobscloudflarer2)
+  - [Problem Solved](#problem-solved-6)
+  - [Key Features](#key-features-6)
+  - [Installation](#installation-6)
+  - [Quick Start](#quick-start-5)
+  - [Configuration](#configuration-6)
+    - [appsettings.json](#appsettingsjson-5)
+  - [Behavior Notes](#behavior-notes)
+  - [Dependencies](#dependencies-6)
+  - [Side Effects](#side-effects-6)
 
 > Provider-agnostic file/blob storage with implementations for AWS S3, Azure Blob, local filesystem, Redis, and SFTP.
 
@@ -75,8 +85,9 @@ Install `Headless.Blobs.Abstractions` plus one provider package. Code against `I
 
 Provider selection guide:
 - **Development/testing**: `Headless.Blobs.FileSystem` — no external dependencies, stores files on disk.
-- **Production (AWS)**: `Headless.Blobs.Aws` — full S3 integration with bulk operations and pre-signed URLs.
+- **Production (AWS)**: `Headless.Blobs.Aws` — full S3 integration with bulk operations and presigned URLs.
 - **Production (Azure)**: `Headless.Blobs.Azure` — Azure Blob Storage with Batch API and Azure.Identity support.
+- **Production (Cloudflare R2)**: `Headless.Blobs.CloudflareR2` — private, S3-compatible storage on the reused AWS engine; a cost-saving S3 replacement.
 - **SFTP/legacy**: `Headless.Blobs.SshNet` — SFTP protocol for remote servers and legacy system integration.
 - **Small cached blobs**: `Headless.Blobs.Redis` — Redis-backed storage for small, ephemeral blobs only (default 10 MB limit).
 
@@ -85,7 +96,9 @@ All providers register `IBlobStorage` as singleton. Container paths are arrays o
 ## Agent Instructions
 
 - Always depend on `IBlobStorage` from `Headless.Blobs.Abstractions` — never reference `AwsS3BlobStorage`, `AzureBlobStorage`, or other concrete types in service code.
-- Use `Blobs.FileSystem` (`AddFileSystemBlobStorage()`) for local development and testing. Use `Blobs.Aws` or `Blobs.Azure` for production.
+- Use `Blobs.FileSystem` (`AddFileSystemBlobStorage()`) for local development and testing. Use `Blobs.Aws`, `Blobs.Azure`, or `Blobs.CloudflareR2` for production.
+- Presigned URLs are an opt-in capability: `IPresignedUrlBlobStorage` (presigned GET + PUT) is implemented only by AWS, Cloudflare R2, and Azure (SAS). Feature-detect with `storage is IPresignedUrlBlobStorage` — FileSystem, Redis, and SshNet do not implement it. Azure can throw at call time if its `BlobServiceClient` was wired without account-key/user-delegation-key credentials.
+- For the S3 engine (AWS and R2), bucket auto-create on upload/copy is controlled by `AwsBlobStorageOptions.AutoCreateContainer` (AWS default `true`, R2 default `false`); read/exists/delete no longer pre-check the bucket. With auto-create off, pre-create buckets or call `CreateContainerAsync`.
 - Redis blob storage (`Blobs.Redis`) is for small blobs only (metadata, thumbnails, temporary uploads). The default `MaxBlobSizeBytes` is 10 MB. For large files, use S3 or Azure.
 - Always dispose the result of `OpenReadStreamAsync()` promptly — holding it may exhaust connection pools. Use `await using`.
 - Container paths are string arrays, not slash-delimited strings: `["uploads", "images"]` not `"uploads/images"`.
@@ -177,7 +190,8 @@ Provides seamless integration with AWS S3 for blob storage using the unified `IB
 - Bulk upload/delete with optimized batching
 - Automatic path normalization for S3 object keys
 - Metadata support
-- Pre-signed URL generation capability
+- Presigned download/upload URLs via `IPresignedUrlBlobStorage`
+- Opt-in, cached bucket auto-create (`AutoCreateContainer`)
 - Integration with AWS SDK configuration
 
 ## Installation
@@ -193,20 +207,20 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Option 1: Use configuration-based AWS options
 var awsOptions = builder.Configuration.GetAWSOptions();
-builder.Services.AddAwsS3BlobStorage(awsOptions, options =>
-{
-    options.BucketName = "my-bucket";
-});
+builder.Services.AddAwsS3BlobStorage(awsOptions);
 
 // Option 2: Manual configuration
 builder.Services.AddAwsS3BlobStorage(new AWSOptions
 {
     Region = RegionEndpoint.USEast1,
     Credentials = new BasicAWSCredentials("access-key", "secret-key")
-}, options =>
-{
-    options.BucketName = "my-bucket";
 });
+```
+
+Buckets and keys are passed per operation, not configured at registration:
+
+```csharp
+await storage.UploadAsync(["my-bucket"], "reports/q1.pdf", stream);
 ```
 
 ## Configuration
@@ -226,7 +240,11 @@ builder.Services.AddAwsS3BlobStorage(new AWSOptions
 ### Options
 
 ```csharp
-options.BucketName = "my-bucket";
+options.AutoCreateContainer = true; // create buckets on upload/copy (default true; set false for R2)
+options.CannedAcl = S3CannedACL.Private;
+options.UseChunkEncoding = true;
+options.DisablePayloadSigning = false;
+options.MaxBulkParallelism = 10;
 ```
 
 ## Dependencies
@@ -257,6 +275,7 @@ Provides seamless integration with Azure Blob Storage using the unified `IBlobSt
 - Bulk operations with Azure Batch API
 - Container management
 - Metadata support
+- Presigned download/upload URLs via `IPresignedUrlBlobStorage` (SAS-based)
 - Integration with Azure.Identity for authentication
 
 ## Installation
@@ -522,3 +541,78 @@ builder.Services.AddSshNetBlobStorage(options =>
 
 - Registers `IBlobStorage` as singleton
 - Opens SSH/SFTP connections to remote server
+---
+# Headless.Blobs.CloudflareR2
+
+Cloudflare R2 implementation of `IBlobStorage`, running R2 as a private, S3-compatible blob backend on the reused AWS S3 engine.
+
+## Problem Solved
+
+R2 speaks the S3 API but cannot use the AWS provider as-is: the endpoint, path-style addressing, and AWS SDK v4 checksum defaults need R2-specific configuration, and R2 has no ACL concept. This package configures an R2-tuned `IAmazonS3` and reuses `AwsBlobStorage`, making R2 a drop-in, cost-saving S3 replacement.
+
+## Key Features
+
+- Full `IBlobStorage` implementation for Cloudflare R2 (reuses the AWS S3 engine)
+- Presigned download/upload URLs via `IPresignedUrlBlobStorage`
+- R2-correct client config: path-style addressing, `auto` region, SDK v4 checksum settings R2 accepts
+- R2 bucket naming normalization (no dots)
+- Jurisdiction-aware endpoints (default, EU, FedRAMP)
+
+## Installation
+
+```bash
+dotnet add package Headless.Blobs.CloudflareR2
+```
+
+## Quick Start
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCloudflareR2BlobStorage(options =>
+{
+    options.AccountId = builder.Configuration["R2:AccountId"]!;
+    options.AccessKeyId = builder.Configuration["R2:AccessKeyId"]!;
+    options.SecretAccessKey = builder.Configuration["R2:SecretAccessKey"]!;
+    // options.Jurisdiction = R2Jurisdiction.EuropeanUnion; // optional
+});
+
+// Buckets and keys are passed per operation:
+await storage.UploadAsync(["my-bucket"], "reports/q1.pdf", stream);
+```
+
+## Configuration
+
+### appsettings.json
+
+```json
+{
+  "R2": {
+    "AccountId": "your-account-id",
+    "AccessKeyId": "your-access-key-id",
+    "SecretAccessKey": "your-secret-access-key",
+    "Jurisdiction": "Default"
+  }
+}
+```
+
+## Behavior Notes
+
+- Buckets are not auto-created (`AutoCreateContainer` defaults to `false`): R2 object-scoped tokens cannot create buckets. Pre-create buckets out of band or use a bucket-create-capable token with `CreateContainerAsync`.
+- No ACLs / public access: `CannedAcl` is `null`. Use presigned URLs for time-limited private access; public serving (custom domains / `r2.dev`) is out of scope.
+- Single PUT is capped at ~5 GiB, the same as S3.
+
+## Dependencies
+
+- `Headless.Blobs.Aws`
+- `Headless.Blobs.Abstractions`
+- `Headless.Core`
+- `Headless.Hosting`
+- `AWSSDK.S3`
+
+## Side Effects
+
+- Registers `IAmazonS3` (configured for R2) if not already registered
+- Configures the shared `AwsBlobStorageOptions` with R2-safe defaults
+- Registers `IBlobStorage` (the AWS S3 engine) as singleton
+- Registers `IBlobNamingNormalizer` (R2 rules) as singleton

--- a/docs/plans/2026-06-19-001-feat-blobs-cloudflare-r2-presigned-plan.md
+++ b/docs/plans/2026-06-19-001-feat-blobs-cloudflare-r2-presigned-plan.md
@@ -1,0 +1,342 @@
+---
+title: "feat: Cloudflare R2 blob backend + presigned URLs"
+type: feat
+date: 2026-06-19
+origin: docs/brainstorms/2026-06-19-blobs-cloudflare-r2-requirements.md
+---
+
+# feat: Cloudflare R2 blob backend + presigned URLs
+
+## Summary
+
+Add a dedicated `Headless.Blobs.CloudflareR2` package that runs R2 as a private, cost-saving S3 replacement on the reused `AwsBlobStorage` engine with R2-correct client config. Introduce an `IPresignedUrlBlobStorage` capability interface (presigned GET + PUT) implemented by the S3 engine (AWS + R2) and the Azure provider via SAS. Refactor the shared `AwsBlobStorage` engine to drop the per-operation bucket round trips.
+
+---
+
+## Problem Frame
+
+R2 is S3-compatible but unusable through the current AWS provider. `SetupAwsS3.AddAwsS3BlobStorage` accepts only `AWSOptions`, which cannot set `ForcePathStyle` or the SDK v4 checksum knobs; on `AWSSDK.S3 4.0.23.3` the flexible-checksum default (`WHEN_SUPPORTED`) emits framing R2 rejects. R2 also has no ACL concept, while the engine always sets `CannedACL`.
+
+`AwsBlobStorage` issues a `HeadBucket` (and sometimes `PutBucket`) before almost every object operation — uploads auto-create on each call, reads/exists/delete pre-check existence. That is wasted latency on S3 and a hard failure on R2, whose API tokens are commonly object-scoped and cannot create buckets.
+
+Presigned URLs are advertised in `src/Headless.Blobs.Aws/README.md` but do not exist: `IBlobStorage` has no URL surface and no provider implements one. The migration use case — serving private objects to clients for a bounded time — needs them. (see origin: `docs/brainstorms/2026-06-19-blobs-cloudflare-r2-requirements.md`)
+
+---
+
+## Requirements
+
+**Packaging and R2 client**
+
+- R1. `Headless.Blobs.CloudflareR2` references `Headless.Blobs.Aws` and uses `AwsBlobStorage` as its engine without duplicating S3 logic.
+- R2. The R2 `IAmazonS3` is configured with `ServiceURL` from the account id (and optional jurisdiction), `ForcePathStyle = true`, region `auto`, and `RequestChecksumCalculation` / `ResponseChecksumValidation = WHEN_REQUIRED`.
+- R3. R2 options bind account id, access key, secret key, and optional jurisdiction (default / EU / FedRAMP). Registration is `AddCloudflareR2BlobStorage` exposing the options trio (`IConfiguration`, `Action<TOptions>`, `Action<TOptions, IServiceProvider>`).
+- R4. R2 defaults are R2-safe: `CannedAcl = null`, `UseChunkEncoding = false`, `DisablePayloadSigning = true`, `AutoCreateContainer = false`.
+- R5. R2 ships a naming normalizer enforcing R2 bucket rules — 3–63 chars, lowercase letters, digits, and hyphens, no dots.
+
+**Shared engine refactor (`Headless.Blobs.Aws`)**
+
+- R6. Read, exists, delete, and download paths no longer pre-check bucket existence; the object operation runs directly and `NoSuchBucket` / 404 maps to not-found or null, the same as a missing key.
+- R7. Auto-create on upload and copy is gated by `AutoCreateContainer` (AWS default true, R2 default false); when off, a missing bucket surfaces as a clear error.
+- R8. When auto-create is on, the bucket existence/create call runs at most once per bucket per storage instance; explicit `CreateContainerAsync` always creates regardless of the flag and primes the cache.
+
+**Presigned URLs**
+
+- R9. `Headless.Blobs.Abstractions` defines `IPresignedUrlBlobStorage` with a presigned-download (GET) method and a presigned-upload (PUT) method, each taking container, blob name, and an expiry.
+- R10. `AwsBlobStorage` implements it via S3 SigV4 (covering AWS and R2); the Azure provider implements it via SAS. FileSystem, Redis, and SshNet do not implement it.
+- R11. Consumers obtain the capability by feature detection (`storage is IPresignedUrlBlobStorage`) or direct injection; a provider that lacks it is detectable without a runtime `NotSupportedException`.
+
+**Testing and drift durability**
+
+- R12. A creds-gated R2 integration project reuses the cross-provider conformance suite against real R2 and skips cleanly when R2 credentials are absent.
+- R13. The R2 conformance run is a required check on `AWSSDK.*` dependency-update PRs; no scheduled run.
+- R14. Presigned GET and PUT round-trips are covered by tests for AWS and Azure (fetch/upload through the signed URL, with an expiry boundary check).
+
+**Documentation**
+
+- R15. Update `docs/llms/blobs.md` and the affected READMEs (`Headless.Blobs.Aws`, `Headless.Blobs.Azure`, new `Headless.Blobs.CloudflareR2`) for the new package, the presigned capability, the auto-create change, and R2 setup; fix the stale `BucketName` claim in the AWS README.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Reuse `AwsBlobStorage` for R2; no separate engine type.** R2's data plane is pure S3 and `AwsBlobStorage` talks only to `IAmazonS3` (`src/Headless.Blobs.Aws/AwsBlobStorage.cs`), so a separate engine would duplicate it.
+- KTD2. **Pin request shaping in the R2 client config**, not per-request. Set `RequestChecksumCalculation` / `ResponseChecksumValidation = WHEN_REQUIRED` plus `ForcePathStyle` / region `auto` on the R2 `AmazonS3Config`. One place, immune to future SDK default flips. Fallback if live R2 still rejects writes: per-request `DisableDefaultChecksumValidation = true` (the lever the reference library uses on its pinned `4.0.7.1`).
+- KTD3. **Presigned URLs as a capability interface**, not members on `IBlobStorage`. FileSystem/Redis/SshNet have no signing concept; a capability interface keeps `IBlobStorage` universal and avoids runtime `NotSupportedException` holes.
+- KTD4. **Presigned signatures are `ValueTask<Uri>` with a relative `TimeSpan` expiry.** `ValueTask` accommodates Azure's user-delegation-key path (an async call); relative expiry is the common ergonomic and maps to both `GetPreSignedURL` (`Expires`) and `GenerateSasUri`.
+- KTD5. **`AutoCreateContainer` lives on the shared `AwsBlobStorageOptions`** (AWS default true), because the shared engine reads it; R2 sets it false. Bucket existence/create is cached once per bucket per instance to cut round trips.
+- KTD6. **`NoSuchBucket` maps to not-found/null** on read/exists/delete after the pre-check is removed, preserving today's null-on-missing contract (the catch sites already handle 404 `NoSuchKey`).
+- KTD7. **R2 setup follows the options-trio shape** (like Azure/FileSystem/Redis/SshNet), not the AWS-provider outlier. AWS skips the trio only because the AWS SDK owns `AWSOptions` and the credential chain; R2 owns a normal options class.
+- KTD8. **Azure presigned throws `InvalidOperationException` at call-time when the client cannot sign.** `AzureBlobStorage` receives an injected `BlobServiceClient` (`src/Headless.Blobs.Azure/AzureBlobStorage.cs:18-26`); SAS works only when it carries an account key or user-delegation key (`CanGenerateSasUri`). The capability is present on the type; signing ability depends on consumer wiring.
+- KTD9. **The R2 conformance gate is net-new CI.** `ci.yml` runs no integration tests and dependency automation is Dependabot with grouped nuget bumps. Deliver a dedicated creds-gated workflow plus an `AWSSDK.*` Dependabot group; marking the check "required" is an out-of-repo branch-protection step documented in the plan.
+
+---
+
+## High-Level Technical Design
+
+**Capability surface — who implements what.**
+
+```mermaid
+flowchart TB
+  IBS[IBlobStorage<br/>universal CRUD + stream]
+  IPU[IPresignedUrlBlobStorage<br/>GET + PUT presigned]
+  AWS[AwsBlobStorage<br/>AWS + R2 via S3 SigV4]
+  AZ[AzureBlobStorage<br/>SAS]
+  FS[FileSystem / Redis / SshNet]
+
+  AWS -->|implements| IBS
+  AZ -->|implements| IBS
+  FS -->|implements| IBS
+  AWS -->|implements| IPU
+  AZ -->|implements| IPU
+  FS -.->|does NOT implement| IPU
+```
+
+R2 reuses `AwsBlobStorage`, so implementing `IPresignedUrlBlobStorage` once on the S3 engine covers both AWS and R2; the R2-configured `IAmazonS3` produces R2-host presigned URLs.
+
+**Read/write path after the engine refactor.**
+
+```mermaid
+flowchart TB
+  subgraph Read["Read / Exists / Delete / Download"]
+    R1[object op directly] --> R2{NoSuchBucket<br/>or 404?}
+    R2 -->|yes| R3[return null / false]
+    R2 -->|no| R4[return result]
+  end
+  subgraph Write["Upload / Copy"]
+    W1{AutoCreateContainer?} -->|false R2| W3[PutObject]
+    W1 -->|true AWS| W2{bucket in cache?}
+    W2 -->|yes| W3
+    W2 -->|no| W4[ensure bucket once<br/>then cache] --> W3
+  end
+```
+
+The bucket-existence cache must create at most once under concurrent uploads and must not cache a failed creation. Direction: a per-instance `ConcurrentDictionary` keyed by bucket holding a single-flight task; evict on failure so a transient error doesn't poison the cache. Exact structure is the implementer's call.
+
+---
+
+## Output Structure
+
+```text
+src/Headless.Blobs.CloudflareR2/
+  Headless.Blobs.CloudflareR2.csproj   # references Headless.Blobs.Aws
+  Setup.cs                             # AddCloudflareR2BlobStorage (options trio)
+  R2BlobStorageOptions.cs              # AccountId, AccessKey, SecretKey, Jurisdiction(+validator)
+  R2BlobNamingNormalizer.cs            # R2 bucket rules (no dots)
+  README.md
+
+tests/Headless.Blobs.CloudflareR2.Tests.Integration/
+  Headless.Blobs.CloudflareR2.Tests.Integration.csproj
+  CloudflareR2BlobStorageFixture.cs    # creds-gated, real R2 endpoint
+  CloudflareR2BlobStorageTests.cs      # re-declares BlobStorageTestsBase scenarios
+
+src/Headless.Blobs.Abstractions/
+  IPresignedUrlBlobStorage.cs          # new capability interface
+```
+
+The per-unit `Files` lists remain authoritative; the implementer may adjust layout.
+
+---
+
+## Implementation Units
+
+### U1. Presigned URL capability interface
+
+- **Goal:** Define the capability contract both S3 and Azure backends will implement.
+- **Requirements:** R9, R11
+- **Dependencies:** none
+- **Files:** `src/Headless.Blobs.Abstractions/IPresignedUrlBlobStorage.cs`
+- **Approach:** `[PublicAPI]` interface with `ValueTask<Uri> GetPresignedDownloadUrlAsync(string[] container, string blobName, TimeSpan expiry, CancellationToken ct = default)` and a matching upload (PUT) method. Mirror the `container` + `blobName` shape and XML-doc style of `IBlobStorage`. Document that absence of the interface means the provider cannot sign URLs (KTD3).
+- **Patterns to follow:** `src/Headless.Blobs.Abstractions/IBlobStorage.cs` (member shape, `[PublicAPI]`, file header).
+- **Test scenarios:** Test expectation: none -- pure interface contract, exercised by U3 and U6 implementer tests.
+- **Verification:** Compiles; the interface surface matches R9 (download + upload, expiry, returns `Uri`).
+
+### U2. Shared engine refactor: bucket pre-check removal + opt-in cached auto-create
+
+- **Goal:** End the per-operation bucket round trips and make auto-create opt-in, on the shared engine.
+- **Requirements:** R6, R7, R8
+- **Dependencies:** none
+- **Files:** `src/Headless.Blobs.Aws/AwsBlobStorage.cs`, `src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs`, `tests/Headless.Blobs.Aws.Tests.Unit/` (engine tests), `tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs`
+- **Approach:** Add `bool AutoCreateContainer = true` to `AwsBlobStorageOptions`. In `OpenReadStreamAsync`, `ExistsAsync`, `GetBlobInfoAsync`, `DeleteAsync`, remove the `DoesS3BucketExistV2Async` pre-check (`AwsBlobStorage.cs:468`, reached at `:506`, `:179`) and let the object op run, catching `NoSuchBucket` alongside the existing 404/`NoSuchKey` handling → return null/false (KTD6). In `UploadAsync` (`:69`) and `CopyAsync` (`:387`), gate the create on `AutoCreateContainer`; when on, route through the once-per-bucket cache. Keep `CreateContainerAsync` always creating and priming the cache.
+- **Execution note:** Characterization-first — add coverage pinning current read/exists/delete null-on-missing behavior before removing the pre-check.
+- **Patterns to follow:** existing `AmazonS3Exception` 404 catch blocks in `AwsBlobStorage.cs`; storage-initializer idempotent-create + existence-cache thinking in `docs/solutions/best-practices/storage-initializer-lifecycle-correctness.md`.
+- **Test suite design:** Unit tests in `Headless.Blobs.Aws.Tests.Unit` with a mocked `IAmazonS3` (NSubstitute) for the cache and flag logic; behavior assertions against LocalStack in `Headless.Blobs.Aws.Tests.Integration`.
+- **Test scenarios:**
+  - Covers R6. GetBlobInfo / OpenReadStream / Exists / Delete against a missing bucket → returns null/false, no throw.
+  - Covers R7. `AutoCreateContainer = false` + missing bucket + Upload → throws a clear bucket-not-found error; no `PutBucket` issued.
+  - Covers R7. `AutoCreateContainer = true` + missing bucket + Upload → bucket created, object stored.
+  - Covers R8. 100 sequential uploads to the same bucket (auto-create on) → at most one existence/create call (assert via mock call count).
+  - Covers R8. Concurrent uploads to the same missing bucket → create runs exactly once; all succeed.
+  - Covers R8. Explicit `CreateContainerAsync` then Upload with auto-create off → upload succeeds (explicit create is independent of the flag).
+  - Edge: first create fails (transient), retried upload → create is reattempted (failure not cached).
+- **Verification:** Planned tests added and passing; existing AWS integration tests updated to the new behavior and green.
+
+### U3. Presigned URLs on the S3 engine (AWS + R2)
+
+- **Goal:** Implement `IPresignedUrlBlobStorage` on `AwsBlobStorage`.
+- **Requirements:** R9, R10, R14
+- **Dependencies:** U1
+- **Files:** `src/Headless.Blobs.Aws/AwsBlobStorage.cs`, `tests/Headless.Blobs.Aws.Tests.Unit/`, `tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs`
+- **Approach:** Implement the interface using the SDK presigned API (`GetPreSignedURL` / `GetPreSignedUrlRequest` with `Verb = HttpVerb.GET`/`PUT`, `Expires = clock.UtcNow + expiry`), building bucket+key via the existing `_BuildObjectKey` path. No new options. The R2-configured client (U5) produces R2-host URLs automatically.
+- **Patterns to follow:** existing key/bucket construction and `IClock` usage in `AwsBlobStorage.cs`.
+- **Test suite design:** Unit for URL composition (verb, expiry, host) with a configured client; integration round-trip against LocalStack (supports presigned GET/PUT) in the AWS integration project.
+- **Test scenarios:**
+  - Covers AE5, R14. Generate download URL, fetch with an unauthenticated HTTP client before expiry → 200 with object bytes.
+  - Covers AE5, R14. Fetch the same URL after expiry → denied.
+  - Covers R14. Generate upload (PUT) URL, PUT bytes through it unauthenticated → object readable via normal download.
+  - Presigned URL host/path reflects `ForcePathStyle` and the configured endpoint.
+- **Verification:** Planned tests added and passing; AWS integration round-trip green locally.
+
+### U4. R2 package: options + naming normalizer
+
+- **Goal:** Create the package with its options surface and R2-correct bucket naming.
+- **Requirements:** R1, R3, R5
+- **Dependencies:** none
+- **Files:** `src/Headless.Blobs.CloudflareR2/Headless.Blobs.CloudflareR2.csproj`, `src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs`, `src/Headless.Blobs.CloudflareR2/R2BlobNamingNormalizer.cs`, `tests/Headless.Blobs.CloudflareR2.Tests.Unit/`
+- **Approach:** New project on `Headless.NET.Sdk`, referencing `Headless.Blobs.Aws` (transitively the abstractions). `R2BlobStorageOptions`: `AccountId`, `AccessKeyId`, `SecretAccessKey`, optional `Jurisdiction` (enum default/EU/FedRAMP), optional explicit `EndpointUrl`; `internal sealed` FluentValidation validator requiring account id + keys (correctness gate, no I/O — see `docs/solutions/architecture-patterns/startup-validation-gate-two-tier-mode-and-env-defaults.md`). `R2BlobNamingNormalizer` mirrors `AwsBlobNamingNormalizer` but strips dots and enforces 3–63 lowercase/digit/hyphen. Attach the project to `headless-framework.slnx`.
+- **Patterns to follow:** `src/Headless.Blobs.Aws/AwsBlobNamingNormalizer.cs`; options+validator co-location per CLAUDE.md.
+- **Test suite design:** Unit tests in a new `Headless.Blobs.CloudflareR2.Tests.Unit`.
+- **Test scenarios:**
+  - Covers R5. Container name with dots → dots removed; uppercase → lowercased; >63 chars → truncated; <3 chars → padded.
+  - Covers R5. Name with invalid characters → stripped to the allowed set.
+  - Covers R3. Validator fails when account id / access key / secret key is missing or blank; passes when all present.
+  - Endpoint derivation: jurisdiction default/EU/FedRAMP produces the expected host; explicit `EndpointUrl` overrides jurisdiction.
+- **Verification:** Planned tests added and passing; project builds under warnings-as-errors and is in the solution.
+
+### U5. R2 setup / DI
+
+- **Goal:** Wire `AddCloudflareR2BlobStorage` to build the R2 client, apply R2-safe defaults, and reuse the engine.
+- **Requirements:** R1, R2, R3, R4
+- **Dependencies:** U2, U4
+- **Files:** `src/Headless.Blobs.CloudflareR2/Setup.cs`, `tests/Headless.Blobs.CloudflareR2.Tests.Unit/`
+- **Approach:** `extension(IServiceCollection services)` block exposing the trio (`IConfiguration` / `Action<R2BlobStorageOptions>` / `Action<R2BlobStorageOptions, IServiceProvider>`), each delegating to a private `_AddCloudflareR2Core`. Core: register options via `services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>` (`Headless.Hosting`); register a singleton `IAmazonS3` built from the options as an `AmazonS3Config` per KTD2 with `BasicAWSCredentials`; configure `AwsBlobStorageOptions` with R2-safe defaults (R4, `AutoCreateContainer = false`); `TryAddSingleton<IBlobNamingNormalizer, R2BlobNamingNormalizer>`; `AddSingleton<IBlobStorage, AwsBlobStorage>`.
+- **Patterns to follow:** `src/Headless.Blobs.Aws/Setup.cs` (S3 client + `IBlobStorage` registration); the trio shape in `src/Headless.Blobs.Azure/Setup.cs`; keyed-vs-unkeyed `IAmazonS3` guidance in `docs/solutions/conventions/keyed-services-for-overridable-abstractions.md` if R2 must coexist with an app-wide S3 client.
+- **Test suite design:** Unit tests resolving the service provider and asserting registrations + config values (no network).
+- **Test scenarios:**
+  - Covers R2. Resolved `IAmazonS3` config has the R2 `ServiceURL`, `ForcePathStyle = true`, region `auto`, and checksum settings `WHEN_REQUIRED`.
+  - Covers R4. Resolved `AwsBlobStorageOptions` has `CannedAcl = null`, `UseChunkEncoding = false`, `DisablePayloadSigning = true`, `AutoCreateContainer = false`.
+  - Covers R1. `IBlobStorage` resolves to `AwsBlobStorage`; `R2BlobNamingNormalizer` is the registered normalizer.
+  - Covers R3. Each overload (config section, action, action+provider) registers and validates options.
+  - Resolved `IBlobStorage` is assignable to `IPresignedUrlBlobStorage` (R2 inherits presigned via the engine).
+- **Verification:** Planned tests added and passing.
+
+### U6. Azure presigned via SAS
+
+- **Goal:** Implement `IPresignedUrlBlobStorage` on `AzureBlobStorage`.
+- **Requirements:** R9, R10, R14
+- **Dependencies:** U1
+- **Files:** `src/Headless.Blobs.Azure/AzureBlobStorage.cs`, `tests/Headless.Blobs.Azure.Tests.Unit/`, `tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs`
+- **Approach:** Implement the interface using `BlobClient.GenerateSasUri(BlobSasBuilder)` for the account-key path; map download→`BlobSasPermissions.Read`, upload→`Write` (`Create`), `ExpiresOn = clock.UtcNow + expiry`. Before generating, check `CanGenerateSasUri`; when false, throw `InvalidOperationException` with a message explaining the client lacks signing credentials (KTD8). User-delegation-key support (AAD-wired clients) may be added behind the same method via the async delegation-key call; scope the call-time path to account-key first and note delegation as follow-up if the injected client is AAD-only.
+- **Patterns to follow:** `BlobContainerClient`/`BlobClient` derivation in `src/Headless.Blobs.Azure/AzureBlobStorage.cs:586-587`.
+- **Test suite design:** Unit for the `CanGenerateSasUri == false` throw path (mock/stub client); integration round-trip against Azurite (account-key connection → `CanGenerateSasUri` true) in the Azure integration project.
+- **Test scenarios:**
+  - Covers R10, KTD8. Client without signing credentials → presigned call throws `InvalidOperationException`.
+  - Covers AE5, R14. Account-key client: generate download SAS, fetch before expiry → 200; after expiry → denied.
+  - Covers R14. Generate upload SAS, PUT through it → object readable.
+- **Verification:** Planned tests added and passing; Azurite round-trip green locally.
+
+### U7. R2 conformance test project (creds-gated)
+
+- **Goal:** Run the cross-provider conformance suite against real R2.
+- **Requirements:** R12
+- **Dependencies:** U5
+- **Files:** `tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj`, `tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageFixture.cs`, `tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs`
+- **Approach:** New `Headless.NET.Sdk.Test` project referencing `Headless.Blobs.Tests.Harness`, `Headless.Blobs.CloudflareR2`, and `Headless.Testing`. The fixture reads R2 creds from env vars and builds the R2-configured `AwsBlobStorage`; when creds are absent, every scenario calls `Assert.Skip`. The test class re-declares the `BlobStorageTestsBase` scenarios with `[Fact]` and `base.<name>()` (no Testcontainer — there is no R2 emulator). Add an R2-specific presigned round-trip scenario beyond the base suite.
+- **Patterns to follow:** `tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs` (re-declare-and-delegate); `tests/Headless.Blobs.Tests.Harness/BlobStorageTestsBase.cs` (`GetStorage()` seam). Do not copy fixtures across projects (CLAUDE.md anti-pattern).
+- **Test suite design:** This unit *is* the integration suite; it owns R2 conformance. Skip-when-no-creds keeps local/PR runs green.
+- **Test scenarios:**
+  - Covers R12. Full `BlobStorageTestsBase` suite passes against real R2 when creds are present.
+  - Covers R12. With creds absent, the suite skips (does not fail).
+  - R2 presigned GET/PUT round-trip against the real endpoint (validates KTD2 checksum settings don't break signed access).
+- **Verification:** Suite green against a real R2 bucket with creds; skips cleanly without.
+
+### U8. CI: creds-gated R2 conformance workflow + Dependabot group
+
+- **Goal:** Run R2 conformance as a check on AWS SDK bumps.
+- **Requirements:** R13
+- **Dependencies:** U7
+- **Files:** `.github/workflows/r2-conformance.yml` (new), `.github/dependabot.yml`
+- **Approach:** New workflow triggered on PRs that touch `Directory.Packages.props` (or carry an `aws-sdk` label), running `make test-project TEST_PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/...` with R2 creds from repo secrets behind a protected GitHub Environment; the suite self-skips when secrets are unset (forks). Add an `AWSSDK.*`-keyed group to the `nuget` ecosystem in `dependabot.yml` so SDK bumps arrive as a distinct PR rather than folded into `nuget-minor-patch`. Marking the check "required" is branch-protection config — document it in U9, do not attempt in-repo.
+- **Patterns to follow:** existing job/Environment usage in `.github/workflows/ci.yml`; the grouped-ecosystem shape in `.github/dependabot.yml`.
+- **Test scenarios:** Test expectation: none -- CI configuration; validated by the workflow running green on a test PR that bumps an `AWSSDK.*` version.
+- **Verification:** Workflow parses and runs on a synthetic AWS-SDK-bump PR; skips on a fork without secrets; Dependabot config validates.
+
+### U9. Documentation
+
+- **Goal:** Sync agent-facing docs and READMEs with the new surface.
+- **Requirements:** R15
+- **Dependencies:** U3, U5, U6
+- **Files:** `docs/llms/blobs.md`, `src/Headless.Blobs.Aws/README.md`, `src/Headless.Blobs.Azure/README.md`, `src/Headless.Blobs.CloudflareR2/README.md`
+- **Approach:** Add the `Headless.Blobs.CloudflareR2` section to `docs/llms/blobs.md` (problem solved, setup, config, R2-safe defaults, presigned). Document the `IPresignedUrlBlobStorage` capability and the auto-create behavior change in the Aws/Azure surfaces. Document the Azure SAS signing-credential requirement (KTD8) and the R2 object-token / pre-create-bucket limitation. Fix the stale `BucketName` Quick Start in the AWS README. Add the branch-protection "make the R2 check required" manual setup note. Follow `docs/authoring/AUTHORING.md` and keep `docs/llms/blobs.md` ↔ READMEs in lockstep.
+- **Patterns to follow:** existing provider sections in `docs/llms/blobs.md`; `src/Headless.Blobs.Aws/README.md` structure.
+- **Test scenarios:** Test expectation: none -- documentation.
+- **Verification:** Docs build/lint clean; llms ↔ README parity holds; no remaining `BucketName` reference.
+
+---
+
+## Testing Strategy
+
+- **Unit** (`Headless.Blobs.Aws.Tests.Unit`, `Headless.Blobs.Azure.Tests.Unit`, new `Headless.Blobs.CloudflareR2.Tests.Unit`): engine flag/cache logic with mocked `IAmazonS3`, presigned URL composition, the Azure no-signing throw path, R2 normalizer/options/validator, R2 DI registration assertions.
+- **Integration** (`Headless.Blobs.Aws.Tests.Integration` on LocalStack, `Headless.Blobs.Azure.Tests.Integration` on Azurite): behavior of the engine refactor and presigned GET/PUT round trips. These run locally via `make test-integration`; CI does not run them today.
+- **Conformance** (new `Headless.Blobs.CloudflareR2.Tests.Integration`): reuses `BlobStorageTestsBase` against real R2, creds-gated with `Assert.Skip`. No R2 emulator exists, so this is the authoritative R2 signal and the only suite wired into CI (U8).
+- New infrastructure: the creds-gated R2 fixture (no Testcontainer) and the R2 unit test project. All other suites reuse existing harness/fixtures.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later** (carried from origin)
+
+- Public / CDN access, including R2 custom domains and `r2.dev`. Does not help presigned URLs (SigV4 and SAS bind to the storage host).
+- Multipart upload / large-file streaming refactor. The single-PUT ~5 GiB cap and in-memory buffering of non-seekable streams remain.
+- Presigned POST-form and multipart-part URLs (ride with the multipart work).
+- Scheduled / nightly conformance runs (bump-PR-only by decision).
+- Multi-account named R2 clients and keyed-DI factories.
+
+**Deferred to Follow-Up Work**
+
+- Azure user-delegation-key (AAD-wired client) presigned path, if the account-key path in U6 proves insufficient for a consumer.
+- Migrating the Blobs feature to the unified `Headless{Feature}SetupBuilder` pattern — out of scope; R2 follows the existing plain-extension convention (see `docs/solutions/architecture-patterns/unified-provider-setup-builder-pattern.md`).
+- Capturing the R2 checksum/signing resolution and presigned design as `docs/solutions/` entries once the work lands (via `x-compound`).
+
+---
+
+## Risks & Dependencies
+
+- **SDK checksum resolution unverified against live R2.** KTD2's config-level lever is ~90% confident on `4.0.23.3`; only a real R2 round-trip (U7) confirms it. Fallback is per-request `DisableDefaultChecksumValidation`. Mitigation: U7 runs before declaring R2 done.
+- **`AWSSDK.S3` is centrally shared** (`Directory.Packages.props:21-22`) across Blobs.Aws/SES/SNS/SQS; no separate pin for R2. Durability rests on KTD2's explicit config plus the U8 bump gate.
+- **Azure SAS depends on consumer client wiring.** A `BlobServiceClient` built from a bare SAS-token or anonymous connection cannot sign; KTD8 surfaces this as a clear runtime error, documented in U9.
+- **R2 object-scoped tokens cannot create buckets.** R2 defaults `AutoCreateContainer = false`; pre-creating buckets out of band is a documented requirement, not a bug.
+- **Engine refactor changes existing AWS provider behavior** (R6–R8). Accepted as greenfield; U2 updates existing AWS tests.
+- **CI integration testing is greenfield** (KTD9). The U8 workflow is net-new and the "required check" step is out-of-repo branch protection.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R7.** R2 storage (auto-create off), bucket missing. **When** a blob is uploaded, **then** the call fails with a clear bucket-not-found error rather than creating the bucket. (U2)
+- AE2. **Covers R6.** Bucket missing. **When** `GetBlobInfoAsync` or `OpenReadStreamAsync` is called, **then** it returns null instead of throwing. (U2)
+- AE3. **Covers R8.** AWS storage (auto-create on). **When** 100 blobs are uploaded to the same bucket, **then** the bucket existence/create call is issued at most once. (U2)
+- AE4. **Covers R11.** FileSystem storage. **When** a consumer evaluates `storage is IPresignedUrlBlobStorage`, **then** the result is false and no exception is thrown. (U1)
+- AE5. **Covers R9, R10.** A presigned download URL is generated with a short expiry. **When** an unauthenticated client fetches it before expiry, **then** it receives the object; after expiry, **then** the request is denied. (U3, U6)
+
+---
+
+## Documentation / Operational Notes
+
+- New repo secrets for U8 (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`), placed behind a protected GitHub Environment as the push jobs already do.
+- Branch-protection: mark the R2 conformance check required on `AWSSDK.*` bump PRs — a manual GitHub setting, documented in U9, not expressible in-repo.
+- `docs/llms/blobs.md` and the provider READMEs must stay in lockstep per `docs/authoring/AUTHORING.md`.
+
+---
+
+## Sources / Research
+
+- `src/Headless.Blobs.Aws/AwsBlobStorage.cs` — per-op bucket dance: upload auto-create (`:69`), copy create (`:387`), `_ExistsAsync` pre-check (`:468`) reached by download (`:506`) and delete (`:179`); non-seekable buffering (`:82`).
+- `src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs`, `src/Headless.Blobs.Aws/Setup.cs` — existing options + the AWS-outlier setup shape.
+- `src/Headless.Blobs.Abstractions/IBlobStorage.cs` — no URL surface today.
+- `src/Headless.Blobs.Azure/AzureBlobStorage.cs:18-26,586-587`, `src/Headless.Blobs.Azure/Setup.cs` — injected `BlobServiceClient`, SAS feasibility tied to client wiring.
+- `tests/Headless.Blobs.Tests.Harness/BlobStorageTestsBase.cs` — `GetStorage()` seam; `tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs` — re-declare-and-delegate fixture pattern.
+- `.github/workflows/ci.yml` (build/pack/push only, no integration tests), `.github/dependabot.yml` (grouped nuget bumps), `Makefile:115,163-169` (`test-project`, `test-integration`), `Directory.Packages.props:21-22` (`AWSSDK.*`).
+- `docs/solutions/best-practices/storage-initializer-lifecycle-correctness.md` (idempotent create + existence cache), `docs/solutions/architecture-patterns/startup-validation-gate-two-tier-mode-and-env-defaults.md` (correctness-vs-diagnostic validation), `docs/solutions/conventions/keyed-services-for-overridable-abstractions.md` (keyed `IAmazonS3` if coexisting with app-wide S3).
+- Reference `Alos-no/Cloudflare.NET`: `src/Cloudflare.NET.R2/R2ClientFactory.cs` (R2 config = `ServiceURL` + `ForcePathStyle=true` + `AuthenticationRegion="auto"`); `src/Cloudflare.NET.R2/R2Client.cs:133,226` (per-request `DisablePayloadSigning` + `DisableDefaultChecksumValidation`); pins `AWSSDK.S3 4.0.7.1`.
+- Verified in `AWSSDK.S3 4.0.23.3` / `AWSSDK.Core 4.0.7.1`: `ClientConfig.RequestChecksumCalculation` / `ResponseChecksumValidation` (`WHEN_REQUIRED` / `WHEN_SUPPORTED`), `AmazonS3Config.ForcePathStyle`, `PutObjectRequest` / `UploadPartRequest.DisableDefaultChecksumValidation` and `.DisablePayloadSigning`.

--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -42,6 +42,7 @@
         <Project Path="src\Headless.Blobs.Abstractions\Headless.Blobs.Abstractions.csproj" />
         <Project Path="src\Headless.Blobs.Aws\Headless.Blobs.Aws.csproj" />
         <Project Path="src\Headless.Blobs.Azure\Headless.Blobs.Azure.csproj" />
+        <Project Path="src\Headless.Blobs.CloudflareR2\Headless.Blobs.CloudflareR2.csproj" />
         <Project Path="src\Headless.Blobs.FileSystem\Headless.Blobs.FileSystem.csproj" />
         <Project Path="src\Headless.Blobs.Redis\Headless.Blobs.Redis.csproj" />
         <Project Path="src\Headless.Blobs.SshNet\Headless.Blobs.SshNet.csproj" />
@@ -53,6 +54,7 @@
         <Project Path="tests\Headless.Blobs.Aws.Tests.Unit\Headless.Blobs.Aws.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Blobs.Azure.Tests.Integration\Headless.Blobs.Azure.Tests.Integration.csproj" />
         <Project Path="tests\Headless.Blobs.Azure.Tests.Unit\Headless.Blobs.Azure.Tests.Unit.csproj" />
+        <Project Path="tests\Headless.Blobs.CloudflareR2.Tests.Unit\Headless.Blobs.CloudflareR2.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Blobs.FileSystem.Tests.Integration\Headless.Blobs.FileSystem.Tests.Integration.csproj" />
         <Project Path="tests\Headless.Blobs.FileSystem.Tests.Unit\Headless.Blobs.FileSystem.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Blobs.Redis.Tests.Integration\Headless.Blobs.Redis.Tests.Integration.csproj" />

--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -54,6 +54,7 @@
         <Project Path="tests\Headless.Blobs.Aws.Tests.Unit\Headless.Blobs.Aws.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Blobs.Azure.Tests.Integration\Headless.Blobs.Azure.Tests.Integration.csproj" />
         <Project Path="tests\Headless.Blobs.Azure.Tests.Unit\Headless.Blobs.Azure.Tests.Unit.csproj" />
+        <Project Path="tests\Headless.Blobs.CloudflareR2.Tests.Integration\Headless.Blobs.CloudflareR2.Tests.Integration.csproj" />
         <Project Path="tests\Headless.Blobs.CloudflareR2.Tests.Unit\Headless.Blobs.CloudflareR2.Tests.Unit.csproj" />
         <Project Path="tests\Headless.Blobs.FileSystem.Tests.Integration\Headless.Blobs.FileSystem.Tests.Integration.csproj" />
         <Project Path="tests\Headless.Blobs.FileSystem.Tests.Unit\Headless.Blobs.FileSystem.Tests.Unit.csproj" />

--- a/src/Headless.Blobs.Abstractions/IPresignedUrlBlobStorage.cs
+++ b/src/Headless.Blobs.Abstractions/IPresignedUrlBlobStorage.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Blobs;
+
+/// <summary>
+/// Optional capability for blob backends that can mint time-limited, pre-authenticated URLs granting direct
+/// access to a private blob without proxying the bytes through the application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a capability interface, not part of <see cref="IBlobStorage"/>: only backends with a native signing
+/// mechanism implement it (S3 SigV4 for AWS and Cloudflare R2, SAS for Azure). Backends with no URL concept
+/// (file system, Redis, SSH) deliberately do not implement it.
+/// </para>
+/// <para>
+/// Consumers feature-detect the capability instead of relying on a runtime failure:
+/// <code>
+/// if (storage is IPresignedUrlBlobStorage presigned)
+/// {
+///     var url = await presigned.GetPresignedDownloadUrlAsync(container, blobName, TimeSpan.FromMinutes(15));
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// Implementing the interface advertises that the backend <i>can</i> sign URLs; it does not guarantee every
+/// configuration can. A backend whose client was wired without signing credentials may throw
+/// <see cref="InvalidOperationException"/> at call time.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public interface IPresignedUrlBlobStorage
+{
+    /// <summary>
+    /// Creates a pre-authenticated URL that allows downloading (HTTP GET) the specified blob until it expires.
+    /// </summary>
+    /// <param name="container">Container path segments.</param>
+    /// <param name="blobName">Name of the blob the URL grants access to.</param>
+    /// <param name="expiry">How long the URL remains valid, measured from now.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A signed, time-limited URL for downloading the blob.</returns>
+    ValueTask<Uri> GetPresignedDownloadUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Creates a pre-authenticated URL that allows uploading (HTTP PUT) to the specified blob key until it expires.
+    /// </summary>
+    /// <param name="container">Container path segments.</param>
+    /// <param name="blobName">Name of the blob the URL grants write access to.</param>
+    /// <param name="expiry">How long the URL remains valid, measured from now.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A signed, time-limited URL for uploading the blob.</returns>
+    ValueTask<Uri> GetPresignedUploadUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Headless.Blobs.Aws/AwsBlobStorage.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorage.cs
@@ -23,6 +23,7 @@ public sealed class AwsBlobStorage(
     IMimeTypeProvider mimeTypeProvider,
     IClock clock,
     IOptions<AwsBlobStorageOptions> optionsAccessor,
+    IBlobNamingNormalizer normalizer,
     ILogger<AwsBlobStorage>? logger = null
 ) : IBlobStorage, IPresignedUrlBlobStorage
 {
@@ -786,7 +787,7 @@ public sealed class AwsBlobStorage(
 
     #region Build Urls
 
-    private static (string Bucket, string ObjectKey) _BuildObjectKey(string blobName, string[] container)
+    private (string Bucket, string ObjectKey) _BuildObjectKey(string blobName, string[] container)
     {
         Argument.IsNotNullOrWhiteSpace(blobName);
         Argument.IsNotNullOrEmpty(container);
@@ -794,16 +795,21 @@ public sealed class AwsBlobStorage(
         PathValidation.ValidateContainer(container);
         PathValidation.ValidatePathSegment(blobName);
 
-        var bucket = container[0];
-        var objectKey = Url.Combine([.. container.Skip(1).Append(blobName)]);
+        // Two-tier naming: the first segment is the bucket (strict S3/R2 bucket rules); the remaining segments and
+        // the blob name form the object key (lenient path-segment rules).
+        var bucket = normalizer.NormalizeContainerName(container[0]);
+        var objectKey = Url.Combine([
+            .. container.Skip(1).Select(normalizer.NormalizeBlobName),
+            normalizer.NormalizeBlobName(blobName),
+        ]);
 
         return (bucket, objectKey);
     }
 
-    private static string _BuildBucketName(string[] container)
+    private string _BuildBucketName(string[] container)
     {
         PathValidation.ValidateContainer(container);
-        return container[0];
+        return normalizer.NormalizeContainerName(container[0]);
     }
 
     #endregion

--- a/src/Headless.Blobs.Aws/AwsBlobStorage.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorage.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text.RegularExpressions;
 using Amazon.S3;
@@ -31,13 +32,48 @@ public sealed class AwsBlobStorage(
     private readonly AwsBlobStorageOptions _options = optionsAccessor.Value;
     private readonly ILogger _logger = logger ?? NullLogger<AwsBlobStorage>.Instance;
 
+    // Buckets this instance has already ensured exist, so the HeadBucket/PutBucket round trip runs at most once
+    // per bucket rather than on every upload/copy. A bucket is recorded only after a successful ensure, so a
+    // failed ensure is naturally retried. The lock serializes concurrent first-time ensures into a single create.
+    private readonly ConcurrentDictionary<string, byte> _ensuredBuckets = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _ensureBucketLock = new(1, 1);
+
     #region Create Container
 
     public async ValueTask CreateContainerAsync(string[] container, CancellationToken cancellationToken = default)
     {
         Argument.IsNotNullOrEmpty(container);
 
-        await _CreateBucketAsync(_BuildBucketName(container), cancellationToken);
+        // Explicit creation always runs regardless of AutoCreateContainer; it also primes the per-instance cache.
+        await _EnsureBucketOnceAsync(_BuildBucketName(container), cancellationToken);
+    }
+
+    private async Task _EnsureBucketOnceAsync(string bucketName, CancellationToken cancellationToken)
+    {
+        if (_ensuredBuckets.ContainsKey(bucketName))
+        {
+            return;
+        }
+
+        await _ensureBucketLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            // Re-check under the lock: a concurrent caller may have ensured this bucket while we waited.
+            if (_ensuredBuckets.ContainsKey(bucketName))
+            {
+                return;
+            }
+
+            await _CreateBucketAsync(bucketName, cancellationToken).ConfigureAwait(false);
+
+            // Record only after a successful create so a failed ensure is retried next time.
+            _ensuredBuckets.TryAdd(bucketName, 0);
+        }
+        finally
+        {
+            _ensureBucketLock.Release();
+        }
     }
 
     private async Task _CreateBucketAsync(string bucketName, CancellationToken cancellationToken)
@@ -66,8 +102,12 @@ public sealed class AwsBlobStorage(
         Argument.IsNotNullOrEmpty(blobName);
         Argument.IsNotNullOrEmpty(container);
 
-        await CreateContainerAsync(container, cancellationToken);
         var (bucket, objectKey) = _BuildObjectKey(blobName, container);
+
+        if (_options.AutoCreateContainer)
+        {
+            await _EnsureBucketOnceAsync(bucket, cancellationToken);
+        }
 
         Stream inputStream;
         var ownsStream = false;
@@ -383,8 +423,11 @@ public sealed class AwsBlobStorage(
         var (oldBucket, oldKey) = _BuildObjectKey(blobName, blobContainer);
         var (newBucket, newKey) = _BuildObjectKey(newBlobName, newBlobContainer);
 
-        // Ensure new bucket exists
-        await _CreateBucketAsync(newBucket, cancellationToken);
+        // Ensure new bucket exists (once per bucket per instance) when auto-create is enabled.
+        if (_options.AutoCreateContainer)
+        {
+            await _EnsureBucketOnceAsync(newBucket, cancellationToken);
+        }
 
         var request = new CopyObjectRequest
         {
@@ -464,18 +507,13 @@ public sealed class AwsBlobStorage(
 
     private async ValueTask<bool> _ExistsAsync(string bucket, string key, CancellationToken cancellationToken = default)
     {
-        // Make sure Blob Container exists.
-        if (!await AmazonS3Util.DoesS3BucketExistV2Async(s3, bucket).ConfigureAwait(false))
-        {
-            return false;
-        }
-
         GetObjectMetadataResponse? response;
 
         try
         {
             response = await s3.GetObjectMetadataAsync(bucket, key, cancellationToken).ConfigureAwait(false);
         }
+        // A missing object or a missing bucket both surface as 404 here.
         catch (AmazonS3Exception e) when (e.StatusCode is HttpStatusCode.NotFound)
         {
             return false;
@@ -503,14 +541,19 @@ public sealed class AwsBlobStorage(
     {
         var (bucket, key) = _BuildObjectKey(blobName, container);
 
-        if (!await _ExistsAsync(bucket, key, cancellationToken).ConfigureAwait(false))
+        var request = new GetObjectRequest { BucketName = bucket, Key = key };
+
+        GetObjectResponse response;
+
+        try
+        {
+            response = await s3.GetObjectAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        // A missing object or a missing bucket both surface as 404 here.
+        catch (AmazonS3Exception e) when (e.StatusCode is HttpStatusCode.NotFound)
         {
             return null;
         }
-
-        var request = new GetObjectRequest { BucketName = bucket, Key = key };
-
-        var response = await s3.GetObjectAsync(request, cancellationToken).ConfigureAwait(false);
 
         if (response.HttpStatusCode is HttpStatusCode.NotFound)
         {
@@ -816,7 +859,12 @@ public sealed class AwsBlobStorage(
 
     #region Dispose
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync()
+    {
+        _ensureBucketLock.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
 
     #endregion
 }

--- a/src/Headless.Blobs.Aws/AwsBlobStorage.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorage.cs
@@ -10,6 +10,7 @@ using Headless.Blobs.Internals;
 using Headless.Checks;
 using Headless.IO;
 using Headless.Primitives;
+using Headless.Threading;
 using Headless.Urls;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,9 +34,10 @@ public sealed class AwsBlobStorage(
 
     // Buckets this instance has already ensured exist, so the HeadBucket/PutBucket round trip runs at most once
     // per bucket rather than on every upload/copy. A bucket is recorded only after a successful ensure, so a
-    // failed ensure is naturally retried. The lock serializes concurrent first-time ensures into a single create.
+    // failed ensure is naturally retried. The per-bucket lock serializes concurrent first-time ensures of the
+    // same bucket into a single create while letting distinct buckets be ensured in parallel.
     private readonly ConcurrentDictionary<string, byte> _ensuredBuckets = new(StringComparer.Ordinal);
-    private readonly SemaphoreSlim _ensureBucketLock = new(1, 1);
+    private readonly KeyedAsyncLock _ensureBucketLock = new();
 
     #region Create Container
 
@@ -54,9 +56,7 @@ public sealed class AwsBlobStorage(
             return;
         }
 
-        await _ensureBucketLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        using (await _ensureBucketLock.LockAsync(bucketName, cancellationToken).ConfigureAwait(false))
         {
             // Re-check under the lock: a concurrent caller may have ensured this bucket while we waited.
             if (_ensuredBuckets.ContainsKey(bucketName))
@@ -68,10 +68,6 @@ public sealed class AwsBlobStorage(
 
             // Record only after a successful create so a failed ensure is retried next time.
             _ensuredBuckets.TryAdd(bucketName, 0);
-        }
-        finally
-        {
-            _ensureBucketLock.Release();
         }
     }
 

--- a/src/Headless.Blobs.Aws/AwsBlobStorage.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorage.cs
@@ -24,7 +24,7 @@ public sealed class AwsBlobStorage(
     IClock clock,
     IOptions<AwsBlobStorageOptions> optionsAccessor,
     ILogger<AwsBlobStorage>? logger = null
-) : IBlobStorage
+) : IBlobStorage, IPresignedUrlBlobStorage
 {
     private const string _DefaultCacheControl = "must-revalidate, max-age=7776000";
     private const string _MetaDataHeaderPrefix = "x-amz-meta-";
@@ -853,6 +853,56 @@ public sealed class AwsBlobStorage(
         )
             ? value
             : DateTimeOffset.MinValue;
+    }
+
+    #endregion
+
+    #region Presigned Urls
+
+    public ValueTask<Uri> GetPresignedDownloadUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _GetPresignedUrlAsync(container, blobName, expiry, HttpVerb.GET, cancellationToken);
+    }
+
+    public ValueTask<Uri> GetPresignedUploadUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _GetPresignedUrlAsync(container, blobName, expiry, HttpVerb.PUT, cancellationToken);
+    }
+
+    private async ValueTask<Uri> _GetPresignedUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        HttpVerb verb,
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var (bucket, key) = _BuildObjectKey(blobName, container);
+
+        var request = new GetPreSignedUrlRequest
+        {
+            BucketName = bucket,
+            Key = key,
+            Verb = verb,
+            // SigV4 presigning is performed locally; Expires is the absolute deadline.
+            Expires = clock.UtcNow.Add(expiry).UtcDateTime,
+        };
+
+        var url = await s3.GetPreSignedURLAsync(request).ConfigureAwait(false);
+
+        return new Uri(url);
     }
 
     #endregion

--- a/src/Headless.Blobs.Aws/AwsBlobStorage.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorage.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Text.RegularExpressions;
 using Amazon.S3;
 using Amazon.S3.Model;
-using Amazon.S3.Util;
 using Headless.Abstractions;
 using Headless.Blobs.Internals;
 using Headless.Checks;
@@ -78,13 +77,19 @@ public sealed class AwsBlobStorage(
 
     private async Task _CreateBucketAsync(string bucketName, CancellationToken cancellationToken)
     {
-        if (await AmazonS3Util.DoesS3BucketExistV2Async(s3, bucketName).ConfigureAwait(false))
+        // Idempotent, cancellation-aware create: PutBucket directly (it carries a CancellationToken, unlike the
+        // DoesS3BucketExistV2Async HEAD probe) and treat "already owned by you" as success. The per-instance
+        // cache means this runs at most once per bucket, so a separate existence pre-check is redundant.
+        try
         {
-            return;
+            var request = new PutBucketRequest { BucketName = bucketName };
+            await s3.PutBucketAsync(request, cancellationToken).ConfigureAwait(false);
         }
-
-        var request = new PutBucketRequest { BucketName = bucketName };
-        await s3.PutBucketAsync(request, cancellationToken).ConfigureAwait(false);
+        catch (AmazonS3Exception e)
+            when (string.Equals(e.ErrorCode, "BucketAlreadyOwnedByYou", StringComparison.Ordinal))
+        {
+            // The bucket already exists and we own it.
+        }
     }
 
     #endregion
@@ -888,6 +893,7 @@ public sealed class AwsBlobStorage(
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        Argument.IsPositive(expiry);
 
         var (bucket, key) = _BuildObjectKey(blobName, container);
 

--- a/src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs
@@ -21,7 +21,8 @@ public sealed class AwsBlobStorageOptions
     /// already exist. The check/create runs at most once per bucket per storage instance. Set to
     /// <see langword="false"/> for backends whose credentials cannot create buckets (for example Cloudflare R2
     /// object-scoped tokens); a missing bucket then surfaces as an error from the write operation. Explicit
-    /// <see cref="IBlobStorage.CreateContainerAsync"/> calls always create regardless of this setting.
+    /// <see cref="IBlobStorage.CreateContainerAsync"/> calls ensure the container regardless of this setting
+    /// (the result is cached per instance, so the bucket is not re-probed once ensured).
     /// </summary>
     public bool AutoCreateContainer { get; set; } = true;
 }

--- a/src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs
+++ b/src/Headless.Blobs.Aws/AwsBlobStorageOptions.cs
@@ -15,6 +15,15 @@ public sealed class AwsBlobStorageOptions
 
     /// <summary>Maximum degree of parallelism for bulk operations. Default is 10.</summary>
     public int MaxBulkParallelism { get; set; } = 10;
+
+    /// <summary>
+    /// When <see langword="true"/> (the default), uploads and copies create the target bucket if it does not
+    /// already exist. The check/create runs at most once per bucket per storage instance. Set to
+    /// <see langword="false"/> for backends whose credentials cannot create buckets (for example Cloudflare R2
+    /// object-scoped tokens); a missing bucket then surfaces as an error from the write operation. Explicit
+    /// <see cref="IBlobStorage.CreateContainerAsync"/> calls always create regardless of this setting.
+    /// </summary>
+    public bool AutoCreateContainer { get; set; } = true;
 }
 
 internal sealed class AwsBlobStorageOptionsValidator : AbstractValidator<AwsBlobStorageOptions>

--- a/src/Headless.Blobs.Aws/README.md
+++ b/src/Headless.Blobs.Aws/README.md
@@ -10,7 +10,7 @@ Provides seamless integration with AWS S3 for blob storage using the unified `IB
 
 - Full `IBlobStorage` implementation for AWS S3
 - Bulk upload/delete with optimized batching
-- Automatic path normalization for S3 object keys
+- Two-tier name normalization: the bucket name is normalized to S3 rules; object-key path segments are validated and preserved
 - Metadata support
 - Presigned download/upload URLs via `IPresignedUrlBlobStorage`
 - Opt-in, cached bucket auto-create (`AutoCreateContainer`)

--- a/src/Headless.Blobs.Aws/README.md
+++ b/src/Headless.Blobs.Aws/README.md
@@ -12,7 +12,8 @@ Provides seamless integration with AWS S3 for blob storage using the unified `IB
 - Bulk upload/delete with optimized batching
 - Automatic path normalization for S3 object keys
 - Metadata support
-- Pre-signed URL generation capability
+- Presigned download/upload URLs via `IPresignedUrlBlobStorage`
+- Opt-in, cached bucket auto-create (`AutoCreateContainer`)
 - Integration with AWS SDK configuration
 
 ## Installation
@@ -28,20 +29,20 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Option 1: Use configuration-based AWS options
 var awsOptions = builder.Configuration.GetAWSOptions();
-builder.Services.AddAwsS3BlobStorage(awsOptions, options =>
-{
-    options.BucketName = "my-bucket";
-});
+builder.Services.AddAwsS3BlobStorage(awsOptions);
 
 // Option 2: Manual configuration
 builder.Services.AddAwsS3BlobStorage(new AWSOptions
 {
     Region = RegionEndpoint.USEast1,
     Credentials = new BasicAWSCredentials("access-key", "secret-key")
-}, options =>
-{
-    options.BucketName = "my-bucket";
 });
+```
+
+Buckets and keys are passed per operation, not configured at registration:
+
+```csharp
+await storage.UploadAsync(["my-bucket"], "reports/q1.pdf", stream);
 ```
 
 ## Configuration
@@ -61,7 +62,11 @@ builder.Services.AddAwsS3BlobStorage(new AWSOptions
 ### Options
 
 ```csharp
-options.BucketName = "my-bucket";
+options.AutoCreateContainer = true; // create buckets on upload/copy (default true)
+options.CannedAcl = S3CannedACL.Private;
+options.UseChunkEncoding = true;
+options.DisablePayloadSigning = false;
+options.MaxBulkParallelism = 10;
 ```
 
 ## Dependencies

--- a/src/Headless.Blobs.Aws/Setup.cs
+++ b/src/Headless.Blobs.Aws/Setup.cs
@@ -40,6 +40,11 @@ public static class SetupAwsS3
         services.TryAddSingleton<IBlobNamingNormalizer, AwsBlobNamingNormalizer>();
         services.AddSingleton<IBlobStorage, AwsBlobStorage>();
 
+        // The engine implements IPresignedUrlBlobStorage; expose it for direct injection too (same instance).
+        services.TryAddSingleton<IPresignedUrlBlobStorage>(serviceProvider =>
+            (IPresignedUrlBlobStorage)serviceProvider.GetRequiredService<IBlobStorage>()
+        );
+
         return services;
     }
 }

--- a/src/Headless.Blobs.Azure/AzureBlobStorage.cs
+++ b/src/Headless.Blobs.Azure/AzureBlobStorage.cs
@@ -430,7 +430,7 @@ public sealed class AzureBlobStorage(
         Argument.IsNotNullOrEmpty(container);
 
         var containerClient = blobServiceClient.GetBlobContainerClient(_GetContainer(container));
-        var normalizedDirs = container.Skip(1).Select(_NormalizeContainerName);
+        var normalizedDirs = container.Skip(1).Select(_NormalizeSegment);
         var normalizedPattern = _NormalizeSearchPattern(blobSearchPattern);
         var criteria = BlobStorageHelpers.GetRequestCriteria(normalizedDirs, normalizedPattern);
 
@@ -475,7 +475,7 @@ public sealed class AzureBlobStorage(
         Argument.IsLessThanOrEqualTo(pageSize, int.MaxValue - 1);
 
         var containerClient = blobServiceClient.GetBlobContainerClient(_GetContainer(container));
-        var normalizedDirs = container.Skip(1).Select(_NormalizeContainerName);
+        var normalizedDirs = container.Skip(1).Select(_NormalizeSegment);
         var normalizedPattern = _NormalizeSearchPattern(blobSearchPattern);
         var criteria = BlobStorageHelpers.GetRequestCriteria(normalizedDirs, normalizedPattern);
 
@@ -709,7 +709,8 @@ public sealed class AzureBlobStorage(
                 sb.Append('/');
             }
 
-            sb.Append(_NormalizeContainerName(container[i]));
+            // Two-tier: the first segment is the Azure container (strict rules); the rest are blob-path segments.
+            sb.Append(i == 0 ? _NormalizeContainerName(container[i]) : _NormalizeSegment(container[i]));
         }
 
         var prefix = sb.ToString();
@@ -738,7 +739,8 @@ public sealed class AzureBlobStorage(
                 sb.Append('/');
             }
 
-            sb.Append(_NormalizeContainerName(container[i]));
+            // Sub-path segments use lenient path-segment normalization (two-tier model).
+            sb.Append(_NormalizeSegment(container[i]));
         }
         if (sb.Length > 0)
         {
@@ -761,6 +763,13 @@ public sealed class AzureBlobStorage(
         return _NormalizeSlashes(normalizer.NormalizeContainerName(containerName));
     }
 
+    // Lenient path-segment normalization for sub-container path parts and blob names (two-tier model): the first
+    // container segment is the Azure container (strict rules); everything after is part of the blob path.
+    private string _NormalizeSegment(string segment)
+    {
+        return _NormalizeSlashes(normalizer.NormalizeBlobName(segment));
+    }
+
     private static string _NormalizeSlashes(string x)
     {
         return BlobStorageHelpers.NormalizePath(x).RemovePostfix('/').RemovePrefix('/');
@@ -768,7 +777,7 @@ public sealed class AzureBlobStorage(
 
     /// <summary>
     /// Normalizes the search pattern's directory segments to match how they're stored.
-    /// E.g., "x\*.txt" becomes "x00/*.txt" because "x" is normalized to "x00".
+    /// Directory segments use the same lenient path-segment normalization as stored blob paths (two-tier model).
     /// Only normalizes directory segments, not the final filename/pattern segment.
     /// </summary>
     private string? _NormalizeSearchPattern(string? pattern)
@@ -796,7 +805,7 @@ public sealed class AzureBlobStorage(
             // Don't normalize segments containing wildcards
             if (!segment.Contains('*', StringComparison.Ordinal))
             {
-                segments[i] = normalizer.NormalizeContainerName(segment);
+                segments[i] = normalizer.NormalizeBlobName(segment);
             }
         }
 

--- a/src/Headless.Blobs.Azure/AzureBlobStorage.cs
+++ b/src/Headless.Blobs.Azure/AzureBlobStorage.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Concurrent;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -27,18 +28,50 @@ public sealed class AzureBlobStorage(
 {
     private readonly AzureStorageOptions _option = optionAccessor.Value;
 
+    // Containers this instance has already ensured exist, so CreateIfNotExists runs at most once per container
+    // rather than on every upload/copy. A container is recorded only after a successful create, so a failed
+    // ensure is naturally retried. The lock serializes concurrent first-time ensures into a single create.
+    private readonly ConcurrentDictionary<string, byte> _ensuredContainers = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _ensureContainerLock = new(1, 1);
+
     #region Create Container
 
     public async ValueTask CreateContainerAsync(string[] container, CancellationToken cancellationToken = default)
     {
         Argument.IsNotNullOrEmpty(container);
 
-        var blobContainer = _GetContainer(container);
-        var containerClient = blobServiceClient.GetBlobContainerClient(blobContainer);
+        await _EnsureContainerOnceAsync(_GetContainer(container), cancellationToken);
+    }
 
-        await containerClient
-            .CreateIfNotExistsAsync(_option.ContainerPublicAccessType, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+    private async Task _EnsureContainerOnceAsync(string container, CancellationToken cancellationToken)
+    {
+        if (_ensuredContainers.ContainsKey(container))
+        {
+            return;
+        }
+
+        await _ensureContainerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            // Re-check under the lock: a concurrent caller may have ensured this container while we waited.
+            if (_ensuredContainers.ContainsKey(container))
+            {
+                return;
+            }
+
+            await blobServiceClient
+                .GetBlobContainerClient(container)
+                .CreateIfNotExistsAsync(_option.ContainerPublicAccessType, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            // Record only after a successful create so a failed ensure is retried next time.
+            _ensuredContainers.TryAdd(container, 0);
+        }
+        finally
+        {
+            _ensureContainerLock.Release();
+        }
     }
 
     #endregion
@@ -56,7 +89,7 @@ public sealed class AzureBlobStorage(
         Argument.IsNotNullOrEmpty(blobName);
         Argument.IsNotNullOrEmpty(container);
 
-        if (_option.CreateContainerIfNotExists)
+        if (_option.AutoCreateContainer)
         {
             await CreateContainerAsync(container, cancellationToken).ConfigureAwait(false);
         }
@@ -227,7 +260,7 @@ public sealed class AzureBlobStorage(
         Argument.IsNotNullOrEmpty(newBlobName);
         Argument.IsNotNullOrEmpty(newBlobContainer);
 
-        if (_option.CreateContainerIfNotExists)
+        if (_option.AutoCreateContainer)
         {
             await CreateContainerAsync(newBlobContainer, cancellationToken).ConfigureAwait(false);
         }
@@ -778,7 +811,12 @@ public sealed class AzureBlobStorage(
 
     #region Dispose
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync()
+    {
+        _ensureContainerLock.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
 
     #endregion
 }

--- a/src/Headless.Blobs.Azure/AzureBlobStorage.cs
+++ b/src/Headless.Blobs.Azure/AzureBlobStorage.cs
@@ -11,6 +11,7 @@ using Headless.Blobs.Azure.Internals;
 using Headless.Blobs.Internals;
 using Headless.Checks;
 using Headless.Primitives;
+using Headless.Threading;
 using Headless.Urls;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -30,9 +31,10 @@ public sealed class AzureBlobStorage(
 
     // Containers this instance has already ensured exist, so CreateIfNotExists runs at most once per container
     // rather than on every upload/copy. A container is recorded only after a successful create, so a failed
-    // ensure is naturally retried. The lock serializes concurrent first-time ensures into a single create.
+    // ensure is naturally retried. The per-container lock serializes concurrent first-time ensures of the same
+    // container into a single create while letting distinct containers be ensured in parallel.
     private readonly ConcurrentDictionary<string, byte> _ensuredContainers = new(StringComparer.Ordinal);
-    private readonly SemaphoreSlim _ensureContainerLock = new(1, 1);
+    private readonly KeyedAsyncLock _ensureContainerLock = new();
 
     #region Create Container
 
@@ -50,9 +52,7 @@ public sealed class AzureBlobStorage(
             return;
         }
 
-        await _ensureContainerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        using (await _ensureContainerLock.LockAsync(container, cancellationToken).ConfigureAwait(false))
         {
             // Re-check under the lock: a concurrent caller may have ensured this container while we waited.
             if (_ensuredContainers.ContainsKey(container))
@@ -67,10 +67,6 @@ public sealed class AzureBlobStorage(
 
             // Record only after a successful create so a failed ensure is retried next time.
             _ensuredContainers.TryAdd(container, 0);
-        }
-        finally
-        {
-            _ensureContainerLock.Release();
         }
     }
 

--- a/src/Headless.Blobs.Azure/AzureBlobStorage.cs
+++ b/src/Headless.Blobs.Azure/AzureBlobStorage.cs
@@ -638,6 +638,8 @@ public sealed class AzureBlobStorage(
             BlobName = blobClient.Name,
             Resource = "b",
             ExpiresOn = clock.UtcNow.Add(expiry),
+            // The SAS is a bearer credential; restrict it to HTTPS so it can't be replayed over plaintext HTTP.
+            Protocol = SasProtocol.Https,
         };
 
         builder.SetPermissions(permissions);

--- a/src/Headless.Blobs.Azure/AzureBlobStorage.cs
+++ b/src/Headless.Blobs.Azure/AzureBlobStorage.cs
@@ -620,6 +620,7 @@ public sealed class AzureBlobStorage(
         cancellationToken.ThrowIfCancellationRequested();
         Argument.IsNotNullOrEmpty(blobName);
         Argument.IsNotNullOrEmpty(container);
+        Argument.IsPositive(expiry);
 
         var blobClient = _GetBlobClient(container, blobName);
 

--- a/src/Headless.Blobs.Azure/AzureBlobStorage.cs
+++ b/src/Headless.Blobs.Azure/AzureBlobStorage.cs
@@ -4,6 +4,7 @@ using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Sas;
 using Headless.Abstractions;
 using Headless.Blobs.Azure.Internals;
 using Headless.Blobs.Internals;
@@ -22,7 +23,7 @@ public sealed class AzureBlobStorage(
     IOptions<AzureStorageOptions> optionAccessor,
     IBlobNamingNormalizer normalizer,
     ILogger<AzureBlobStorage> logger
-) : IBlobStorage
+) : IBlobStorage, IPresignedUrlBlobStorage
 {
     private readonly AzureStorageOptions _option = optionAccessor.Value;
 
@@ -579,6 +580,72 @@ public sealed class AzureBlobStorage(
 
     #region Build URLs
 
+
+    #region Presigned Urls
+
+    public ValueTask<Uri> GetPresignedDownloadUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _GetPresignedUrlAsync(container, blobName, expiry, BlobSasPermissions.Read, cancellationToken);
+    }
+
+    public ValueTask<Uri> GetPresignedUploadUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _GetPresignedUrlAsync(
+            container,
+            blobName,
+            expiry,
+            BlobSasPermissions.Create | BlobSasPermissions.Write,
+            cancellationToken
+        );
+    }
+
+    private ValueTask<Uri> _GetPresignedUrlAsync(
+        string[] container,
+        string blobName,
+        TimeSpan expiry,
+        BlobSasPermissions permissions,
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Argument.IsNotNullOrEmpty(blobName);
+        Argument.IsNotNullOrEmpty(container);
+
+        var blobClient = _GetBlobClient(container, blobName);
+
+        if (!blobClient.CanGenerateSasUri)
+        {
+            throw new InvalidOperationException(
+                "The configured BlobServiceClient cannot generate a SAS URI. Presigned URLs require a client built "
+                    + "with an account key (StorageSharedKeyCredential) or a user delegation key; a bare SAS-token or "
+                    + "anonymous connection cannot sign."
+            );
+        }
+
+        var builder = new BlobSasBuilder
+        {
+            BlobContainerName = blobClient.BlobContainerName,
+            BlobName = blobClient.Name,
+            Resource = "b",
+            ExpiresOn = clock.UtcNow.Add(expiry),
+        };
+
+        builder.SetPermissions(permissions);
+
+        return ValueTask.FromResult(blobClient.GenerateSasUri(builder));
+    }
+
+    #endregion
 
     private BlobClient _GetBlobClient(string[] container, string blobName)
     {

--- a/src/Headless.Blobs.Azure/AzureStorageOptions.cs
+++ b/src/Headless.Blobs.Azure/AzureStorageOptions.cs
@@ -7,8 +7,14 @@ namespace Headless.Blobs.Azure;
 
 public sealed class AzureStorageOptions
 {
-    /// <summary>Whether to create the container if it does not already exist.</summary>
-    public bool CreateContainerIfNotExists { get; set; } = true;
+    /// <summary>
+    /// When <see langword="true"/> (the default), uploads and copies create the target container if it does not
+    /// already exist. The check/create runs at most once per container per storage instance. Set to
+    /// <see langword="false"/> for clients whose credentials cannot create containers; a missing container then
+    /// surfaces as an error from the operation. Explicit <see cref="IBlobStorage.CreateContainerAsync"/> calls
+    /// ensure the container regardless of this setting (the result is cached per instance).
+    /// </summary>
+    public bool AutoCreateContainer { get; set; } = true;
 
     /// <summary>Access type when creating a new container if it does not exist.</summary>
     public PublicAccessType ContainerPublicAccessType { get; set; } = PublicAccessType.None;

--- a/src/Headless.Blobs.Azure/README.md
+++ b/src/Headless.Blobs.Azure/README.md
@@ -10,7 +10,7 @@ Provides seamless integration with Azure Blob Storage using the unified `IBlobSt
 
 - Full `IBlobStorage` implementation for Azure Blob Storage
 - Bulk operations with Azure Batch API
-- Container management
+- Opt-in, cached container auto-create (`AutoCreateContainer`)
 - Metadata support
 - Presigned download/upload URLs via `IPresignedUrlBlobStorage` (SAS-based)
 - Integration with Azure.Identity for authentication
@@ -18,6 +18,10 @@ Provides seamless integration with Azure Blob Storage using the unified `IBlobSt
 > Presigned URLs require the registered `BlobServiceClient` to carry signing credentials (an account key or a
 > user-delegation key). A client built from a bare SAS token or an anonymous connection cannot sign, and the
 > presigned call throws `InvalidOperationException` at call time.
+
+> `AutoCreateContainer` (default `true`) creates the target container on upload/copy, at most once per
+> container per instance. Set it to `false` when the client's credentials cannot create containers; a missing
+> container then surfaces as an error. (Renamed from `CreateContainerIfNotExists`.)
 
 ## Installation
 

--- a/src/Headless.Blobs.Azure/README.md
+++ b/src/Headless.Blobs.Azure/README.md
@@ -12,7 +12,12 @@ Provides seamless integration with Azure Blob Storage using the unified `IBlobSt
 - Bulk operations with Azure Batch API
 - Container management
 - Metadata support
+- Presigned download/upload URLs via `IPresignedUrlBlobStorage` (SAS-based)
 - Integration with Azure.Identity for authentication
+
+> Presigned URLs require the registered `BlobServiceClient` to carry signing credentials (an account key or a
+> user-delegation key). A client built from a bare SAS token or an anonymous connection cannot sign, and the
+> presigned call throws `InvalidOperationException` at call time.
 
 ## Installation
 

--- a/src/Headless.Blobs.Azure/Setup.cs
+++ b/src/Headless.Blobs.Azure/Setup.cs
@@ -61,6 +61,11 @@ public static class AddAzureBlobExtensions
             services.TryAddSingleton<IBlobNamingNormalizer, AzureBlobNamingNormalizer>();
             services.AddSingleton<IBlobStorage, AzureBlobStorage>();
 
+            // The provider implements IPresignedUrlBlobStorage; expose it for direct injection too (same instance).
+            services.TryAddSingleton<IPresignedUrlBlobStorage>(serviceProvider =>
+                (IPresignedUrlBlobStorage)serviceProvider.GetRequiredService<IBlobStorage>()
+            );
+
             return services;
         }
     }

--- a/src/Headless.Blobs.CloudflareR2/Headless.Blobs.CloudflareR2.csproj
+++ b/src/Headless.Blobs.CloudflareR2/Headless.Blobs.CloudflareR2.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Headless.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Headless.Blobs.Aws\Headless.Blobs.Aws.csproj" />
+    <ProjectReference Include="..\Headless.Blobs.Abstractions\Headless.Blobs.Abstractions.csproj" />
+    <ProjectReference Include="..\Headless.Core\Headless.Core.csproj" />
+    <ProjectReference Include="..\Headless.Hosting\Headless.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Headless.Blobs.CloudflareR2/R2BlobNamingNormalizer.cs
+++ b/src/Headless.Blobs.CloudflareR2/R2BlobNamingNormalizer.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Text.RegularExpressions;
+using Headless.Blobs.Internals;
+using Headless.Core;
+
+namespace Headless.Blobs.CloudflareR2;
+
+/// <summary>
+/// Normalizes container names to Cloudflare R2 bucket rules: 3–63 characters, lowercase letters, digits, and
+/// hyphens only. Unlike Amazon S3, R2 bucket names may not contain dots.
+/// </summary>
+public sealed partial class R2BlobNamingNormalizer : IBlobNamingNormalizer
+{
+    /// <summary><a href="https://developers.cloudflare.com/r2/buckets/" /></summary>
+    public string NormalizeContainerName(string containerName)
+    {
+        using (CultureHelper.Use(CultureInfo.InvariantCulture))
+        {
+            containerName = containerName.ToLowerInvariant();
+
+            if (containerName.Length > 63)
+            {
+                containerName = containerName[..63];
+            }
+
+            // R2 bucket names allow only lowercase letters, digits, and hyphens (no dots).
+            containerName = _NotAllowedCharactersRegex().Replace(containerName, string.Empty);
+            containerName = _LeadingHyphensRegex().Replace(containerName, string.Empty);
+            containerName = _TrailingHyphensRegex().Replace(containerName, string.Empty);
+
+            if (containerName.Length >= 3)
+            {
+                return containerName;
+            }
+
+            var length = containerName.Length;
+
+            for (var i = 0; i < 3 - length; i++)
+            {
+                containerName += "0";
+            }
+
+            return containerName;
+        }
+    }
+
+    public string NormalizeBlobName(string blobName)
+    {
+        PathValidation.ValidatePathSegment(blobName);
+
+        return blobName;
+    }
+
+    #region Helpers
+
+    [GeneratedRegex("[^a-z0-9-]", RegexOptions.None, 100)]
+    private static partial Regex _NotAllowedCharactersRegex();
+
+    [GeneratedRegex("^-+", RegexOptions.None, 100)]
+    private static partial Regex _LeadingHyphensRegex();
+
+    [GeneratedRegex("-+$", RegexOptions.None, 100)]
+    private static partial Regex _TrailingHyphensRegex();
+
+    #endregion
+}

--- a/src/Headless.Blobs.CloudflareR2/R2BlobNamingNormalizer.cs
+++ b/src/Headless.Blobs.CloudflareR2/R2BlobNamingNormalizer.cs
@@ -19,29 +19,20 @@ public sealed partial class R2BlobNamingNormalizer : IBlobNamingNormalizer
         {
             containerName = containerName.ToLowerInvariant();
 
+            // R2 bucket names allow only lowercase letters, digits, and hyphens (no dots).
+            containerName = _NotAllowedCharactersRegex().Replace(containerName, string.Empty);
+            containerName = _LeadingHyphensRegex().Replace(containerName, string.Empty);
+
+            // Enforce the 63-char ceiling after normalization, then strip any hyphen the truncation may expose.
             if (containerName.Length > 63)
             {
                 containerName = containerName[..63];
             }
 
-            // R2 bucket names allow only lowercase letters, digits, and hyphens (no dots).
-            containerName = _NotAllowedCharactersRegex().Replace(containerName, string.Empty);
-            containerName = _LeadingHyphensRegex().Replace(containerName, string.Empty);
             containerName = _TrailingHyphensRegex().Replace(containerName, string.Empty);
 
-            if (containerName.Length >= 3)
-            {
-                return containerName;
-            }
-
-            var length = containerName.Length;
-
-            for (var i = 0; i < 3 - length; i++)
-            {
-                containerName += "0";
-            }
-
-            return containerName;
+            // R2 bucket names must be at least 3 characters.
+            return containerName.Length >= 3 ? containerName : containerName.PadRight(3, '0');
         }
     }
 

--- a/src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs
+++ b/src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs
@@ -32,7 +32,9 @@ public sealed class R2BlobStorageOptions
     {
         if (!string.IsNullOrWhiteSpace(EndpointUrl))
         {
-            return string.Format(CultureInfo.InvariantCulture, EndpointUrl, AccountId);
+            // Plain token replacement, not string.Format: a custom URL may contain literal braces that are not
+            // a format placeholder, which would otherwise throw FormatException at client construction.
+            return EndpointUrl.Replace("{0}", AccountId, StringComparison.Ordinal);
         }
 
         var infix = Jurisdiction switch

--- a/src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs
+++ b/src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 
 namespace Headless.Blobs.CloudflareR2;
 
+[PublicAPI]
 public sealed class R2BlobStorageOptions
 {
     /// <summary>Cloudflare account id used to build the R2 S3 endpoint. Required.</summary>
@@ -49,6 +50,7 @@ public sealed class R2BlobStorageOptions
 }
 
 /// <summary>Cloudflare R2 jurisdiction, selecting the geographic S3 endpoint.</summary>
+[PublicAPI]
 public enum R2Jurisdiction
 {
     /// <summary>Global endpoint: <c>https://{account}.r2.cloudflarestorage.com</c>.</summary>

--- a/src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs
+++ b/src/Headless.Blobs.CloudflareR2/R2BlobStorageOptions.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using FluentValidation;
+
+namespace Headless.Blobs.CloudflareR2;
+
+public sealed class R2BlobStorageOptions
+{
+    /// <summary>Cloudflare account id used to build the R2 S3 endpoint. Required.</summary>
+    public string AccountId { get; set; } = string.Empty;
+
+    /// <summary>R2 access key id. Required.</summary>
+    public string AccessKeyId { get; set; } = string.Empty;
+
+    /// <summary>R2 secret access key. Required.</summary>
+    public string SecretAccessKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Jurisdiction selecting the R2 endpoint when <see cref="EndpointUrl"/> is not set.
+    /// Defaults to <see cref="R2Jurisdiction.Default"/> (the global endpoint).
+    /// </summary>
+    public R2Jurisdiction Jurisdiction { get; set; } = R2Jurisdiction.Default;
+
+    /// <summary>
+    /// Optional explicit endpoint override. When set, it takes precedence over <see cref="Jurisdiction"/>.
+    /// A <c>{0}</c> placeholder is replaced with <see cref="AccountId"/>.
+    /// </summary>
+    public string? EndpointUrl { get; set; }
+
+    /// <summary>Resolves the effective S3 endpoint URL for this configuration.</summary>
+    public string GetEffectiveEndpointUrl()
+    {
+        if (!string.IsNullOrWhiteSpace(EndpointUrl))
+        {
+            return string.Format(CultureInfo.InvariantCulture, EndpointUrl, AccountId);
+        }
+
+        var infix = Jurisdiction switch
+        {
+            R2Jurisdiction.EuropeanUnion => ".eu",
+            R2Jurisdiction.FedRamp => ".fedramp",
+            _ => string.Empty,
+        };
+
+        return $"https://{AccountId}{infix}.r2.cloudflarestorage.com";
+    }
+}
+
+/// <summary>Cloudflare R2 jurisdiction, selecting the geographic S3 endpoint.</summary>
+public enum R2Jurisdiction
+{
+    /// <summary>Global endpoint: <c>https://{account}.r2.cloudflarestorage.com</c>.</summary>
+    Default = 0,
+
+    /// <summary>European Union endpoint: <c>https://{account}.eu.r2.cloudflarestorage.com</c>.</summary>
+    EuropeanUnion = 1,
+
+    /// <summary>FedRAMP endpoint: <c>https://{account}.fedramp.r2.cloudflarestorage.com</c>.</summary>
+    FedRamp = 2,
+}
+
+internal sealed class R2BlobStorageOptionsValidator : AbstractValidator<R2BlobStorageOptions>
+{
+    public R2BlobStorageOptionsValidator()
+    {
+        RuleFor(x => x.AccountId).NotEmpty();
+        RuleFor(x => x.AccessKeyId).NotEmpty();
+        RuleFor(x => x.SecretAccessKey).NotEmpty();
+    }
+}

--- a/src/Headless.Blobs.CloudflareR2/R2ClientFactory.cs
+++ b/src/Headless.Blobs.CloudflareR2/R2ClientFactory.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Runtime.CompilerServices;
+using Amazon.Runtime;
+using Amazon.S3;
+
+[assembly: InternalsVisibleTo("Headless.Blobs.CloudflareR2.Tests.Integration")]
+
+namespace Headless.Blobs.CloudflareR2;
+
+/// <summary>
+/// Builds the R2-tuned <see cref="IAmazonS3"/>. Centralized so the DI setup and the conformance test fixture
+/// share one source of truth for the R2 client configuration and cannot drift apart.
+/// </summary>
+internal static class R2ClientFactory
+{
+    /// <summary>Cloudflare R2 signs every request against the <c>auto</c> region.</summary>
+    public const string Region = "auto";
+
+    public static IAmazonS3 Create(R2BlobStorageOptions options)
+    {
+        var config = new AmazonS3Config
+        {
+            ServiceURL = options.GetEffectiveEndpointUrl(),
+            ForcePathStyle = true,
+            AuthenticationRegion = Region,
+            // SDK v4 defaults add CRC checksums that R2 rejects; only send them when an operation requires it.
+            RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED,
+            ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
+        };
+
+        return new AmazonS3Client(new BasicAWSCredentials(options.AccessKeyId, options.SecretAccessKey), config);
+    }
+}

--- a/src/Headless.Blobs.CloudflareR2/README.md
+++ b/src/Headless.Blobs.CloudflareR2/README.md
@@ -1,0 +1,85 @@
+# Headless.Blobs.CloudflareR2
+
+Cloudflare R2 implementation of the `IBlobStorage` interface, running R2 as a private, S3-compatible blob backend.
+
+## Problem Solved
+
+R2 speaks the S3 API, but the AWS provider cannot be pointed at it directly: the endpoint, path-style addressing, and AWS SDK v4 checksum defaults all need R2-specific configuration, and R2 has no ACL concept. This package reuses the AWS S3 engine behind an R2-tuned client so R2 works as a drop-in, cost-saving replacement for S3.
+
+## Key Features
+
+- Full `IBlobStorage` implementation for Cloudflare R2 (reuses the AWS S3 engine)
+- Presigned download/upload URLs via `IPresignedUrlBlobStorage`
+- R2-correct client config: path-style addressing, `auto` region, and SDK v4 checksum settings R2 accepts
+- R2 bucket naming normalization (no dots)
+- Jurisdiction-aware endpoints (default, EU, FedRAMP)
+
+## Installation
+
+```bash
+dotnet add package Headless.Blobs.CloudflareR2
+```
+
+## Quick Start
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCloudflareR2BlobStorage(options =>
+{
+    options.AccountId = builder.Configuration["R2:AccountId"]!;
+    options.AccessKeyId = builder.Configuration["R2:AccessKeyId"]!;
+    options.SecretAccessKey = builder.Configuration["R2:SecretAccessKey"]!;
+    // options.Jurisdiction = R2Jurisdiction.EuropeanUnion; // optional
+});
+```
+
+Container and blob names are passed per operation, not configured here:
+
+```csharp
+await storage.UploadAsync(["my-bucket"], "reports/q1.pdf", stream);
+
+// Time-limited delegated access to a private object:
+if (storage is IPresignedUrlBlobStorage presigned)
+{
+    var url = await presigned.GetPresignedDownloadUrlAsync(["my-bucket"], "reports/q1.pdf", TimeSpan.FromMinutes(15));
+}
+```
+
+## Configuration
+
+### appsettings.json
+
+```json
+{
+  "R2": {
+    "AccountId": "your-account-id",
+    "AccessKeyId": "your-access-key-id",
+    "SecretAccessKey": "your-secret-access-key",
+    "Jurisdiction": "Default"
+  }
+}
+```
+
+Bind with `builder.Services.AddCloudflareR2BlobStorage(builder.Configuration.GetSection("R2"))`.
+
+## Behavior Notes
+
+- **Buckets are not auto-created.** R2 API tokens are commonly scoped to object operations and cannot create buckets, so `AutoCreateContainer` defaults to `false`. Pre-create buckets out of band (the Cloudflare dashboard or an account-scoped token), or call `CreateContainerAsync` with a token that has bucket-create permission.
+- **No ACLs / public access.** R2 has no per-object ACLs (`CannedAcl` is `null`). Public serving is a custom-domain / `r2.dev` concern and is out of scope for this provider; use presigned URLs for time-limited private access.
+- **Single PUT is capped at ~5 GiB**, the same as S3.
+
+## Dependencies
+
+- `Headless.Blobs.Aws` (the reused S3 engine)
+- `Headless.Blobs.Abstractions`
+- `Headless.Core`
+- `Headless.Hosting`
+- `AWSSDK.S3`
+
+## Side Effects
+
+- Registers `IAmazonS3` (configured for R2) if not already registered
+- Configures the shared `AwsBlobStorageOptions` with R2-safe defaults
+- Registers `IBlobStorage` (the AWS S3 engine) as singleton
+- Registers `IBlobNamingNormalizer` (R2 rules) as singleton

--- a/src/Headless.Blobs.CloudflareR2/Setup.cs
+++ b/src/Headless.Blobs.CloudflareR2/Setup.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Amazon.Runtime;
+using Amazon.S3;
+using Headless.Blobs.Aws;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Headless.Blobs.CloudflareR2;
+
+[PublicAPI]
+public static class SetupCloudflareR2Blob
+{
+    // Cloudflare R2 signs every request against the "auto" region.
+    private const string _Region = "auto";
+
+    extension(IServiceCollection services)
+    {
+        /// <summary>Registers Cloudflare R2 blob storage, reusing the S3 engine behind an R2-tuned client.</summary>
+        public IServiceCollection AddCloudflareR2BlobStorage(Action<R2BlobStorageOptions, IServiceProvider> setupAction)
+        {
+            services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>(setupAction);
+
+            return services._AddCloudflareR2Core();
+        }
+
+        /// <summary>Registers Cloudflare R2 blob storage, reusing the S3 engine behind an R2-tuned client.</summary>
+        public IServiceCollection AddCloudflareR2BlobStorage(Action<R2BlobStorageOptions> setupAction)
+        {
+            services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>(setupAction);
+
+            return services._AddCloudflareR2Core();
+        }
+
+        /// <summary>Registers Cloudflare R2 blob storage, reusing the S3 engine behind an R2-tuned client.</summary>
+        public IServiceCollection AddCloudflareR2BlobStorage(IConfiguration config)
+        {
+            services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>(config);
+
+            return services._AddCloudflareR2Core();
+        }
+
+        private IServiceCollection _AddCloudflareR2Core()
+        {
+            // R2-safe behavior defaults on the reused AWS engine: R2 has no ACLs, rejects chunked/payload signing,
+            // and object-scoped tokens cannot create buckets.
+            services.Configure<AwsBlobStorageOptions>(options =>
+            {
+                options.CannedAcl = null;
+                options.UseChunkEncoding = false;
+                options.DisablePayloadSigning = true;
+                options.AutoCreateContainer = false;
+            });
+
+            services.TryAddSingleton<IAmazonS3>(serviceProvider =>
+            {
+                var options = serviceProvider.GetRequiredService<IOptions<R2BlobStorageOptions>>().Value;
+
+                var config = new AmazonS3Config
+                {
+                    ServiceURL = options.GetEffectiveEndpointUrl(),
+                    ForcePathStyle = true,
+                    AuthenticationRegion = _Region,
+                    // SDK v4 defaults add CRC checksums that R2 rejects; only send them when an operation requires it.
+                    RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED,
+                    ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
+                };
+
+                var credentials = new BasicAWSCredentials(options.AccessKeyId, options.SecretAccessKey);
+
+                return new AmazonS3Client(credentials, config);
+            });
+
+            services.TryAddSingleton<IBlobNamingNormalizer, R2BlobNamingNormalizer>();
+            services.AddSingleton<IBlobStorage, AwsBlobStorage>();
+
+            return services;
+        }
+    }
+}

--- a/src/Headless.Blobs.CloudflareR2/Setup.cs
+++ b/src/Headless.Blobs.CloudflareR2/Setup.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Amazon.Runtime;
 using Amazon.S3;
 using Headless.Blobs.Aws;
 using Microsoft.Extensions.Configuration;
@@ -13,9 +12,6 @@ namespace Headless.Blobs.CloudflareR2;
 [PublicAPI]
 public static class SetupCloudflareR2Blob
 {
-    // Cloudflare R2 signs every request against the "auto" region.
-    private const string _Region = "auto";
-
     extension(IServiceCollection services)
     {
         /// <summary>Registers Cloudflare R2 blob storage, reusing the S3 engine behind an R2-tuned client.</summary>
@@ -23,7 +19,7 @@ public static class SetupCloudflareR2Blob
         {
             services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>(setupAction);
 
-            return services._AddCloudflareR2Core();
+            return services._AddCore();
         }
 
         /// <summary>Registers Cloudflare R2 blob storage, reusing the S3 engine behind an R2-tuned client.</summary>
@@ -31,7 +27,7 @@ public static class SetupCloudflareR2Blob
         {
             services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>(setupAction);
 
-            return services._AddCloudflareR2Core();
+            return services._AddCore();
         }
 
         /// <summary>Registers Cloudflare R2 blob storage, reusing the S3 engine behind an R2-tuned client.</summary>
@@ -39,10 +35,10 @@ public static class SetupCloudflareR2Blob
         {
             services.Configure<R2BlobStorageOptions, R2BlobStorageOptionsValidator>(config);
 
-            return services._AddCloudflareR2Core();
+            return services._AddCore();
         }
 
-        private IServiceCollection _AddCloudflareR2Core()
+        private IServiceCollection _AddCore()
         {
             // R2-safe behavior defaults on the reused AWS engine: R2 has no ACLs, rejects chunked/payload signing,
             // and object-scoped tokens cannot create buckets.
@@ -58,23 +54,16 @@ public static class SetupCloudflareR2Blob
             {
                 var options = serviceProvider.GetRequiredService<IOptions<R2BlobStorageOptions>>().Value;
 
-                var config = new AmazonS3Config
-                {
-                    ServiceURL = options.GetEffectiveEndpointUrl(),
-                    ForcePathStyle = true,
-                    AuthenticationRegion = _Region,
-                    // SDK v4 defaults add CRC checksums that R2 rejects; only send them when an operation requires it.
-                    RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED,
-                    ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
-                };
-
-                var credentials = new BasicAWSCredentials(options.AccessKeyId, options.SecretAccessKey);
-
-                return new AmazonS3Client(credentials, config);
+                return R2ClientFactory.Create(options);
             });
 
             services.TryAddSingleton<IBlobNamingNormalizer, R2BlobNamingNormalizer>();
             services.AddSingleton<IBlobStorage, AwsBlobStorage>();
+
+            // The engine implements IPresignedUrlBlobStorage; expose it for direct injection too (same instance).
+            services.TryAddSingleton<IPresignedUrlBlobStorage>(serviceProvider =>
+                (IPresignedUrlBlobStorage)serviceProvider.GetRequiredService<IBlobStorage>()
+            );
 
             return services;
         }

--- a/src/Headless.Blobs.FileSystem/FileSystemBlobStorage.cs
+++ b/src/Headless.Blobs.FileSystem/FileSystemBlobStorage.cs
@@ -566,7 +566,9 @@ public sealed class FileSystemBlobStorage(
         segments[0] = _basePath;
         for (var i = 0; i < container.Length; i++)
         {
-            segments[i + 1] = _normalizer.NormalizeContainerName(container[i]);
+            // Two-tier: the first segment is the top-level container; the rest are path segments.
+            segments[i + 1] =
+                i == 0 ? _normalizer.NormalizeContainerName(container[i]) : _normalizer.NormalizeBlobName(container[i]);
         }
         segments[^1] = normalizedBlobName;
 
@@ -581,7 +583,13 @@ public sealed class FileSystemBlobStorage(
         Argument.IsNotNullOrEmpty(container);
         PathValidation.ValidateContainer(container);
 
-        var normalizedContainer = container.Select(_normalizer.NormalizeContainerName).ToArray();
+        var normalizedContainer = new string[container.Length];
+        for (var i = 0; i < container.Length; i++)
+        {
+            // Two-tier: the first segment is the top-level container; the rest are path segments.
+            normalizedContainer[i] =
+                i == 0 ? _normalizer.NormalizeContainerName(container[i]) : _normalizer.NormalizeBlobName(container[i]);
+        }
 
         var filePath = Path.Combine(_basePath, Path.Combine(normalizedContainer));
         _ThrowIfPathTraversal(filePath, nameof(container));

--- a/src/Headless.Blobs.Redis/RedisBlobStorage.cs
+++ b/src/Headless.Blobs.Redis/RedisBlobStorage.cs
@@ -24,6 +24,7 @@ public sealed class RedisBlobStorage : IBlobStorage
     private readonly TimeProvider _timeProvider;
     private readonly RedisBlobStorageOptions _options;
     private readonly ResiliencePipeline _retryPipeline;
+    private readonly IBlobNamingNormalizer _normalizer;
 
     // Lua script for atomic rename: copies blob+info then deletes source
     // KEYS[1] = source blob hash, KEYS[2] = source info hash
@@ -78,6 +79,7 @@ public sealed class RedisBlobStorage : IBlobStorage
     public RedisBlobStorage(
         IOptions<RedisBlobStorageOptions> optionsAccessor,
         IJsonSerializer defaultSerializer,
+        IBlobNamingNormalizer normalizer,
         TimeProvider? timeProvider = null
     )
     {
@@ -85,6 +87,7 @@ public sealed class RedisBlobStorage : IBlobStorage
         _logger = _options.LoggerFactory?.CreateLogger(typeof(RedisBlobStorage)) ?? NullLogger.Instance;
         _serializer = _options.Serializer ?? defaultSerializer;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _normalizer = normalizer;
 
         var pipelineLogger = _logger;
 
@@ -812,9 +815,12 @@ public sealed class RedisBlobStorage : IBlobStorage
         return list;
     }
 
-    private static SearchCriteria _GetRequestCriteria(IEnumerable<string> directories, string? searchPattern)
+    private SearchCriteria _GetRequestCriteria(IEnumerable<string> directories, string? searchPattern)
     {
-        searchPattern = Url.Combine(string.Join('/', directories), _NormalizePath(searchPattern));
+        // Two-tier: directory segments use lenient path-segment normalization (matching stored keys); the search
+        // pattern itself is only slash-normalized so wildcards survive.
+        var normalizedDirectories = string.Join('/', directories.Select(_normalizer.NormalizeBlobName));
+        searchPattern = Url.Combine(normalizedDirectories, _NormalizePath(searchPattern));
 
         if (string.IsNullOrEmpty(searchPattern))
         {
@@ -843,26 +849,32 @@ public sealed class RedisBlobStorage : IBlobStorage
 
     #region Build Paths
 
-    private static (string BlobsContainer, string InfoContainer) _BuildContainerPath(string[] container)
+    private (string BlobsContainer, string InfoContainer) _BuildContainerPath(string[] container)
     {
         Argument.IsNotNullOrEmpty(container);
 
-        var path = _NormalizePath(container[0]);
+        // Two-tier: the first segment is the top-level container (strict rules).
+        var path = _normalizer.NormalizeContainerName(container[0]);
 
         return (path.EnsureEndsWith('/'), ("blob-info/" + path).EnsureEndsWith('/'));
     }
 
-    private static string _BuildBlobPath(string[] container, string blobName)
+    private string _BuildBlobPath(string[] container, string blobName)
     {
         PathValidation.ValidatePathSegment(blobName);
         PathValidation.ValidateContainer(container);
 
+        var normalizedBlobName = _normalizer.NormalizeBlobName(blobName);
+
         if (container.Length == 1)
         {
-            return blobName;
+            return normalizedBlobName;
         }
 
-        return _NormalizePath(string.Join('/', container.Skip(1)).EnsureEndsWith('/') + blobName);
+        // Sub-path segments use lenient path-segment normalization (two-tier model); join with '/'.
+        var prefix = string.Join('/', container.Skip(1).Select(_normalizer.NormalizeBlobName));
+
+        return prefix.EnsureEndsWith('/') + normalizedBlobName;
     }
 
     [return: NotNullIfNotNull(nameof(path))]

--- a/src/Headless.Blobs.SshNet/SshBlobStorage.cs
+++ b/src/Headless.Blobs.SshNet/SshBlobStorage.cs
@@ -1032,14 +1032,17 @@ public sealed class SshBlobStorage(
 
         var sb = new StringBuilder();
 
-        foreach (var segment in container)
+        for (var i = 0; i < container.Length; i++)
         {
             if (sb.Length > 0)
             {
                 sb.Append('/');
             }
 
-            sb.Append(normalizer.NormalizeContainerName(segment));
+            // Two-tier: the first segment is the top-level container; the rest are path segments.
+            sb.Append(
+                i == 0 ? normalizer.NormalizeContainerName(container[i]) : normalizer.NormalizeBlobName(container[i])
+            );
         }
 
         if (!string.IsNullOrEmpty(normalizedBlobName))
@@ -1064,7 +1067,9 @@ public sealed class SshBlobStorage(
         var normalizedSegments = new string[container.Length];
         for (var i = 0; i < container.Length; i++)
         {
-            normalizedSegments[i] = normalizer.NormalizeContainerName(container[i]);
+            // Two-tier: the first segment is the top-level container; the rest are path segments.
+            normalizedSegments[i] =
+                i == 0 ? normalizer.NormalizeContainerName(container[i]) : normalizer.NormalizeBlobName(container[i]);
         }
 
         return $"{string.Join('/', normalizedSegments)}/";

--- a/tests/Headless.Api.DataProtection.Tests.Integration/BlobStorageDataProtectionIntegrationTests.cs
+++ b/tests/Headless.Api.DataProtection.Tests.Integration/BlobStorageDataProtectionIntegrationTests.cs
@@ -38,7 +38,7 @@ public sealed class BlobStorageDataProtectionIntegrationTests(AzuriteFixture fix
             new BlobClientOptions(BlobClientOptions.ServiceVersion.V2024_11_04)
         );
 
-        var azureStorageOptions = new AzureStorageOptions { CreateContainerIfNotExists = true };
+        var azureStorageOptions = new AzureStorageOptions { AutoCreateContainer = true };
         var optionsAccessor = new OptionsWrapper<AzureStorageOptions>(azureStorageOptions);
         var mimeTypeProvider = new MimeTypeProvider();
         var clock = new Clock(TimeProvider.System);

--- a/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
@@ -33,7 +33,13 @@ public sealed class AwsBlobStorageTests(AwsBlobStorageFixture fixture) : BlobSto
         var options = new AwsBlobStorageOptions();
         var optionsWrapper = new OptionsWrapper<AwsBlobStorageOptions>(options);
 
-        return new AwsBlobStorage(amazonS3Client, mimeTypeProvider, clock, optionsWrapper);
+        return new AwsBlobStorage(
+            amazonS3Client,
+            mimeTypeProvider,
+            clock,
+            optionsWrapper,
+            new AwsBlobNamingNormalizer()
+        );
     }
 
     [Fact]
@@ -59,7 +65,8 @@ public sealed class AwsBlobStorageTests(AwsBlobStorageFixture fixture) : BlobSto
             amazonS3Client,
             new MimeTypeProvider(),
             new Clock(TimeProvider.System),
-            options
+            options,
+            new AwsBlobNamingNormalizer()
         );
 
         var missingBucket = $"missing-{Guid.NewGuid():N}";

--- a/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
@@ -71,6 +71,26 @@ public sealed class AwsBlobStorageTests(AwsBlobStorageFixture fixture) : BlobSto
     }
 
     [Fact]
+    public async Task can_round_trip_via_presigned_download_url()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign-{Guid.NewGuid():N}" };
+        var content = "presigned-content"u8.ToArray();
+
+        using (var stream = new MemoryStream(content))
+        {
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream);
+        }
+
+        var url = await storage.GetPresignedDownloadUrlAsync(container, "file.txt", TimeSpan.FromMinutes(5));
+
+        using var http = new HttpClient();
+        var downloaded = await http.GetByteArrayAsync(url);
+
+        downloaded.Should().Equal(content);
+    }
+
+    [Fact]
     public override Task can_get_empty_file_list_on_missing_directory()
     {
         return base.can_get_empty_file_list_on_missing_directory();

--- a/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
@@ -37,6 +37,40 @@ public sealed class AwsBlobStorageTests(AwsBlobStorageFixture fixture) : BlobSto
     }
 
     [Fact]
+    public async Task upload_throws_when_auto_create_disabled_and_bucket_missing()
+    {
+        var s3Config = new AmazonS3Config
+        {
+            RegionEndpoint = RegionEndpoint.USEast1,
+            ServiceURL = fixture.Container.GetConnectionString(),
+            ForcePathStyle = true,
+        };
+
+        var awsCredentials = new BasicAWSCredentials("xxx", "xxx");
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        var amazonS3Client = new AmazonS3Client(awsCredentials, s3Config);
+#pragma warning restore CA2000
+
+        var options = new OptionsWrapper<AwsBlobStorageOptions>(
+            new AwsBlobStorageOptions { AutoCreateContainer = false }
+        );
+
+        await using var storage = new AwsBlobStorage(
+            amazonS3Client,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            options
+        );
+
+        var missingBucket = $"missing-{Guid.NewGuid():N}";
+        using var stream = new MemoryStream("hello"u8.ToArray());
+
+        var act = async () => await storage.UploadAsync([missingBucket], "file.txt", stream);
+
+        await act.Should().ThrowAsync<AmazonS3Exception>();
+    }
+
+    [Fact]
     public override Task can_get_empty_file_list_on_missing_directory()
     {
         return base.can_get_empty_file_list_on_missing_directory();

--- a/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
@@ -79,15 +79,49 @@ public sealed class AwsBlobStorageTests(AwsBlobStorageFixture fixture) : BlobSto
 
         using (var stream = new MemoryStream(content))
         {
-            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream);
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream, cancellationToken: AbortToken);
         }
 
-        var url = await storage.GetPresignedDownloadUrlAsync(container, "file.txt", TimeSpan.FromMinutes(5));
+        var url = await storage.GetPresignedDownloadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
 
         using var http = new HttpClient();
-        var downloaded = await http.GetByteArrayAsync(url);
+        var downloaded = await http.GetByteArrayAsync(url, AbortToken);
 
         downloaded.Should().Equal(content);
+    }
+
+    [Fact]
+    public async Task can_round_trip_via_presigned_upload_url()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign-{Guid.NewGuid():N}" };
+        var content = "presigned-upload"u8.ToArray();
+
+        var uploadUrl = await storage.GetPresignedUploadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
+
+        using (var http = new HttpClient())
+        using (var body = new ByteArrayContent(content))
+        {
+            var response = await http.PutAsync(uploadUrl, body, AbortToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var readBack = await ((IBlobStorage)storage).OpenReadStreamAsync(container, "file.txt", AbortToken);
+        readBack.Should().NotBeNull();
+
+        using var buffer = new MemoryStream();
+        await readBack!.Stream.CopyToAsync(buffer, AbortToken);
+        buffer.ToArray().Should().Equal(content);
     }
 
     [Fact]

--- a/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Integration/AwsBlobStorageTests.cs
@@ -102,6 +102,9 @@ public sealed class AwsBlobStorageTests(AwsBlobStorageFixture fixture) : BlobSto
         var container = new[] { $"presign-{Guid.NewGuid():N}" };
         var content = "presigned-upload"u8.ToArray();
 
+        // The presigned PUT goes straight to S3 and does not create the bucket; create it first.
+        await ((IBlobStorage)storage).CreateContainerAsync(container, AbortToken);
+
         var uploadUrl = await storage.GetPresignedUploadUrlAsync(
             container,
             "file.txt",

--- a/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
@@ -21,7 +21,13 @@ public sealed class AwsBlobStorageEngineTests : TestBase
     {
         var wrapper = new OptionsWrapper<AwsBlobStorageOptions>(options ?? new AwsBlobStorageOptions());
 
-        return new AwsBlobStorage(_s3, new MimeTypeProvider(), new Clock(TimeProvider.System), wrapper);
+        return new AwsBlobStorage(
+            _s3,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            wrapper,
+            new AwsBlobNamingNormalizer()
+        );
     }
 
     [Fact]
@@ -37,6 +43,25 @@ public sealed class AwsBlobStorageEngineTests : TestBase
 
         await _s3.DidNotReceiveWithAnyArgs().PutBucketAsync(default(PutBucketRequest)!, default);
         await _s3.ReceivedWithAnyArgs(1).PutObjectAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task upload_normalizes_bucket_and_preserves_object_key_path()
+    {
+        PutObjectRequest? captured = null;
+        _s3.PutObjectAsync(Arg.Do<PutObjectRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var sut = _CreateSut(new AwsBlobStorageOptions { AutoCreateContainer = false });
+
+        using var stream = new MemoryStream("hi"u8.ToArray());
+        await sut.UploadAsync(["My-Bucket", "Reports"], "Q1.pdf", stream);
+
+        // Two-tier naming: the first segment (bucket) is lowercased by NormalizeContainerName; the sub-path and
+        // blob name are preserved because AwsBlobNamingNormalizer.NormalizeBlobName is validate-only.
+        captured.Should().NotBeNull();
+        captured!.BucketName.Should().Be("my-bucket");
+        captured.Key.Should().Be("Reports/Q1.pdf");
     }
 
     [Fact]
@@ -107,7 +132,8 @@ public sealed class AwsBlobStorageEngineTests : TestBase
             fresh,
             new MimeTypeProvider(),
             new Clock(TimeProvider.System),
-            new OptionsWrapper<AwsBlobStorageOptions>(new AwsBlobStorageOptions())
+            new OptionsWrapper<AwsBlobStorageOptions>(new AwsBlobStorageOptions()),
+            new AwsBlobNamingNormalizer()
         );
         await freshSut.CreateContainerAsync(["bucket"]);
 

--- a/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
@@ -115,6 +115,57 @@ public sealed class AwsBlobStorageEngineTests : TestBase
     }
 
     [Fact]
+    public async Task create_container_is_idempotent_when_bucket_already_owned()
+    {
+        _s3.PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new AmazonS3Exception("already owned") { ErrorCode = "BucketAlreadyOwnedByYou" });
+
+        var sut = _CreateSut();
+
+        var act = async () => await sut.CreateContainerAsync(["bucket"]);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task bucket_create_failure_is_not_cached()
+    {
+        var calls = 0;
+        _s3.PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                calls++;
+
+                return calls == 1
+                    ? Task.FromException<PutBucketResponse>(
+                        new AmazonS3Exception("transient") { StatusCode = HttpStatusCode.ServiceUnavailable }
+                    )
+                    : Task.FromResult(new PutBucketResponse());
+            });
+
+        var sut = _CreateSut();
+
+        // First ensure fails; the failure must not be cached.
+        var firstAttempt = async () => await sut.CreateContainerAsync(["bucket"]);
+        await firstAttempt.Should().ThrowAsync<AmazonS3Exception>();
+
+        // Retry re-attempts the create rather than serving a poisoned cache entry.
+        await sut.CreateContainerAsync(["bucket"]);
+
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task presigned_download_throws_on_non_positive_expiry()
+    {
+        var sut = _CreateSut();
+
+        var act = async () => await sut.GetPresignedDownloadUrlAsync(["bucket"], "file.txt", TimeSpan.Zero);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
     public void implements_presigned_url_capability()
     {
         _CreateSut().Should().BeAssignableTo<IPresignedUrlBlobStorage>();

--- a/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Headless.Abstractions;
+using Headless.Blobs;
 using Headless.Blobs.Aws;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Options;
@@ -85,5 +86,43 @@ public sealed class AwsBlobStorageEngineTests : TestBase
 
         // The second call is served from the per-instance cache and issues no further S3 calls.
         _s3.ReceivedCalls().Count().Should().Be(callsAfterFirst);
+    }
+
+    [Fact]
+    public void implements_presigned_url_capability()
+    {
+        _CreateSut().Should().BeAssignableTo<IPresignedUrlBlobStorage>();
+    }
+
+    [Fact]
+    public async Task presigned_download_url_uses_get_verb_for_the_blob()
+    {
+        _s3.GetPreSignedURLAsync(Arg.Any<GetPreSignedUrlRequest>()).Returns("https://example.com/signed-get");
+
+        var sut = _CreateSut();
+
+        var url = await sut.GetPresignedDownloadUrlAsync(["bucket"], "file.txt", TimeSpan.FromMinutes(15));
+
+        url.Should().Be(new Uri("https://example.com/signed-get"));
+        await _s3.Received(1)
+            .GetPreSignedURLAsync(
+                Arg.Is<GetPreSignedUrlRequest>(r =>
+                    r.Verb == HttpVerb.GET && r.BucketName == "bucket" && r.Key == "file.txt"
+                )
+            );
+    }
+
+    [Fact]
+    public async Task presigned_upload_url_uses_put_verb_for_the_blob()
+    {
+        _s3.GetPreSignedURLAsync(Arg.Any<GetPreSignedUrlRequest>()).Returns("https://example.com/signed-put");
+
+        var sut = _CreateSut();
+
+        var url = await sut.GetPresignedUploadUrlAsync(["bucket"], "file.txt", TimeSpan.FromMinutes(15));
+
+        url.Should().Be(new Uri("https://example.com/signed-put"));
+        await _s3.Received(1)
+            .GetPreSignedURLAsync(Arg.Is<GetPreSignedUrlRequest>(r => r.Verb == HttpVerb.PUT && r.Key == "file.txt"));
     }
 }

--- a/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
@@ -89,6 +89,32 @@ public sealed class AwsBlobStorageEngineTests : TestBase
     }
 
     [Fact]
+    public async Task concurrent_create_container_ensures_bucket_at_most_once()
+    {
+        _s3.PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>()).Returns(new PutBucketResponse());
+        var sut = _CreateSut();
+
+        // 20 concurrent first-time ensures of the same bucket.
+        await Task.WhenAll(Enumerable.Range(0, 20).Select(_ => sut.CreateContainerAsync(["bucket"]).AsTask()));
+        var concurrentCalls = _s3.ReceivedCalls().Count();
+
+        // A single ensure on a fresh instance issues the same S3 calls; concurrency must not multiply them.
+        var fresh = Substitute.For<IAmazonS3>();
+        fresh
+            .PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PutBucketResponse());
+        var freshSut = new AwsBlobStorage(
+            fresh,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            new OptionsWrapper<AwsBlobStorageOptions>(new AwsBlobStorageOptions())
+        );
+        await freshSut.CreateContainerAsync(["bucket"]);
+
+        concurrentCalls.Should().Be(fresh.ReceivedCalls().Count());
+    }
+
+    [Fact]
     public void implements_presigned_url_capability()
     {
         _CreateSut().Should().BeAssignableTo<IPresignedUrlBlobStorage>();
@@ -107,7 +133,12 @@ public sealed class AwsBlobStorageEngineTests : TestBase
         await _s3.Received(1)
             .GetPreSignedURLAsync(
                 Arg.Is<GetPreSignedUrlRequest>(r =>
-                    r.Verb == HttpVerb.GET && r.BucketName == "bucket" && r.Key == "file.txt"
+                    r.Verb == HttpVerb.GET
+                    && r.BucketName == "bucket"
+                    && r.Key == "file.txt"
+                    // Expires is the absolute deadline: roughly now + the requested 15-minute window.
+                    && r.Expires > DateTime.UtcNow.AddMinutes(14)
+                    && r.Expires < DateTime.UtcNow.AddMinutes(16)
                 )
             );
     }

--- a/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
+++ b/tests/Headless.Blobs.Aws.Tests.Unit/AwsBlobStorageEngineTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Headless.Abstractions;
+using Headless.Blobs.Aws;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Tests;
+
+public sealed class AwsBlobStorageEngineTests : TestBase
+{
+    private readonly IAmazonS3 _s3 = Substitute.For<IAmazonS3>();
+
+    private AwsBlobStorage _CreateSut(AwsBlobStorageOptions? options = null)
+    {
+        var wrapper = new OptionsWrapper<AwsBlobStorageOptions>(options ?? new AwsBlobStorageOptions());
+
+        return new AwsBlobStorage(_s3, new MimeTypeProvider(), new Clock(TimeProvider.System), wrapper);
+    }
+
+    [Fact]
+    public async Task upload_does_not_create_bucket_when_auto_create_disabled()
+    {
+        _s3.PutObjectAsync(Arg.Any<PutObjectRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var sut = _CreateSut(new AwsBlobStorageOptions { AutoCreateContainer = false });
+
+        using var stream = new MemoryStream("hello"u8.ToArray());
+        await sut.UploadAsync(["bucket"], "file.txt", stream);
+
+        await _s3.DidNotReceiveWithAnyArgs().PutBucketAsync(default(PutBucketRequest)!, default);
+        await _s3.ReceivedWithAnyArgs(1).PutObjectAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task exists_returns_false_when_bucket_missing()
+    {
+        _s3.GetObjectMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new AmazonS3Exception("no such bucket") { StatusCode = HttpStatusCode.NotFound });
+
+        var sut = _CreateSut();
+
+        (await sut.ExistsAsync(["missing"], "file.txt")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task get_blob_info_returns_null_when_bucket_missing()
+    {
+        _s3.GetObjectMetadataAsync(Arg.Any<GetObjectMetadataRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new AmazonS3Exception("no such bucket") { StatusCode = HttpStatusCode.NotFound });
+
+        var sut = _CreateSut();
+
+        (await sut.GetBlobInfoAsync(["missing"], "file.txt")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task open_read_stream_returns_null_when_bucket_missing()
+    {
+        _s3.GetObjectAsync(Arg.Any<GetObjectRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new AmazonS3Exception("no such bucket") { StatusCode = HttpStatusCode.NotFound });
+
+        var sut = _CreateSut();
+
+        (await sut.OpenReadStreamAsync(["missing"], "file.txt")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task create_container_ensures_bucket_at_most_once()
+    {
+        _s3.PutBucketAsync(Arg.Any<PutBucketRequest>(), Arg.Any<CancellationToken>()).Returns(new PutBucketResponse());
+
+        var sut = _CreateSut();
+
+        await sut.CreateContainerAsync(["bucket"]);
+        var callsAfterFirst = _s3.ReceivedCalls().Count();
+
+        await sut.CreateContainerAsync(["bucket"]);
+
+        // The second call is served from the per-instance cache and issues no further S3 calls.
+        _s3.ReceivedCalls().Count().Should().Be(callsAfterFirst);
+    }
+}

--- a/tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs
@@ -36,6 +36,26 @@ public sealed class AzureStorageTests(AzureBlobStorageFixture fixture) : BlobSto
     }
 
     [Fact]
+    public async Task can_round_trip_via_presigned_download_url()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign{Guid.NewGuid():N}" };
+        var content = "presigned-content"u8.ToArray();
+
+        using (var stream = new MemoryStream(content))
+        {
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream);
+        }
+
+        var url = await storage.GetPresignedDownloadUrlAsync(container, "file.txt", TimeSpan.FromMinutes(5));
+
+        using var http = new HttpClient();
+        var downloaded = await http.GetByteArrayAsync(url);
+
+        downloaded.Should().Equal(content);
+    }
+
+    [Fact]
     public override Task can_get_empty_file_list_on_missing_directory()
     {
         return base.can_get_empty_file_list_on_missing_directory();

--- a/tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs
@@ -44,15 +44,51 @@ public sealed class AzureStorageTests(AzureBlobStorageFixture fixture) : BlobSto
 
         using (var stream = new MemoryStream(content))
         {
-            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream);
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream, cancellationToken: AbortToken);
         }
 
-        var url = await storage.GetPresignedDownloadUrlAsync(container, "file.txt", TimeSpan.FromMinutes(5));
+        var url = await storage.GetPresignedDownloadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
 
         using var http = new HttpClient();
-        var downloaded = await http.GetByteArrayAsync(url);
+        var downloaded = await http.GetByteArrayAsync(url, AbortToken);
 
         downloaded.Should().Equal(content);
+    }
+
+    [Fact]
+    public async Task can_round_trip_via_presigned_upload_url()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign{Guid.NewGuid():N}" };
+        var content = "presigned-upload"u8.ToArray();
+
+        var uploadUrl = await storage.GetPresignedUploadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
+
+        using (var http = new HttpClient())
+        using (var body = new ByteArrayContent(content))
+        {
+            // Azure block-blob PUT requires the blob-type header.
+            body.Headers.Add("x-ms-blob-type", "BlockBlob");
+            var response = await http.PutAsync(uploadUrl, body, AbortToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var readBack = await ((IBlobStorage)storage).OpenReadStreamAsync(container, "file.txt", AbortToken);
+        readBack.Should().NotBeNull();
+
+        using var buffer = new MemoryStream();
+        await readBack!.Stream.CopyToAsync(buffer, AbortToken);
+        buffer.ToArray().Should().Equal(content);
     }
 
     [Fact]

--- a/tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Integration/AzureStorageTests.cs
@@ -67,6 +67,9 @@ public sealed class AzureStorageTests(AzureBlobStorageFixture fixture) : BlobSto
         var container = new[] { $"presign{Guid.NewGuid():N}" };
         var content = "presigned-upload"u8.ToArray();
 
+        // The presigned PUT goes straight to Azure and does not create the container; create it first.
+        await ((IBlobStorage)storage).CreateContainerAsync(container, AbortToken);
+
         var uploadUrl = await storage.GetPresignedUploadUrlAsync(
             container,
             "file.txt",

--- a/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStorageContainerTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStorageContainerTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Headless.Abstractions;
+using Headless.Blobs.Azure;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Tests;
+
+public sealed class AzureBlobStorageContainerTests : TestBase
+{
+    [Fact]
+    public async Task create_container_ensures_at_most_once()
+    {
+        var containerClient = Substitute.For<BlobContainerClient>();
+        var serviceClient = Substitute.For<BlobServiceClient>();
+        serviceClient.GetBlobContainerClient(Arg.Any<string>()).Returns(containerClient);
+
+        await using var sut = new AzureBlobStorage(
+            serviceClient,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            new OptionsWrapper<AzureStorageOptions>(new AzureStorageOptions()),
+            new AzureBlobNamingNormalizer(),
+            NullLogger<AzureBlobStorage>.Instance
+        );
+
+        await sut.CreateContainerAsync(["mycontainer"]);
+        await sut.CreateContainerAsync(["mycontainer"]);
+
+        // The second call is served from the per-instance cache; CreateIfNotExists runs once.
+        await containerClient
+            .Received(1)
+            .CreateIfNotExistsAsync(
+                Arg.Any<PublicAccessType>(),
+                Arg.Any<IDictionary<string, string>>(),
+                Arg.Any<BlobContainerEncryptionScopeOptions>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+}

--- a/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStoragePresignedTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStoragePresignedTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure.Storage.Blobs;
+using Headless.Abstractions;
+using Headless.Blobs;
+using Headless.Blobs.Azure;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+public sealed class AzureBlobStoragePresignedTests : TestBase
+{
+    private static AzureBlobStorage _CreateStorageWithoutSigningCredentials()
+    {
+        // An anonymous client (no account key / user delegation key) cannot generate a SAS.
+        var blobServiceClient = new BlobServiceClient(new Uri("https://account.blob.core.windows.net"));
+
+        return new AzureBlobStorage(
+            blobServiceClient,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            new OptionsWrapper<AzureStorageOptions>(new AzureStorageOptions()),
+            new AzureBlobNamingNormalizer(),
+            NullLogger<AzureBlobStorage>.Instance
+        );
+    }
+
+    [Fact]
+    public void implements_presigned_url_capability()
+    {
+        _CreateStorageWithoutSigningCredentials().Should().BeAssignableTo<IPresignedUrlBlobStorage>();
+    }
+
+    [Fact]
+    public async Task download_presigned_throws_when_client_cannot_sign()
+    {
+        var sut = _CreateStorageWithoutSigningCredentials();
+
+        var act = async () =>
+            await sut.GetPresignedDownloadUrlAsync(["mycontainer"], "file.txt", TimeSpan.FromMinutes(5));
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*cannot generate a SAS*");
+    }
+
+    [Fact]
+    public async Task upload_presigned_throws_when_client_cannot_sign()
+    {
+        var sut = _CreateStorageWithoutSigningCredentials();
+
+        var act = async () =>
+            await sut.GetPresignedUploadUrlAsync(["mycontainer"], "file.txt", TimeSpan.FromMinutes(5));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStoragePresignedTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStoragePresignedTests.cs
@@ -52,6 +52,6 @@ public sealed class AzureBlobStoragePresignedTests : TestBase
         var act = async () =>
             await sut.GetPresignedUploadUrlAsync(["mycontainer"], "file.txt", TimeSpan.FromMinutes(5));
 
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*cannot generate a SAS*");
     }
 }

--- a/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStoragePresignedTests.cs
+++ b/tests/Headless.Blobs.Azure.Tests.Unit/AzureBlobStoragePresignedTests.cs
@@ -54,4 +54,14 @@ public sealed class AzureBlobStoragePresignedTests : TestBase
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*cannot generate a SAS*");
     }
+
+    [Fact]
+    public async Task presigned_throws_on_non_positive_expiry()
+    {
+        var sut = _CreateStorageWithoutSigningCredentials();
+
+        var act = async () => await sut.GetPresignedDownloadUrlAsync(["mycontainer"], "file.txt", TimeSpan.Zero);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
 }

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
@@ -54,7 +54,13 @@ public sealed class CloudflareR2BlobStorageTests : BlobStorageTestsBase
             }
         );
 
-        return new AwsBlobStorage(client, new MimeTypeProvider(), new Clock(TimeProvider.System), options);
+        return new AwsBlobStorage(
+            client,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            options,
+            new R2BlobNamingNormalizer()
+        );
     }
 
     [Fact]
@@ -80,7 +86,8 @@ public sealed class CloudflareR2BlobStorageTests : BlobStorageTestsBase
             client,
             new MimeTypeProvider(),
             new Clock(TimeProvider.System),
-            options
+            options,
+            new R2BlobNamingNormalizer()
         );
 
         var url = await ((IPresignedUrlBlobStorage)storage).GetPresignedDownloadUrlAsync(

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Amazon.Runtime;
+using Amazon.S3;
+using Headless.Abstractions;
+using Headless.Blobs;
+using Headless.Blobs.Aws;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+/// <summary>
+/// Cross-provider conformance run against a real Cloudflare R2 account. There is no R2 emulator, so this suite
+/// is credentials-gated: when the R2_* environment variables are absent (local runs, forks), every scenario
+/// skips instead of failing. The configured token must allow bucket creation for the full suite to run.
+/// </summary>
+public sealed class CloudflareR2BlobStorageTests : BlobStorageTestsBase
+{
+    protected override IBlobStorage GetStorage()
+    {
+        var accountId = Environment.GetEnvironmentVariable("R2_ACCOUNT_ID");
+        var accessKey = Environment.GetEnvironmentVariable("R2_ACCESS_KEY_ID");
+        var secretKey = Environment.GetEnvironmentVariable("R2_SECRET_ACCESS_KEY");
+
+        Assert.SkipWhen(
+            string.IsNullOrWhiteSpace(accountId)
+                || string.IsNullOrWhiteSpace(accessKey)
+                || string.IsNullOrWhiteSpace(secretKey),
+            "R2 credentials are not configured (R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY)."
+        );
+
+        var config = new AmazonS3Config
+        {
+            ServiceURL = $"https://{accountId}.r2.cloudflarestorage.com",
+            ForcePathStyle = true,
+            AuthenticationRegion = "auto",
+            RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED,
+            ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
+        };
+
+#pragma warning disable CA2000 // Disposed by AwsBlobStorage / the test host.
+        var client = new AmazonS3Client(new BasicAWSCredentials(accessKey!, secretKey!), config);
+#pragma warning restore CA2000
+
+        // Conformance exercises the full lifecycle, so it needs bucket creation; the test token must allow it.
+        var options = new OptionsWrapper<AwsBlobStorageOptions>(
+            new AwsBlobStorageOptions
+            {
+                CannedAcl = null,
+                UseChunkEncoding = false,
+                DisablePayloadSigning = true,
+                AutoCreateContainer = true,
+            }
+        );
+
+        return new AwsBlobStorage(client, new MimeTypeProvider(), new Clock(TimeProvider.System), options);
+    }
+
+    [Fact]
+    public async Task presigned_download_url_targets_the_r2_endpoint()
+    {
+        // Presigning is a local SigV4 operation needing no real credentials or network, so this always runs
+        // (even without R2 creds) and keeps the module from reporting zero tests.
+        var config = new AmazonS3Config
+        {
+            ServiceURL = "https://testacc.r2.cloudflarestorage.com",
+            ForcePathStyle = true,
+            AuthenticationRegion = "auto",
+        };
+
+#pragma warning disable CA2000 // Disposed via the storage.
+        var client = new AmazonS3Client(new BasicAWSCredentials("ak", "sk"), config);
+#pragma warning restore CA2000
+
+        var options = new OptionsWrapper<AwsBlobStorageOptions>(
+            new AwsBlobStorageOptions { AutoCreateContainer = false }
+        );
+        await using var storage = new AwsBlobStorage(
+            client,
+            new MimeTypeProvider(),
+            new Clock(TimeProvider.System),
+            options
+        );
+
+        var url = await ((IPresignedUrlBlobStorage)storage).GetPresignedDownloadUrlAsync(
+            ["bucket"],
+            "file.txt",
+            TimeSpan.FromMinutes(5)
+        );
+
+        url.Host.Should().Be("testacc.r2.cloudflarestorage.com");
+        url.AbsolutePath.Should().Contain("bucket");
+    }
+
+    [Fact]
+    public async Task can_round_trip_via_presigned_download_url()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign-{Guid.NewGuid():N}" };
+        var content = "presigned-content"u8.ToArray();
+
+        using (var stream = new MemoryStream(content))
+        {
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream);
+        }
+
+        var url = await storage.GetPresignedDownloadUrlAsync(container, "file.txt", TimeSpan.FromMinutes(5));
+
+        using var http = new HttpClient();
+        var downloaded = await http.GetByteArrayAsync(url);
+
+        downloaded.Should().Equal(content);
+    }
+
+    [Fact]
+    public override Task can_get_empty_file_list_on_missing_directory() =>
+        base.can_get_empty_file_list_on_missing_directory();
+
+    [Fact]
+    public override Task can_get_file_list_for_single_folder() => base.can_get_file_list_for_single_folder();
+
+    [Fact]
+    public override Task can_get_file_list_for_single_file() => base.can_get_file_list_for_single_file();
+
+    [Fact]
+    public override Task can_get_paged_file_list_for_single_folder() =>
+        base.can_get_paged_file_list_for_single_folder();
+
+    [Fact]
+    public override Task can_get_file_info() => base.can_get_file_info();
+
+    [Fact]
+    public override Task can_get_non_existent_file_info() => base.can_get_non_existent_file_info();
+
+    [Fact]
+    public override Task can_manage_files() => base.can_manage_files();
+
+    [Fact]
+    public override Task can_rename_files() => base.can_rename_files();
+
+    [Fact]
+    public override Task can_concurrently_manage_files() => base.can_concurrently_manage_files();
+
+    [Fact]
+    public override Task can_delete_entire_folder() => base.can_delete_entire_folder();
+
+    [Fact]
+    public override Task can_delete_entire_folder_with_wildcard() => base.can_delete_entire_folder_with_wildcard();
+
+    [Fact]
+    public override Task can_delete_folder_with_multi_folder_wildcards() =>
+        base.can_delete_folder_with_multi_folder_wildcards();
+
+    [Fact]
+    public override Task can_delete_specific_files() => base.can_delete_specific_files();
+
+    [Fact]
+    public override Task can_delete_nested_folder() => base.can_delete_nested_folder();
+
+    [Fact]
+    public override Task can_delete_specific_files_in_nested_folder() =>
+        base.can_delete_specific_files_in_nested_folder();
+
+    [Fact]
+    public override Task can_round_trip_seekable_stream() => base.can_round_trip_seekable_stream();
+
+    [Fact]
+    public override Task will_reset_stream_position() => base.will_reset_stream_position();
+
+    [Fact]
+    public override Task can_save_over_existing_stored_content() => base.can_save_over_existing_stored_content();
+
+    [Fact]
+    public override Task can_call_delete_with_empty_container() => base.can_call_delete_with_empty_container();
+
+    [Fact]
+    public override Task can_call_bulk_Delete_with_empty_container() =>
+        base.can_call_bulk_Delete_with_empty_container();
+
+    [Fact]
+    public override Task can_call_delete_all_async_with_empty_container() =>
+        base.can_call_delete_all_async_with_empty_container();
+
+    [Fact]
+    public override Task can_call_copy_with_empty_container() => base.can_call_copy_with_empty_container();
+
+    [Fact]
+    public override Task can_call_rename_with_empty_container() => base.can_call_rename_with_empty_container();
+
+    [Fact]
+    public override Task can_call_exists_with_empty_container() => base.can_call_exists_with_empty_container();
+
+    [Fact]
+    public override Task can_call_download_with_empty_container() => base.can_call_download_with_empty_container();
+
+    [Fact]
+    public override Task can_call_get_blob_info_with_empty_container() =>
+        base.can_call_get_blob_info_with_empty_container();
+
+    [Fact]
+    public override Task can_call_get_paged_list_with_empty_container() =>
+        base.can_call_get_paged_list_with_empty_container();
+
+    [Theory]
+    [InlineData("../../../etc/passwd")]
+    [InlineData("..\\..\\..\\etc\\passwd")]
+    [InlineData("subdir/../../../etc/passwd")]
+    public override Task should_throw_when_blob_name_has_path_traversal(string blobName) =>
+        base.should_throw_when_blob_name_has_path_traversal(blobName);
+
+    [Fact]
+    public override Task should_throw_when_container_has_path_traversal() =>
+        base.should_throw_when_container_has_path_traversal();
+
+    [Fact]
+    public override Task should_throw_when_upload_blob_has_path_traversal() =>
+        base.should_throw_when_upload_blob_has_path_traversal();
+
+    [Fact]
+    public override Task should_throw_when_download_blob_has_path_traversal() =>
+        base.should_throw_when_download_blob_has_path_traversal();
+
+    [Fact]
+    public override Task should_throw_when_delete_blob_has_path_traversal() =>
+        base.should_throw_when_delete_blob_has_path_traversal();
+
+    [Fact]
+    public override Task should_throw_when_rename_source_blob_has_path_traversal() =>
+        base.should_throw_when_rename_source_blob_has_path_traversal();
+
+    [Fact]
+    public override Task should_throw_when_copy_source_blob_has_path_traversal() =>
+        base.should_throw_when_copy_source_blob_has_path_traversal();
+
+    [Fact]
+    public override Task should_throw_when_blob_name_has_control_characters() =>
+        base.should_throw_when_blob_name_has_control_characters();
+
+    [Theory]
+    [InlineData("/etc/passwd")]
+    public override Task should_throw_when_blob_name_is_absolute_path(string blobName) =>
+        base.should_throw_when_blob_name_is_absolute_path(blobName);
+}

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
@@ -125,6 +125,10 @@ public sealed class CloudflareR2BlobStorageTests : BlobStorageTestsBase
         var container = new[] { $"presign-{Guid.NewGuid():N}" };
         var content = "presigned-upload"u8.ToArray();
 
+        // The presigned PUT goes straight to R2 and does not create the bucket; create it first (the
+        // conformance token allows bucket creation).
+        await ((IBlobStorage)storage).CreateContainerAsync(container, AbortToken);
+
         var uploadUrl = await storage.GetPresignedUploadUrlAsync(
             container,
             "file.txt",

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
@@ -102,15 +102,75 @@ public sealed class CloudflareR2BlobStorageTests : BlobStorageTestsBase
 
         using (var stream = new MemoryStream(content))
         {
-            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream);
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream, cancellationToken: AbortToken);
         }
 
-        var url = await storage.GetPresignedDownloadUrlAsync(container, "file.txt", TimeSpan.FromMinutes(5));
+        var url = await storage.GetPresignedDownloadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
 
         using var http = new HttpClient();
-        var downloaded = await http.GetByteArrayAsync(url);
+        var downloaded = await http.GetByteArrayAsync(url, AbortToken);
 
         downloaded.Should().Equal(content);
+    }
+
+    [Fact]
+    public async Task can_round_trip_via_presigned_upload_url()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign-{Guid.NewGuid():N}" };
+        var content = "presigned-upload"u8.ToArray();
+
+        var uploadUrl = await storage.GetPresignedUploadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromMinutes(5),
+            AbortToken
+        );
+
+        using (var http = new HttpClient())
+        using (var body = new ByteArrayContent(content))
+        {
+            var response = await http.PutAsync(uploadUrl, body, AbortToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var readBack = await ((IBlobStorage)storage).OpenReadStreamAsync(container, "file.txt", AbortToken);
+        readBack.Should().NotBeNull();
+
+        using var buffer = new MemoryStream();
+        await readBack!.Stream.CopyToAsync(buffer, AbortToken);
+        buffer.ToArray().Should().Equal(content);
+    }
+
+    [Fact]
+    public async Task presigned_download_url_is_denied_after_expiry()
+    {
+        var storage = (IPresignedUrlBlobStorage)GetStorage();
+        var container = new[] { $"presign-{Guid.NewGuid():N}" };
+
+        using (var stream = new MemoryStream("expiring"u8.ToArray()))
+        {
+            await ((IBlobStorage)storage).UploadAsync(container, "file.txt", stream, cancellationToken: AbortToken);
+        }
+
+        var url = await storage.GetPresignedDownloadUrlAsync(
+            container,
+            "file.txt",
+            TimeSpan.FromSeconds(2),
+            AbortToken
+        );
+
+        await Task.Delay(TimeSpan.FromSeconds(4), AbortToken);
+
+        using var http = new HttpClient();
+        var response = await http.GetAsync(url, AbortToken);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Integration/CloudflareR2BlobStorageTests.cs
@@ -5,6 +5,7 @@ using Amazon.S3;
 using Headless.Abstractions;
 using Headless.Blobs;
 using Headless.Blobs.Aws;
+using Headless.Blobs.CloudflareR2;
 using Microsoft.Extensions.Options;
 
 namespace Tests;
@@ -29,17 +30,17 @@ public sealed class CloudflareR2BlobStorageTests : BlobStorageTestsBase
             "R2 credentials are not configured (R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY)."
         );
 
-        var config = new AmazonS3Config
-        {
-            ServiceURL = $"https://{accountId}.r2.cloudflarestorage.com",
-            ForcePathStyle = true,
-            AuthenticationRegion = "auto",
-            RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED,
-            ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
-        };
-
+        // Build the client through the same factory the production setup uses, so the conformance suite can
+        // never drift from the real R2 client configuration (the whole point of the SDK-bump gate).
 #pragma warning disable CA2000 // Disposed by AwsBlobStorage / the test host.
-        var client = new AmazonS3Client(new BasicAWSCredentials(accessKey!, secretKey!), config);
+        var client = R2ClientFactory.Create(
+            new R2BlobStorageOptions
+            {
+                AccountId = accountId!,
+                AccessKeyId = accessKey!,
+                SecretAccessKey = secretKey!,
+            }
+        );
 #pragma warning restore CA2000
 
         // Conformance exercises the full lifecycle, so it needs bucket creation; the test token must allow it.

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Headless.NET.Sdk.Test">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Headless.Blobs.CloudflareR2\Headless.Blobs.CloudflareR2.csproj" />
+    <ProjectReference Include="..\Headless.Blobs.Tests.Harness\Headless.Blobs.Tests.Harness.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Unit/Headless.Blobs.CloudflareR2.Tests.Unit.csproj
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Unit/Headless.Blobs.CloudflareR2.Tests.Unit.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Headless.NET.Sdk.Test">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Headless.Blobs.CloudflareR2\Headless.Blobs.CloudflareR2.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Unit/R2BlobNamingNormalizerTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Unit/R2BlobNamingNormalizerTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Blobs.CloudflareR2;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+public sealed class R2BlobNamingNormalizerTests : TestBase
+{
+    private readonly R2BlobNamingNormalizer _sut = new();
+
+    [Theory]
+    [InlineData("my.bucket", "mybucket")]
+    [InlineData("my.bucket.name", "mybucketname")]
+    [InlineData("a.b.c", "abc")]
+    public void should_remove_dots(string input, string expected)
+    {
+        _sut.NormalizeContainerName(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_lowercase_container_name()
+    {
+        _sut.NormalizeContainerName("MyBucket").Should().Be("mybucket");
+    }
+
+    [Fact]
+    public void should_truncate_to_63_characters()
+    {
+        _sut.NormalizeContainerName(new string('a', 70)).Should().HaveLength(63);
+    }
+
+    [Theory]
+    [InlineData("my_bucket!", "mybucket")]
+    [InlineData("my@bucket#test", "mybuckettest")]
+    public void should_remove_invalid_characters(string input, string expected)
+    {
+        _sut.NormalizeContainerName(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("-mybucket", "mybucket")]
+    [InlineData("--mybucket", "mybucket")]
+    [InlineData("mybucket-", "mybucket")]
+    [InlineData("mybucket--", "mybucket")]
+    public void should_trim_leading_and_trailing_hyphens(string input, string expected)
+    {
+        _sut.NormalizeContainerName(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("ab", "ab0")]
+    [InlineData("a", "a00")]
+    public void should_pad_short_names_to_minimum_3(string input, string expected)
+    {
+        _sut.NormalizeContainerName(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("...", "000")]
+    [InlineData("@@@", "000")]
+    public void should_handle_empty_after_normalization(string input, string expected)
+    {
+        _sut.NormalizeContainerName(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("valid-bucket-123")]
+    [InlineData("my-bucket")]
+    public void should_preserve_valid_names(string input)
+    {
+        _sut.NormalizeContainerName(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void should_return_valid_blob_name()
+    {
+        _sut.NormalizeBlobName("folder/file.txt").Should().Be("folder/file.txt");
+    }
+
+    [Fact]
+    public void should_throw_for_blob_path_traversal()
+    {
+        var act = () => _sut.NormalizeBlobName("../file.txt");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Unit/R2BlobStorageOptionsTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Unit/R2BlobStorageOptionsTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Blobs.CloudflareR2;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+public sealed class R2BlobStorageOptionsTests : TestBase
+{
+    [Fact]
+    public void default_jurisdiction_uses_global_endpoint()
+    {
+        var options = new R2BlobStorageOptions { AccountId = "acc123" };
+
+        options.GetEffectiveEndpointUrl().Should().Be("https://acc123.r2.cloudflarestorage.com");
+    }
+
+    [Fact]
+    public void eu_jurisdiction_uses_eu_endpoint()
+    {
+        var options = new R2BlobStorageOptions { AccountId = "acc123", Jurisdiction = R2Jurisdiction.EuropeanUnion };
+
+        options.GetEffectiveEndpointUrl().Should().Be("https://acc123.eu.r2.cloudflarestorage.com");
+    }
+
+    [Fact]
+    public void fedramp_jurisdiction_uses_fedramp_endpoint()
+    {
+        var options = new R2BlobStorageOptions { AccountId = "acc123", Jurisdiction = R2Jurisdiction.FedRamp };
+
+        options.GetEffectiveEndpointUrl().Should().Be("https://acc123.fedramp.r2.cloudflarestorage.com");
+    }
+
+    [Fact]
+    public void explicit_endpoint_url_overrides_jurisdiction()
+    {
+        var options = new R2BlobStorageOptions
+        {
+            AccountId = "acc123",
+            Jurisdiction = R2Jurisdiction.EuropeanUnion,
+            EndpointUrl = "https://{0}.custom.example.com",
+        };
+
+        options.GetEffectiveEndpointUrl().Should().Be("https://acc123.custom.example.com");
+    }
+}

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Unit/SetupCloudflareR2BlobTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Unit/SetupCloudflareR2BlobTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Amazon.Runtime;
+using Amazon.S3;
+using Headless.Abstractions;
+using Headless.Blobs;
+using Headless.Blobs.Aws;
+using Headless.Blobs.CloudflareR2;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+public sealed class SetupCloudflareR2BlobTests : TestBase
+{
+    private static ServiceProvider _BuildProvider(Action<R2BlobStorageOptions>? configure = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IClock>(new Clock(TimeProvider.System));
+        services.AddSingleton<IMimeTypeProvider, MimeTypeProvider>();
+        services.AddLogging();
+
+        services.AddCloudflareR2BlobStorage(
+            configure
+                ?? (
+                    options =>
+                    {
+                        options.AccountId = "acc123";
+                        options.AccessKeyId = "key";
+                        options.SecretAccessKey = "secret";
+                    }
+                )
+        );
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void registers_amazon_s3_configured_for_r2()
+    {
+        using var sp = _BuildProvider();
+
+        var config = (AmazonS3Config)((AmazonS3Client)sp.GetRequiredService<IAmazonS3>()).Config;
+
+        // The AWS SDK normalizes ServiceURL with a trailing slash.
+        config.ServiceURL.Should().Be("https://acc123.r2.cloudflarestorage.com/");
+        config.ForcePathStyle.Should().BeTrue();
+        config.AuthenticationRegion.Should().Be("auto");
+        config.RequestChecksumCalculation.Should().Be(RequestChecksumCalculation.WHEN_REQUIRED);
+        config.ResponseChecksumValidation.Should().Be(ResponseChecksumValidation.WHEN_REQUIRED);
+    }
+
+    [Fact]
+    public void applies_r2_safe_blob_storage_options()
+    {
+        using var sp = _BuildProvider();
+
+        var options = sp.GetRequiredService<IOptions<AwsBlobStorageOptions>>().Value;
+
+        options.CannedAcl.Should().BeNull();
+        options.UseChunkEncoding.Should().BeFalse();
+        options.DisablePayloadSigning.Should().BeTrue();
+        options.AutoCreateContainer.Should().BeFalse();
+    }
+
+    [Fact]
+    public void registers_r2_naming_normalizer()
+    {
+        using var sp = _BuildProvider();
+
+        sp.GetRequiredService<IBlobNamingNormalizer>().Should().BeOfType<R2BlobNamingNormalizer>();
+    }
+
+    [Fact]
+    public async Task registers_aws_engine_with_presigned_capability()
+    {
+        // AwsBlobStorage is IAsyncDisposable, so the provider must be disposed asynchronously once resolved.
+        await using var sp = _BuildProvider();
+
+        var storage = sp.GetRequiredService<IBlobStorage>();
+
+        storage.Should().BeOfType<AwsBlobStorage>();
+        storage.Should().BeAssignableTo<IPresignedUrlBlobStorage>();
+    }
+
+    [Fact]
+    public void invalid_options_fail_validation()
+    {
+        using var sp = _BuildProvider(options =>
+        {
+            options.AccountId = "";
+            options.AccessKeyId = "";
+            options.SecretAccessKey = "";
+        });
+
+        var act = () => sp.GetRequiredService<IOptions<R2BlobStorageOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>();
+    }
+}

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Unit/SetupCloudflareR2BlobTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Unit/SetupCloudflareR2BlobTests.cs
@@ -101,7 +101,7 @@ public sealed class SetupCloudflareR2BlobTests : TestBase
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(
-                new Dictionary<string, string?>
+                new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
                     ["R2:AccountId"] = "acc123",
                     ["R2:AccessKeyId"] = "key",

--- a/tests/Headless.Blobs.CloudflareR2.Tests.Unit/SetupCloudflareR2BlobTests.cs
+++ b/tests/Headless.Blobs.CloudflareR2.Tests.Unit/SetupCloudflareR2BlobTests.cs
@@ -7,6 +7,7 @@ using Headless.Blobs;
 using Headless.Blobs.Aws;
 using Headless.Blobs.CloudflareR2;
 using Headless.Testing.Tests;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -83,6 +84,41 @@ public sealed class SetupCloudflareR2BlobTests : TestBase
 
         storage.Should().BeOfType<AwsBlobStorage>();
         storage.Should().BeAssignableTo<IPresignedUrlBlobStorage>();
+    }
+
+    [Fact]
+    public async Task presigned_capability_is_injectable_and_is_the_same_instance()
+    {
+        await using var sp = _BuildProvider();
+
+        var presigned = sp.GetRequiredService<IPresignedUrlBlobStorage>();
+
+        presigned.Should().BeSameAs(sp.GetRequiredService<IBlobStorage>());
+    }
+
+    [Fact]
+    public void binds_options_from_configuration_section()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["R2:AccountId"] = "acc123",
+                    ["R2:AccessKeyId"] = "key",
+                    ["R2:SecretAccessKey"] = "secret",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IClock>(new Clock(TimeProvider.System));
+        services.AddSingleton<IMimeTypeProvider, MimeTypeProvider>();
+        services.AddLogging();
+        services.AddCloudflareR2BlobStorage(configuration.GetSection("R2"));
+
+        using var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<IOptions<R2BlobStorageOptions>>().Value.AccountId.Should().Be("acc123");
     }
 
     [Fact]

--- a/tests/Headless.Blobs.Redis.Tests.Integration/RedisBlobStorageTests.cs
+++ b/tests/Headless.Blobs.Redis.Tests.Integration/RedisBlobStorageTests.cs
@@ -16,7 +16,7 @@ public sealed class RedisBlobStorageTests(RedisBlobStorageFixture fixture) : Blo
         var options = new RedisBlobStorageOptions { ConnectionMultiplexer = fixture.ConnectionMultiplexer };
         var optionsWrapper = new OptionsWrapper<RedisBlobStorageOptions>(options);
 
-        return new RedisBlobStorage(optionsWrapper, new SystemJsonSerializer());
+        return new RedisBlobStorage(optionsWrapper, new SystemJsonSerializer(), new CrossOsNamingNormalizer());
     }
 
     [Fact]
@@ -191,7 +191,11 @@ public sealed class RedisBlobStorageTests(RedisBlobStorageFixture fixture) : Blo
             MaxBlobSizeBytes = 100, // 100 bytes limit
         };
         var optionsWrapper = new OptionsWrapper<RedisBlobStorageOptions>(options);
-        await using var storage = new RedisBlobStorage(optionsWrapper, new SystemJsonSerializer());
+        await using var storage = new RedisBlobStorage(
+            optionsWrapper,
+            new SystemJsonSerializer(),
+            new CrossOsNamingNormalizer()
+        );
 
         var largeData = new byte[200]; // Exceeds 100 byte limit
         Array.Fill(largeData, (byte)'x');
@@ -212,7 +216,11 @@ public sealed class RedisBlobStorageTests(RedisBlobStorageFixture fixture) : Blo
             MaxBlobSizeBytes = 1000,
         };
         var optionsWrapper = new OptionsWrapper<RedisBlobStorageOptions>(options);
-        await using var storage = new RedisBlobStorage(optionsWrapper, new SystemJsonSerializer());
+        await using var storage = new RedisBlobStorage(
+            optionsWrapper,
+            new SystemJsonSerializer(),
+            new CrossOsNamingNormalizer()
+        );
 
         var data = new byte[500]; // Within limit
         Array.Fill(data, (byte)'x');
@@ -233,7 +241,11 @@ public sealed class RedisBlobStorageTests(RedisBlobStorageFixture fixture) : Blo
             MaxBlobSizeBytes = 0, // Disabled
         };
         var optionsWrapper = new OptionsWrapper<RedisBlobStorageOptions>(options);
-        await using var storage = new RedisBlobStorage(optionsWrapper, new SystemJsonSerializer());
+        await using var storage = new RedisBlobStorage(
+            optionsWrapper,
+            new SystemJsonSerializer(),
+            new CrossOsNamingNormalizer()
+        );
 
         var data = new byte[1000];
         Array.Fill(data, (byte)'x');


### PR DESCRIPTION
## Summary

Adds **Cloudflare R2** as a private, S3-compatible blob backend (cost-saving S3 replacement), introduces a **presigned-URL capability** shared by the S3 and Azure providers, and refactors the shared S3 engine to end its per-operation bucket round trips.

Origin: `docs/brainstorms/2026-06-19-blobs-cloudflare-r2-requirements.md` · Plan: `docs/plans/2026-06-19-001-feat-blobs-cloudflare-r2-presigned-plan.md`

## What changed

- **New package `Headless.Blobs.CloudflareR2`** — reuses `AwsBlobStorage` behind an R2-tuned `IAmazonS3` (path-style, `auto` region, SDK v4 checksum `WHEN_REQUIRED`), R2-safe option defaults (`CannedAcl=null`, no chunk encoding, no payload signing, auto-create off), a dot-rejecting `R2BlobNamingNormalizer`, and jurisdiction-aware endpoints (default/EU/FedRAMP).
- **`IPresignedUrlBlobStorage` capability** (presigned GET + PUT) in `Headless.Blobs.Abstractions` — implemented by the S3 engine (AWS **and** R2 via SigV4) and Azure (via SAS). FileSystem/Redis/SshNet deliberately don't implement it; consumers feature-detect with `storage is IPresignedUrlBlobStorage`. Azure throws a clear `InvalidOperationException` at call time when its client lacks signing credentials.
- **Shared `AwsBlobStorage` engine refactor** — read/exists/delete/download no longer pre-check the bucket (`NoSuchBucket`/404 → not-found); auto-create is now opt-in via `AutoCreateContainer` (AWS default `true`, R2 `false`) and runs at most once per bucket per instance.
- **Creds-gated R2 conformance suite** reusing the cross-provider harness — skips cleanly without R2 credentials; one always-on, network-free presigned-targeting test keeps the module from reporting zero tests.
- **CI** — new `r2-conformance.yml` workflow (creds-gated, behind the `R2 Conformance` environment) + an `AWSSDK.*` Dependabot group so SDK bumps land as a distinct, gateable PR.
- **Docs** — `docs/llms/blobs.md` + AWS/Azure/R2 READMEs updated; fixed the stale `BucketName` claim in the AWS docs.

## Testing

- **111 passing**: AWS unit (53), Azure unit (29), R2 unit (28), R2 conformance always-on (1). R2 conformance: 40 skipped (no creds). Format-check clean.
- AWS/Azure **integration** tests (LocalStack/Azurite) compile here but were not run (no Docker in the authoring env); they run under Docker locally / CI.

## Follow-ups / manual setup

- Create the `R2 Conformance` GitHub Environment + `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` secrets, and mark the conformance check **required** in branch protection.
- The config-level checksum lever is ~90% confident on `AWSSDK.S3 4.0.23.3`; a live R2 conformance run is the authoritative confirmation (fallback `DisableDefaultChecksumValidation` documented in the plan).
- Unrelated pre-existing blocker: full-solution restore fails on `NU1903` (`SQLitePCLRaw.lib.e_sqlite3` advisory in `Headless.Jobs.Tests.Unit`) — not touched here.