### PR TITLE
feat(emails)!: add Azure provider; replace per-provider extensions with unified builder

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.14.4" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.33" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.31" />
+    <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />

--- a/docs/llms/emails.md
+++ b/docs/llms/emails.md
@@ -1,6 +1,6 @@
 ---
 domain: Email
-packages: Emails.Abstractions, Emails.Core, Emails.Aws, Emails.Dev, Emails.Mailkit
+packages: Emails.Abstractions, Emails.Core, Emails.Aws, Emails.Azure, Emails.Dev, Emails.Mailkit
 ---
 
 # Email
@@ -35,7 +35,7 @@ packages: Emails.Abstractions, Emails.Core, Emails.Aws, Emails.Dev, Emails.Mailk
     - [Configuration](#configuration-2)
     - [Dependencies](#dependencies-2)
     - [Side Effects](#side-effects-2)
-- [Headless.Emails.Dev](#headlessemailsdev)
+- [Headless.Emails.Azure](#headlessemailsazure)
     - [Problem Solved](#problem-solved-3)
     - [Key Features](#key-features-3)
     - [Installation](#installation-3)
@@ -43,7 +43,7 @@ packages: Emails.Abstractions, Emails.Core, Emails.Aws, Emails.Dev, Emails.Mailk
     - [Configuration](#configuration-3)
     - [Dependencies](#dependencies-3)
     - [Side Effects](#side-effects-3)
-- [Headless.Emails.Mailkit](#headlessemailsmailkit)
+- [Headless.Emails.Dev](#headlessemailsdev)
     - [Problem Solved](#problem-solved-4)
     - [Key Features](#key-features-4)
     - [Installation](#installation-4)
@@ -51,33 +51,44 @@ packages: Emails.Abstractions, Emails.Core, Emails.Aws, Emails.Dev, Emails.Mailk
     - [Configuration](#configuration-4)
     - [Dependencies](#dependencies-4)
     - [Side Effects](#side-effects-4)
+- [Headless.Emails.Mailkit](#headlessemailsmailkit)
+    - [Problem Solved](#problem-solved-5)
+    - [Key Features](#key-features-5)
+    - [Installation](#installation-5)
+    - [Quick Start](#quick-start-5)
+    - [Configuration](#configuration-5)
+    - [Dependencies](#dependencies-5)
+    - [Side Effects](#side-effects-5)
 
-> Provider-agnostic email sending with implementations for AWS SES, SMTP (MailKit), and development/testing modes.
+> Provider-agnostic email sending with implementations for Azure Communication Services, AWS SES, SMTP (MailKit), and development/testing modes.
 
 ## Quick Orientation
 
-Install `Headless.Emails.Abstractions` + one provider. Code against `IEmailSender`.
+Install `Headless.Emails.Abstractions` + one provider. Register with `AddHeadlessEmails(setup => setup.Use…())` — exactly one `Use*` provider per call. Code against `IEmailSender`.
 
-- **Development/testing**: `Headless.Emails.Dev` — writes emails to a local file (`DevEmailSender`) or discards them silently (`NoopEmailSender`). No network calls.
-- **AWS production**: `Headless.Emails.Aws` — sends via AWS SES v2. Call `AddAwsSesEmailSender()`.
-- **SMTP (any server)**: `Headless.Emails.Mailkit` — sends via SMTP using MailKit with connection pooling. Supports SSL/TLS, authentication, and works with Gmail, Outlook, SendGrid, on-premises servers. Call `AddMailKitEmailSender()`.
+- **Development/testing**: `Headless.Emails.Dev` — `UseDevelopment(path)` writes emails to a local file (`DevEmailSender`) or `UseNoop()` discards them silently (`NoopEmailSender`). No network calls.
+- **Azure production**: `Headless.Emails.Azure` — sends via Azure Communication Services (ACS) Email. Call `UseAzure(...)`. Three auth modes: connection string, endpoint + access key, endpoint + managed-identity `TokenCredential`.
+- **AWS production**: `Headless.Emails.Aws` — sends via AWS SES v2. Call `UseAwsSes(awsOptions)`.
+- **SMTP (any server)**: `Headless.Emails.Mailkit` — sends via SMTP using MailKit with connection pooling. Supports SSL/TLS, authentication, and works with Gmail, Outlook, SendGrid, on-premises servers. Call `UseMailkit(...)`.
 
-`Headless.Emails.Core` provides shared MimeKit conversion utilities (`ConvertToMimeMessageAsync()`) used internally by the Aws and Mailkit providers. Both providers pull it transitively — you rarely need to install it directly.
+`Headless.Emails.Core` owns the setup builder (`AddHeadlessEmails`, `HeadlessEmailsSetupBuilder`, `IEmailProviderOptionsExtension`) plus shared MimeKit conversion (`ConvertToMimeMessageAsync()`) and attachment content-type derivation (`EmailAttachmentContentType.Resolve()`). Providers pull it transitively — you rarely install it directly.
 
 Send emails via `IEmailSender.SendAsync(SendSingleEmailRequest)` which returns `SendSingleEmailResponse` with `Success` and `FailureError`.
 
 ## Agent Instructions
 
-- Always use `Emails.Dev` (`AddDevEmailSender()` or `AddNoopEmailSender()`) in development environments to prevent sending real emails. Gate with `builder.Environment.IsDevelopment()`.
-- Use `IEmailSender` from `Headless.Emails.Abstractions` — never reference `AwsSesEmailSender`, `MailkitEmailSender`, or other concrete types in application code.
+- Register exactly one provider per container: `services.AddHeadlessEmails(setup => setup.Use…())`. Zero, multiple, or a repeated `AddHeadlessEmails` on the same `IServiceCollection` throws `InvalidOperationException` at registration time. The available `Use*` calls are `UseAzure`, `UseAwsSes`, `UseMailkit`, `UseDevelopment`, `UseNoop`.
+- Use `IEmailSender` from `Headless.Emails.Abstractions` — never reference `AzureCommunicationEmailSender`, `AwsSesEmailSender`, `MailkitEmailSender`, or other concrete types in application code.
+- Always use `Emails.Dev` (`UseDevelopment(path)` or `UseNoop()`) in development environments to prevent sending real emails. Gate with `builder.Environment.IsDevelopment()`.
 - `SendSingleEmailRequest` requires both `From` (an `EmailRequestAddress`) and `Destination` (an `EmailRequestDestination`) — they are `required` properties. Provide at least one of `MessageHtml` or `MessageText`; `MailkitEmailSender` throws `InvalidOperationException` if both are null.
 - Check `response.Success` after calling `SendAsync` — do not assume success. Read `response.FailureError` (non-null when `Success` is false) on failure.
-- `Emails.Aws` uses AWS SES **v2** (`AWSSDK.SimpleEmailV2`), not v1. Pass `AWSOptions?` (nullable — `null` uses the default `AWSOptions` registered in the DI container) to `AddAwsSesEmailSender()`.
+- `Emails.Azure` requires a sender domain that is **verified and linked** in the Communication Services resource. A misconfigured sender surfaces as a failed `SendSingleEmailResponse`, not an exception you can pre-validate. `UseAzure` requires exactly one auth mode (connection string, endpoint + access key, or endpoint + `TokenCredential`); the `IConfiguration` overload binds only the string/key modes (a `TokenCredential` cannot be bound from configuration). ACS ignores the sender's display name (`senderAddress` is a bare string).
+- `Emails.Aws` uses AWS SES **v2** (`AWSSDK.SimpleEmailV2`), not v1. Pass `AWSOptions?` (nullable — `null` uses the default `AWSOptions` registered in the DI container) to `UseAwsSes(...)`.
 - For SMTP via MailKit, configure `MailkitSmtpOptions`: `Server` (required), `Port` (default 587), `SocketOptions` (default `StartTls`), `Timeout` (default 30s), `MaxPoolSize` (default 10; set 0 to disable pooling).
 - `MailkitEmailSender` uses an `ObjectPool<SmtpClient>` — SMTP connections are pooled and reused. Authentication happens on reconnect. If `AuthenticationException` is thrown (wrong credentials), it propagates — it is not swallowed like SMTP command/protocol errors.
 - All providers register `IEmailSender` as singleton.
 - `DevEmailSender` appends to a file with separators — it writes `MessageText` preferring it over `MessageHtml` for readability.
-- `Emails.Core` is a utility package consumed by providers — it is not used directly in application code.
+- `Emails.Core` provides the builder and shared utilities consumed by providers — it is not used directly in application code (except the `AddHeadlessEmails` entry point, which is the provider-agnostic registration call).
 
 ## Core Concepts
 
@@ -92,7 +103,7 @@ Send emails via `IEmailSender.SendAsync(SendSingleEmailRequest)` which returns `
 | `Subject` | `string` | Email subject line |
 | `MessageHtml` | `string?` | HTML body (optional, but provide at least one body) |
 | `MessageText` | `string?` | Plain-text body (optional, but provide at least one body) |
-| `Attachments` | `IReadOnlyList<EmailRequestAttachment>` | File attachments (default empty) |
+| `Attachments` | `IReadOnlyList<EmailRequestAttachment>` | File attachments (default empty); each carries a `Name` + `File` (bytes) only |
 
 `EmailRequestAddress` accepts a display name: `new EmailRequestAddress("addr@ex.com", "Alice")` or bare string `"addr@ex.com"` (implicit conversion).
 
@@ -102,27 +113,32 @@ Send emails via `IEmailSender.SendAsync(SendSingleEmailRequest)` which returns `
 
 The `[MemberNotNullWhen(false, nameof(FailureError))]` attribute enables null-safe access: if `response.Success` is false, the compiler knows `FailureError` is not null.
 
-### Provider wiring
+### Provider wiring (unified setup builder)
 
-Each provider registers `IEmailSender` as a singleton. Only one provider may be wired per DI container. The `Emails.Core` conversion utilities are an internal implementation detail shared by Aws and Mailkit; consumers never call `ConvertToMimeMessageAsync()` directly.
+Email uses the framework's unified provider setup-builder grammar. `AddHeadlessEmails(Action<HeadlessEmailsSetupBuilder>)` (in `Headless.Emails.Core`) is the single registration entry point. Inside the delegate, each provider package contributes a `Use*` extension member on `HeadlessEmailsSetupBuilder` that registers an `IEmailProviderOptionsExtension`; the core gate then enforces **exactly one provider** and runs that extension's wiring.
+
+Zero providers, multiple providers in one delegate, or a repeated `AddHeadlessEmails` on the same `IServiceCollection` all throw `InvalidOperationException` at registration time — a host resolves a single `IEmailSender`, so exactly one provider is required.
+
+Since the attachment contract (`EmailRequestAttachment`) carries only a name and bytes, providers whose transport needs an explicit MIME type derive it from the file name via `EmailAttachmentContentType.Resolve()` (MimeKit lookup, `application/octet-stream` fallback). The `Emails.Core` conversion utilities (`ConvertToMimeMessageAsync()`) remain an internal detail shared by Aws and Mailkit; consumers never call them directly.
 
 ## Choosing a Provider
 
 | Provider | Use when | Avoid when | Trade-offs |
 |---|---|---|---|
+| `Headless.Emails.Azure` | Running on Azure, want ACS Email with managed-identity auth and a verified sender domain | No Azure Communication Services resource; want SMTP portability | ACS REST API (not SMTP); blocks until ACS reaches a terminal status (`WaitUntil.Completed`); managed-domain send limit is low (5/min); sender display name not honored; `Azure.Communication.Email` dependency |
 | `Headless.Emails.Aws` | Running on AWS, need SES deliverability, compliance, and send-rate guarantees | No AWS account; want SMTP portability | SES API (not SMTP); simple sends use a REST path, attachments fall back to raw MIME via SES; AWS SDK dependency |
-| `Headless.Emails.Mailkit` | Need SMTP portability (SendGrid, Gmail, Outlook, on-premises); want connection pooling | SES API required; not running SMTP server | SMTP is synchronous per-connection; pooling amortizes connect cost; `AuthenticationException` propagates (not returned as failure) |
+| `Headless.Emails.Mailkit` | Need SMTP portability (SendGrid, Gmail, Outlook, on-premises); want connection pooling | SES/ACS API required; not running SMTP server | SMTP is synchronous per-connection; pooling amortizes connect cost; `AuthenticationException` propagates (not returned as failure) |
 | `Headless.Emails.Dev` | Local development, CI, integration tests | Production traffic | No real delivery; `DevEmailSender` writes to disk; `NoopEmailSender` silently discards |
 
 ---
 
 # Headless.Emails.Abstractions
 
-Defines the unified interface for sending emails across different providers (AWS SES, SMTP/MailKit, development).
+Defines the unified interface for sending emails across different providers (Azure Communication Services, AWS SES, SMTP/MailKit, development).
 
 ## Problem Solved
 
-Provides a provider-agnostic email sending API, enabling seamless switching between email providers without changing application code.
+Provides a provider-agnostic email sending API, enabling switching between email providers without changing application code.
 
 ## Key Features
 
@@ -182,21 +198,23 @@ None.
 
 # Headless.Emails.Core
 
-Core utilities and MimeKit integration for email implementations.
+Setup builder, MimeKit integration, and shared utilities for email implementations.
 
 ## Problem Solved
 
-Provides shared conversion logic to bridge the framework email contracts with MimeKit, eliminating duplication across the Aws and Mailkit provider implementations.
+Owns the unified email setup builder (`AddHeadlessEmails`) plus shared conversion logic that bridges the framework email contracts with MimeKit, eliminating duplication across the provider implementations.
 
 ## Key Features
 
+- `AddHeadlessEmails(Action<HeadlessEmailsSetupBuilder>)` — the single provider-agnostic registration entry point, with an exactly-one-provider gate
+- `HeadlessEmailsSetupBuilder` — receives `Use*` provider selections; `IEmailProviderOptionsExtension` — the hook each provider implements
+- `EmailAttachmentContentType.Resolve(fileName)` — derives an attachment MIME type from its file name (MimeKit lookup, `application/octet-stream` fallback)
 - `EmailToMimMessageConverter.ConvertToMimeMessageAsync()` — converts `SendSingleEmailRequest` to a MimeKit `MimeMessage` (extension method on `SendSingleEmailRequest`)
 - `EmailRequestAddress.MapToMailboxAddress()` — maps to MimeKit `MailboxAddress`
-- Full address mapping (From, To, Cc, Bcc), body building (text + HTML via `BodyBuilder`), and attachment streaming
 
 ## Design Notes
 
-This package is consumed transitively by `Headless.Emails.Aws` and `Headless.Emails.Mailkit` — application code does not reference it directly. The converter returns a `MimeMessage` that callers are responsible for disposing; the implementation disposes the message if an exception occurs during construction, preventing a resource leak.
+The builder carries no shared, cross-provider feature options — it is provider-selection-only; each provider binds its own options inside its `Use*` member. The gate counts registered extensions and rejects zero, multiple, or a repeated `AddHeadlessEmails` on the same `IServiceCollection` (a host resolves a single `IEmailSender`). The MimeKit converter returns a `MimeMessage` that callers dispose; the implementation disposes the message if an exception occurs during construction, preventing a resource leak.
 
 ## Installation
 
@@ -207,8 +225,11 @@ dotnet add package Headless.Emails.Core
 ## Quick Start
 
 ```csharp
-// Used internally by providers — not called from application code.
-// Shown for provider implementors:
+// Provider-agnostic registration entry point (a provider package supplies the Use* member):
+builder.Services.AddHeadlessEmails(setup => setup.UseNoop());
+
+// Shared helpers used internally by providers — not called from application code:
+var contentType = EmailAttachmentContentType.Resolve("invoice.pdf"); // "application/pdf"
 using var mimeMessage = await request.ConvertToMimeMessageAsync(cancellationToken);
 ```
 
@@ -219,11 +240,12 @@ No configuration required.
 ## Dependencies
 
 - `Headless.Emails.Abstractions`
-- `MimeKit`
+- `Headless.Hosting`
+- `MailKit`
 
 ## Side Effects
 
-None. This is a utility package with no DI registrations.
+None directly. `AddHeadlessEmails` registers a provider-registration marker and delegates all `IEmailSender` wiring to the selected provider's extension.
 
 ---
 
@@ -255,19 +277,19 @@ dotnet add package Headless.Emails.Aws
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-// Option 1: from configuration (reads AWS:Region, AWS credentials from environment/profile)
+// Option 1: from configuration (reads AWS:Region, credentials from environment/profile)
 var awsOptions = builder.Configuration.GetAWSOptions();
-builder.Services.AddAwsSesEmailSender(awsOptions);
+builder.Services.AddHeadlessEmails(setup => setup.UseAwsSes(awsOptions));
 
 // Option 2: explicit credentials
-builder.Services.AddAwsSesEmailSender(new AWSOptions
+builder.Services.AddHeadlessEmails(setup => setup.UseAwsSes(new AWSOptions
 {
     Region = RegionEndpoint.USEast1,
     Credentials = new BasicAWSCredentials("accessKey", "secretKey"),
-});
+}));
 
 // Option 3: use default AWSOptions already registered in DI (pass null)
-builder.Services.AddAwsSesEmailSender(null);
+builder.Services.AddHeadlessEmails(setup => setup.UseAwsSes(null));
 ```
 
 ## Configuration
@@ -295,6 +317,92 @@ Credentials are resolved from the standard AWS credential chain (environment var
 
 ---
 
+# Headless.Emails.Azure
+
+Azure Communication Services (ACS) Email implementation of the email sending abstraction.
+
+## Problem Solved
+
+Provides email sending via Azure Communication Services using the unified `IEmailSender` abstraction — the intended cloud-email backend for Azure-hosted consumers, with managed-identity support.
+
+## Key Features
+
+- Full `IEmailSender` implementation over `Azure.Communication.Email`
+- Three authentication modes: connection string, endpoint + access key, and endpoint + managed-identity `TokenCredential`
+- Maps `SendSingleEmailRequest` (From, To/Cc/Bcc, Subject, HTML + plain-text bodies, attachments) to an ACS `EmailMessage`
+- Attachment content type derived from the file name via `EmailAttachmentContentType.Resolve()` (`application/octet-stream` fallback)
+- Both a thrown `RequestFailedException` and a completed-but-failed terminal status map to `SendSingleEmailResponse.Failed(...)`
+- Non-PII logging on failure (operation id, status, error code — no recipient/sender addresses)
+
+## Design Notes
+
+The send uses `EmailClient.SendAsync(WaitUntil.Completed, …)`, so the call blocks until ACS reaches a terminal state — matching the contract's "accepted for delivery" success semantics. ACS can complete a long-running send with a non-`Succeeded` status **without throwing**, so the sender inspects `operation.Value.Status` and treats any terminal non-`Succeeded` state as a failure (an exception-only check would report rejected mail as delivered). Only `Succeeded` returns `Succeeded()`; unrelated exceptions (cancellation, argument errors) propagate.
+
+The package depends on `Azure.Core` (not `Azure.Identity`): supply your own `DefaultAzureCredential` through the delegate overload to keep the dependency surface narrow. The `IConfiguration` overload binds only the connection-string and endpoint + access-key modes. ACS's `senderAddress` is a bare string, so the sender's display name is not honored. No custom retry loop is added — `Azure.Core`'s pipeline already retries 429/5xx honoring `Retry-After`. The sender domain must be verified and linked in the Communication Services resource; managed-domain send limits are low (5/min; custom domains 30/min).
+
+## Installation
+
+```bash
+dotnet add package Headless.Emails.Azure
+```
+
+## Quick Start
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Option 1: connection string or endpoint + access key, bound from configuration
+builder.Services.AddHeadlessEmails(setup =>
+    setup.UseAzure(builder.Configuration.GetSection("AzureEmail")));
+
+// Option 2: endpoint + access key (delegate)
+builder.Services.AddHeadlessEmails(setup => setup.UseAzure(options =>
+{
+    options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
+    options.AccessKey = builder.Configuration["AzureEmail:AccessKey"]!;
+}));
+
+// Option 3: managed identity (TokenCredential — delegate only; requires the Azure.Identity package)
+builder.Services.AddHeadlessEmails(setup => setup.UseAzure(options =>
+{
+    options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
+    options.TokenCredential = new DefaultAzureCredential();
+}));
+```
+
+## Configuration
+
+```json
+{
+    "AzureEmail": {
+        "ConnectionString": "endpoint=https://my-resource.communication.azure.com/;accesskey=<key>"
+    }
+}
+```
+
+`AzureCommunicationEmailOptions` properties — exactly one auth mode must be configured:
+
+| Property | Type | Description |
+|---|---|---|
+| `ConnectionString` | `string?` | Resource connection string (connection-string mode) |
+| `Endpoint` | `Uri?` | Resource endpoint; pair with `AccessKey` or `TokenCredential` |
+| `AccessKey` | `string?` | Resource access key (access-key mode) |
+| `TokenCredential` | `TokenCredential?` | Managed-identity credential (delegate overload only — not bindable from configuration) |
+
+## Dependencies
+
+- `Headless.Emails.Abstractions`
+- `Headless.Emails.Core`
+- `Azure.Communication.Email`
+
+## Side Effects
+
+- Binds and validates `AzureCommunicationEmailOptions` (exactly one auth mode required)
+- Registers `EmailClient` as singleton (constructed from the configured auth mode)
+- Registers `IEmailSender` as singleton
+
+---
+
 # Headless.Emails.Dev
 
 Development email implementations for local testing and debugging.
@@ -307,7 +415,7 @@ Provides safe email implementations for development and testing that do not send
 
 - `DevEmailSender` — writes full email content to a local file; appends with a `--------------------` separator per message; prefers `MessageText` over `MessageHtml` for readability
 - `NoopEmailSender` — silently discards all emails, always returns `Succeeded()`
-- No network calls, no external dependencies beyond the abstractions package
+- No network calls, no external dependencies beyond the abstractions and core packages
 
 ## Installation
 
@@ -323,10 +431,10 @@ var builder = WebApplication.CreateBuilder(args);
 if (builder.Environment.IsDevelopment())
 {
     // Write emails to a local file for inspection
-    builder.Services.AddDevEmailSender("path/to/emails.txt");
+    builder.Services.AddHeadlessEmails(setup => setup.UseDevelopment("path/to/emails.txt"));
 
     // Or discard silently (useful in automated tests)
-    // builder.Services.AddNoopEmailSender();
+    // builder.Services.AddHeadlessEmails(setup => setup.UseNoop());
 }
 ```
 
@@ -344,18 +452,19 @@ Hello World!
 
 ## Configuration
 
-`AddDevEmailSender(string filePath)` — the file path is the only parameter. The file is created if it does not exist; emails are appended.
+`UseDevelopment(string filePath)` — the file path is the only parameter. The file is created if it does not exist; emails are appended.
 
-`AddNoopEmailSender()` — no parameters. Useful in test projects where you want `IEmailSender` resolved but do not want file I/O.
+`UseNoop()` — no parameters. Useful in test projects where you want `IEmailSender` resolved but do not want file I/O.
 
 ## Dependencies
 
 - `Headless.Emails.Abstractions`
+- `Headless.Emails.Core`
 
 ## Side Effects
 
-- `AddDevEmailSender` registers `IEmailSender` as singleton (instance of `DevEmailSender`); appends to the specified file on each `SendAsync` call
-- `AddNoopEmailSender` registers `IEmailSender` as singleton (instance of `NoopEmailSender`); no I/O
+- `UseDevelopment` registers `IEmailSender` as singleton (instance of `DevEmailSender`); appends to the specified file on each `SendAsync` call
+- `UseNoop` registers `IEmailSender` as singleton (instance of `NoopEmailSender`); no I/O
 
 ---
 
@@ -373,7 +482,7 @@ Provides email sending via standard SMTP protocol using MailKit, supporting any 
 - SMTP connection pool (`ObjectPool<SmtpClient>`) — connections are retained and reused across sends
 - SSL/TLS support: `SecureSocketOptions.StartTls` (default), `SslOnConnect`, `None`, `Auto`
 - Optional authentication (username + password); anonymous SMTP when credentials are omitted
-- Three registration overloads: `IConfiguration`, `Action<MailkitSmtpOptions>`, `Action<MailkitSmtpOptions, IServiceProvider>`
+- Three `UseMailkit` overloads: `IConfiguration`, `Action<MailkitSmtpOptions>`, `Action<MailkitSmtpOptions, IServiceProvider>`
 - `SmtpCommandException` and `SmtpProtocolException` are caught and returned as `Failed()` responses; `AuthenticationException` propagates
 
 ## Design Notes
@@ -392,25 +501,25 @@ dotnet add package Headless.Emails.Mailkit
 var builder = WebApplication.CreateBuilder(args);
 
 // Option 1: from configuration section
-builder.Services.AddMailKitEmailSender(builder.Configuration.GetSection("Smtp"));
+builder.Services.AddHeadlessEmails(setup => setup.UseMailkit(builder.Configuration.GetSection("Smtp")));
 
 // Option 2: action
-builder.Services.AddMailKitEmailSender(options =>
+builder.Services.AddHeadlessEmails(setup => setup.UseMailkit(options =>
 {
     options.Server = "smtp.example.com";
     options.Port = 587;
     options.User = "user@example.com";
     options.Password = "securepassword";
     options.SocketOptions = SecureSocketOptions.StartTls;
-});
+}));
 
 // Option 3: action with IServiceProvider
-builder.Services.AddMailKitEmailSender((options, sp) =>
+builder.Services.AddHeadlessEmails(setup => setup.UseMailkit((options, sp) =>
 {
     var cfg = sp.GetRequiredService<IConfiguration>();
     options.Server = cfg["Smtp:Server"]!;
     options.Port = int.Parse(cfg["Smtp:Port"]!);
-});
+}));
 ```
 
 ## Configuration

--- a/docs/llms/index.md
+++ b/docs/llms/index.md
@@ -104,7 +104,7 @@ Fetch only what's relevant to the task. Each file documents the domain's package
 - [caching.md](caching.md) — Memory, Redis, and Hybrid (L1+L2) caching with fail-safe, refresh, tagging, and distributed factory locks.
 - [commit-coordination.md](commit-coordination.md) — Post-commit and rollback callback coordination for outbox, jobs, cache, and events.
 - [coordination.md](coordination.md) — Node membership, liveness, lifecycle events, and provider-backed fail-stop fencing.
-- [emails.md](emails.md) — Email sending (AWS SES, MailKit SMTP, dev no-op).
+- [emails.md](emails.md) — Email sending (Azure Communication Services, AWS SES, MailKit SMTP, dev no-op).
 - [features.md](features.md) — Feature flags with caching, value providers, EF Core storage.
 - [identity.md](identity.md) — ASP.NET Core Identity with EF Core integration.
 - [imaging.md](imaging.md) — ImageSharp-based resizing and compression.
@@ -201,8 +201,9 @@ Catalog of all Headless packages, grouped by domain. Use this to identify which 
 
 ### Email
 - `Headless.Emails.Abstractions` — Email sending interface.
-- `Headless.Emails.Core` — MimeKit-based core utilities.
+- `Headless.Emails.Core` — Setup builder + MimeKit-based core utilities.
 - `Headless.Emails.Aws` — AWS SES v2.
+- `Headless.Emails.Azure` — Azure Communication Services Email.
 - `Headless.Emails.Mailkit` — SMTP via MailKit.
 - `Headless.Emails.Dev` — Dev no-op (use in local/dev).
 

--- a/docs/llms/utilities.md
+++ b/docs/llms/utilities.md
@@ -415,7 +415,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Conditional registration
 builder.Services.AddIf(
     builder.Environment.IsDevelopment(),
-    s => s.AddDevEmailSender("emails.txt")
+    s => s.AddHeadlessEmails(setup => setup.UseDevelopment("emails.txt"))
 );
 
 // Options with FluentValidation

--- a/docs/plans/2026-06-22-001-feat-emails-azure-communication-provider-plan.md
+++ b/docs/plans/2026-06-22-001-feat-emails-azure-communication-provider-plan.md
@@ -1,0 +1,328 @@
+---
+title: "feat: Azure Communication Services email provider + unified Emails setup builder"
+type: feat
+date: 2026-06-22
+---
+
+# feat: Azure Communication Services email provider + unified Emails setup builder
+
+## Summary
+
+Add `Headless.Emails.Azure`, an `IEmailSender` provider over Azure Communication Services (ACS) Email (`Azure.Communication.Email`). As a prerequisite, migrate the Emails feature onto the framework's unified provider setup-builder pattern: introduce `HeadlessEmailsSetupBuilder` + an `AddHeadlessEmails(setup => setup.Use…())` root entry with a global exactly-one-provider gate in `Headless.Emails.Core`, then move the existing MailKit, AWS SES, and Dev/Noop providers onto `Use*` members. The `IEmailSender` contract and its request/response records are unchanged.
+
+---
+
+## Problem Frame
+
+The Emails feature is the last multi-provider feature still on the legacy per-provider registration style: each provider exposes its own `IServiceCollection` extension (`AddMailKitEmailSender`, `AddAwsSesEmailSender`, `AddDevEmailSender`, `AddNoopEmailSender`). Every other multi-provider feature (Coordination, Caching, Settings, Permissions, AuditLog, Features) uses the unified setup-builder grammar documented in `docs/solutions/architecture-patterns/unified-provider-setup-builder-pattern.md`: one `AddHeadless{Feature}(Action<…SetupBuilder>)` entry, exactly-one-provider invariant, provider-owned `Use{Provider}` members.
+
+Adding a fourth email provider (ACS) is the trigger to converge Emails onto that grammar rather than grow a fifth bespoke `Add*EmailSender` extension. The migration is low-risk: a repo-wide search found **no internal callers** of the four legacy extensions, so removing them ripples only into the provider `Setup.cs` files and docs.
+
+ACS Email is the intended cloud-email backend for Azure-hosted consumers — an alternative to AWS SES (cloud API) and MailKit (self-hosted SMTP).
+
+---
+
+## Requirements
+
+### Setup grammar (Emails feature)
+
+- R1. `AddHeadlessEmails(Action<HeadlessEmailsSetupBuilder>)` in `Headless.Emails.Core` is the single consumer entry point for selecting an email provider.
+- R2. Exactly one `Use*` provider must be selected per call. Zero, multiple, or a repeated `AddHeadlessEmails` on the same `IServiceCollection` throws `InvalidOperationException` at registration time; the zero-provider message lists every available `Use*` call.
+- R3. Each provider package selects itself via a `Use*` extension member on `HeadlessEmailsSetupBuilder` that registers an `IEmailProviderOptionsExtension`; the provider's DI wiring runs later from the core gate, so all providers pass through the same invariant.
+
+### Azure provider behavior
+
+- R4. `Headless.Emails.Azure` implements `IEmailSender` over `Azure.Communication.Email`, mapping `SendSingleEmailRequest` (From, To/Cc/Bcc, Subject, MessageHtml, MessageText, Attachments) to an ACS `EmailMessage` and sending it.
+- R5. Authentication supports three modes — connection string, endpoint + access key, and endpoint + `TokenCredential` (managed identity) — and options validation requires exactly one mode to be configured.
+- R6. A successful send returns `SendSingleEmailResponse.Succeeded()`; an ACS failure returns `SendSingleEmailResponse.Failed(...)` with a non-PII message. Recipient and sender addresses never appear in log output.
+- R7. Attachment content type is derived from the attachment file name (the abstraction carries only name + bytes), defaulting to `application/octet-stream`.
+
+### Migration and compatibility
+
+- R8. The legacy `IServiceCollection` extensions (`AddMailKitEmailSender`, `AddAwsSesEmailSender`, `AddDevEmailSender`, `AddNoopEmailSender`) are removed. MailKit, AWS SES, Dev, and Noop are reachable only through `Use*` members on the builder. No compatibility shim (greenfield; no internal callers exist).
+- R9. The `IEmailSender` abstraction and the `SendSingleEmailRequest` / `SendSingleEmailResponse` / `EmailRequestAddress` / `EmailRequestDestination` / `EmailRequestAttachment` contracts are not changed.
+
+### Testing and docs
+
+- R10. Unit tests cover the exactly-one-provider gate (zero / one / multiple / repeated) and the Azure provider (request→`EmailMessage` mapping, content-type derivation, error mapping, options validation).
+- R11. `docs/llms/emails.md` and the affected package READMEs reflect the new grammar and the Azure provider, per `docs/authoring/AUTHORING.md`.
+
+---
+
+## Key Technical Decisions
+
+- KTD1 — **Global exactly-one-provider gate, mirroring Coordination (not Caching's per-slot gate).** Emails resolves to a single `IEmailSender`, so a host needs exactly one provider — the simplest invariant applies. Mirror `src/Headless.Coordination.Core/Setup.cs`: count `Extensions`, plus a marker-singleton sentinel (`EmailProviderRegistration`) to reject a repeated `AddHeadlessEmails` on the same collection.
+
+- KTD2 — **Breaking change with no compat shim.** Remove the four legacy `Add*EmailSender` extensions outright. Greenfield project policy and a verified absence of internal callers make a shim pure ceremony.
+
+- KTD3 — **Send with `WaitUntil.Completed`, map both the exception and the terminal status.** Use `EmailClient.SendAsync(WaitUntil.Completed, EmailMessage, ct)`. This matches the contract's "accepted for delivery" success semantics and keeps the wrapper synchronous-style. Map the outcome two ways: (a) catch `RequestFailedException` → `Failed(...)`; and (b) on a normal return, inspect `operation.Value.Status` and treat any terminal non-`Succeeded` state (`Failed` / `Canceled`) as `Failed(...)` — ACS can complete a long-running send with a failed status **without throwing**, so an exception-only check would report rejected mail as delivered (R6). Only `Succeeded` returns `Succeeded()`. Let unrelated exceptions (cancellation, argument errors) propagate. Do not add a custom retry loop — `Azure.Core`'s pipeline already retries 429/5xx with `Retry-After`. (An enqueue-only `WaitUntil.Started` mode is deferred — see Scope Boundaries.)
+
+- KTD4 — **Three auth modes via options; provider depends on `Azure.Core`, not `Azure.Identity`.** `AzureCommunicationEmailOptions` carries `ConnectionString`, `Endpoint` + `AccessKey`, and an optional `TokenCredential` (a `Azure.Core` type, transitive via `Azure.Communication.Email`). The consumer supplies their own `DefaultAzureCredential` through the delegate overload, so the package keeps a narrow dependency surface. The `IConfiguration` overload binds only string/key modes; `TokenCredential` requires a `Use*` delegate overload.
+
+- KTD5 — **Derive attachment content type via MimeKit's `MimeTypes.GetMimeType(name)`** (already transitively available through `Headless.Emails.Core` → MailKit), defaulting to `application/octet-stream`. This keeps the `EmailRequestAttachment` contract unchanged (R9) while satisfying ACS's required `EmailAttachment.contentType`. Expose it as a small shared helper in Core so future providers reuse it.
+
+- KTD6 — **Extract request→`EmailMessage` mapping into a pure static mapper** (`AzureCommunicationEmailMessageMapper`) so the bulk of provider logic is unit-testable without mocking the ACS LRO; the sender stays a thin send + error-map shell.
+
+- KTD7 — **Naming:** package `Headless.Emails.Azure`; builder member `UseAzure`; types `AzureCommunicationEmailSender` / `AzureCommunicationEmailOptions`. `UseAzure` matches sibling brevity (`UseRedis`, `UsePostgreSql`) and the package suffix; the `AzureCommunicationEmail*` type names disambiguate the implementation. (`UseAzureCommunication` was the considered alternative.)
+
+---
+
+## High-Level Technical Design
+
+### Registration topology
+
+```mermaid
+flowchart TB
+  Consumer["Consumer: AddHeadlessEmails(setup => setup.UseAzure(...))"]
+  subgraph Core["Headless.Emails.Core"]
+    Root["SetupEmailsCore.AddHeadlessEmails"]
+    Builder["HeadlessEmailsSetupBuilder<br/>(Services, Extensions, RegisterExtension)"]
+    Gate["_AddEmailsProviderCore<br/>exactly-one gate + repeat sentinel"]
+    IExt["IEmailProviderOptionsExtension"]
+  end
+  subgraph Providers["Provider packages"]
+    Azure["Emails.Azure: UseAzure"]
+    Mailkit["Emails.Mailkit: UseMailkit"]
+    Aws["Emails.Aws: UseAwsSes"]
+    Dev["Emails.Dev: UseDevelopment / UseNoop"]
+  end
+  Consumer --> Root --> Builder
+  Azure -. RegisterExtension .-> Builder
+  Mailkit -. RegisterExtension .-> Builder
+  Aws -. RegisterExtension .-> Builder
+  Dev -. RegisterExtension .-> Builder
+  Root --> Gate
+  Gate -->|"extension.AddServices(services)"| IExt
+  IExt -->|"registers IEmailSender singleton"| DI["IServiceCollection"]
+```
+
+### Azure send path
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Sender as AzureCommunicationEmailSender
+  participant Mapper as AzureCommunicationEmailMessageMapper
+  participant Client as EmailClient (singleton)
+  App->>Sender: SendAsync(SendSingleEmailRequest, ct)
+  Sender->>Mapper: ToEmailMessage(request)
+  Mapper-->>Sender: EmailMessage (To/Cc/Bcc, content, attachments)
+  Sender->>Client: SendAsync(WaitUntil.Completed, message, ct)
+  alt operation.Value.Status == Succeeded
+    Client-->>Sender: EmailSendOperation (Succeeded)
+    Sender-->>App: SendSingleEmailResponse.Succeeded()
+  else completed with Status Failed/Canceled
+    Client-->>Sender: EmailSendOperation (Failed)
+    Sender->>Sender: log status/operationId (no PII)
+    Sender-->>App: SendSingleEmailResponse.Failed("…")
+  else RequestFailedException
+    Client-->>Sender: throws RequestFailedException
+    Sender->>Sender: log status/errorCode/operationId (no PII)
+    Sender-->>App: SendSingleEmailResponse.Failed("…")
+  end
+```
+
+---
+
+## Output Structure
+
+```text
+src/Headless.Emails.Core/
+  IEmailProviderOptionsExtension.cs     (new)
+  HeadlessEmailsSetupBuilder.cs         (new)
+  Setup.cs                              (new: AddHeadlessEmails + gate)
+  EmailAttachmentContentType.cs         (new: shared content-type helper)
+  EmailToMimMessageConverter.cs         (unchanged)
+src/Headless.Emails.Azure/             (new package)
+  Headless.Emails.Azure.csproj
+  AzureCommunicationEmailOptions.cs     (+ in-file validator)
+  AzureCommunicationEmailMessageMapper.cs
+  AzureCommunicationEmailSender.cs
+  Setup.cs                              (UseAzure trio + extension)
+  README.md
+tests/Headless.Emails.Core.Tests.Unit/ (new)
+tests/Headless.Emails.Azure.Tests.Unit/ (new)
+```
+
+---
+
+## Implementation Units
+
+### Phase 1 — Builder infrastructure
+
+#### U1. Introduce the unified Emails setup builder + exactly-one-provider gate
+
+- **Goal:** Establish `AddHeadlessEmails`, `HeadlessEmailsSetupBuilder`, and `IEmailProviderOptionsExtension` in `Headless.Emails.Core`.
+- **Requirements:** R1, R2, R3.
+- **Dependencies:** none.
+- **Files:** `src/Headless.Emails.Core/IEmailProviderOptionsExtension.cs`, `src/Headless.Emails.Core/HeadlessEmailsSetupBuilder.cs`, `src/Headless.Emails.Core/Setup.cs`.
+- **Approach:** Mirror `src/Headless.Coordination.Core/{Setup.cs,HeadlessCoordinationSetupBuilder.cs,ICoordinationProviderOptionsExtension.cs}` exactly:
+  - `IEmailProviderOptionsExtension { void AddServices(IServiceCollection services); }` — `[PublicAPI]`.
+  - `HeadlessEmailsSetupBuilder` — internal ctor taking `IServiceCollection`; `internal IServiceCollection Services`; `internal IList<IEmailProviderOptionsExtension> Extensions`; public `void RegisterExtension(...)` with `Argument.IsNotNull`. Emails has no shared feature options, so omit the `Configure(...)` overloads Coordination carries.
+  - `SetupEmailsCore` — `extension(IServiceCollection services)` with `public IServiceCollection AddHeadlessEmails(Action<HeadlessEmailsSetupBuilder> configure)`. Construct the builder, invoke `configure`, delegate to a private `_AddEmailsProviderCore`. The gate throws when `Extensions.Count != 1` (zero-case message: ``"Headless.Emails requires exactly one provider. Call one of `UseAzure`, `UseAwsSes`, `UseMailkit`, `UseDevelopment`, or `UseNoop`."``; multiple-case: `"…Multiple providers were configured."`), enforces a `EmailProviderRegistration` marker-singleton sentinel against repeated calls, then runs `extension.AddServices(services)`.
+- **Patterns to follow:** `SetupCoordinationCore` (gate + sentinel record), `HeadlessCoordinationSetupBuilder`, `ICoordinationProviderOptionsExtension`.
+- **Test suite design:** Covered by U8 (`Headless.Emails.Core.Tests.Unit`); no test infra in this unit.
+- **Test scenarios:** none in this unit (exercised in U8). `Test expectation: none -- builder/gate behavior is verified end-to-end in U8 once a real provider (UseNoop) exists to register.`
+- **Verification:** `make build-project PROJECT=src/Headless.Emails.Core/Headless.Emails.Core.csproj` compiles; the new public types match the Coordination shape.
+
+### Phase 2 — Migrate existing providers onto the builder
+
+#### U2. Migrate MailKit to `UseMailkit` on the builder
+
+- **Goal:** Replace `SetupMailkit.AddMailKitEmailSender` (three `IServiceCollection` overloads) with `UseMailkit` members on `HeadlessEmailsSetupBuilder`.
+- **Requirements:** R3, R8.
+- **Dependencies:** U1.
+- **Files:** `src/Headless.Emails.Mailkit/Setup.cs`.
+- **Approach:** Convert `extension(IServiceCollection services)` → `extension(HeadlessEmailsSetupBuilder setup)`. Keep the overload trio (`IConfiguration` / `Action<MailkitSmtpOptions>` / `Action<MailkitSmtpOptions, IServiceProvider>`) but each now calls `setup.RegisterExtension(new MailkitEmailOptionsExtension(...))`. Move the current `_AddCore` body (options `Configure<…,Validator>` + `SmtpClientPooledObjectPolicy` + `ObjectPool<SmtpClient>` + `AddSingleton<IEmailSender, MailkitEmailSender>`) into the private `MailkitEmailOptionsExtension.AddServices`. Mirror `SetupRedisCoordination`'s captured-delegate extension shape.
+- **Patterns to follow:** `src/Headless.Coordination.Redis/Setup.cs` (`RedisCoordinationOptionsExtension`).
+- **Test suite design:** Registration success is covered transitively by U8's one-provider gate test (can use `UseMailkit` or `UseNoop`); no MailKit-specific behavioral change.
+- **Test scenarios:** `Test expectation: none -- pure registration-shape refactor; no behavioral change to MailkitEmailSender.`
+- **Verification:** Project builds; `MailkitEmailSender` unchanged; no remaining `AddMailKitEmailSender` symbol.
+
+#### U3. Migrate AWS SES to `UseAwsSes` on the builder
+
+- **Goal:** Replace `SetupAwsSes.AddAwsSesEmailSender(AWSOptions?)` with `UseAwsSes(AWSOptions?)` on the builder.
+- **Requirements:** R3, R8.
+- **Dependencies:** U1.
+- **Files:** `src/Headless.Emails.Aws/Setup.cs`.
+- **Approach:** `extension(HeadlessEmailsSetupBuilder setup)` with `public HeadlessEmailsSetupBuilder UseAwsSes(AWSOptions? options)` → `setup.RegisterExtension(new AwsSesEmailOptionsExtension(options))`. The extension's `AddServices` runs the current body (`TryAddAWSService<IAmazonSimpleEmailServiceV2>(options)` + `AddSingleton<IEmailSender, AwsSesEmailSender>`). AWS keeps its single `AWSOptions?` parameter (not the config/delegate trio) — it delegates to the AWS SDK's own options model, as today.
+- **Patterns to follow:** existing `SetupAwsSes` body; `RedisCoordinationOptionsExtension` for the extension wrapper.
+- **Test suite design:** Covered transitively by U8 gate tests; `AwsSesEmailSender` behavior unchanged.
+- **Test scenarios:** `Test expectation: none -- registration-shape refactor; AwsSesEmailSender logic untouched.`
+- **Verification:** Project builds; no remaining `AddAwsSesEmailSender` symbol.
+
+#### U4. Migrate Dev/Noop to `UseDevelopment` / `UseNoop` on the builder
+
+- **Goal:** Replace `AddDevEmailSender(string)` / `AddNoopEmailSender()` with `UseDevelopment(string filePath)` / `UseNoop()` on the builder.
+- **Requirements:** R3, R8.
+- **Dependencies:** U1.
+- **Files:** `src/Headless.Emails.Dev/Setup.cs`, `src/Headless.Emails.Dev/Headless.Emails.Dev.csproj`.
+- **Approach:** `extension(HeadlessEmailsSetupBuilder setup)` with two members, each registering a small `IEmailProviderOptionsExtension` whose `AddServices` does `AddSingleton<IEmailSender>(new DevEmailSender(filePath))` / `AddSingleton<IEmailSender, NoopEmailSender>()`. **Add a `ProjectReference` to `Headless.Emails.Core`** in the csproj (Dev currently references only Abstractions + Hosting; the builder lives in Core). No dependency cycle — Core → Abstractions + Hosting.
+- **Patterns to follow:** existing `SetupDevEmail`; `RedisCoordinationOptionsExtension`.
+- **Test suite design:** `UseNoop` is the canonical one-provider success path in U8's gate tests.
+- **Test scenarios:** `Test expectation: none -- registration-shape refactor; DevEmailSender/NoopEmailSender logic untouched.`
+- **Verification:** Project builds; Dev references Core; no remaining `AddDevEmailSender` / `AddNoopEmailSender` symbols.
+
+### Phase 3 — Azure Communication Services provider
+
+#### U5. Scaffold `Headless.Emails.Azure` (project, package pins, options + validator)
+
+- **Goal:** Create the new provider project, wire it into the solution and CPM, and define validated options.
+- **Requirements:** R4, R5.
+- **Dependencies:** U1.
+- **Files:** `src/Headless.Emails.Azure/Headless.Emails.Azure.csproj`, `src/Headless.Emails.Azure/AzureCommunicationEmailOptions.cs`, `Directory.Packages.props`, `headless-framework.slnx`.
+- **Approach:**
+  - csproj uses `Sdk="Headless.NET.Sdk"`, `TargetFramework net10.0`, `RootNamespace Headless.Emails.Azure`; `ProjectReference` to `Headless.Emails.Abstractions` and `Headless.Emails.Core`; `PackageReference Include="Azure.Communication.Email"` (no `Version` — CPM).
+  - `Directory.Packages.props`: add `<PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />` (Oct 2025 — past the 7-day quarantine). `Azure.Core` arrives transitively; pin it only if a build warning requires it.
+  - `headless-framework.slnx`: add the project under the existing `/Emails/` folder.
+  - `AzureCommunicationEmailOptions` — `ConnectionString` (string?), `Endpoint` (Uri?), `AccessKey` (string?), `TokenCredential` (`Azure.Core.TokenCredential?`). `internal sealed class AzureCommunicationEmailOptionsValidator : AbstractValidator<…>` in the same file (below the options) enforcing exactly one auth mode: connection string set; OR endpoint + access key; OR endpoint + token credential — and rejecting zero/ambiguous combinations. Add a `[PublicAPI]`-friendly `ToString()` that never emits the connection string or key (diagnostics-safe, per the messaging-transport-provider guidance).
+- **Patterns to follow:** `src/Headless.Emails.Mailkit/MailkitSmtpOptions.cs` (options + in-file FluentValidation validator + sanitized `ToString`); `src/Headless.Blobs.Azure/AzureStorageOptions.cs` for the Azure auth-options shape; CLAUDE.md "New .NET Projects" + "Package Management".
+- **Test suite design:** Validator covered in U8 (`Headless.Emails.Azure.Tests.Unit`).
+- **Test scenarios:** none here (validator tested in U8). `Test expectation: none -- scaffolding + options; validation behavior tested in U8.`
+- **Verification:** Solution restores and `make build-project PROJECT=src/Headless.Emails.Azure/Headless.Emails.Azure.csproj` builds; package resolves without quarantine failure.
+
+#### U6. `AzureCommunicationEmailMessageMapper` + `AzureCommunicationEmailSender`
+
+- **Goal:** Implement the pure mapper and the thin `IEmailSender`.
+- **Requirements:** R4, R6, R7.
+- **Dependencies:** U5.
+- **Files:** `src/Headless.Emails.Azure/AzureCommunicationEmailMessageMapper.cs`, `src/Headless.Emails.Azure/AzureCommunicationEmailSender.cs`, `src/Headless.Emails.Core/EmailAttachmentContentType.cs`.
+- **Approach:**
+  - `EmailAttachmentContentType` (Core, shared): `static string Resolve(string fileName)` → `MimeKit.MimeTypes.GetMimeType(fileName)` with `application/octet-stream` fallback (KTD5, KTD7).
+  - `AzureCommunicationEmailMessageMapper` — pure `static EmailMessage ToEmailMessage(SendSingleEmailRequest request)`: build `EmailContent(request.Subject) { PlainText = request.MessageText, Html = request.MessageHtml }`; `EmailRecipients` from To/Cc/Bcc mapping `EmailRequestAddress` → `EmailAddress(address.EmailAddress, address.DisplayName)`; sender = `request.From.EmailAddress` (ACS `senderAddress` is a bare string — sender display name is not honored; note in README); attachments → `EmailAttachment(name, EmailAttachmentContentType.Resolve(name), BinaryData.FromBytes(file))` (pass raw bytes; the SDK base64-encodes). No ReplyTo/Headers (contract has none).
+  - `AzureCommunicationEmailSender(EmailClient client, ILogger<…>) : IEmailSender` — `SendAsync`: map via the mapper, call `client.SendAsync(WaitUntil.Completed, message, ct)`. On a normal return, inspect `operation.Value.Status`: `Succeeded` → `Succeeded()`; any other terminal state (`Failed` / `Canceled`) → log the operation id + status (no addresses) and return `Failed("Failed to send an email to the recipient.")` — ACS can complete a long-running send with a failed status without throwing. Catch `RequestFailedException`: log `Status`, `ErrorCode`, and the operation id only (no addresses), return the same `Failed(...)`. Let other exceptions propagate. `[LoggerMessage]` partial class at the **bottom** of the file.
+- **Patterns to follow:** `src/Headless.Emails.Aws/AwsSesEmailSender.cs` (non-PII logging, `Succeeded`/`Failed` mapping, `[LoggerMessage]` placement); ACS SDK reference (`SendAsync(WaitUntil, EmailMessage, ct)`, `BinaryData.FromBytes`).
+- **Test suite design:** `Headless.Emails.Azure.Tests.Unit` (U8) — mapper tested directly; sender's error/success path tested with a substituted `EmailClient` (virtual `SendAsync`).
+- **Test scenarios:**
+  - Mapper: single To recipient → `EmailMessage` with matching sender/subject/recipient.
+  - Mapper: To + Cc + Bcc populated → all three `EmailRecipients` lists mapped, display names preserved.
+  - Mapper: html + text both set → `EmailContent.Html` and `.PlainText` both populated; only html set → `.PlainText` null; only text set → `.Html` null.
+  - Mapper: attachment `report.pdf` → `EmailAttachment.ContentType == "application/pdf"`; unknown extension `data.zzz` → `application/octet-stream`; content bytes round-trip through `BinaryData`.
+  - Sender: `EmailClient.SendAsync` returns an operation with `Value.Status == Succeeded` → `Succeeded()`.
+  - Sender: `EmailClient.SendAsync` returns normally but `operation.Value.Status` is `Failed` (or `Canceled`) → `Failed(...)`, with no recipient/sender address in the message or log args.
+  - Sender: `EmailClient.SendAsync` throws `RequestFailedException` → `Failed(...)`, and the failure message + log args contain no recipient/sender address.
+  - Sender: `OperationCanceledException` from the client propagates (not swallowed).
+- **Verification:** `Headless.Emails.Azure.Tests.Unit` passes; planned tests above added and green.
+
+#### U7. `SetupAzureEmail.UseAzure` + `EmailClient` construction
+
+- **Goal:** Expose `UseAzure` on the builder and construct the `EmailClient` singleton across the three auth modes.
+- **Requirements:** R3, R5.
+- **Dependencies:** U5, U6.
+- **Files:** `src/Headless.Emails.Azure/Setup.cs`.
+- **Approach:** `SetupAzureEmail` with `extension(HeadlessEmailsSetupBuilder setup)` and the `UseAzure` overload trio (`IConfiguration` / `Action<AzureCommunicationEmailOptions>` / `Action<AzureCommunicationEmailOptions, IServiceProvider>`), each `setup.RegisterExtension(new AzureCommunicationEmailOptionsExtension(...))`. The extension's `AddServices`: `services.Configure<AzureCommunicationEmailOptions, AzureCommunicationEmailOptionsValidator>(…)`, then register `EmailClient` as a singleton from resolved options — connection string → `new EmailClient(cs)`; endpoint + access key → `new EmailClient(endpoint, new AzureKeyCredential(key))`; endpoint + token credential → `new EmailClient(endpoint, tokenCredential)` — and `AddSingleton<IEmailSender, AzureCommunicationEmailSender>()`. The `IConfiguration` overload supports only string/key modes (TokenCredential is not bindable); document that on the method.
+- **Patterns to follow:** `src/Headless.Coordination.Redis/Setup.cs` (`UseRedis` trio + captured-delegate extension); `src/Headless.Emails.Mailkit/Setup.cs` (overload trio + `Configure<TOptions,TValidator>`).
+- **Test suite design:** Registration success path is covered by U8's gate test (`UseAzure` as the single provider, connection-string mode).
+- **Test scenarios:**
+  - `AddHeadlessEmails(s => s.UseAzure(o => o.ConnectionString = "..."))` resolves a singleton `IEmailSender` of type `AzureCommunicationEmailSender` and a singleton `EmailClient`.
+  - Endpoint + access key options → container builds and resolves `IEmailSender` without throwing.
+- **Verification:** Gate/registration tests in U8 pass; `EmailClient` resolves for each auth mode exercised.
+
+### Phase 4 — Tests and docs
+
+#### U8. Unit tests: builder gate + Azure provider
+
+- **Goal:** Cover the new invariant and the Azure provider behavior.
+- **Requirements:** R10 (and validates R2, R4, R5, R6, R7).
+- **Dependencies:** U1–U7.
+- **Files:** `tests/Headless.Emails.Core.Tests.Unit/Headless.Emails.Core.Tests.Unit.csproj`, `tests/Headless.Emails.Core.Tests.Unit/EmailsSetupBuilderTests.cs`, `tests/Headless.Emails.Azure.Tests.Unit/Headless.Emails.Azure.Tests.Unit.csproj`, `tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailMessageMapperTests.cs`, `tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailSenderTests.cs`, `tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailOptionsValidatorTests.cs`. Add both test projects to `headless-framework.slnx`.
+- **Approach:** New test projects use `Sdk="Headless.NET.Sdk.Test"` (xUnit v3 / MTP, AwesomeAssertions, NSubstitute). The Core test project references `Headless.Emails.Core` + `Headless.Emails.Dev` (for `UseNoop` as the real one-provider). Build the service collection, call `AddHeadlessEmails`, then `BuildServiceProvider()` and assert resolution. Substitute `EmailClient` via NSubstitute (its `SendAsync` is virtual); for the success path return a substituted `EmailSendOperation` or assert via the thrown-exception path for `Failed`.
+- **Patterns to follow:** `tests/Headless.Coordination.Core.Tests.Unit/CoordinationSetupBuilderTests.cs` and `tests/Headless.Caching.Core.Tests.Unit/CachingSetupBuilderTests.cs` (gate regression suites named in the pattern doc).
+- **Test suite design:** Two new unit projects; no integration project (ACS Email has no Testcontainer/emulator — see Scope Boundaries). This is the test infrastructure for the Emails feature, which had none.
+- **Test scenarios:**
+  - Gate: zero `Use*` calls → `InvalidOperationException`; message lists `UseAzure`, `UseAwsSes`, `UseMailkit`, `UseDevelopment`, `UseNoop`.
+  - Gate: two `Use*` calls in one delegate → `InvalidOperationException` (multiple-providers message).
+  - Gate: one `Use*` call (`UseNoop`) → resolves a single `IEmailSender`.
+  - Gate: two `AddHeadlessEmails` calls on the same collection → `InvalidOperationException` (repeat sentinel).
+  - Mapper + sender + validator scenarios per U5/U6 (consolidated here).
+- **Verification:** `make test-project TEST_PROJECT=tests/Headless.Emails.Core.Tests.Unit` and `…/Headless.Emails.Azure.Tests.Unit` pass; all planned scenarios green.
+
+#### U9. Docs: agent surface + package READMEs
+
+- **Goal:** Sync the agent docs and READMEs to the new grammar and the Azure provider.
+- **Requirements:** R11.
+- **Dependencies:** U1–U7.
+- **Files:** `docs/llms/emails.md`, `src/Headless.Emails.Core/README.md`, `src/Headless.Emails.Mailkit/README.md`, `src/Headless.Emails.Aws/README.md`, `src/Headless.Emails.Dev/README.md`, `src/Headless.Emails.Azure/README.md` (new). `src/Headless.Emails.Abstractions/README.md` only if it documents registration.
+- **Approach:** Read `docs/authoring/AUTHORING.md` first (mandatory before editing either doc surface). Replace `Add*EmailSender` examples with `AddHeadlessEmails(setup => setup.Use…())`; document the exactly-one-provider rule; add an Azure section covering the three auth modes, sender-domain verification requirement, attachment content-type derivation, and the sender-display-name limitation. New `Headless.Emails.Azure/README.md` follows the Ankane-style README convention used by sibling provider packages.
+- **Patterns to follow:** existing `src/Headless.Emails.*/README.md`; `docs/authoring/AUTHORING.md` templates.
+- **Test suite design:** n/a (docs).
+- **Test scenarios:** `Test expectation: none -- documentation only.`
+- **Verification:** Examples compile mentally against the new API; no lingering `Add*EmailSender` references in docs; drift checks in AUTHORING.md pass.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- **Azure SMS provider (`Headless.Sms.Azure`).** ACS also does SMS, but native ACS SMS can't reach most destinations (e.g. Egypt) without Messaging Connect (public preview), which adds a per-message partner-credential surface and a preview API dependency. Plan separately if needed.
+- **Enqueue-only send mode (`WaitUntil.Started`).** A non-blocking path that returns the operation id immediately. Deferred because it can't report final delivery status through the current `SendSingleEmailResponse` contract (KTD3).
+- **`Headless.Emails.Tests.Harness` conformance package.** The CLAUDE.md harness trigger fires for multi-provider features, but email providers have no shared integration test infrastructure today and ACS Email has no Testcontainer/emulator. Revisit if/when a local-testable email backend or a real-resource integration suite is added.
+- **Shared `EmailOptions` on the builder** (e.g. a global default From or tracking toggle). Not introduced — no current cross-provider feature option exists; the builder stays provider-selection-only.
+
+### Out of scope
+
+- Changing the `IEmailSender` abstraction or its request/response contracts (R9).
+- ACS resource provisioning, domain verification, or DNS (SPF/DKIM) — operator responsibility, surfaced as service errors.
+- Bulk/multi-message send APIs beyond the existing single-message contract.
+
+---
+
+## Risks & Dependencies
+
+- **ACS sender domain must be verified and linked** in the Communication Services resource; the SDK can't pre-validate this, so a misconfigured sender surfaces as a `RequestFailedException` → `Failed(...)`. Mitigation: clear README guidance; non-PII error logging includes the operation id for troubleshooting.
+- **Rate limits / LRO polling cost.** `WaitUntil.Completed` auto-polls the status endpoint; ACS limits are low on Azure-managed domains (5 sends/min) and modest on custom domains (30/min). Mitigation: rely on `Azure.Core` retry honoring `Retry-After`; document the limits; the enqueue-only mode is a deferred lever if volume demands it.
+- **Package TFM.** `Azure.Communication.Email` 1.1.0 ships `net8.0` / `netstandard2.0` assets (no `net10.0`-specific asset); consumed fine by the `net10.0` project. No action, noted for awareness.
+- **Message-size / recipient limits** (10 MB total, 50 recipients). Per CLAUDE.md, input-size validation is delegated to consumers; the provider does not pre-enforce. A fast-fail check is a possible future addition, not planned here.
+- **Mocking the ACS LRO.** `EmailClient.SendAsync` is virtual (mockable), but `EmailSendOperation` is awkward to construct in tests — the success and completed-but-failed paths both require stubbing `operation.Value.Status`. Mitigation: KTD6 extracts the mapper as a pure static so the bulk of logic is tested without the client; the sender's failure paths are tested via both a substituted operation with a `Failed` status and the thrown-`RequestFailedException` route. If stubbing `EmailSendOperation` proves impractical, the SDK's `EmailSendOperation` test helpers / a thin seam over `Value.Status` is the fallback — an execution-time detail for the implementer.
+
+---
+
+## Sources & Research
+
+- `docs/solutions/architecture-patterns/unified-provider-setup-builder-pattern.md` — the builder/gate/extension contract this plan applies; names the regression suites to mirror.
+- `src/Headless.Coordination.Core/Setup.cs`, `HeadlessCoordinationSetupBuilder.cs`, `ICoordinationProviderOptionsExtension.cs` — minimal global-gate template (Emails mirrors this).
+- `src/Headless.Coordination.Redis/Setup.cs` — provider `Use*` trio + captured-delegate `…OptionsExtension` shape.
+- `src/Headless.Emails.Aws/AwsSesEmailSender.cs`, `src/Headless.Emails.Mailkit/{Setup.cs,MailkitSmtpOptions.cs}` — existing email provider conventions (non-PII logging, options+validator, overload trio).
+- `src/Headless.Emails.Abstractions/{IEmailSender.cs,Contracts/*}`, `src/Headless.Emails.Core/EmailToMimMessageConverter.cs` — the contract (unchanged) and shared conversion.
+- `Azure.Communication.Email` 1.1.0 (NuGet, Oct 2025): [package](https://www.nuget.org/packages/Azure.Communication.Email), [.NET README](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/communication.email-readme?view=azure-dotnet), [`SendAsync`](https://learn.microsoft.com/en-us/dotnet/api/azure.communication.email.emailclient.sendasync?view=azure-dotnet), [`EmailMessage`](https://learn.microsoft.com/en-us/dotnet/api/azure.communication.email.emailmessage?view=azure-dotnet), [service limits](https://learn.microsoft.com/en-us/azure/communication-services/concepts/service-limits), [domain & sender auth](https://learn.microsoft.com/en-us/azure/communication-services/concepts/email/email-domain-and-sender-authentication).

--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -165,6 +165,10 @@
         <Project Path="src\Headless.Emails.Dev\Headless.Emails.Dev.csproj" />
         <Project Path="src\Headless.Emails.Mailkit\Headless.Emails.Mailkit.csproj" />
     </Folder>
+    <Folder Name="/Emails/Tests/">
+        <Project Path="tests/Headless.Emails.Core.Tests.Unit/Headless.Emails.Core.Tests.Unit.csproj" />
+        <Project Path="tests/Headless.Emails.Azure.Tests.Unit/Headless.Emails.Azure.Tests.Unit.csproj" />
+    </Folder>
     <Folder Name="/Features/">
         <Project Path="src\Headless.Features.Abstractions\Headless.Features.Abstractions.csproj" />
         <Project Path="src\Headless.Features.Core\Headless.Features.Core.csproj" />

--- a/headless-framework.slnx
+++ b/headless-framework.slnx
@@ -160,6 +160,7 @@
     <Folder Name="/Emails/">
         <Project Path="src\Headless.Emails.Abstractions\Headless.Emails.Abstractions.csproj" />
         <Project Path="src\Headless.Emails.Aws\Headless.Emails.Aws.csproj" />
+        <Project Path="src\Headless.Emails.Azure\Headless.Emails.Azure.csproj" />
         <Project Path="src\Headless.Emails.Core\Headless.Emails.Core.csproj" />
         <Project Path="src\Headless.Emails.Dev\Headless.Emails.Dev.csproj" />
         <Project Path="src\Headless.Emails.Mailkit\Headless.Emails.Mailkit.csproj" />

--- a/src/Headless.Emails.Aws/README.md
+++ b/src/Headless.Emails.Aws/README.md
@@ -28,17 +28,17 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Option 1: from configuration (reads AWS:Region, credentials from environment/profile)
 var awsOptions = builder.Configuration.GetAWSOptions();
-builder.Services.AddAwsSesEmailSender(awsOptions);
+builder.Services.AddHeadlessEmails(setup => setup.UseAwsSes(awsOptions));
 
 // Option 2: explicit credentials
-builder.Services.AddAwsSesEmailSender(new AWSOptions
+builder.Services.AddHeadlessEmails(setup => setup.UseAwsSes(new AWSOptions
 {
     Region = RegionEndpoint.USEast1,
     Credentials = new BasicAWSCredentials("accessKey", "secretKey"),
-});
+}));
 
 // Option 3: use default AWSOptions already registered in DI (pass null)
-builder.Services.AddAwsSesEmailSender(null);
+builder.Services.AddHeadlessEmails(setup => setup.UseAwsSes(null));
 ```
 
 ## Configuration

--- a/src/Headless.Emails.Aws/Setup.cs
+++ b/src/Headless.Emails.Aws/Setup.cs
@@ -7,45 +7,57 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Headless.Emails.Aws;
 
 /// <summary>
-/// Registers the Amazon SES v2 email sender with the DI container.
+/// Extension members on <see cref="HeadlessEmailsSetupBuilder"/> for selecting Amazon SES v2 as the
+/// email provider.
 /// </summary>
 [PublicAPI]
 public static class SetupAwsSes
 {
-    /// <summary>
-    /// Registers <see cref="AwsSesEmailSender"/> as the <see cref="IEmailSender"/> singleton
-    /// backed by Amazon Simple Email Service v2.
-    /// </summary>
-    /// <param name="services">The service collection to register into.</param>
-    /// <param name="options">
-    /// AWS configuration (region, credentials). Pass <see langword="null"/> to use the
-    /// default <see cref="AWSOptions"/> already registered in the DI container (for example
-    /// from <c>builder.Configuration.GetAWSOptions()</c>).
-    /// </param>
-    /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
-    /// <remarks>
-    /// <code>
-    /// // From configuration:
-    /// var awsOptions = builder.Configuration.GetAWSOptions();
-    ///
-    /// // Explicit credentials:
-    /// var awsOptions = new AWSOptions
-    /// {
-    ///     Region = RegionEndpoint.GetBySystemName(builder.Configuration["AWS:Region"]),
-    ///     Credentials = new BasicAWSCredentials(
-    ///         builder.Configuration["AWS:AccessKey"],
-    ///         builder.Configuration["AWS:SecretKey"]),
-    /// };
-    ///
-    /// // Or pass null to rely on the AWSOptions already in DI:
-    /// services.AddAwsSesEmailSender(null);
-    /// </code>
-    /// </remarks>
-    public static IServiceCollection AddAwsSesEmailSender(this IServiceCollection services, AWSOptions? options)
+    extension(HeadlessEmailsSetupBuilder setup)
     {
-        services.TryAddAWSService<IAmazonSimpleEmailServiceV2>(options);
-        services.AddSingleton<IEmailSender, AwsSesEmailSender>();
+        /// <summary>
+        /// Selects Amazon Simple Email Service v2 as the email provider.
+        /// </summary>
+        /// <param name="options">
+        /// AWS configuration (region, credentials). Pass <see langword="null"/> to use the
+        /// default <see cref="AWSOptions"/> already registered in the DI container (for example
+        /// from <c>builder.Configuration.GetAWSOptions()</c>).
+        /// </param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <remarks>
+        /// <code>
+        /// // From configuration:
+        /// var awsOptions = builder.Configuration.GetAWSOptions();
+        ///
+        /// // Explicit credentials:
+        /// var awsOptions = new AWSOptions
+        /// {
+        ///     Region = RegionEndpoint.GetBySystemName(builder.Configuration["AWS:Region"]),
+        ///     Credentials = new BasicAWSCredentials(
+        ///         builder.Configuration["AWS:AccessKey"],
+        ///         builder.Configuration["AWS:SecretKey"]),
+        /// };
+        ///
+        /// services.AddHeadlessEmails(setup => setup.UseAwsSes(awsOptions));
+        ///
+        /// // Or pass null to rely on the AWSOptions already in DI:
+        /// services.AddHeadlessEmails(setup => setup.UseAwsSes(null));
+        /// </code>
+        /// </remarks>
+        public HeadlessEmailsSetupBuilder UseAwsSes(AWSOptions? options)
+        {
+            setup.RegisterExtension(new AwsSesEmailOptionsExtension(options));
 
-        return services;
+            return setup;
+        }
+    }
+
+    private sealed class AwsSesEmailOptionsExtension(AWSOptions? options) : IEmailProviderOptionsExtension
+    {
+        public void AddServices(IServiceCollection services)
+        {
+            services.TryAddAWSService<IAmazonSimpleEmailServiceV2>(options);
+            services.AddSingleton<IEmailSender, AwsSesEmailSender>();
+        }
     }
 }

--- a/src/Headless.Emails.Azure/AzureCommunicationEmailMessageMapper.cs
+++ b/src/Headless.Emails.Azure/AzureCommunicationEmailMessageMapper.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure.Communication.Email;
+
+namespace Headless.Emails.Azure;
+
+/// <summary>
+/// Pure mapping from the provider-agnostic <see cref="SendSingleEmailRequest"/> to an Azure
+/// Communication Services <see cref="EmailMessage"/>.
+/// </summary>
+/// <remarks>
+/// Extracted as a side-effect-free static so the bulk of provider logic is unit-testable without
+/// exercising the ACS long-running send operation. ACS accepts a bare string sender address
+/// (<c>senderAddress</c>), so <see cref="EmailRequestAddress.DisplayName"/> on the sender is not honored.
+/// </remarks>
+internal static class AzureCommunicationEmailMessageMapper
+{
+    public static EmailMessage ToEmailMessage(SendSingleEmailRequest request)
+    {
+        var content = new EmailContent(request.Subject) { PlainText = request.MessageText, Html = request.MessageHtml };
+
+        var recipients = new EmailRecipients(request.Destination.ToAddresses.Select(_ToEmailAddress).ToList());
+
+        foreach (var cc in request.Destination.CcAddresses)
+        {
+            recipients.CC.Add(_ToEmailAddress(cc));
+        }
+
+        foreach (var bcc in request.Destination.BccAddresses)
+        {
+            recipients.BCC.Add(_ToEmailAddress(bcc));
+        }
+
+        // ACS senderAddress is a bare string; the sender's display name is not carried.
+        var message = new EmailMessage(request.From.EmailAddress, recipients, content);
+
+        foreach (var attachment in request.Attachments)
+        {
+            message.Attachments.Add(
+                new EmailAttachment(
+                    attachment.Name,
+                    EmailAttachmentContentType.Resolve(attachment.Name),
+                    BinaryData.FromBytes(attachment.File)
+                )
+            );
+        }
+
+        return message;
+    }
+
+    private static EmailAddress _ToEmailAddress(EmailRequestAddress address)
+    {
+        return new EmailAddress(address.EmailAddress, address.DisplayName);
+    }
+}

--- a/src/Headless.Emails.Azure/AzureCommunicationEmailOptions.cs
+++ b/src/Headless.Emails.Azure/AzureCommunicationEmailOptions.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure.Core;
+using FluentValidation;
+
+namespace Headless.Emails.Azure;
+
+/// <summary>
+/// Configuration options for the Azure Communication Services email sender.
+/// </summary>
+/// <remarks>
+/// Exactly one authentication mode must be configured:
+/// <list type="bullet">
+/// <item><description><see cref="ConnectionString"/> — the resource connection string.</description></item>
+/// <item><description><see cref="Endpoint"/> + <see cref="AccessKey"/> — the resource endpoint and an access key.</description></item>
+/// <item><description><see cref="Endpoint"/> + <see cref="TokenCredential"/> — the resource endpoint and a
+/// Microsoft Entra ID credential (for example <c>DefaultAzureCredential</c>) for managed-identity auth.</description></item>
+/// </list>
+/// </remarks>
+[PublicAPI]
+public sealed class AzureCommunicationEmailOptions
+{
+    /// <summary>
+    /// The Communication Services resource connection string. When set, <see cref="Endpoint"/>,
+    /// <see cref="AccessKey"/>, and <see cref="TokenCredential"/> must be left unset.
+    /// Store in user-secrets or a key vault — do not commit to source control.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// The Communication Services resource endpoint (for example
+    /// <c>https://my-resource.communication.azure.com</c>). Pair with either <see cref="AccessKey"/>
+    /// or <see cref="TokenCredential"/>.
+    /// </summary>
+    public Uri? Endpoint { get; set; }
+
+    /// <summary>
+    /// The Communication Services access key, paired with <see cref="Endpoint"/>.
+    /// Store in user-secrets or a key vault — do not commit to source control.
+    /// </summary>
+    public string? AccessKey { get; set; }
+
+    /// <summary>
+    /// A Microsoft Entra ID credential (for example <c>DefaultAzureCredential</c>), paired with
+    /// <see cref="Endpoint"/>. Supply your own credential via the <c>UseAzure</c> delegate overload —
+    /// it cannot be bound from configuration.
+    /// </summary>
+    public TokenCredential? TokenCredential { get; set; }
+
+    /// <summary>Returns a diagnostics-safe description that never includes the connection string or access key.</summary>
+    public override string ToString()
+    {
+        if (!string.IsNullOrWhiteSpace(ConnectionString))
+        {
+            return "AzureCommunicationEmail: connection-string auth";
+        }
+
+        if (Endpoint is not null && TokenCredential is not null)
+        {
+            return $"AzureCommunicationEmail: {Endpoint} (token-credential auth)";
+        }
+
+        if (Endpoint is not null && !string.IsNullOrWhiteSpace(AccessKey))
+        {
+            return $"AzureCommunicationEmail: {Endpoint} (access-key auth)";
+        }
+
+        return "AzureCommunicationEmail: <unconfigured>";
+    }
+}
+
+[UsedImplicitly]
+internal sealed class AzureCommunicationEmailOptionsValidator : AbstractValidator<AzureCommunicationEmailOptions>
+{
+    public AzureCommunicationEmailOptionsValidator()
+    {
+        RuleFor(x => x)
+            .Must(_HasExactlyOneAuthMode)
+            .WithMessage(
+                "AzureCommunicationEmailOptions requires exactly one authentication mode: set ConnectionString, "
+                    + "or Endpoint + AccessKey, or Endpoint + TokenCredential."
+            );
+    }
+
+    private static bool _HasExactlyOneAuthMode(AzureCommunicationEmailOptions options)
+    {
+        var connectionStringMode = !string.IsNullOrWhiteSpace(options.ConnectionString);
+        var accessKeyMode = options.Endpoint is not null && !string.IsNullOrWhiteSpace(options.AccessKey);
+        var tokenCredentialMode = options.Endpoint is not null && options.TokenCredential is not null;
+
+        var configuredModes = (connectionStringMode ? 1 : 0) + (accessKeyMode ? 1 : 0) + (tokenCredentialMode ? 1 : 0);
+
+        return configuredModes == 1;
+    }
+}

--- a/src/Headless.Emails.Azure/AzureCommunicationEmailOptions.cs
+++ b/src/Headless.Emails.Azure/AzureCommunicationEmailOptions.cs
@@ -50,23 +50,69 @@ public sealed class AzureCommunicationEmailOptions
     /// <summary>Returns a diagnostics-safe description that never includes the connection string or access key.</summary>
     public override string ToString()
     {
-        if (!string.IsNullOrWhiteSpace(ConnectionString))
+        return ResolveAuthMode() switch
         {
-            return "AzureCommunicationEmail: connection-string auth";
-        }
-
-        if (Endpoint is not null && TokenCredential is not null)
-        {
-            return $"AzureCommunicationEmail: {Endpoint} (token-credential auth)";
-        }
-
-        if (Endpoint is not null && !string.IsNullOrWhiteSpace(AccessKey))
-        {
-            return $"AzureCommunicationEmail: {Endpoint} (access-key auth)";
-        }
-
-        return "AzureCommunicationEmail: <unconfigured>";
+            AzureCommunicationEmailAuthMode.ConnectionString => "AzureCommunicationEmail: connection-string auth",
+            AzureCommunicationEmailAuthMode.TokenCredential =>
+                $"AzureCommunicationEmail: {Endpoint} (token-credential auth)",
+            AzureCommunicationEmailAuthMode.AccessKey => $"AzureCommunicationEmail: {Endpoint} (access-key auth)",
+            _ => "AzureCommunicationEmail: <unconfigured>",
+        };
     }
+
+    /// <summary>
+    /// Resolves which single authentication mode these options describe. Returns
+    /// <see cref="AzureCommunicationEmailAuthMode.Unconfigured"/> when none is set and
+    /// <see cref="AzureCommunicationEmailAuthMode.Ambiguous"/> when more than one is set — the validator
+    /// rejects both. Centralizing the precedence here keeps the client factory, <see cref="ToString"/>,
+    /// and the validator from drifting when an authentication mode is added.
+    /// </summary>
+    internal AzureCommunicationEmailAuthMode ResolveAuthMode()
+    {
+        var connectionStringMode = !string.IsNullOrWhiteSpace(ConnectionString);
+        var accessKeyMode = Endpoint is not null && !string.IsNullOrWhiteSpace(AccessKey);
+        var tokenCredentialMode = Endpoint is not null && TokenCredential is not null;
+
+        var configuredModes = (connectionStringMode ? 1 : 0) + (accessKeyMode ? 1 : 0) + (tokenCredentialMode ? 1 : 0);
+
+        if (configuredModes == 0)
+        {
+            return AzureCommunicationEmailAuthMode.Unconfigured;
+        }
+
+        if (configuredModes > 1)
+        {
+            return AzureCommunicationEmailAuthMode.Ambiguous;
+        }
+
+        if (connectionStringMode)
+        {
+            return AzureCommunicationEmailAuthMode.ConnectionString;
+        }
+
+        return tokenCredentialMode
+            ? AzureCommunicationEmailAuthMode.TokenCredential
+            : AzureCommunicationEmailAuthMode.AccessKey;
+    }
+}
+
+/// <summary>The single authentication mode an <see cref="AzureCommunicationEmailOptions"/> instance describes.</summary>
+internal enum AzureCommunicationEmailAuthMode
+{
+    /// <summary>No authentication mode is configured.</summary>
+    Unconfigured,
+
+    /// <summary>More than one authentication mode is configured.</summary>
+    Ambiguous,
+
+    /// <summary>The resource connection string.</summary>
+    ConnectionString,
+
+    /// <summary>Endpoint paired with an access key.</summary>
+    AccessKey,
+
+    /// <summary>Endpoint paired with a Microsoft Entra ID token credential.</summary>
+    TokenCredential,
 }
 
 [UsedImplicitly]
@@ -84,12 +130,7 @@ internal sealed class AzureCommunicationEmailOptionsValidator : AbstractValidato
 
     private static bool _HasExactlyOneAuthMode(AzureCommunicationEmailOptions options)
     {
-        var connectionStringMode = !string.IsNullOrWhiteSpace(options.ConnectionString);
-        var accessKeyMode = options.Endpoint is not null && !string.IsNullOrWhiteSpace(options.AccessKey);
-        var tokenCredentialMode = options.Endpoint is not null && options.TokenCredential is not null;
-
-        var configuredModes = (connectionStringMode ? 1 : 0) + (accessKeyMode ? 1 : 0) + (tokenCredentialMode ? 1 : 0);
-
-        return configuredModes == 1;
+        return options.ResolveAuthMode()
+            is not (AzureCommunicationEmailAuthMode.Unconfigured or AzureCommunicationEmailAuthMode.Ambiguous);
     }
 }

--- a/src/Headless.Emails.Azure/AzureCommunicationEmailSender.cs
+++ b/src/Headless.Emails.Azure/AzureCommunicationEmailSender.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure;
+using Azure.Communication.Email;
+using Microsoft.Extensions.Logging;
+
+namespace Headless.Emails.Azure;
+
+/*
+ * API Docs
+ * https://learn.microsoft.com/en-us/dotnet/api/overview/azure/communication.email-readme
+ */
+/// <summary>
+/// <see cref="IEmailSender"/> implementation backed by Azure Communication Services (ACS) Email.
+/// </summary>
+/// <remarks>
+/// The send uses <see cref="WaitUntil.Completed"/>, so the call blocks until ACS reaches a terminal
+/// state. ACS can complete a send with a non-<c>Succeeded</c> status <em>without</em> throwing, so the
+/// outcome is mapped two ways: a thrown <see cref="RequestFailedException"/> and a completed-but-failed
+/// status both produce a failed <see cref="SendSingleEmailResponse"/>. Recipient and sender addresses are
+/// deliberately excluded from log output; only the operation id, status, and error code are recorded.
+/// Unrelated exceptions (for example cancellation) propagate. Transient throttling/5xx responses are
+/// retried by the <c>Azure.Core</c> pipeline (honoring <c>Retry-After</c>); no custom retry is added.
+/// </remarks>
+public sealed class AzureCommunicationEmailSender(EmailClient client, ILogger<AzureCommunicationEmailSender> logger)
+    : IEmailSender
+{
+    private const string _FailureError = "Failed to send an email to the recipient.";
+
+    /// <summary>
+    /// Sends a single email via Azure Communication Services.
+    /// </summary>
+    /// <param name="request">The email message to send.</param>
+    /// <param name="cancellationToken">Token used to cancel the send operation.</param>
+    /// <returns>
+    /// A successful response when ACS completes the send with a <c>Succeeded</c> status; a failed
+    /// response when ACS rejects the request (<see cref="RequestFailedException"/>) or completes with a
+    /// non-<c>Succeeded</c> terminal status.
+    /// </returns>
+    public async ValueTask<SendSingleEmailResponse> SendAsync(
+        SendSingleEmailRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        EmailSendOperation operation;
+
+        try
+        {
+            operation = await client.SendAsync(WaitUntil.Completed, message, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex)
+        {
+            // Log only non-PII tracking fields — recipient/sender addresses must not leak into log sinks.
+            logger.LogEmailSendRequestFailed(ex.Status, ex.ErrorCode);
+
+            return SendSingleEmailResponse.Failed(_FailureError);
+        }
+
+        var result = operation.Value;
+
+        if (result.Status == EmailSendStatus.Succeeded)
+        {
+            return SendSingleEmailResponse.Succeeded();
+        }
+
+        // ACS reached a terminal non-Succeeded state (for example Failed/Canceled) without throwing.
+        logger.LogEmailCompletedWithFailureStatus(result.Status.ToString(), operation.Id);
+
+        return SendSingleEmailResponse.Failed(_FailureError);
+    }
+}
+
+internal static partial class AzureCommunicationEmailSenderLoggerExtensions
+{
+    [LoggerMessage(
+        EventId = 1,
+        EventName = "EmailSendRequestFailed",
+        Level = LogLevel.Error,
+        Message = "Azure Communication Services rejected the email send. Status={Status}, ErrorCode={ErrorCode}"
+    )]
+    public static partial void LogEmailSendRequestFailed(this ILogger logger, int status, string? errorCode);
+
+    [LoggerMessage(
+        EventId = 2,
+        EventName = "EmailCompletedWithFailureStatus",
+        Level = LogLevel.Error,
+        Message = "Azure Communication Services completed the email send with a non-success status. Status={Status}, OperationId={OperationId}"
+    )]
+    public static partial void LogEmailCompletedWithFailureStatus(
+        this ILogger logger,
+        string status,
+        string operationId
+    );
+}

--- a/src/Headless.Emails.Azure/AzureCommunicationEmailSender.cs
+++ b/src/Headless.Emails.Azure/AzureCommunicationEmailSender.cs
@@ -18,11 +18,15 @@ namespace Headless.Emails.Azure;
 /// state. ACS can complete a send with a non-<c>Succeeded</c> status <em>without</em> throwing, so the
 /// outcome is mapped two ways: a thrown <see cref="RequestFailedException"/> and a completed-but-failed
 /// status both produce a failed <see cref="SendSingleEmailResponse"/>. Recipient and sender addresses are
-/// deliberately excluded from log output; only the operation id, status, and error code are recorded.
-/// Unrelated exceptions (for example cancellation) propagate. Transient throttling/5xx responses are
-/// retried by the <c>Azure.Core</c> pipeline (honoring <c>Retry-After</c>); no custom retry is added.
+/// deliberately excluded from log output: a rejected request records the HTTP status, the ACS error code,
+/// and the <c>x-ms-request-id</c> correlation id; a completed-but-failed terminal status records the send
+/// status and operation id. Unrelated exceptions (for example cancellation) propagate. Transient
+/// throttling/5xx responses are retried by the <c>Azure.Core</c> pipeline (honoring <c>Retry-After</c>);
+/// no custom retry is added. Because the call blocks until a terminal state and that pipeline backs off
+/// under throttling — ACS managed-domain limits are low (5/min) — a caller that needs a hard wall-clock
+/// bound should pass a cancellation token with a deadline (for example <c>CancellationTokenSource.CancelAfter(...)</c>).
 /// </remarks>
-public sealed class AzureCommunicationEmailSender(EmailClient client, ILogger<AzureCommunicationEmailSender> logger)
+internal sealed class AzureCommunicationEmailSender(EmailClient client, ILogger<AzureCommunicationEmailSender> logger)
     : IEmailSender
 {
     private const string _FailureError = "Failed to send an email to the recipient.";
@@ -53,7 +57,8 @@ public sealed class AzureCommunicationEmailSender(EmailClient client, ILogger<Az
         catch (RequestFailedException ex)
         {
             // Log only non-PII tracking fields — recipient/sender addresses must not leak into log sinks.
-            logger.LogEmailSendRequestFailed(ex.Status, ex.ErrorCode);
+            // x-ms-request-id is the ACS-side correlation handle for the rejected request (no operation id exists yet).
+            logger.LogEmailSendRequestFailed(ex.Status, ex.ErrorCode, _TryGetRequestId(ex));
 
             return SendSingleEmailResponse.Failed(_FailureError);
         }
@@ -70,6 +75,16 @@ public sealed class AzureCommunicationEmailSender(EmailClient client, ILogger<Az
 
         return SendSingleEmailResponse.Failed(_FailureError);
     }
+
+    // The ACS-side correlation id for a rejected request; null when the SDK did not attach a raw response.
+    private static string? _TryGetRequestId(RequestFailedException exception)
+    {
+        return
+            exception.GetRawResponse() is { } response
+            && response.Headers.TryGetValue("x-ms-request-id", out var requestId)
+            ? requestId
+            : null;
+    }
 }
 
 internal static partial class AzureCommunicationEmailSenderLoggerExtensions
@@ -78,9 +93,14 @@ internal static partial class AzureCommunicationEmailSenderLoggerExtensions
         EventId = 1,
         EventName = "EmailSendRequestFailed",
         Level = LogLevel.Error,
-        Message = "Azure Communication Services rejected the email send. Status={Status}, ErrorCode={ErrorCode}"
+        Message = "Azure Communication Services rejected the email send. Status={Status}, ErrorCode={ErrorCode}, CorrelationId={CorrelationId}"
     )]
-    public static partial void LogEmailSendRequestFailed(this ILogger logger, int status, string? errorCode);
+    public static partial void LogEmailSendRequestFailed(
+        this ILogger logger,
+        int status,
+        string? errorCode,
+        string? correlationId
+    );
 
     [LoggerMessage(
         EventId = 2,

--- a/src/Headless.Emails.Azure/Headless.Emails.Azure.csproj
+++ b/src/Headless.Emails.Azure/Headless.Emails.Azure.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Headless.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Headless.Emails.Azure</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Communication.Email" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Headless.Emails.Azure.Tests.Unit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Headless.Emails.Abstractions\Headless.Emails.Abstractions.csproj" />
+    <ProjectReference Include="..\Headless.Emails.Core\Headless.Emails.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Headless.Emails.Azure/README.md
+++ b/src/Headless.Emails.Azure/README.md
@@ -1,0 +1,83 @@
+# Headless.Emails.Azure
+
+Azure Communication Services (ACS) Email implementation of the email sending abstraction.
+
+## Problem Solved
+
+Provides email sending via Azure Communication Services using the unified `IEmailSender` abstraction — the intended cloud-email backend for Azure-hosted consumers, with managed-identity support.
+
+## Key Features
+
+- Full `IEmailSender` implementation over `Azure.Communication.Email`
+- Three authentication modes: connection string, endpoint + access key, and endpoint + managed-identity `TokenCredential`
+- Maps `SendSingleEmailRequest` (From, To/Cc/Bcc, Subject, HTML + plain-text bodies, attachments) to an ACS `EmailMessage`
+- Attachment content type derived from the file name via `EmailAttachmentContentType.Resolve()` (`application/octet-stream` fallback)
+- Both a thrown `RequestFailedException` and a completed-but-failed terminal status map to `SendSingleEmailResponse.Failed(...)`
+- Non-PII logging on failure (operation id, status, error code — no recipient/sender addresses)
+
+## Design Notes
+
+The send uses `EmailClient.SendAsync(WaitUntil.Completed, …)`, so the call blocks until ACS reaches a terminal state — matching the contract's "accepted for delivery" success semantics. ACS can complete a long-running send with a non-`Succeeded` status **without throwing**, so the sender inspects `operation.Value.Status` and treats any terminal non-`Succeeded` state as a failure (an exception-only check would report rejected mail as delivered). Only `Succeeded` returns `Succeeded()`; unrelated exceptions (cancellation, argument errors) propagate.
+
+The package depends on `Azure.Core` (not `Azure.Identity`): supply your own `DefaultAzureCredential` through the delegate overload to keep the dependency surface narrow. The `IConfiguration` overload binds only the connection-string and endpoint + access-key modes. ACS's `senderAddress` is a bare string, so the sender's display name is not honored. No custom retry loop is added — `Azure.Core`'s pipeline already retries 429/5xx honoring `Retry-After`. The sender domain must be verified and linked in the Communication Services resource; managed-domain send limits are low (5/min; custom domains 30/min).
+
+## Installation
+
+```bash
+dotnet add package Headless.Emails.Azure
+```
+
+## Quick Start
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Option 1: connection string or endpoint + access key, bound from configuration
+builder.Services.AddHeadlessEmails(setup =>
+    setup.UseAzure(builder.Configuration.GetSection("AzureEmail")));
+
+// Option 2: endpoint + access key (delegate)
+builder.Services.AddHeadlessEmails(setup => setup.UseAzure(options =>
+{
+    options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
+    options.AccessKey = builder.Configuration["AzureEmail:AccessKey"]!;
+}));
+
+// Option 3: managed identity (TokenCredential — delegate only; requires the Azure.Identity package)
+builder.Services.AddHeadlessEmails(setup => setup.UseAzure(options =>
+{
+    options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
+    options.TokenCredential = new DefaultAzureCredential();
+}));
+```
+
+## Configuration
+
+```json
+{
+    "AzureEmail": {
+        "ConnectionString": "endpoint=https://my-resource.communication.azure.com/;accesskey=<key>"
+    }
+}
+```
+
+`AzureCommunicationEmailOptions` properties — exactly one auth mode must be configured:
+
+| Property | Type | Description |
+|---|---|---|
+| `ConnectionString` | `string?` | Resource connection string (connection-string mode) |
+| `Endpoint` | `Uri?` | Resource endpoint; pair with `AccessKey` or `TokenCredential` |
+| `AccessKey` | `string?` | Resource access key (access-key mode) |
+| `TokenCredential` | `TokenCredential?` | Managed-identity credential (delegate overload only — not bindable from configuration) |
+
+## Dependencies
+
+- `Headless.Emails.Abstractions`
+- `Headless.Emails.Core`
+- `Azure.Communication.Email`
+
+## Side Effects
+
+- Binds and validates `AzureCommunicationEmailOptions` (exactly one auth mode required)
+- Registers `EmailClient` as singleton (constructed from the configured auth mode)
+- Registers `IEmailSender` as singleton

--- a/src/Headless.Emails.Azure/Setup.cs
+++ b/src/Headless.Emails.Azure/Setup.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure;
+using Azure.Communication.Email;
+using Headless.Checks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Headless.Emails.Azure;
+
+/// <summary>
+/// Extension members on <see cref="HeadlessEmailsSetupBuilder"/> for selecting Azure Communication
+/// Services (ACS) Email as the email provider.
+/// </summary>
+[PublicAPI]
+public static class SetupAzureEmail
+{
+    extension(HeadlessEmailsSetupBuilder setup)
+    {
+        /// <summary>
+        /// Selects Azure Communication Services Email as the email provider, binding
+        /// <see cref="AzureCommunicationEmailOptions"/> from the supplied configuration section.
+        /// </summary>
+        /// <param name="configuration">The configuration section to bind provider options from.</param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <remarks>
+        /// Configuration binding supports only the connection-string and endpoint + access-key auth modes.
+        /// Managed-identity (<see cref="AzureCommunicationEmailOptions.TokenCredential"/>) auth requires a
+        /// delegate overload, since a credential cannot be bound from configuration.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is <see langword="null"/>.</exception>
+        public HeadlessEmailsSetupBuilder UseAzure(IConfiguration configuration)
+        {
+            Argument.IsNotNull(configuration);
+
+            setup.RegisterExtension(new AzureCommunicationEmailOptionsExtension(configuration));
+
+            return setup;
+        }
+
+        /// <summary>
+        /// Selects Azure Communication Services Email as the email provider, configuring
+        /// <see cref="AzureCommunicationEmailOptions"/> via a setup delegate.
+        /// </summary>
+        /// <param name="configure">Delegate that populates the options.</param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        public HeadlessEmailsSetupBuilder UseAzure(Action<AzureCommunicationEmailOptions> configure)
+        {
+            Argument.IsNotNull(configure);
+
+            setup.RegisterExtension(new AzureCommunicationEmailOptionsExtension(configure));
+
+            return setup;
+        }
+
+        /// <summary>
+        /// Selects Azure Communication Services Email as the email provider, configuring
+        /// <see cref="AzureCommunicationEmailOptions"/> via a setup delegate that also receives the
+        /// <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="configure">Delegate that populates the options using DI-resolved services.</param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        public HeadlessEmailsSetupBuilder UseAzure(Action<AzureCommunicationEmailOptions, IServiceProvider> configure)
+        {
+            Argument.IsNotNull(configure);
+
+            setup.RegisterExtension(new AzureCommunicationEmailOptionsExtension(configure));
+
+            return setup;
+        }
+    }
+
+    private sealed class AzureCommunicationEmailOptionsExtension : IEmailProviderOptionsExtension
+    {
+        private readonly Action<IServiceCollection> _configure;
+
+        public AzureCommunicationEmailOptionsExtension(IConfiguration configuration)
+        {
+            _configure = services =>
+                services.Configure<AzureCommunicationEmailOptions, AzureCommunicationEmailOptionsValidator>(
+                    configuration
+                );
+        }
+
+        public AzureCommunicationEmailOptionsExtension(Action<AzureCommunicationEmailOptions> configure)
+        {
+            _configure = services =>
+                services.Configure<AzureCommunicationEmailOptions, AzureCommunicationEmailOptionsValidator>(configure);
+        }
+
+        public AzureCommunicationEmailOptionsExtension(
+            Action<AzureCommunicationEmailOptions, IServiceProvider> configure
+        )
+        {
+            _configure = services =>
+                services.Configure<AzureCommunicationEmailOptions, AzureCommunicationEmailOptionsValidator>(configure);
+        }
+
+        public void AddServices(IServiceCollection services)
+        {
+            _configure(services);
+
+            services.AddSingleton(static sp =>
+            {
+                var options = sp.GetRequiredService<IOptions<AzureCommunicationEmailOptions>>().Value;
+
+                return _CreateClient(options);
+            });
+
+            services.AddSingleton<IEmailSender, AzureCommunicationEmailSender>();
+        }
+    }
+
+    private static EmailClient _CreateClient(AzureCommunicationEmailOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            return new EmailClient(options.ConnectionString);
+        }
+
+        if (options.Endpoint is not null && options.TokenCredential is not null)
+        {
+            return new EmailClient(options.Endpoint, options.TokenCredential);
+        }
+
+        if (options.Endpoint is not null && !string.IsNullOrWhiteSpace(options.AccessKey))
+        {
+            return new EmailClient(options.Endpoint, new AzureKeyCredential(options.AccessKey));
+        }
+
+        throw new InvalidOperationException(
+            "AzureCommunicationEmailOptions is not configured with a valid authentication mode. Set ConnectionString, "
+                + "or Endpoint + AccessKey, or Endpoint + TokenCredential."
+        );
+    }
+}

--- a/src/Headless.Emails.Azure/Setup.cs
+++ b/src/Headless.Emails.Azure/Setup.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Diagnostics;
 using Azure;
 using Azure.Communication.Email;
 using Headless.Checks;
@@ -116,24 +117,24 @@ public static class SetupAzureEmail
 
     private static EmailClient _CreateClient(AzureCommunicationEmailOptions options)
     {
-        if (!string.IsNullOrWhiteSpace(options.ConnectionString))
+        // The options validator (wired with ValidateOnStart via Configure<TOptions, TValidator>) guarantees
+        // exactly one mode before this factory runs, so the resolved mode is never Unconfigured/Ambiguous on
+        // the validated path. Note: in a non-hosted container (bare BuildServiceProvider without IHost),
+        // ValidateOnStart never fires, so a misconfiguration instead surfaces here on first resolve.
+        return options.ResolveAuthMode() switch
         {
-            return new EmailClient(options.ConnectionString);
-        }
-
-        if (options.Endpoint is not null && options.TokenCredential is not null)
-        {
-            return new EmailClient(options.Endpoint, options.TokenCredential);
-        }
-
-        if (options.Endpoint is not null && !string.IsNullOrWhiteSpace(options.AccessKey))
-        {
-            return new EmailClient(options.Endpoint, new AzureKeyCredential(options.AccessKey));
-        }
-
-        throw new InvalidOperationException(
-            "AzureCommunicationEmailOptions is not configured with a valid authentication mode. Set ConnectionString, "
-                + "or Endpoint + AccessKey, or Endpoint + TokenCredential."
-        );
+            AzureCommunicationEmailAuthMode.ConnectionString => new EmailClient(options.ConnectionString!),
+            AzureCommunicationEmailAuthMode.TokenCredential => new EmailClient(
+                options.Endpoint!,
+                options.TokenCredential!
+            ),
+            AzureCommunicationEmailAuthMode.AccessKey => new EmailClient(
+                options.Endpoint!,
+                new AzureKeyCredential(options.AccessKey!)
+            ),
+            var mode => throw new UnreachableException(
+                $"AzureCommunicationEmailOptions resolved to {mode}; the options validator should have rejected this before the EmailClient factory ran."
+            ),
+        };
     }
 }

--- a/src/Headless.Emails.Core/EmailAttachmentContentType.cs
+++ b/src/Headless.Emails.Core/EmailAttachmentContentType.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Checks;
+using MimeKit;
+
+namespace Headless.Emails;
+
+/// <summary>
+/// Resolves an attachment's MIME content type from its file name. Shared across email providers whose
+/// transport requires an explicit content type (for example Azure Communication Services), since the
+/// <see cref="EmailRequestAttachment"/> contract carries only the file name and bytes.
+/// </summary>
+[PublicAPI]
+public static class EmailAttachmentContentType
+{
+    /// <summary>The fallback content type used when the file name has no recognized extension.</summary>
+    public const string Default = "application/octet-stream";
+
+    /// <summary>
+    /// Resolves the MIME content type for <paramref name="fileName"/> from its extension, falling back
+    /// to <see cref="Default"/> (<c>application/octet-stream</c>) when the extension is unknown.
+    /// </summary>
+    /// <param name="fileName">The attachment file name (for example <c>invoice.pdf</c>).</param>
+    /// <returns>The resolved MIME content type, never <see langword="null"/> or empty.</returns>
+    /// <exception cref="System.ArgumentException">Thrown when <paramref name="fileName"/> is <see langword="null"/> or empty.</exception>
+    public static string Resolve(string fileName)
+    {
+        Argument.IsNotNullOrEmpty(fileName);
+
+        var contentType = MimeTypes.GetMimeType(fileName);
+
+        return string.IsNullOrEmpty(contentType) ? Default : contentType;
+    }
+}

--- a/src/Headless.Emails.Core/HeadlessEmailsSetupBuilder.cs
+++ b/src/Headless.Emails.Core/HeadlessEmailsSetupBuilder.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Checks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Headless.Emails;
+
+/// <summary>
+/// Fluent builder passed to the <c>AddHeadlessEmails</c> delegate. Used to select exactly one email
+/// provider via a <c>Use*</c> extension (for example <c>UseAzure</c>, <c>UseAwsSes</c>,
+/// <c>UseMailkit</c>, <c>UseDevelopment</c>, <c>UseNoop</c>).
+/// </summary>
+/// <remarks>
+/// Emails has no shared, cross-provider feature options, so the builder is provider-selection-only and
+/// carries no <c>Configure</c> overloads. Each provider binds its own options inside its <c>Use*</c> member.
+/// </remarks>
+[PublicAPI]
+public sealed class HeadlessEmailsSetupBuilder
+{
+    internal HeadlessEmailsSetupBuilder(IServiceCollection services)
+    {
+        Services = Argument.IsNotNull(services);
+    }
+
+    internal IServiceCollection Services { get; }
+
+    internal IList<IEmailProviderOptionsExtension> Extensions { get; } = new List<IEmailProviderOptionsExtension>();
+
+    /// <summary>
+    /// Registers a provider extension. Called internally by each <c>Use*</c> extension method; not
+    /// intended for direct use by application code.
+    /// </summary>
+    /// <param name="extension">The provider extension to add.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="extension"/> is <see langword="null"/>.</exception>
+    public void RegisterExtension(IEmailProviderOptionsExtension extension)
+    {
+        Argument.IsNotNull(extension);
+
+        Extensions.Add(extension);
+    }
+}

--- a/src/Headless.Emails.Core/IEmailProviderOptionsExtension.cs
+++ b/src/Headless.Emails.Core/IEmailProviderOptionsExtension.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Headless.Emails;
+
+/// <summary>Setup-time extension hook implemented by each email provider package.</summary>
+/// <remarks>
+/// Provider packages create an internal implementation of this interface and register it via
+/// <see cref="HeadlessEmailsSetupBuilder.RegisterExtension"/>. Exactly one extension must be
+/// registered per <c>AddHeadlessEmails</c> call; the core setup validates this constraint and
+/// throws <see cref="InvalidOperationException"/> if zero or multiple providers are found.
+/// </remarks>
+[PublicAPI]
+public interface IEmailProviderOptionsExtension
+{
+    /// <summary>Registers the provider-specific <see cref="IEmailSender"/> and its dependencies into <paramref name="services"/>.</summary>
+    /// <param name="services">The application's <see cref="IServiceCollection"/>.</param>
+    void AddServices(IServiceCollection services);
+}

--- a/src/Headless.Emails.Core/README.md
+++ b/src/Headless.Emails.Core/README.md
@@ -1,20 +1,22 @@
 # Headless.Emails.Core
 
-Core utilities and MimeKit integration for email implementations.
+Setup builder, MimeKit integration, and shared utilities for email implementations.
 
 ## Problem Solved
 
-Provides shared conversion logic to bridge the framework email contracts with MimeKit, eliminating duplication across the Aws and Mailkit provider implementations.
+Owns the unified email setup builder (`AddHeadlessEmails`) plus shared conversion logic that bridges the framework email contracts with MimeKit, eliminating duplication across the provider implementations.
 
 ## Key Features
 
+- `AddHeadlessEmails(Action<HeadlessEmailsSetupBuilder>)` — the single provider-agnostic registration entry point, with an exactly-one-provider gate
+- `HeadlessEmailsSetupBuilder` — receives `Use*` provider selections; `IEmailProviderOptionsExtension` — the hook each provider implements
+- `EmailAttachmentContentType.Resolve(fileName)` — derives an attachment MIME type from its file name (MimeKit lookup, `application/octet-stream` fallback)
 - `EmailToMimMessageConverter.ConvertToMimeMessageAsync()` — converts `SendSingleEmailRequest` to a MimeKit `MimeMessage` (extension method on `SendSingleEmailRequest`)
 - `EmailRequestAddress.MapToMailboxAddress()` — maps to MimeKit `MailboxAddress`
-- Full address mapping (From, To, Cc, Bcc), body building (text + HTML via `BodyBuilder`), and attachment streaming
 
 ## Design Notes
 
-This package is consumed transitively by `Headless.Emails.Aws` and `Headless.Emails.Mailkit` — application code does not reference it directly. The converter returns a `MimeMessage` that callers are responsible for disposing; the implementation disposes the message if an exception occurs during construction, preventing a resource leak.
+The builder carries no shared, cross-provider feature options — it is provider-selection-only; each provider binds its own options inside its `Use*` member. The gate counts registered extensions and rejects zero, multiple, or a repeated `AddHeadlessEmails` on the same `IServiceCollection` (a host resolves a single `IEmailSender`). The MimeKit converter returns a `MimeMessage` that callers dispose; the implementation disposes the message if an exception occurs during construction, preventing a resource leak.
 
 ## Installation
 
@@ -25,8 +27,11 @@ dotnet add package Headless.Emails.Core
 ## Quick Start
 
 ```csharp
-// Used internally by providers — not called from application code.
-// Shown for provider implementors:
+// Provider-agnostic registration entry point (a provider package supplies the Use* member):
+builder.Services.AddHeadlessEmails(setup => setup.UseNoop());
+
+// Shared helpers used internally by providers — not called from application code:
+var contentType = EmailAttachmentContentType.Resolve("invoice.pdf"); // "application/pdf"
 using var mimeMessage = await request.ConvertToMimeMessageAsync(cancellationToken);
 ```
 
@@ -37,8 +42,9 @@ No configuration required.
 ## Dependencies
 
 - `Headless.Emails.Abstractions`
-- `MimeKit`
+- `Headless.Hosting`
+- `MailKit`
 
 ## Side Effects
 
-None. This is a utility package with no DI registrations.
+None directly. `AddHeadlessEmails` registers a provider-registration marker and delegates all `IEmailSender` wiring to the selected provider's extension.

--- a/src/Headless.Emails.Core/Setup.cs
+++ b/src/Headless.Emails.Core/Setup.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Checks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Headless.Emails;
+
+/// <summary>
+/// Extension methods on <see cref="IServiceCollection"/> for registering the Headless email sender.
+/// </summary>
+[PublicAPI]
+public static class SetupEmailsCore
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Registers a Headless <see cref="IEmailSender"/> with the provider configured inside
+        /// <paramref name="configure"/>. Exactly one <c>Use*</c> call (for example <c>UseAzure</c>,
+        /// <c>UseAwsSes</c>, <c>UseMailkit</c>, <c>UseDevelopment</c>, <c>UseNoop</c>) must be made
+        /// inside the delegate; zero or multiple providers throw <see cref="InvalidOperationException"/>
+        /// at registration time.
+        /// </summary>
+        /// <param name="configure">Delegate that selects exactly one email provider.</param>
+        /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the delegate registers zero or more than one provider, or when an email provider
+        /// has already been registered on the same <see cref="IServiceCollection"/>.
+        /// </exception>
+        public IServiceCollection AddHeadlessEmails(Action<HeadlessEmailsSetupBuilder> configure)
+        {
+            Argument.IsNotNull(configure);
+
+            var setup = new HeadlessEmailsSetupBuilder(services);
+            configure(setup);
+
+            return _AddEmailsProviderCore(services, setup);
+        }
+    }
+
+    private static IServiceCollection _AddEmailsProviderCore(
+        IServiceCollection services,
+        HeadlessEmailsSetupBuilder setup
+    )
+    {
+        if (setup.Extensions.Count != 1)
+        {
+            throw new InvalidOperationException(
+                setup.Extensions.Count == 0
+                    ? "Headless.Emails requires exactly one provider. Call one of `UseAzure`, `UseAwsSes`, `UseMailkit`, `UseDevelopment`, or `UseNoop`."
+                    : "Headless.Emails requires exactly one provider. Multiple providers were configured."
+            );
+        }
+
+        if (services.Any(static descriptor => descriptor.ServiceType == typeof(EmailProviderRegistration)))
+        {
+            throw new InvalidOperationException(
+                "Headless.Emails requires exactly one provider. Multiple providers were configured."
+            );
+        }
+
+        var extension = setup.Extensions.Single();
+        var extensionTypeName = extension.GetType().FullName ?? "unknown";
+        services.AddSingleton(new EmailProviderRegistration(extensionTypeName));
+
+        extension.AddServices(services);
+
+        return services;
+    }
+
+    private sealed record EmailProviderRegistration(string Provider);
+}

--- a/src/Headless.Emails.Dev/Headless.Emails.Dev.csproj
+++ b/src/Headless.Emails.Dev/Headless.Emails.Dev.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Headless.Emails.Abstractions\Headless.Emails.Abstractions.csproj" />
+    <ProjectReference Include="..\Headless.Emails.Core\Headless.Emails.Core.csproj" />
     <ProjectReference Include="..\Headless.Hosting\Headless.Hosting.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Headless.Emails.Dev/README.md
+++ b/src/Headless.Emails.Dev/README.md
@@ -10,7 +10,7 @@ Provides safe email implementations for development and testing that do not send
 
 - `DevEmailSender` — writes full email content to a local file; appends with a `--------------------` separator per message; prefers `MessageText` over `MessageHtml` for readability
 - `NoopEmailSender` — silently discards all emails, always returns `Succeeded()`
-- No network calls, no external dependencies beyond the abstractions package
+- No network calls, no external dependencies beyond the abstractions and core packages
 
 ## Installation
 
@@ -26,10 +26,10 @@ var builder = WebApplication.CreateBuilder(args);
 if (builder.Environment.IsDevelopment())
 {
     // Write emails to a local file for inspection
-    builder.Services.AddDevEmailSender("path/to/emails.txt");
+    builder.Services.AddHeadlessEmails(setup => setup.UseDevelopment("path/to/emails.txt"));
 
     // Or discard silently (useful in automated tests)
-    // builder.Services.AddNoopEmailSender();
+    // builder.Services.AddHeadlessEmails(setup => setup.UseNoop());
 }
 ```
 
@@ -47,15 +47,16 @@ Hello World!
 
 ## Configuration
 
-`AddDevEmailSender(string filePath)` — the file path is the only parameter. The file is created if it does not exist; emails are appended.
+`UseDevelopment(string filePath)` — the file path is the only parameter. The file is created if it does not exist; emails are appended.
 
-`AddNoopEmailSender()` — no parameters. Useful in test projects where you want `IEmailSender` resolved but do not want file I/O.
+`UseNoop()` — no parameters. Useful in test projects where you want `IEmailSender` resolved but do not want file I/O.
 
 ## Dependencies
 
 - `Headless.Emails.Abstractions`
+- `Headless.Emails.Core`
 
 ## Side Effects
 
-- `AddDevEmailSender` registers `IEmailSender` as singleton (instance of `DevEmailSender`); appends to the specified file on each `SendAsync` call
-- `AddNoopEmailSender` registers `IEmailSender` as singleton (instance of `NoopEmailSender`); no I/O
+- `UseDevelopment` registers `IEmailSender` as singleton (instance of `DevEmailSender`); appends to the specified file on each `SendAsync` call
+- `UseNoop` registers `IEmailSender` as singleton (instance of `NoopEmailSender`); no I/O

--- a/src/Headless.Emails.Dev/Setup.cs
+++ b/src/Headless.Emails.Dev/Setup.cs
@@ -1,47 +1,67 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Checks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Headless.Emails.Dev;
 
 /// <summary>
-/// Registers development and no-op email senders with the DI container.
+/// Extension members on <see cref="HeadlessEmailsSetupBuilder"/> for selecting the development
+/// (file-writing) or no-op email providers.
 /// </summary>
 [PublicAPI]
 public static class SetupDevEmail
 {
-    extension(IServiceCollection services)
+    extension(HeadlessEmailsSetupBuilder setup)
     {
         /// <summary>
-        /// Registers <see cref="DevEmailSender"/> as the <see cref="IEmailSender"/> singleton,
-        /// which appends email content to a local file instead of sending to real recipients.
+        /// Selects <see cref="DevEmailSender"/> as the email provider, which appends email content to a
+        /// local file instead of sending to real recipients.
         /// </summary>
         /// <param name="filePath">
         /// Absolute or relative path to the file where outgoing emails are recorded.
         /// The file is created if it does not exist; existing content is preserved and
         /// new entries are appended.
         /// </param>
-        /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
+        /// <returns>The same builder for chaining.</returns>
         /// <exception cref="System.ArgumentException">
         /// Thrown when <paramref name="filePath"/> is <see langword="null"/> or empty.
         /// </exception>
-        public IServiceCollection AddDevEmailSender(string filePath)
+        public HeadlessEmailsSetupBuilder UseDevelopment(string filePath)
         {
-            services.AddSingleton<IEmailSender>(new DevEmailSender(filePath));
+            Argument.IsNotNullOrEmpty(filePath);
 
-            return services;
+            setup.RegisterExtension(new DevEmailOptionsExtension(filePath));
+
+            return setup;
         }
 
         /// <summary>
-        /// Registers <see cref="NoopEmailSender"/> as the <see cref="IEmailSender"/> singleton,
-        /// which silently discards every email without sending or logging it.
+        /// Selects <see cref="NoopEmailSender"/> as the email provider, which silently discards every
+        /// email without sending or logging it.
         /// </summary>
-        /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
-        public IServiceCollection AddNoopEmailSender()
+        /// <returns>The same builder for chaining.</returns>
+        public HeadlessEmailsSetupBuilder UseNoop()
+        {
+            setup.RegisterExtension(new NoopEmailOptionsExtension());
+
+            return setup;
+        }
+    }
+
+    private sealed class DevEmailOptionsExtension(string filePath) : IEmailProviderOptionsExtension
+    {
+        public void AddServices(IServiceCollection services)
+        {
+            services.AddSingleton<IEmailSender>(new DevEmailSender(filePath));
+        }
+    }
+
+    private sealed class NoopEmailOptionsExtension : IEmailProviderOptionsExtension
+    {
+        public void AddServices(IServiceCollection services)
         {
             services.AddSingleton<IEmailSender, NoopEmailSender>();
-
-            return services;
         }
     }
 }

--- a/src/Headless.Emails.Mailkit/README.md
+++ b/src/Headless.Emails.Mailkit/README.md
@@ -12,7 +12,7 @@ Provides email sending via standard SMTP protocol using MailKit, supporting any 
 - SMTP connection pool (`ObjectPool<SmtpClient>`) — connections are retained and reused across sends
 - SSL/TLS support: `SecureSocketOptions.StartTls` (default), `SslOnConnect`, `None`, `Auto`
 - Optional authentication (username + password); anonymous SMTP when credentials are omitted
-- Three registration overloads: `IConfiguration`, `Action<MailkitSmtpOptions>`, `Action<MailkitSmtpOptions, IServiceProvider>`
+- Three `UseMailkit` overloads: `IConfiguration`, `Action<MailkitSmtpOptions>`, `Action<MailkitSmtpOptions, IServiceProvider>`
 - `SmtpCommandException` and `SmtpProtocolException` are caught and returned as `Failed()` responses; `AuthenticationException` propagates
 
 ## Design Notes
@@ -31,25 +31,25 @@ dotnet add package Headless.Emails.Mailkit
 var builder = WebApplication.CreateBuilder(args);
 
 // Option 1: from configuration section
-builder.Services.AddMailKitEmailSender(builder.Configuration.GetSection("Smtp"));
+builder.Services.AddHeadlessEmails(setup => setup.UseMailkit(builder.Configuration.GetSection("Smtp")));
 
 // Option 2: action
-builder.Services.AddMailKitEmailSender(options =>
+builder.Services.AddHeadlessEmails(setup => setup.UseMailkit(options =>
 {
     options.Server = "smtp.example.com";
     options.Port = 587;
     options.User = "user@example.com";
     options.Password = "securepassword";
     options.SocketOptions = SecureSocketOptions.StartTls;
-});
+}));
 
 // Option 3: action with IServiceProvider
-builder.Services.AddMailKitEmailSender((options, sp) =>
+builder.Services.AddHeadlessEmails(setup => setup.UseMailkit((options, sp) =>
 {
     var cfg = sp.GetRequiredService<IConfiguration>();
     options.Server = cfg["Smtp:Server"]!;
     options.Port = int.Parse(cfg["Smtp:Port"]!);
-});
+}));
 ```
 
 ## Configuration

--- a/src/Headless.Emails.Mailkit/Setup.cs
+++ b/src/Headless.Emails.Mailkit/Setup.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Checks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.ObjectPool;
@@ -9,65 +10,95 @@ using SmtpClient = MailKit.Net.Smtp.SmtpClient;
 namespace Headless.Emails.Mailkit;
 
 /// <summary>
-/// Registers the MailKit SMTP email sender with the DI container.
+/// Extension members on <see cref="HeadlessEmailsSetupBuilder"/> for selecting MailKit/SMTP as the
+/// email provider.
 /// </summary>
 [PublicAPI]
 public static class SetupMailkit
 {
-    extension(IServiceCollection services)
+    extension(HeadlessEmailsSetupBuilder setup)
     {
         /// <summary>
-        /// Registers <see cref="MailkitEmailSender"/> as the <see cref="IEmailSender"/> singleton,
-        /// binding <see cref="MailkitSmtpOptions"/> from the supplied configuration section.
+        /// Selects MailKit/SMTP as the email provider, binding <see cref="MailkitSmtpOptions"/> from the
+        /// supplied configuration section.
         /// </summary>
-        /// <param name="config">
-        /// The configuration section that maps to <see cref="MailkitSmtpOptions"/> properties.
-        /// </param>
-        /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
-        public IServiceCollection AddMailKitEmailSender(IConfiguration config)
+        /// <param name="config">The configuration section that maps to <see cref="MailkitSmtpOptions"/> properties.</param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="config"/> is <see langword="null"/>.</exception>
+        public HeadlessEmailsSetupBuilder UseMailkit(IConfiguration config)
         {
-            services.Configure<MailkitSmtpOptions, MailkitSmtpOptionsValidator>(config);
-            return _AddCore(services);
+            Argument.IsNotNull(config);
+
+            setup.RegisterExtension(new MailkitEmailOptionsExtension(config));
+
+            return setup;
         }
 
         /// <summary>
-        /// Registers <see cref="MailkitEmailSender"/> as the <see cref="IEmailSender"/> singleton,
-        /// configuring <see cref="MailkitSmtpOptions"/> via a setup delegate.
+        /// Selects MailKit/SMTP as the email provider, configuring <see cref="MailkitSmtpOptions"/> via a
+        /// setup delegate.
         /// </summary>
         /// <param name="configure">Delegate that populates the options.</param>
-        /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
-        public IServiceCollection AddMailKitEmailSender(Action<MailkitSmtpOptions> configure)
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        public HeadlessEmailsSetupBuilder UseMailkit(Action<MailkitSmtpOptions> configure)
         {
-            services.Configure<MailkitSmtpOptions, MailkitSmtpOptionsValidator>(configure);
-            return _AddCore(services);
+            Argument.IsNotNull(configure);
+
+            setup.RegisterExtension(new MailkitEmailOptionsExtension(configure));
+
+            return setup;
         }
 
         /// <summary>
-        /// Registers <see cref="MailkitEmailSender"/> as the <see cref="IEmailSender"/> singleton,
-        /// configuring <see cref="MailkitSmtpOptions"/> via a setup delegate that also receives
-        /// the <see cref="IServiceProvider"/>.
+        /// Selects MailKit/SMTP as the email provider, configuring <see cref="MailkitSmtpOptions"/> via a
+        /// setup delegate that also receives the <see cref="IServiceProvider"/>.
         /// </summary>
         /// <param name="configure">Delegate that populates the options using DI-resolved services.</param>
-        /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
-        public IServiceCollection AddMailKitEmailSender(Action<MailkitSmtpOptions, IServiceProvider> configure)
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        public HeadlessEmailsSetupBuilder UseMailkit(Action<MailkitSmtpOptions, IServiceProvider> configure)
         {
-            services.Configure<MailkitSmtpOptions, MailkitSmtpOptionsValidator>(configure);
-            return _AddCore(services);
+            Argument.IsNotNull(configure);
+
+            setup.RegisterExtension(new MailkitEmailOptionsExtension(configure));
+
+            return setup;
         }
     }
 
-    private static IServiceCollection _AddCore(IServiceCollection services)
+    private sealed class MailkitEmailOptionsExtension : IEmailProviderOptionsExtension
     {
-        services.AddSingleton<IPooledObjectPolicy<SmtpClient>, SmtpClientPooledObjectPolicy>();
-        services.AddSingleton<ObjectPool<SmtpClient>>(sp =>
-        {
-            var opts = sp.GetRequiredService<IOptions<MailkitSmtpOptions>>().Value;
-            var policy = sp.GetRequiredService<IPooledObjectPolicy<SmtpClient>>();
-            var provider = new DefaultObjectPoolProvider { MaximumRetained = opts.MaxPoolSize };
-            return provider.Create(policy);
-        });
-        services.AddSingleton<IEmailSender, MailkitEmailSender>();
+        private readonly Action<IServiceCollection> _configure;
 
-        return services;
+        public MailkitEmailOptionsExtension(IConfiguration config)
+        {
+            _configure = services => services.Configure<MailkitSmtpOptions, MailkitSmtpOptionsValidator>(config);
+        }
+
+        public MailkitEmailOptionsExtension(Action<MailkitSmtpOptions> configure)
+        {
+            _configure = services => services.Configure<MailkitSmtpOptions, MailkitSmtpOptionsValidator>(configure);
+        }
+
+        public MailkitEmailOptionsExtension(Action<MailkitSmtpOptions, IServiceProvider> configure)
+        {
+            _configure = services => services.Configure<MailkitSmtpOptions, MailkitSmtpOptionsValidator>(configure);
+        }
+
+        public void AddServices(IServiceCollection services)
+        {
+            _configure(services);
+
+            services.AddSingleton<IPooledObjectPolicy<SmtpClient>, SmtpClientPooledObjectPolicy>();
+            services.AddSingleton<ObjectPool<SmtpClient>>(sp =>
+            {
+                var opts = sp.GetRequiredService<IOptions<MailkitSmtpOptions>>().Value;
+                var policy = sp.GetRequiredService<IPooledObjectPolicy<SmtpClient>>();
+                var provider = new DefaultObjectPoolProvider { MaximumRetained = opts.MaxPoolSize };
+                return provider.Create(policy);
+            });
+            services.AddSingleton<IEmailSender, MailkitEmailSender>();
+        }
     }
 }

--- a/src/Headless.Hosting/README.md
+++ b/src/Headless.Hosting/README.md
@@ -30,7 +30,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Conditional registration
 builder.Services.AddIf(
     builder.Environment.IsDevelopment(),
-    s => s.AddDevEmailSender("emails.txt")
+    s => s.AddHeadlessEmails(setup => setup.UseDevelopment("emails.txt"))
 );
 
 // Options with FluentValidation

--- a/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailMessageMapperTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailMessageMapperTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Text;
+using Headless.Emails;
+using Headless.Emails.Azure;
+
+namespace Tests;
+
+public sealed class AzureCommunicationEmailMessageMapperTests
+{
+    [Fact]
+    public void should_map_sender_subject_and_single_recipient()
+    {
+        // given
+        var request = new SendSingleEmailRequest
+        {
+            From = new EmailRequestAddress("sender@example.com", "Sender Name"),
+            Destination = new EmailRequestDestination { ToAddresses = [new EmailRequestAddress("to@example.com")] },
+            Subject = "Hello",
+            MessageHtml = "<p>Hi</p>",
+        };
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.SenderAddress.Should().Be("sender@example.com");
+        message.Content.Subject.Should().Be("Hello");
+        message.Recipients.To.Should().ContainSingle();
+        message.Recipients.To[0].Address.Should().Be("to@example.com");
+    }
+
+    [Fact]
+    public void should_map_to_cc_and_bcc_preserving_display_names()
+    {
+        // given
+        var request = new SendSingleEmailRequest
+        {
+            From = new EmailRequestAddress("sender@example.com"),
+            Destination = new EmailRequestDestination
+            {
+                ToAddresses = [new EmailRequestAddress("to@example.com", "To Person")],
+                CcAddresses = [new EmailRequestAddress("cc@example.com", "Cc Person")],
+                BccAddresses = [new EmailRequestAddress("bcc@example.com", "Bcc Person")],
+            },
+            Subject = "Subject",
+            MessageText = "body",
+        };
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.Recipients.To.Should().ContainSingle();
+        message.Recipients.To[0].Address.Should().Be("to@example.com");
+        message.Recipients.To[0].DisplayName.Should().Be("To Person");
+
+        message.Recipients.CC.Should().ContainSingle();
+        message.Recipients.CC[0].Address.Should().Be("cc@example.com");
+        message.Recipients.CC[0].DisplayName.Should().Be("Cc Person");
+
+        message.Recipients.BCC.Should().ContainSingle();
+        message.Recipients.BCC[0].Address.Should().Be("bcc@example.com");
+        message.Recipients.BCC[0].DisplayName.Should().Be("Bcc Person");
+    }
+
+    [Fact]
+    public void should_map_both_html_and_text_when_both_set()
+    {
+        // given
+        var request = _RequestWithBody(html: "<p>Html</p>", text: "Text");
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.Content.Html.Should().Be("<p>Html</p>");
+        message.Content.PlainText.Should().Be("Text");
+    }
+
+    [Fact]
+    public void should_leave_plaintext_null_when_only_html_set()
+    {
+        // given
+        var request = _RequestWithBody(html: "<p>Html</p>", text: null);
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.Content.Html.Should().Be("<p>Html</p>");
+        message.Content.PlainText.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_leave_html_null_when_only_text_set()
+    {
+        // given
+        var request = _RequestWithBody(html: null, text: "Text");
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.Content.PlainText.Should().Be("Text");
+        message.Content.Html.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_derive_known_attachment_content_type_and_round_trip_bytes()
+    {
+        // given
+        var bytes = Encoding.UTF8.GetBytes("pdf-bytes");
+        var request = _RequestWithAttachment("report.pdf", bytes);
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.Attachments.Should().ContainSingle();
+        message.Attachments[0].Name.Should().Be("report.pdf");
+        message.Attachments[0].ContentType.Should().Be("application/pdf");
+        message.Attachments[0].Content.ToArray().Should().Equal(bytes);
+    }
+
+    [Fact]
+    public void should_fall_back_to_octet_stream_for_unknown_attachment_extension()
+    {
+        // given
+        var request = _RequestWithAttachment("data.zzz", [1, 2, 3]);
+
+        // when
+        var message = AzureCommunicationEmailMessageMapper.ToEmailMessage(request);
+
+        // then
+        message.Attachments[0].ContentType.Should().Be("application/octet-stream");
+    }
+
+    private static SendSingleEmailRequest _RequestWithBody(string? html, string? text)
+    {
+        return new SendSingleEmailRequest
+        {
+            From = new EmailRequestAddress("sender@example.com"),
+            Destination = new EmailRequestDestination { ToAddresses = [new EmailRequestAddress("to@example.com")] },
+            Subject = "Subject",
+            MessageHtml = html,
+            MessageText = text,
+        };
+    }
+
+    private static SendSingleEmailRequest _RequestWithAttachment(string name, byte[] file)
+    {
+        return new SendSingleEmailRequest
+        {
+            From = new EmailRequestAddress("sender@example.com"),
+            Destination = new EmailRequestDestination { ToAddresses = [new EmailRequestAddress("to@example.com")] },
+            Subject = "Subject",
+            MessageText = "body",
+            Attachments = [new EmailRequestAttachment { Name = name, File = file }],
+        };
+    }
+}

--- a/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailOptionsValidatorTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailOptionsValidatorTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure.Core;
+using Headless.Emails.Azure;
+using NSubstitute;
+
+namespace Tests;
+
+public sealed class AzureCommunicationEmailOptionsValidatorTests
+{
+    private readonly AzureCommunicationEmailOptionsValidator _validator = new();
+
+    [Fact]
+    public void should_accept_connection_string_only()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions { ConnectionString = "endpoint=https://x;accesskey=k" };
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_accept_endpoint_and_access_key()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions
+        {
+            Endpoint = new Uri("https://my-resource.communication.azure.com"),
+            AccessKey = "the-key",
+        };
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_accept_endpoint_and_token_credential()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions
+        {
+            Endpoint = new Uri("https://my-resource.communication.azure.com"),
+            TokenCredential = Substitute.For<TokenCredential>(),
+        };
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_reject_when_no_auth_mode_is_configured()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions();
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_reject_when_endpoint_set_without_key_or_credential()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions
+        {
+            Endpoint = new Uri("https://my-resource.communication.azure.com"),
+        };
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_reject_ambiguous_connection_string_and_access_key()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions
+        {
+            ConnectionString = "endpoint=https://x;accesskey=k",
+            Endpoint = new Uri("https://my-resource.communication.azure.com"),
+            AccessKey = "the-key",
+        };
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_reject_ambiguous_access_key_and_token_credential()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions
+        {
+            Endpoint = new Uri("https://my-resource.communication.azure.com"),
+            AccessKey = "the-key",
+            TokenCredential = Substitute.For<TokenCredential>(),
+        };
+
+        // when / then
+        _validator.Validate(options).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void to_string_should_not_leak_connection_string_or_access_key()
+    {
+        // given
+        var options = new AzureCommunicationEmailOptions
+        {
+            ConnectionString = "endpoint=https://x;accesskey=super-secret",
+        };
+        var keyOptions = new AzureCommunicationEmailOptions
+        {
+            Endpoint = new Uri("https://my-resource.communication.azure.com"),
+            AccessKey = "super-secret-key",
+        };
+
+        // when / then
+        options.ToString().Should().NotContain("super-secret");
+        keyOptions.ToString().Should().NotContain("super-secret-key");
+    }
+}

--- a/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailSenderTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailSenderTests.cs
@@ -4,12 +4,13 @@ using Azure;
 using Azure.Communication.Email;
 using Headless.Emails;
 using Headless.Emails.Azure;
+using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace Tests;
 
-public sealed class AzureCommunicationEmailSenderTests
+public sealed class AzureCommunicationEmailSenderTests : TestBase
 {
     private const string _SenderAddress = "sender@example.com";
     private const string _RecipientAddress = "recipient@example.com";
@@ -24,7 +25,7 @@ public sealed class AzureCommunicationEmailSenderTests
         var sender = new AzureCommunicationEmailSender(new FakeEmailClient(_ => operation), _logger);
 
         // when
-        var response = await sender.SendAsync(_Request());
+        var response = await sender.SendAsync(_Request(), AbortToken);
 
         // then
         response.Success.Should().BeTrue();
@@ -39,7 +40,7 @@ public sealed class AzureCommunicationEmailSenderTests
         var sender = new AzureCommunicationEmailSender(new FakeEmailClient(_ => operation), _logger);
 
         // when
-        var response = await sender.SendAsync(_Request());
+        var response = await sender.SendAsync(_Request(), AbortToken);
 
         // then
         response.Success.Should().BeFalse();
@@ -60,7 +61,7 @@ public sealed class AzureCommunicationEmailSenderTests
         );
 
         // when
-        var response = await sender.SendAsync(_Request());
+        var response = await sender.SendAsync(_Request(), AbortToken);
 
         // then
         response.Success.Should().BeFalse();
@@ -79,7 +80,7 @@ public sealed class AzureCommunicationEmailSenderTests
         );
 
         // when
-        var action = async () => await sender.SendAsync(_Request());
+        var action = async () => await sender.SendAsync(_Request(), AbortToken);
 
         // then
         await action.Should().ThrowAsync<OperationCanceledException>();

--- a/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailSenderTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/AzureCommunicationEmailSenderTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure;
+using Azure.Communication.Email;
+using Headless.Emails;
+using Headless.Emails.Azure;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests;
+
+public sealed class AzureCommunicationEmailSenderTests
+{
+    private const string _SenderAddress = "sender@example.com";
+    private const string _RecipientAddress = "recipient@example.com";
+
+    private readonly CapturingLogger<AzureCommunicationEmailSender> _logger = new();
+
+    [Fact]
+    public async Task should_return_succeeded_when_operation_completes_with_succeeded_status()
+    {
+        // given
+        var operation = _OperationWith(EmailSendStatus.Succeeded);
+        var sender = new AzureCommunicationEmailSender(new FakeEmailClient(_ => operation), _logger);
+
+        // when
+        var response = await sender.SendAsync(_Request());
+
+        // then
+        response.Success.Should().BeTrue();
+        _logger.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_return_failed_when_operation_completes_with_non_success_status()
+    {
+        // given
+        var operation = _OperationWith(EmailSendStatus.Failed, operationId: "op-failed");
+        var sender = new AzureCommunicationEmailSender(new FakeEmailClient(_ => operation), _logger);
+
+        // when
+        var response = await sender.SendAsync(_Request());
+
+        // then
+        response.Success.Should().BeFalse();
+        response.FailureError.Should().NotBeNull();
+        _logger.Messages.Should().NotBeEmpty();
+        _AssertNoAddressLeaked(response.FailureError);
+    }
+
+    [Fact]
+    public async Task should_return_failed_when_request_failed_exception_is_thrown()
+    {
+        // given
+        var sender = new AzureCommunicationEmailSender(
+            new FakeEmailClient(_ =>
+                throw new RequestFailedException(400, "Bad Request", "EmailRejected", innerException: null)
+            ),
+            _logger
+        );
+
+        // when
+        var response = await sender.SendAsync(_Request());
+
+        // then
+        response.Success.Should().BeFalse();
+        response.FailureError.Should().NotBeNull();
+        _logger.Messages.Should().NotBeEmpty();
+        _AssertNoAddressLeaked(response.FailureError);
+    }
+
+    [Fact]
+    public async Task should_propagate_operation_canceled_exception()
+    {
+        // given
+        var sender = new AzureCommunicationEmailSender(
+            new FakeEmailClient(_ => throw new OperationCanceledException()),
+            _logger
+        );
+
+        // when
+        var action = async () => await sender.SendAsync(_Request());
+
+        // then
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private void _AssertNoAddressLeaked(string? failureError)
+    {
+        failureError.Should().NotContain(_RecipientAddress).And.NotContain(_SenderAddress);
+
+        foreach (var message in _logger.Messages)
+        {
+            message.Should().NotContain(_RecipientAddress).And.NotContain(_SenderAddress);
+        }
+    }
+
+    private static EmailSendOperation _OperationWith(EmailSendStatus status, string operationId = "op-123")
+    {
+        var result = EmailModelFactory.EmailSendResult(operationId, status);
+        var operation = Substitute.For<EmailSendOperation>();
+        operation.Value.Returns(result);
+        operation.Id.Returns(operationId);
+
+        return operation;
+    }
+
+    private static SendSingleEmailRequest _Request()
+    {
+        return new SendSingleEmailRequest
+        {
+            From = new EmailRequestAddress(_SenderAddress),
+            Destination = new EmailRequestDestination { ToAddresses = [new EmailRequestAddress(_RecipientAddress)] },
+            Subject = "Subject",
+            MessageText = "body",
+        };
+    }
+
+    private sealed class FakeEmailClient(Func<EmailMessage, EmailSendOperation> onSend) : EmailClient
+    {
+        public override Task<EmailSendOperation> SendAsync(
+            WaitUntil waitUntil,
+            EmailMessage message,
+            CancellationToken cancellationToken = default
+        )
+        {
+            return Task.FromResult(onSend(message));
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Headless.Emails.Azure.Tests.Unit/Headless.Emails.Azure.Tests.Unit.csproj
+++ b/tests/Headless.Emails.Azure.Tests.Unit/Headless.Emails.Azure.Tests.Unit.csproj
@@ -9,5 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Headless.Emails.Azure\Headless.Emails.Azure.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Headless.Emails.Azure.Tests.Unit/Headless.Emails.Azure.Tests.Unit.csproj
+++ b/tests/Headless.Emails.Azure.Tests.Unit/Headless.Emails.Azure.Tests.Unit.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Headless.NET.Sdk.Test">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Headless.Emails.Azure\Headless.Emails.Azure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Headless.Emails.Azure.Tests.Unit/SetupAzureEmailTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/SetupAzureEmailTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Azure.Communication.Email;
+using Azure.Core;
 using Headless.Emails;
 using Headless.Emails.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NSubstitute;
 
 namespace Tests;
 
@@ -48,6 +50,28 @@ public sealed class SetupAzureEmailTests
             {
                 options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
                 options.AccessKey = "bm90LWEtcmVhbC1rZXk=";
+            })
+        );
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IEmailSender>().Should().BeOfType<AzureCommunicationEmailSender>();
+        provider.GetRequiredService<EmailClient>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_resolve_azure_sender_for_endpoint_and_token_credential_mode()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // when
+        services.AddHeadlessEmails(setup =>
+            setup.UseAzure(options =>
+            {
+                options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
+                options.TokenCredential = Substitute.For<TokenCredential>();
             })
         );
         using var provider = services.BuildServiceProvider();

--- a/tests/Headless.Emails.Azure.Tests.Unit/SetupAzureEmailTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/SetupAzureEmailTests.cs
@@ -4,6 +4,7 @@ using Azure.Communication.Email;
 using Azure.Core;
 using Headless.Emails;
 using Headless.Emails.Azure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -73,6 +74,45 @@ public sealed class SetupAzureEmailTests
                 options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
                 options.TokenCredential = Substitute.For<TokenCredential>();
             })
+        );
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IEmailSender>().Should().BeOfType<AzureCommunicationEmailSender>();
+        provider.GetRequiredService<EmailClient>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_resolve_azure_sender_for_configuration_binding_overload()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.Ordinal) { ["ConnectionString"] = _ConnectionString }
+            )
+            .Build();
+
+        // when
+        services.AddHeadlessEmails(setup => setup.UseAzure(configuration));
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IEmailSender>().Should().BeOfType<AzureCommunicationEmailSender>();
+        provider.GetRequiredService<EmailClient>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void should_resolve_azure_sender_for_service_provider_delegate_overload()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // when
+        services.AddHeadlessEmails(setup =>
+            setup.UseAzure((options, _) => options.ConnectionString = _ConnectionString)
         );
         using var provider = services.BuildServiceProvider();
 

--- a/tests/Headless.Emails.Azure.Tests.Unit/SetupAzureEmailTests.cs
+++ b/tests/Headless.Emails.Azure.Tests.Unit/SetupAzureEmailTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Azure.Communication.Email;
+using Headless.Emails;
+using Headless.Emails.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Tests;
+
+public sealed class SetupAzureEmailTests
+{
+    // Well-formed but non-functional connection string; EmailClient parses it at construction without contacting ACS.
+    private const string _ConnectionString =
+        "endpoint=https://my-resource.communication.azure.com/;accesskey=bm90LWEtcmVhbC1rZXk=";
+
+    [Fact]
+    public void should_resolve_azure_sender_and_email_client_for_connection_string_mode()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // when
+        services.AddHeadlessEmails(setup => setup.UseAzure(options => options.ConnectionString = _ConnectionString));
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider
+            .GetServices<IEmailSender>()
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .BeOfType<AzureCommunicationEmailSender>();
+        provider.GetServices<EmailClient>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void should_resolve_azure_sender_for_endpoint_and_access_key_mode()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // when
+        services.AddHeadlessEmails(setup =>
+            setup.UseAzure(options =>
+            {
+                options.Endpoint = new Uri("https://my-resource.communication.azure.com/");
+                options.AccessKey = "bm90LWEtcmVhbC1rZXk=";
+            })
+        );
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IEmailSender>().Should().BeOfType<AzureCommunicationEmailSender>();
+        provider.GetRequiredService<EmailClient>().Should().NotBeNull();
+    }
+}

--- a/tests/Headless.Emails.Core.Tests.Unit/EmailsSetupBuilderTests.cs
+++ b/tests/Headless.Emails.Core.Tests.Unit/EmailsSetupBuilderTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Emails;
+using Headless.Emails.Dev;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class EmailsSetupBuilderTests
+{
+    [Fact]
+    public void should_reject_setup_when_provider_is_missing()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        var action = () => services.AddHeadlessEmails(static _ => { });
+
+        // then
+        action
+            .Should()
+            .Throw<InvalidOperationException>()
+            .Which.Message.Should()
+            .Contain("exactly one provider")
+            .And.Contain("UseAzure")
+            .And.Contain("UseAwsSes")
+            .And.Contain("UseMailkit")
+            .And.Contain("UseDevelopment")
+            .And.Contain("UseNoop");
+    }
+
+    [Fact]
+    public void should_reject_setup_when_multiple_providers_are_configured()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        var action = () =>
+            services.AddHeadlessEmails(static setup =>
+            {
+                setup.UseNoop();
+                setup.UseDevelopment("emails.txt");
+            });
+
+        // then
+        action.Should().Throw<InvalidOperationException>().WithMessage("*Multiple providers*");
+    }
+
+    [Fact]
+    public void should_resolve_single_email_sender_when_one_provider_is_configured()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddHeadlessEmails(static setup => setup.UseNoop());
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetServices<IEmailSender>().Should().ContainSingle().Which.Should().BeOfType<NoopEmailSender>();
+    }
+
+    [Fact]
+    public void should_reject_repeated_provider_registration_on_same_service_collection()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddHeadlessEmails(static setup => setup.UseNoop());
+
+        // when
+        var action = () => services.AddHeadlessEmails(static setup => setup.UseNoop());
+
+        // then
+        action.Should().Throw<InvalidOperationException>().WithMessage("*Multiple providers*");
+    }
+}

--- a/tests/Headless.Emails.Core.Tests.Unit/Headless.Emails.Core.Tests.Unit.csproj
+++ b/tests/Headless.Emails.Core.Tests.Unit/Headless.Emails.Core.Tests.Unit.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Headless.NET.Sdk.Test">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Headless.Emails.Core\Headless.Emails.Core.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Emails.Dev\Headless.Emails.Dev.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Adds `Headless.Emails.Azure`, an `IEmailSender` backed by Azure Communication Services (ACS) Email — the intended cloud-email backend for Azure-hosted consumers, alongside AWS SES and SMTP. As a prerequisite, the Emails feature moves onto the framework's unified provider setup-builder grammar: one `AddHeadlessEmails(setup => setup.Use…())` entry with a global exactly-one-provider gate, replacing the four bespoke `Add*EmailSender` registration extensions. The `IEmailSender` contract and its request/response records are unchanged.

Emails was the last multi-provider feature still on the legacy per-provider registration style; it now matches Coordination, Caching, Settings, Permissions, AuditLog, and Features.

## Registration: before → after

```csharp
// before
services.AddMailKitEmailSender(config);
services.AddAwsSesEmailSender(awsOptions);
services.AddDevEmailSender("emails.txt");

// after — one entry, exactly one provider per call
services.AddHeadlessEmails(setup => setup.UseMailkit(config));
services.AddHeadlessEmails(setup => setup.UseAwsSes(awsOptions));
services.AddHeadlessEmails(setup => setup.UseDevelopment("emails.txt"));
services.AddHeadlessEmails(setup => setup.UseAzure(o => o.ConnectionString = "...")); // new
```

## Breaking change

The four legacy extensions are removed (greenfield, no internal callers — no compat shim):

| Removed | Replacement |
|---|---|
| `AddMailKitEmailSender(...)` | `setup.UseMailkit(...)` |
| `AddAwsSesEmailSender(opts)` | `setup.UseAwsSes(opts)` |
| `AddDevEmailSender(path)` | `setup.UseDevelopment(path)` |
| `AddNoopEmailSender()` | `setup.UseNoop()` |

Zero, multiple, or a repeated `AddHeadlessEmails` on the same `IServiceCollection` now throws `InvalidOperationException` at registration time — a host resolves a single `IEmailSender`, so exactly one provider is required.

## Azure provider

- Three auth modes: connection string, endpoint + access key, and endpoint + managed-identity `TokenCredential`; options validation requires exactly one. The package depends on `Azure.Core` (not `Azure.Identity`), so consumers supply their own `DefaultAzureCredential` via the delegate overload and the dependency surface stays narrow.
- Sends with `EmailClient.SendAsync(WaitUntil.Completed, …)` and maps **both** failure shapes to `Failed(...)`: a thrown `RequestFailedException` and a completed-but-non-`Succeeded` terminal status. ACS can complete a send with a failed status without throwing, so an exception-only check would report rejected mail as delivered.
- Recipient and sender addresses never reach log output — only the operation id, status, and error code are recorded.
- Attachment content type is derived from the file name via a shared `EmailAttachmentContentType` helper in Core (the contract carries only name + bytes). ACS's `senderAddress` is a bare string, so the sender's display name is not honored.

## Tests

26 unit tests across two new projects:

- `Headless.Emails.Core.Tests.Unit` — the exactly-one-provider gate (zero / one / multiple / repeated).
- `Headless.Emails.Azure.Tests.Unit` — request→`EmailMessage` mapping, content-type derivation, options validation (every auth-mode combination), the sender's success / completed-failed / `RequestFailedException` / cancellation paths (including a no-PII-in-logs assertion), and DI resolution across all three auth modes.

Full-solution build is clean (0 warnings/errors). `docs/llms/emails.md` and the package READMEs are synced to the new grammar per the repo's authoring rules.
