### PR TITLE
refactor(jobs): extract in-memory owner-fence predicate helpers (partial #467)

### DIFF
--- a/src/Headless.Jobs.Core/Src/Provider/JobsInMemoryPersistenceProvider.cs
+++ b/src/Headless.Jobs.Core/Src/Provider/JobsInMemoryPersistenceProvider.cs
@@ -34,6 +34,18 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         _leaseDuration = optionsBuilder?.LeaseDuration ?? TimeSpan.FromMinutes(5);
     }
 
+    // The #5 completion/claim fence (mirror of EF WhereOwnedBy): a row is touchable only when this node owns it and it
+    // is still non-terminal. Extracted (#467) so the predicate that guards every completion/claim path lives in one
+    // place — it was inlined 4× and a single typo would silently let one path clobber a swept/reclaimed row.
+    private bool _IsOwnedNonTerminal(string? ownerId, JobStatus status) =>
+        string.Equals(ownerId, _ownerId, StringComparison.Ordinal)
+        && status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress;
+
+    // Renewal slides a RUNNING lease only (mirror of the EF RenewTimeJobLease InProgress fence): extending an
+    // Idle/Queued row would read as "lease held" and suppress cancel-on-loss. Extracted (#467) — inlined 2×.
+    private bool _IsOwnedRunning(string? ownerId, JobStatus status) =>
+        string.Equals(ownerId, _ownerId, StringComparison.Ordinal) && status is JobStatus.InProgress;
+
     #region Time Job Methods
 
     public async IAsyncEnumerable<TimeJobEntity> QueueTimeJobs(
@@ -193,9 +205,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         {
             // #5 completion fence (mirror EF WhereOwnedBy): only the still-owning node may complete a
             // non-terminal row, so a swept/reclaimed row is not clobbered by a late completion.
-            var ownedNonTerminal =
-                string.Equals(job.OwnerId, _ownerId, StringComparison.Ordinal)
-                && job.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress;
+            var ownedNonTerminal = _IsOwnedNonTerminal(job.OwnerId, job.Status);
 
             if (!ownedNonTerminal)
             {
@@ -236,9 +246,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
             {
                 // #316/U5 claim→start ownership recheck (mirror EF WhereOwnedBy): only stamp rows still owned by
                 // this node and non-terminal, so a row re-claimed by another owner is not clobbered.
-                var ownedNonTerminal =
-                    string.Equals(job.OwnerId, _ownerId, StringComparison.Ordinal)
-                    && job.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress;
+                var ownedNonTerminal = _IsOwnedNonTerminal(job.OwnerId, job.Status);
 
                 if (!ownedNonTerminal)
                 {
@@ -307,8 +315,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         {
             // Renewal slides a RUNNING lease only: extending an Idle/Queued row would return 1 ("lease held") and
             // suppress cancel-on-loss. Mirror the EF RenewTimeJobLease InProgress fence.
-            var ownedRunning =
-                string.Equals(job.OwnerId, _ownerId, StringComparison.Ordinal) && job.Status is JobStatus.InProgress;
+            var ownedRunning = _IsOwnedRunning(job.OwnerId, job.Status);
 
             if (!ownedRunning)
             {
@@ -990,9 +997,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         if (_CronOccurrences.TryGetValue(functionContext.JobId, out var occurrence))
         {
             // #5 completion fence (mirror EF WhereOwnedBy): only the still-owning node may complete a non-terminal occurrence.
-            var ownedNonTerminal =
-                string.Equals(occurrence.OwnerId, _ownerId, StringComparison.Ordinal)
-                && occurrence.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress;
+            var ownedNonTerminal = _IsOwnedNonTerminal(occurrence.OwnerId, occurrence.Status);
 
             if (ownedNonTerminal)
             {
@@ -1018,9 +1023,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         if (_CronOccurrences.TryGetValue(occurrenceId, out var occurrence))
         {
             // Renewal slides a RUNNING lease only (see RenewTimeJobLease InProgress fence).
-            var ownedRunning =
-                string.Equals(occurrence.OwnerId, _ownerId, StringComparison.Ordinal)
-                && occurrence.Status is JobStatus.InProgress;
+            var ownedRunning = _IsOwnedRunning(occurrence.OwnerId, occurrence.Status);
 
             if (!ownedRunning)
             {
@@ -1166,9 +1169,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
             if (_CronOccurrences.TryGetValue(id, out var occurrence))
             {
                 // #316/U5 — cron mirror of the claim→start ownership recheck.
-                var ownedNonTerminal =
-                    string.Equals(occurrence.OwnerId, _ownerId, StringComparison.Ordinal)
-                    && occurrence.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress;
+                var ownedNonTerminal = _IsOwnedNonTerminal(occurrence.OwnerId, occurrence.Status);
 
                 if (!ownedNonTerminal)
                 {


### PR DESCRIPTION
First, safe slice of #467 (decompose the large Jobs persistence providers). Addresses the maintainability review's **primary** concern.

## What changed
The #5 completion/claim fence predicate — `OwnerId == _ownerId && Status is Idle/Queued/InProgress` — was inlined **6×** across the in-memory provider's completion, claim, and renewal paths. A single typo in any one copy would silently let that path clobber a swept/reclaimed row (the exact "divergence is one typo away" risk the reviewer flagged).

- Extracted `_IsOwnedNonTerminal` (4 sites — completion/claim fences) and `_IsOwnedRunning` (2 sites — the InProgress renewal fence).
- Behavior-preserving: the helpers are byte-for-byte the inlined predicates. **137 unit tests green.**

## Deliberately NOT in this PR (stays on #467)
- **In-memory `TryApply` extraction** — the 4× local helper factors `UpdatedAt = now` out per-method; a clean class-level generic re-adds it per switch-arm, so the payoff is modest. Low priority.
- **EF generic reclaim/dead-node extraction** — the 4 near-identical `ExecuteUpdate` blocks. The entities (`TimeJobEntity` / `CronJobOccurrenceEntity`) share no base class and have `internal set` properties, so a generic helper needs a getters-only interface or `EF.Property` string access — and **EF Core must translate that member access to SQL** on both Postgres and SqlServer. That's verifiable only against the Docker conformance suite, with a real "doesn't translate → revert" risk. The 4 methods are stable and well-tested, so this is a separate, carefully-verified slice.

#467 stays open for the EF extraction. Does not close it.