### PR TITLE
fix(jobs-dashboard): drop redundant withDefaults import for vue-tsc 3

### DIFF
--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/TimeJobCharts.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/TimeJobCharts.vue
@@ -88,7 +88,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch, withDefaults } from 'vue'
+import { ref, computed, watch } from 'vue'
 import VChart from 'vue-echarts'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'


### PR DESCRIPTION
## What
Remove the explicit `withDefaults` import in `TimeJobCharts.vue`.

## Why
`withDefaults` is a Vue compiler macro auto-injected as a global (like `defineProps`, which was correctly never imported in this file). Importing it explicitly trips **vue-tsc 3**'s stricter check:

```
src/components/TimeJobCharts.vue(91,32): error TS2440: Import declaration conflicts with local declaration of 'withDefaults'.
```

This is the sole blocker for the vue-tsc 2→3 upgrade (#488). The Messaging dashboard had no such import, which is why the same bump (#491) passed there.

## Verification
- vue-tsc 2 `--build` type-check passes locally (no regression on current main).
- vue-tsc 3 validation will run on #488 after rebasing onto this fix.