### PR TITLE
fix(caching): review-driven reliability, perf & correctness hardening

### DIFF
--- a/src/Headless.Caching.Abstractions/ICache`T.cs
+++ b/src/Headless.Caching.Abstractions/ICache`T.cs
@@ -281,7 +281,7 @@ public interface ICache<T>
 /// <typeparam name="T">The type of every value stored and retrieved through this wrapper.</typeparam>
 /// <param name="cache">The underlying untyped cache to delegate all operations to.</param>
 [PublicAPI]
-public class Cache<T>(ICache cache) : ICache<T>
+public sealed class Cache<T>(ICache cache) : ICache<T>
 {
     /// <inheritdoc />
     public CacheEntryOptions? DefaultEntryOptions => cache.DefaultEntryOptions;

--- a/src/Headless.Caching.Bcl/HeadlessDistributedCacheAdapter.cs
+++ b/src/Headless.Caching.Bcl/HeadlessDistributedCacheAdapter.cs
@@ -13,6 +13,13 @@ namespace Headless.Caching;
 /// <see cref="IBufferCache"/> (Redis/InMemory/Hybrid) when the named cache supports it and fall back to the
 /// generic <c>byte[]</c> path otherwise.
 /// </summary>
+/// <remarks>
+/// The synchronous BCL members (<c>Get</c>, <c>Set</c>, <c>Refresh</c>, <c>Remove</c>, <c>TryGet</c>) block
+/// on their async counterparts via <c>GetAwaiter().GetResult()</c>. This is safe for all current
+/// <see cref="ICache"/> implementations because they use <c>ConfigureAwait(false)</c> throughout and do not
+/// capture a synchronization context. A future <see cref="ICache"/> implementation that captures the ambient
+/// context could deadlock these synchronous members; prefer the async overloads when possible.
+/// </remarks>
 internal sealed class HeadlessDistributedCacheAdapter(
     ICache cache,
     IOptions<HeadlessDistributedCacheAdapterOptions> options,

--- a/src/Headless.Caching.Core/FactoryCacheStoreExtensions.cs
+++ b/src/Headless.Caching.Core/FactoryCacheStoreExtensions.cs
@@ -59,6 +59,7 @@ public static class FactoryCacheStoreExtensions
             SkipDistributedCacheWrite = options.SkipDistributedCacheWrite,
         };
 
-        await store.SetEntryAsync(key, in entry, cancellationToken).ConfigureAwait(false);
+        // Result discarded: unconditional upsert, no CAS guard.
+        _ = await store.SetEntryAsync(key, in entry, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Headless.Caching.Core/Setup.cs
+++ b/src/Headless.Caching.Core/Setup.cs
@@ -26,7 +26,7 @@ public static class SetupCachingCore
             var setup = new HeadlessCachingSetupBuilder(services);
             configure(setup);
 
-            return _AddCachingProviderCore(services, setup);
+            return _AddCachingCore(services, setup);
         }
 
         /// <summary>
@@ -43,10 +43,7 @@ public static class SetupCachingCore
         }
     }
 
-    private static IServiceCollection _AddCachingProviderCore(
-        IServiceCollection services,
-        HeadlessCachingSetupBuilder setup
-    )
+    private static IServiceCollection _AddCachingCore(IServiceCollection services, HeadlessCachingSetupBuilder setup)
     {
         if (setup.DefaultExtensions.Count != 1)
         {

--- a/src/Headless.Caching.Hybrid/HybridCache.DistributedResilience.cs
+++ b/src/Headless.Caching.Hybrid/HybridCache.DistributedResilience.cs
@@ -65,15 +65,20 @@ public sealed partial class HybridCache
             }
         }
 
-        // Only link to the caller token when it can actually fire; otherwise a plain source avoids the
-        // linked-registration allocation while still supporting the timeout-path CancelAsync below.
-        CancellationTokenSource? operationCts = cancellationToken.CanBeCanceled
-            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-            : new CancellationTokenSource();
-        var operationTask = operation(operationCts.Token).AsTask();
+        // Declare before the try so the finally can always dispose them. Both are assigned inside the try so a
+        // synchronous throw from operation() is covered by the finally (no CTS leak).
+        CancellationTokenSource? operationCts = null;
+        Task<T>? operationTask = null;
 
         try
         {
+            // Only link to the caller token when it can actually fire; otherwise a plain source avoids the
+            // linked-registration allocation while still supporting the timeout-path CancelAsync below.
+            operationCts = cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : new CancellationTokenSource();
+            operationTask = operation(operationCts.Token).AsTask();
+
             using var delayCts = new CancellationTokenSource();
             var delayTask = Task.Delay(timeout, _timeProvider, delayCts.Token);
 

--- a/src/Headless.Caching.Hybrid/HybridCache.RecoveryHelpers.cs
+++ b/src/Headless.Caching.Hybrid/HybridCache.RecoveryHelpers.cs
@@ -149,6 +149,30 @@ public sealed partial class HybridCache
             removeTimestamp + queue.DefaultRetention,
             async ct =>
             {
+                // Guard against replaying a remove that would delete a value written during the outage. If L1
+                // still has an entry for this key then a newer write landed after the remove was queued; replaying
+                // the remove would silently clobber that write. Mirrors the stamp-aware guard in
+                // _QueueScalarUpsertRecovery / _QueueSetEntryRecovery (but uses presence-only because removes do
+                // not produce a physical stamp to compare against).
+                if (LocalCache is IFactoryCacheStore l1Store)
+                {
+                    var current = await l1Store.TryGetEntryAsync<object>(key, ct).ConfigureAwait(false);
+
+                    if (current.Found && current.PhysicalExpiresAt > removeTimestamp)
+                    {
+                        return HybridCacheRecoveryReplayOutcome.Obsolete;
+                    }
+                }
+                else
+                {
+                    var current = await LocalCache.GetAsync<object>(key, ct).ConfigureAwait(false);
+
+                    if (current.HasValue)
+                    {
+                        return HybridCacheRecoveryReplayOutcome.Obsolete;
+                    }
+                }
+
                 await l2Cache.RemoveAsync(key, ct).ConfigureAwait(false);
                 await _PublishReplayedInvalidationAsync(key, removeTimestamp, ct).ConfigureAwait(false);
                 return HybridCacheRecoveryReplayOutcome.Replayed;
@@ -167,6 +191,28 @@ public sealed partial class HybridCache
             expireTimestamp + queue.DefaultRetention,
             async ct =>
             {
+                // Guard: if L1 has a newer entry (physical stamp after the expire timestamp), a write landed
+                // during the outage and replaying the expire would evict it on L2. Return Obsolete to preserve
+                // the newer write — mirrors the remove guard above.
+                if (LocalCache is IFactoryCacheStore l1Store)
+                {
+                    var current = await l1Store.TryGetEntryAsync<object>(key, ct).ConfigureAwait(false);
+
+                    if (current.Found && current.PhysicalExpiresAt > expireTimestamp)
+                    {
+                        return HybridCacheRecoveryReplayOutcome.Obsolete;
+                    }
+                }
+                else
+                {
+                    var current = await LocalCache.GetAsync<object>(key, ct).ConfigureAwait(false);
+
+                    if (current.HasValue)
+                    {
+                        return HybridCacheRecoveryReplayOutcome.Obsolete;
+                    }
+                }
+
                 await l2Cache.ExpireAsync(key, ct).ConfigureAwait(false);
                 await _PublishReplayedInvalidationAsync(key, expireTimestamp, ct, expire: true).ConfigureAwait(false);
                 return HybridCacheRecoveryReplayOutcome.Replayed;

--- a/src/Headless.Caching.Hybrid/HybridCache.WriteOperations.cs
+++ b/src/Headless.Caching.Hybrid/HybridCache.WriteOperations.cs
@@ -311,7 +311,26 @@ public sealed partial class HybridCache
 
         _logger.LogAddingKeyToLocalCache(key, expiration);
 
-        var added = await l2Cache.TryInsertAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
+        if (!_IsDistributedCacheCircuitClosed())
+        {
+            return false;
+        }
+
+        bool added;
+
+        try
+        {
+            added = await l2Cache.TryInsertAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+            when (!FactoryCacheCoordinator.IsCallerCancellation(exception, cancellationToken)
+                && (RecoveryQueue is not null || options.DistributedCacheCircuitBreakerDuration > TimeSpan.Zero)
+            )
+        {
+            _OpenDistributedCacheCircuit(exception, key);
+            _logger.LogFailedToWriteToL2Cache(exception, key);
+            return false;
+        }
 
         if (added)
         {
@@ -340,7 +359,28 @@ public sealed partial class HybridCache
             return false;
         }
 
-        var replaced = await l2Cache.TryReplaceAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
+        if (!_IsDistributedCacheCircuitClosed())
+        {
+            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        bool replaced;
+
+        try
+        {
+            replaced = await l2Cache.TryReplaceAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+            when (!FactoryCacheCoordinator.IsCallerCancellation(exception, cancellationToken)
+                && (RecoveryQueue is not null || options.DistributedCacheCircuitBreakerDuration > TimeSpan.Zero)
+            )
+        {
+            _OpenDistributedCacheCircuit(exception, key);
+            _logger.LogFailedToWriteToL2Cache(exception, key);
+            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+            return false;
+        }
 
         if (replaced)
         {
@@ -408,7 +448,7 @@ public sealed partial class HybridCache
     }
 
     /// <inheritdoc />
-    public async ValueTask<double> IncrementAsync(
+    public ValueTask<double> IncrementAsync(
         string key,
         double amount,
         TimeSpan? expiration,
@@ -421,34 +461,21 @@ public sealed partial class HybridCache
 
         if (expiration is { Ticks: <= 0 })
         {
-            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-            return 0;
+            return _RemoveAndReturn(key, 0d, cancellationToken);
         }
 
-        var newValue = await l2Cache.IncrementAsync(key, amount, expiration, cancellationToken).ConfigureAwait(false);
-
-        if (newValue == 0)
-        {
-            // When result is 0, remove from local cache (conservative approach)
-            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            var localExpiration = _GetLocalExpiration(expiration);
-            await LocalCache.UpsertAsync(key, newValue, localExpiration, cancellationToken).ConfigureAwait(false);
-        }
-
-        await _PublishInvalidationAsync(
-                new CacheInvalidationMessage { InstanceId = _instanceId, Key = key },
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        return newValue;
+        return _RunNumericL2AndSyncL1Async(
+            key,
+            expiration,
+            ct => l2Cache.IncrementAsync(key, amount, expiration, ct),
+            static result => result != 0,
+            static result => result,
+            cancellationToken
+        );
     }
 
     /// <inheritdoc />
-    public async ValueTask<long> IncrementAsync(
+    public ValueTask<long> IncrementAsync(
         string key,
         long amount,
         TimeSpan? expiration,
@@ -461,34 +488,21 @@ public sealed partial class HybridCache
 
         if (expiration is { Ticks: <= 0 })
         {
-            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-            return 0;
+            return _RemoveAndReturn(key, 0L, cancellationToken);
         }
 
-        var newValue = await l2Cache.IncrementAsync(key, amount, expiration, cancellationToken).ConfigureAwait(false);
-
-        if (newValue == 0)
-        {
-            // When result is 0, remove from local cache (conservative approach)
-            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            var localExpiration = _GetLocalExpiration(expiration);
-            await LocalCache.UpsertAsync(key, newValue, localExpiration, cancellationToken).ConfigureAwait(false);
-        }
-
-        await _PublishInvalidationAsync(
-                new CacheInvalidationMessage { InstanceId = _instanceId, Key = key },
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        return newValue;
+        return _RunNumericL2AndSyncL1Async(
+            key,
+            expiration,
+            ct => l2Cache.IncrementAsync(key, amount, expiration, ct),
+            static result => result != 0,
+            static result => result,
+            cancellationToken
+        );
     }
 
     /// <inheritdoc />
-    public async ValueTask<double> SetIfHigherAsync(
+    public ValueTask<double> SetIfHigherAsync(
         string key,
         double value,
         TimeSpan? expiration,
@@ -501,37 +515,21 @@ public sealed partial class HybridCache
 
         if (expiration is { Ticks: <= 0 })
         {
-            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-            return 0;
+            return _RemoveAndReturn(key, 0d, cancellationToken);
         }
 
-        var difference = await l2Cache
-            .SetIfHigherAsync(key, value, expiration, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (Math.Abs(difference) > double.Epsilon)
-        {
-            // Value was updated - we know the new value is exactly what we passed in
-            var localExpiration = _GetLocalExpiration(expiration);
-            await LocalCache.UpsertAsync(key, value, localExpiration, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            // Value was not updated - remove from local cache since we don't know actual value
-            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-        }
-
-        await _PublishInvalidationAsync(
-                new CacheInvalidationMessage { InstanceId = _instanceId, Key = key },
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        return difference;
+        return _RunNumericL2AndSyncL1Async(
+            key,
+            expiration,
+            ct => l2Cache.SetIfHigherAsync(key, value, expiration, ct),
+            static result => Math.Abs(result) > double.Epsilon,
+            _ => value,
+            cancellationToken
+        );
     }
 
     /// <inheritdoc />
-    public async ValueTask<long> SetIfHigherAsync(
+    public ValueTask<long> SetIfHigherAsync(
         string key,
         long value,
         TimeSpan? expiration,
@@ -544,35 +542,21 @@ public sealed partial class HybridCache
 
         if (expiration is { Ticks: <= 0 })
         {
-            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-            return 0;
+            return _RemoveAndReturn(key, 0L, cancellationToken);
         }
 
-        var difference = await l2Cache
-            .SetIfHigherAsync(key, value, expiration, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (difference != 0)
-        {
-            var localExpiration = _GetLocalExpiration(expiration);
-            await LocalCache.UpsertAsync(key, value, localExpiration, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-        }
-
-        await _PublishInvalidationAsync(
-                new CacheInvalidationMessage { InstanceId = _instanceId, Key = key },
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        return difference;
+        return _RunNumericL2AndSyncL1Async(
+            key,
+            expiration,
+            ct => l2Cache.SetIfHigherAsync(key, value, expiration, ct),
+            static result => result != 0,
+            _ => value,
+            cancellationToken
+        );
     }
 
     /// <inheritdoc />
-    public async ValueTask<double> SetIfLowerAsync(
+    public ValueTask<double> SetIfLowerAsync(
         string key,
         double value,
         TimeSpan? expiration,
@@ -585,33 +569,21 @@ public sealed partial class HybridCache
 
         if (expiration is { Ticks: <= 0 })
         {
-            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-            return 0;
+            return _RemoveAndReturn(key, 0d, cancellationToken);
         }
 
-        var difference = await l2Cache.SetIfLowerAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
-
-        if (Math.Abs(difference) > double.Epsilon)
-        {
-            var localExpiration = _GetLocalExpiration(expiration);
-            await LocalCache.UpsertAsync(key, value, localExpiration, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-        }
-
-        await _PublishInvalidationAsync(
-                new CacheInvalidationMessage { InstanceId = _instanceId, Key = key },
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-
-        return difference;
+        return _RunNumericL2AndSyncL1Async(
+            key,
+            expiration,
+            ct => l2Cache.SetIfLowerAsync(key, value, expiration, ct),
+            static result => Math.Abs(result) > double.Epsilon,
+            _ => value,
+            cancellationToken
+        );
     }
 
     /// <inheritdoc />
-    public async ValueTask<long> SetIfLowerAsync(
+    public ValueTask<long> SetIfLowerAsync(
         string key,
         long value,
         TimeSpan? expiration,
@@ -624,19 +596,68 @@ public sealed partial class HybridCache
 
         if (expiration is { Ticks: <= 0 })
         {
-            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
-            return 0;
+            return _RemoveAndReturn(key, 0L, cancellationToken);
         }
 
-        var difference = await l2Cache.SetIfLowerAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
+        return _RunNumericL2AndSyncL1Async(
+            key,
+            expiration,
+            ct => l2Cache.SetIfLowerAsync(key, value, expiration, ct),
+            static result => result != 0,
+            _ => value,
+            cancellationToken
+        );
+    }
 
-        if (difference != 0)
+    /// <summary>
+    /// Removes the key and immediately returns <paramref name="zeroValue"/>; shared early-exit path for
+    /// numeric operations whose expiration has already elapsed.
+    /// </summary>
+    private async ValueTask<TResult> _RemoveAndReturn<TResult>(
+        string key,
+        TResult zeroValue,
+        CancellationToken cancellationToken
+    )
+    {
+        await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+        return zeroValue;
+    }
+
+    /// <summary>
+    /// Executes a numeric L2 operation, syncs the result to L1, and publishes a key invalidation. Shared by
+    /// <see cref="IncrementAsync(string,double,TimeSpan?,CancellationToken)"/>,
+    /// <see cref="SetIfHigherAsync(string,double,TimeSpan?,CancellationToken)"/>,
+    /// <see cref="SetIfLowerAsync(string,double,TimeSpan?,CancellationToken)"/>, and their <c>long</c> overloads.
+    /// </summary>
+    /// <typeparam name="TResult">Return type of the L2 operation (e.g. <c>double</c> or <c>long</c>).</typeparam>
+    /// <typeparam name="TL1">Type stored in L1 (equals <typeparamref name="TResult"/> for increment, equals the
+    /// input value type for set-if-higher/lower).</typeparam>
+    /// <param name="isUpdated">
+    /// Returns <see langword="true"/> when the L2 result indicates the value was actually changed and should be
+    /// populated in L1. When <see langword="false"/>, L1 is cleared instead (we don't know the actual value).
+    /// </param>
+    /// <param name="l1Value">Derives the L1 value to store from the L2 result.</param>
+    private async ValueTask<TResult> _RunNumericL2AndSyncL1Async<TResult, TL1>(
+        string key,
+        TimeSpan? expiration,
+        Func<CancellationToken, ValueTask<TResult>> l2Op,
+        Func<TResult, bool> isUpdated,
+        Func<TResult, TL1> l1Value,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await l2Op(cancellationToken).ConfigureAwait(false);
+
+        if (isUpdated(result))
         {
             var localExpiration = _GetLocalExpiration(expiration);
-            await LocalCache.UpsertAsync(key, value, localExpiration, cancellationToken).ConfigureAwait(false);
+            await LocalCache
+                .UpsertAsync(key, l1Value(result), localExpiration, cancellationToken)
+                .ConfigureAwait(false);
         }
         else
         {
+            // Result indicates no change — remove from L1 since we don't know the actual stored value.
             await LocalCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
         }
 
@@ -646,7 +667,7 @@ public sealed partial class HybridCache
             )
             .ConfigureAwait(false);
 
-        return difference;
+        return result;
     }
 
     /// <inheritdoc />
@@ -840,42 +861,39 @@ public sealed partial class HybridCache
     )
     {
         _ThrowIfDisposed();
+        Argument.IsNotNull(cacheKeys);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var items = cacheKeys?.ToArray();
-        var flushAll = items is null or { Length: 0 };
+        var items = cacheKeys.ToArray();
 
         int removed;
 
         try
         {
-            removed = await l2Cache.RemoveAllAsync(items!, cancellationToken).ConfigureAwait(false);
+            removed = await l2Cache.RemoveAllAsync(items, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception exception) when (!FactoryCacheCoordinator.IsCallerCancellation(exception, cancellationToken))
         {
             // Bulk ops are not captured by auto-recovery in v1 (issue #440); surface the L2 failure for
-            // observability and rethrow so the caller is not told the bulk remove succeeded.
-            if (items is { Length: > 0 })
+            // observability. Clean up L1 first so this node is not left with stale entries, then rethrow so
+            // the caller is not told the bulk remove succeeded.
+            if (items.Length > 0)
             {
                 _OpenDistributedCacheCircuit(exception, items[0]);
             }
 
-            _logger.LogFailedBulkL2CacheOperation(exception, items?.Length ?? 0);
+            _logger.LogFailedBulkL2CacheOperation(exception, items.Length);
+            await LocalCache.RemoveAllAsync(items, cancellationToken).ConfigureAwait(false);
             throw;
         }
 
-        await LocalCache.RemoveAllAsync(items!, cancellationToken).ConfigureAwait(false);
+        await LocalCache.RemoveAllAsync(items, cancellationToken).ConfigureAwait(false);
 
         // Only notify other nodes if keys were actually removed
         if (removed > 0)
         {
             await _PublishInvalidationAsync(
-                    new CacheInvalidationMessage
-                    {
-                        InstanceId = _instanceId,
-                        FlushAll = flushAll,
-                        Keys = items,
-                    },
+                    new CacheInvalidationMessage { InstanceId = _instanceId, Keys = items },
                     cancellationToken
                 )
                 .ConfigureAwait(false);

--- a/src/Headless.Caching.Hybrid/HybridCache.cs
+++ b/src/Headless.Caching.Hybrid/HybridCache.cs
@@ -546,13 +546,13 @@ public sealed partial class HybridCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Check if key exists in local cache first
-        var localExists = await LocalCache.ExistsAsync(key, cancellationToken).ConfigureAwait(false);
-        if (localExists)
+        // Single L1 lookup: a null return means the key is absent, avoiding a separate ExistsAsync round-trip.
+        var localExpiration = await LocalCache.GetExpirationAsync(key, cancellationToken).ConfigureAwait(false);
+        if (localExpiration is not null)
         {
             _logger.LogLocalCacheHit(key);
             Interlocked.Increment(ref _localCacheHits);
-            return await LocalCache.GetExpirationAsync(key, cancellationToken).ConfigureAwait(false);
+            return localExpiration;
         }
 
         _logger.LogLocalCacheMiss(key);
@@ -786,16 +786,21 @@ public sealed partial class HybridCache(
     #region IAsyncDisposable
 
     /// <inheritdoc />
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
         {
-            return ValueTask.CompletedTask;
+            return;
         }
 
         _coordinator.Dispose();
-        RecoveryQueue?.Dispose();
-        return ValueTask.CompletedTask;
+
+        if (RecoveryQueue is not null)
+        {
+            // Cancel the timer before draining so no new ProcessAsync pass starts after we await the active one.
+            RecoveryQueue.Dispose();
+            await RecoveryQueue.DrainAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     #endregion

--- a/src/Headless.Caching.Hybrid/HybridCacheLoggerExtensions.cs
+++ b/src/Headless.Caching.Hybrid/HybridCacheLoggerExtensions.cs
@@ -71,7 +71,7 @@ internal static partial class HybridCacheLoggerExtensions
     [LoggerMessage(
         EventId = 8,
         EventName = "FailedToReadFromL2Cache",
-        Level = LogLevel.Debug,
+        Level = LogLevel.Warning,
         Message = "Failed to read from L2 cache for key {Key}, treating it as a miss"
     )]
     public static partial void LogFailedToReadFromL2Cache(this ILogger logger, Exception exception, string key);

--- a/src/Headless.Caching.Hybrid/HybridCacheRecoveryQueue.cs
+++ b/src/Headless.Caching.Hybrid/HybridCacheRecoveryQueue.cs
@@ -62,6 +62,9 @@ internal sealed class HybridCacheRecoveryQueue : IDisposable
     private int _isDisposed;
     private RecoveryItem? _replaying;
 
+    // Tracks the most-recently-started ProcessAsync task so DrainAsync can await it on disposal.
+    private volatile Task? _activeProcessTask;
+
     // Tracks the item with the earliest ExpiresAt so the queue-full eviction path avoids an O(N) scan.
     // Maintained incrementally on every add inside _admissionLock; invalidated (set to null) when that tracked item
     // is removed so the next queue-full add triggers a one-time O(N) re-scan to find the new minimum.
@@ -450,12 +453,43 @@ internal sealed class HybridCacheRecoveryQueue : IDisposable
         // Attach a fault observer so an unexpected exception (e.g. from logger or TimeProvider) is logged
         // rather than silently lost as an unobserved task fault.
         var task = ProcessAsync(_disposeCts.Token);
+        _activeProcessTask = task;
         _ = task.ContinueWith(
             faulted => _logger.LogAutoRecoveryProcessUnexpectedFault(faulted.Exception!),
             CancellationToken.None,
             TaskContinuationOptions.OnlyOnFaulted,
             TaskScheduler.Default
         );
+    }
+
+    /// <summary>
+    /// Awaits any in-flight <see cref="ProcessAsync"/> task so that <see cref="HybridCache.DisposeAsync"/>
+    /// does not return while recovery work is still outstanding. The active task runs with the internal
+    /// dispose token which is cancelled before this is called, so it will complete promptly.
+    /// </summary>
+    internal async Task DrainAsync(CancellationToken cancellationToken)
+    {
+        var active = _activeProcessTask;
+
+        if (active is null || active.IsCompleted)
+        {
+            return;
+        }
+
+        try
+        {
+            await active.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Drain timed out or was cancelled — acceptable during shutdown.
+        }
+        catch (Exception ex)
+        {
+            // ProcessAsync is documented not to throw; fault observers are wired up in _OnTimerTick.
+            // Log and continue so disposal always completes.
+            _logger.LogAutoRecoveryProcessUnexpectedFault(ex);
+        }
     }
 
     private RecoveryItem? _FindEarliestExpiry()
@@ -604,7 +638,7 @@ internal static partial class HybridCacheRecoveryQueueLoggerExtensions
     [LoggerMessage(
         EventId = 8,
         EventName = "AutoRecoveryReplayFailed",
-        Level = LogLevel.Debug,
+        Level = LogLevel.Warning,
         Message = "Auto-recovery replay of the pending {Kind} for key {Key} failed (attempt {RetryCount}); barrier armed before the next pass"
     )]
     public static partial void LogAutoRecoveryReplayFailed(

--- a/src/Headless.Caching.InMemory/InMemoryCache.cs
+++ b/src/Headless.Caching.InMemory/InMemoryCache.cs
@@ -261,17 +261,77 @@ public sealed class InMemoryCache
             return 0;
         }
 
+        // Batch all inserts: read the clock once, accumulate the total size delta, and call
+        // _StartMaintenanceAsync a single time after the loop — instead of N clock reads,
+        // N Interlocked.Add calls, and N maintenance checks.
+        var nowTicks = _timeProvider.GetUtcNow().UtcDateTime.Ticks;
+        var expiresAt = expiration.HasValue
+            ? new DateTime(nowTicks, DateTimeKind.Utc).Add(expiration.Value)
+            : (DateTime?)null;
+
         var count = 0;
+        long totalSizeDelta = 0;
 
         foreach (var (k, v) in value)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (await UpsertAsync(k, v, expiration, cancellationToken).ConfigureAwait(false))
+            var prefixedKey = _GetKey(k);
+            var entrySize = _CalculateEntrySize(v);
+
+            if (!_ValidateEntrySize(entrySize))
             {
-                count++;
+                continue;
             }
+
+            var entry = new CacheEntry(
+                v,
+                expiresAt,
+                _timeProvider,
+                _shouldClone,
+                _shouldThrowOnSerializationError,
+                entrySize,
+                nowTicksOverride: nowTicks
+            );
+
+            if (entry.IsExpired)
+            {
+                _RemoveExpiredKey(prefixedKey);
+                continue;
+            }
+
+            long sizeDelta = 0;
+
+            _memory.AddOrUpdate(
+                prefixedKey,
+                _ =>
+                {
+                    sizeDelta = entrySize;
+                    return entry;
+                },
+                (_, existingEntry) =>
+                {
+                    sizeDelta = entrySize - existingEntry.Size;
+                    return entry;
+                }
+            );
+
+            totalSizeDelta += sizeDelta;
+            _TrackUpdate(entry.TrackedExpiresAt);
+            count++;
         }
+
+        if (totalSizeDelta != 0)
+        {
+            Interlocked.Add(ref _currentMemorySize, totalSizeDelta);
+        }
+
+        if (ShouldCompact)
+        {
+            await _CompactAsync().ConfigureAwait(false);
+        }
+
+        _ScheduleMaintenance(nowTicks);
 
         return count;
     }
@@ -1047,6 +1107,8 @@ public sealed class InMemoryCache
         var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
         var expiresAt = expiration.HasValue ? utcNow.Add(expiration.Value) : (DateTime?)null;
 
+        long result;
+
         if (typeof(T) == typeof(string))
         {
             var newItems = new Dictionary<string, DateTime?>(StringComparer.OrdinalIgnoreCase);
@@ -1059,74 +1121,7 @@ public sealed class InMemoryCache
                 }
             }
 
-            if (newItems.Count is 0)
-            {
-                return 0;
-            }
-
-            var entrySize = _CalculateEntrySize(newItems);
-            var entry = new CacheEntry(
-                newItems,
-                expiresAt,
-                _timeProvider,
-                _shouldClone,
-                _shouldThrowOnSerializationError,
-                entrySize
-            );
-            long sizeDelta = 0;
-
-            var committed = _memory.AddOrUpdate(
-                key,
-                _ =>
-                {
-                    sizeDelta = entrySize;
-                    return entry;
-                },
-                (existingKey, existingEntry) =>
-                {
-                    if (existingEntry.PeekValue() is not IDictionary<string, DateTime?> dictionary)
-                    {
-                        throw new InvalidOperationException(
-                            $"Unable to add value for key: {existingKey}. Cache value does not contain a set"
-                        );
-                    }
-
-                    var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
-                    var currentMax = _ExpireAndGetMaxExpiration(updatedDict);
-
-                    foreach (var kvp in newItems)
-                    {
-                        updatedDict[kvp.Key] = kvp.Value;
-                    }
-
-                    var newExpiresAt =
-                        (expiresAt is null || currentMax is null) ? (DateTime?)null
-                        : expiresAt.Value > currentMax.Value ? expiresAt.Value
-                        : currentMax.Value;
-                    var newSize = _CalculateEntrySize(updatedDict);
-                    sizeDelta = newSize - existingEntry.Size;
-
-                    return new CacheEntry(
-                        updatedDict,
-                        newExpiresAt,
-                        _timeProvider,
-                        _shouldClone,
-                        _shouldThrowOnSerializationError,
-                        newSize
-                    );
-                }
-            );
-
-            if (sizeDelta != 0)
-            {
-                Interlocked.Add(ref _currentMemorySize, sizeDelta);
-            }
-
-            _TrackUpdate(committed.PhysicalExpiresAt);
-
-            await _StartMaintenanceAsync().ConfigureAwait(false);
-
-            return newItems.Count;
+            result = _SetAddStringItems(key, newItems, expiresAt);
         }
         else
         {
@@ -1140,75 +1135,152 @@ public sealed class InMemoryCache
                 }
             }
 
-            if (newItems.Count is 0)
+            result = _SetAddObjectItems(key, newItems, expiresAt);
+        }
+
+        await _StartMaintenanceAsync().ConfigureAwait(false);
+
+        return result;
+    }
+
+    private long _SetAddStringItems(string key, Dictionary<string, DateTime?> newItems, DateTime? expiresAt)
+    {
+        if (newItems.Count is 0)
+        {
+            return 0;
+        }
+
+        var entrySize = _CalculateEntrySize(newItems);
+        var entry = new CacheEntry(
+            newItems,
+            expiresAt,
+            _timeProvider,
+            _shouldClone,
+            _shouldThrowOnSerializationError,
+            entrySize
+        );
+        long sizeDelta = 0;
+
+        var committed = _memory.AddOrUpdate(
+            key,
+            _ =>
             {
-                return 0;
-            }
-
-            var entrySize = _CalculateEntrySize(newItems);
-            var entry = new CacheEntry(
-                newItems,
-                expiresAt,
-                _timeProvider,
-                _shouldClone,
-                _shouldThrowOnSerializationError,
-                entrySize
-            );
-            long sizeDelta = 0;
-
-            var committed = _memory.AddOrUpdate(
-                key,
-                _ =>
+                sizeDelta = entrySize;
+                return entry;
+            },
+            (existingKey, existingEntry) =>
+            {
+                if (existingEntry.PeekValue() is not IDictionary<string, DateTime?> dictionary)
                 {
-                    sizeDelta = entrySize;
-                    return entry;
-                },
-                (existingKey, existingEntry) =>
-                {
-                    if (existingEntry.PeekValue() is not IDictionary<object, DateTime?> dictionary)
-                    {
-                        throw new InvalidOperationException(
-                            $"Unable to add value for key: {existingKey}. Cache value does not contain a set"
-                        );
-                    }
-
-                    var updatedDict = new Dictionary<object, DateTime?>(dictionary);
-                    var currentMax = _ExpireAndGetMaxExpiration(updatedDict);
-
-                    foreach (var kvp in newItems)
-                    {
-                        updatedDict[kvp.Key] = kvp.Value;
-                    }
-
-                    var newExpiresAt =
-                        (expiresAt is null || currentMax is null) ? (DateTime?)null
-                        : expiresAt.Value > currentMax.Value ? expiresAt.Value
-                        : currentMax.Value;
-                    var newSize = _CalculateEntrySize(updatedDict);
-                    sizeDelta = newSize - existingEntry.Size;
-
-                    return new CacheEntry(
-                        updatedDict,
-                        newExpiresAt,
-                        _timeProvider,
-                        _shouldClone,
-                        _shouldThrowOnSerializationError,
-                        newSize
+                    throw new InvalidOperationException(
+                        $"Unable to add value for key: {existingKey}. Cache value does not contain a set"
                     );
                 }
-            );
 
-            if (sizeDelta != 0)
-            {
-                Interlocked.Add(ref _currentMemorySize, sizeDelta);
+                var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
+                var currentMax = _ExpireAndGetMaxExpiration(updatedDict);
+
+                foreach (var kvp in newItems)
+                {
+                    updatedDict[kvp.Key] = kvp.Value;
+                }
+
+                var newExpiresAt =
+                    (expiresAt is null || currentMax is null) ? (DateTime?)null
+                    : expiresAt.Value > currentMax.Value ? expiresAt.Value
+                    : currentMax.Value;
+                var newSize = _CalculateEntrySize(updatedDict);
+                sizeDelta = newSize - existingEntry.Size;
+
+                return new CacheEntry(
+                    updatedDict,
+                    newExpiresAt,
+                    _timeProvider,
+                    _shouldClone,
+                    _shouldThrowOnSerializationError,
+                    newSize
+                );
             }
+        );
 
-            _TrackUpdate(committed.PhysicalExpiresAt);
-
-            await _StartMaintenanceAsync().ConfigureAwait(false);
-
-            return newItems.Count;
+        if (sizeDelta != 0)
+        {
+            Interlocked.Add(ref _currentMemorySize, sizeDelta);
         }
+
+        _TrackUpdate(committed.PhysicalExpiresAt);
+
+        return newItems.Count;
+    }
+
+    private long _SetAddObjectItems(string key, Dictionary<object, DateTime?> newItems, DateTime? expiresAt)
+    {
+        if (newItems.Count is 0)
+        {
+            return 0;
+        }
+
+        var entrySize = _CalculateEntrySize(newItems);
+        var entry = new CacheEntry(
+            newItems,
+            expiresAt,
+            _timeProvider,
+            _shouldClone,
+            _shouldThrowOnSerializationError,
+            entrySize
+        );
+        long sizeDelta = 0;
+
+        var committed = _memory.AddOrUpdate(
+            key,
+            _ =>
+            {
+                sizeDelta = entrySize;
+                return entry;
+            },
+            (existingKey, existingEntry) =>
+            {
+                if (existingEntry.PeekValue() is not IDictionary<object, DateTime?> dictionary)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to add value for key: {existingKey}. Cache value does not contain a set"
+                    );
+                }
+
+                var updatedDict = new Dictionary<object, DateTime?>(dictionary);
+                var currentMax = _ExpireAndGetMaxExpiration(updatedDict);
+
+                foreach (var kvp in newItems)
+                {
+                    updatedDict[kvp.Key] = kvp.Value;
+                }
+
+                var newExpiresAt =
+                    (expiresAt is null || currentMax is null) ? (DateTime?)null
+                    : expiresAt.Value > currentMax.Value ? expiresAt.Value
+                    : currentMax.Value;
+                var newSize = _CalculateEntrySize(updatedDict);
+                sizeDelta = newSize - existingEntry.Size;
+
+                return new CacheEntry(
+                    updatedDict,
+                    newExpiresAt,
+                    _timeProvider,
+                    _shouldClone,
+                    _shouldThrowOnSerializationError,
+                    newSize
+                );
+            }
+        );
+
+        if (sizeDelta != 0)
+        {
+            Interlocked.Add(ref _currentMemorySize, sizeDelta);
+        }
+
+        _TrackUpdate(committed.PhysicalExpiresAt);
+
+        return newItems.Count;
     }
 
     #endregion
@@ -1322,6 +1394,12 @@ public sealed class InMemoryCache
         );
     }
 
+    /// <summary>Returns the count of live, logically-valid entries whose keys begin with <paramref name="prefix"/>. Pass an empty string to count all entries.</summary>
+    /// <remarks>
+    /// When <paramref name="prefix"/> is non-empty this method performs an O(N) full scan of all live entries
+    /// (N = current item count). Do not call it on hot request paths; reserve it for admin, monitoring, or
+    /// diagnostic use.
+    /// </remarks>
     public ValueTask<long> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
     {
         _ThrowIfDisposed();
@@ -1386,57 +1464,77 @@ public sealed class InMemoryCache
             var dictionaryCacheValue = await GetAsync<IDictionary<string, DateTime?>>(key, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (!dictionaryCacheValue.HasValue)
-            {
-                return new CacheValue<ICollection<T>>([], false);
-            }
-
-            var nonExpiredKeys = dictionaryCacheValue
-                .Value!.Where(kvp => kvp.Value is null || kvp.Value >= utcNow)
-                .Select(kvp => (T)(object)kvp.Key)
-                .ToArray();
-
-            if (nonExpiredKeys.Length is 0)
-            {
-                return new CacheValue<ICollection<T>>([], false);
-            }
-
-            if (!pageIndex.HasValue)
-            {
-                return new CacheValue<ICollection<T>>(nonExpiredKeys, true);
-            }
-
-            var skip = (pageIndex.Value - 1) * pageSize;
-            return new CacheValue<ICollection<T>>(nonExpiredKeys.Skip(skip).Take(pageSize).ToArray(), true);
+            return _GetSetStringItems<T>(dictionaryCacheValue, pageIndex, pageSize, utcNow);
         }
         else
         {
             var dictionaryCacheValue = await GetAsync<IDictionary<object, DateTime?>>(key, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (!dictionaryCacheValue.HasValue)
-            {
-                return new CacheValue<ICollection<T>>([], false);
-            }
-
-            var nonExpiredKeys = dictionaryCacheValue
-                .Value!.Where(kvp => kvp.Value is null || kvp.Value >= utcNow)
-                .Select(kvp => (T)kvp.Key)
-                .ToArray();
-
-            if (nonExpiredKeys.Length is 0)
-            {
-                return new CacheValue<ICollection<T>>([], false);
-            }
-
-            if (!pageIndex.HasValue)
-            {
-                return new CacheValue<ICollection<T>>(nonExpiredKeys, true);
-            }
-
-            var skip = (pageIndex.Value - 1) * pageSize;
-            return new CacheValue<ICollection<T>>(nonExpiredKeys.Skip(skip).Take(pageSize).ToArray(), true);
+            return _GetSetObjectItems<T>(dictionaryCacheValue, pageIndex, pageSize, utcNow);
         }
+    }
+
+    private static CacheValue<ICollection<T>> _GetSetStringItems<T>(
+        CacheValue<IDictionary<string, DateTime?>> dictionaryCacheValue,
+        int? pageIndex,
+        int pageSize,
+        DateTime utcNow
+    )
+    {
+        if (!dictionaryCacheValue.HasValue)
+        {
+            return new CacheValue<ICollection<T>>([], false);
+        }
+
+        var nonExpiredKeys = dictionaryCacheValue
+            .Value!.Where(kvp => kvp.Value is null || kvp.Value >= utcNow)
+            .Select(kvp => (T)(object)kvp.Key)
+            .ToArray();
+
+        if (nonExpiredKeys.Length is 0)
+        {
+            return new CacheValue<ICollection<T>>([], false);
+        }
+
+        if (!pageIndex.HasValue)
+        {
+            return new CacheValue<ICollection<T>>(nonExpiredKeys, true);
+        }
+
+        var skip = (pageIndex.Value - 1) * pageSize;
+        return new CacheValue<ICollection<T>>(nonExpiredKeys.Skip(skip).Take(pageSize).ToArray(), true);
+    }
+
+    private static CacheValue<ICollection<T>> _GetSetObjectItems<T>(
+        CacheValue<IDictionary<object, DateTime?>> dictionaryCacheValue,
+        int? pageIndex,
+        int pageSize,
+        DateTime utcNow
+    )
+    {
+        if (!dictionaryCacheValue.HasValue)
+        {
+            return new CacheValue<ICollection<T>>([], false);
+        }
+
+        var nonExpiredKeys = dictionaryCacheValue
+            .Value!.Where(kvp => kvp.Value is null || kvp.Value >= utcNow)
+            .Select(kvp => (T)kvp.Key)
+            .ToArray();
+
+        if (nonExpiredKeys.Length is 0)
+        {
+            return new CacheValue<ICollection<T>>([], false);
+        }
+
+        if (!pageIndex.HasValue)
+        {
+            return new CacheValue<ICollection<T>>(nonExpiredKeys, true);
+        }
+
+        var skip = (pageIndex.Value - 1) * pageSize;
+        return new CacheValue<ICollection<T>>(nonExpiredKeys.Skip(skip).Take(pageSize).ToArray(), true);
     }
 
     /// <summary>
@@ -1871,117 +1969,125 @@ public sealed class InMemoryCache
         if (typeof(T) == typeof(string))
         {
             var stringsToRemove = value.Where(v => v is not null).Select(v => (string)(object)v!).ToList();
-
-            if (stringsToRemove.Count is 0)
-            {
-                return new ValueTask<long>(0L);
-            }
-
-            long removed = 0;
-            long sizeDelta = 0;
-
-            _memory.TryUpdate(
-                key,
-                (_, existingEntry) =>
-                {
-                    if (existingEntry.PeekValue() is not IDictionary<string, DateTime?> { Count: > 0 } dictionary)
-                    {
-                        sizeDelta = 0;
-                        return existingEntry;
-                    }
-
-                    var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
-                    long localRemoved = 0;
-
-                    foreach (var v in stringsToRemove)
-                    {
-                        if (updatedDict.Remove(v))
-                        {
-                            localRemoved++;
-                        }
-                    }
-
-                    removed = localRemoved;
-
-                    var newExpiresAt = _ExpireAndGetMaxExpiration(updatedDict);
-                    var newSize = _CalculateEntrySize(updatedDict);
-                    sizeDelta = newSize - existingEntry.Size;
-
-                    return new CacheEntry(
-                        updatedDict,
-                        newExpiresAt,
-                        _timeProvider,
-                        _shouldClone,
-                        _shouldThrowOnSerializationError,
-                        newSize
-                    );
-                }
-            );
-
-            if (sizeDelta != 0)
-            {
-                Interlocked.Add(ref _currentMemorySize, sizeDelta);
-            }
-
-            return new ValueTask<long>(removed);
+            return new ValueTask<long>(_SetRemoveStringItems(key, stringsToRemove));
         }
         else
         {
             var valuesToRemove = value.Where(v => v is not null).Select(v => (object)v!).ToList();
-
-            if (valuesToRemove.Count is 0)
-            {
-                return new ValueTask<long>(0L);
-            }
-
-            long removed = 0;
-            long sizeDelta = 0;
-
-            _memory.TryUpdate(
-                key,
-                (_, existingEntry) =>
-                {
-                    if (existingEntry.PeekValue() is not IDictionary<object, DateTime?> { Count: > 0 } dictionary)
-                    {
-                        sizeDelta = 0;
-                        return existingEntry;
-                    }
-
-                    var updatedDict = new Dictionary<object, DateTime?>(dictionary);
-                    long localRemoved = 0;
-
-                    foreach (var v in valuesToRemove)
-                    {
-                        if (updatedDict.Remove(v))
-                        {
-                            localRemoved++;
-                        }
-                    }
-
-                    removed = localRemoved;
-
-                    var newExpiresAt = _ExpireAndGetMaxExpiration(updatedDict);
-                    var newSize = _CalculateEntrySize(updatedDict);
-                    sizeDelta = newSize - existingEntry.Size;
-
-                    return new CacheEntry(
-                        updatedDict,
-                        newExpiresAt,
-                        _timeProvider,
-                        _shouldClone,
-                        _shouldThrowOnSerializationError,
-                        newSize
-                    );
-                }
-            );
-
-            if (sizeDelta != 0)
-            {
-                Interlocked.Add(ref _currentMemorySize, sizeDelta);
-            }
-
-            return new ValueTask<long>(removed);
+            return new ValueTask<long>(_SetRemoveObjectItems(key, valuesToRemove));
         }
+    }
+
+    private long _SetRemoveStringItems(string key, List<string> stringsToRemove)
+    {
+        if (stringsToRemove.Count is 0)
+        {
+            return 0L;
+        }
+
+        long removed = 0;
+        long sizeDelta = 0;
+
+        _memory.TryUpdate(
+            key,
+            (_, existingEntry) =>
+            {
+                if (existingEntry.PeekValue() is not IDictionary<string, DateTime?> { Count: > 0 } dictionary)
+                {
+                    sizeDelta = 0;
+                    return existingEntry;
+                }
+
+                var updatedDict = new Dictionary<string, DateTime?>(dictionary, StringComparer.OrdinalIgnoreCase);
+                long localRemoved = 0;
+
+                foreach (var v in stringsToRemove)
+                {
+                    if (updatedDict.Remove(v))
+                    {
+                        localRemoved++;
+                    }
+                }
+
+                removed = localRemoved;
+
+                var newExpiresAt = _ExpireAndGetMaxExpiration(updatedDict);
+                var newSize = _CalculateEntrySize(updatedDict);
+                sizeDelta = newSize - existingEntry.Size;
+
+                return new CacheEntry(
+                    updatedDict,
+                    newExpiresAt,
+                    _timeProvider,
+                    _shouldClone,
+                    _shouldThrowOnSerializationError,
+                    newSize
+                );
+            }
+        );
+
+        if (sizeDelta != 0)
+        {
+            Interlocked.Add(ref _currentMemorySize, sizeDelta);
+        }
+
+        return removed;
+    }
+
+    private long _SetRemoveObjectItems(string key, List<object> valuesToRemove)
+    {
+        if (valuesToRemove.Count is 0)
+        {
+            return 0L;
+        }
+
+        long removed = 0;
+        long sizeDelta = 0;
+
+        _memory.TryUpdate(
+            key,
+            (_, existingEntry) =>
+            {
+                if (existingEntry.PeekValue() is not IDictionary<object, DateTime?> { Count: > 0 } dictionary)
+                {
+                    sizeDelta = 0;
+                    return existingEntry;
+                }
+
+                var updatedDict = new Dictionary<object, DateTime?>(dictionary);
+                long localRemoved = 0;
+
+                foreach (var v in valuesToRemove)
+                {
+                    if (updatedDict.Remove(v))
+                    {
+                        localRemoved++;
+                    }
+                }
+
+                removed = localRemoved;
+
+                var newExpiresAt = _ExpireAndGetMaxExpiration(updatedDict);
+                var newSize = _CalculateEntrySize(updatedDict);
+                sizeDelta = newSize - existingEntry.Size;
+
+                return new CacheEntry(
+                    updatedDict,
+                    newExpiresAt,
+                    _timeProvider,
+                    _shouldClone,
+                    _shouldThrowOnSerializationError,
+                    newSize
+                );
+            }
+        );
+
+        if (sizeDelta != 0)
+        {
+            Interlocked.Add(ref _currentMemorySize, sizeDelta);
+        }
+
+        return removed;
     }
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)
@@ -2221,13 +2327,25 @@ public sealed class InMemoryCache
         var prefixedPrefix = string.IsNullOrEmpty(prefix) ? null : _GetKey(prefix);
         var stripLength = _keyPrefix.Length;
 
-        return _memory
-            .Where(kvp =>
-                !kvp.Value.IsExpired
-                && (prefixedPrefix is null || kvp.Key.StartsWith(prefixedPrefix, StringComparison.Ordinal))
-            )
-            .Select(kvp => stripLength == 0 ? kvp.Key : kvp.Key[stripLength..])
-            .ToList();
+        // Manual foreach avoids the LINQ Where+Select iterator-wrapper allocations on every prefix scan.
+        var result = new List<string>();
+
+        foreach (var kvp in _memory)
+        {
+            if (kvp.Value.IsExpired)
+            {
+                continue;
+            }
+
+            if (prefixedPrefix is not null && !kvp.Key.StartsWith(prefixedPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            result.Add(stripLength == 0 ? kvp.Key : kvp.Key[stripLength..]);
+        }
+
+        return result;
     }
 
     private void _RemoveExpiredKey(string key)

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -90,8 +90,9 @@ public sealed class RedisCache(
 
     private readonly FactoryCacheCoordinator _coordinator = new(timeProvider, logger, factoryLockProvider);
 
-    private volatile bool _supportsMsetEx;
-    private volatile bool _supportsMsetExChecked;
+    // #37: collapsed two volatile bool fields (_supportsMsetEx + _supportsMsetExChecked) into a single
+    // Lazy<bool> to make the check-and-set atomic, matching the _isClusterLazy pattern.
+    private readonly Lazy<bool> _supportsMsetExLazy = new(() => _DetectMsetexSupport(options.ConnectionMultiplexer));
     private readonly Lazy<bool> _isClusterLazy = new(() => _CheckIsCluster(options.ConnectionMultiplexer));
     private readonly IDatabase _database = options.ConnectionMultiplexer.GetDatabase();
 
@@ -416,24 +417,17 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
-        var expiresArg = expiresMs ?? RedisValue.EmptyString;
-
-        var result = await scriptsLoader
-            .EvaluateAsync(
-                _database,
+        // #18: thin delegation to shared numeric-script helper
+        var raw = await _RunNumericScriptAsync(
                 IncrementWithExpireScriptDefinition.Instance,
-                new
-                {
-                    key = (RedisKey)_GetKey(key),
-                    value = amount,
-                    expires = expiresArg,
-                },
+                key,
+                (RedisValue)amount,
+                expiration,
                 cancellationToken
             )
             .ConfigureAwait(false);
 
-        return double.Parse(result.ToString(), CultureInfo.InvariantCulture);
+        return double.Parse(raw.ToString(), CultureInfo.InvariantCulture);
     }
 
     public async ValueTask<long> IncrementAsync(
@@ -453,24 +447,17 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
-        var expiresArg = expiresMs ?? RedisValue.EmptyString;
-
-        var result = await scriptsLoader
-            .EvaluateAsync(
-                _database,
+        // #18: thin delegation to shared numeric-script helper
+        var raw = await _RunNumericScriptAsync(
                 IncrementWithExpireScriptDefinition.Instance,
-                new
-                {
-                    key = (RedisKey)_GetKey(key),
-                    value = amount,
-                    expires = expiresArg,
-                },
+                key,
+                (RedisValue)amount,
+                expiration,
                 cancellationToken
             )
             .ConfigureAwait(false);
 
-        return long.Parse(result.ToString(), CultureInfo.InvariantCulture);
+        return long.Parse(raw.ToString(), CultureInfo.InvariantCulture);
     }
 
     public async ValueTask<double> SetIfHigherAsync(
@@ -490,24 +477,17 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
-        var expiresArg = expiresMs ?? RedisValue.EmptyString;
-
-        var result = await scriptsLoader
-            .EvaluateAsync(
-                _database,
+        // #18: thin delegation to shared numeric-script helper
+        var raw = await _RunNumericScriptAsync(
                 SetIfHigherScriptDefinition.Instance,
-                new
-                {
-                    key = (RedisKey)_GetKey(key),
-                    value,
-                    expires = expiresArg,
-                },
+                key,
+                (RedisValue)value,
+                expiration,
                 cancellationToken
             )
             .ConfigureAwait(false);
 
-        return double.Parse(result.ToString(), CultureInfo.InvariantCulture);
+        return double.Parse(raw.ToString(), CultureInfo.InvariantCulture);
     }
 
     public async ValueTask<long> SetIfHigherAsync(
@@ -527,24 +507,17 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
-        var expiresArg = expiresMs ?? RedisValue.EmptyString;
-
-        var result = await scriptsLoader
-            .EvaluateAsync(
-                _database,
+        // #18: thin delegation to shared numeric-script helper
+        var raw = await _RunNumericScriptAsync(
                 SetIfHigherScriptDefinition.Instance,
-                new
-                {
-                    key = (RedisKey)_GetKey(key),
-                    value,
-                    expires = expiresArg,
-                },
+                key,
+                (RedisValue)value,
+                expiration,
                 cancellationToken
             )
             .ConfigureAwait(false);
 
-        return long.Parse(result.ToString(), CultureInfo.InvariantCulture);
+        return long.Parse(raw.ToString(), CultureInfo.InvariantCulture);
     }
 
     public async ValueTask<double> SetIfLowerAsync(
@@ -564,24 +537,17 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
-        var expiresArg = expiresMs ?? RedisValue.EmptyString;
-
-        var result = await scriptsLoader
-            .EvaluateAsync(
-                _database,
+        // #18: thin delegation to shared numeric-script helper
+        var raw = await _RunNumericScriptAsync(
                 SetIfLowerScriptDefinition.Instance,
-                new
-                {
-                    key = (RedisKey)_GetKey(key),
-                    value,
-                    expires = expiresArg,
-                },
+                key,
+                (RedisValue)value,
+                expiration,
                 cancellationToken
             )
             .ConfigureAwait(false);
 
-        return double.Parse(result.ToString(), CultureInfo.InvariantCulture);
+        return double.Parse(raw.ToString(), CultureInfo.InvariantCulture);
     }
 
     public async ValueTask<long> SetIfLowerAsync(
@@ -601,24 +567,17 @@ public sealed class RedisCache(
             return 0;
         }
 
-        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
-        var expiresArg = expiresMs ?? RedisValue.EmptyString;
-
-        var result = await scriptsLoader
-            .EvaluateAsync(
-                _database,
+        // #18: thin delegation to shared numeric-script helper
+        var raw = await _RunNumericScriptAsync(
                 SetIfLowerScriptDefinition.Instance,
-                new
-                {
-                    key = (RedisKey)_GetKey(key),
-                    value,
-                    expires = expiresArg,
-                },
+                key,
+                (RedisValue)value,
+                expiration,
                 cancellationToken
             )
             .ConfigureAwait(false);
 
-        return long.Parse(result.ToString(), CultureInfo.InvariantCulture);
+        return long.Parse(raw.ToString(), CultureInfo.InvariantCulture);
     }
 
     public async ValueTask<long> SetAddAsync<T>(
@@ -685,8 +644,10 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var redisValue = await _database.StringGetAsync(_GetKey(key), options.ReadMode).ConfigureAwait(false);
-        return await _RedisValueToCacheValueAsync<T>(_GetKey(key), redisValue).ConfigureAwait(false);
+        // #11: cache prefixed key to avoid two _GetKey allocations for the same key
+        var redisKey = _GetKey(key);
+        var redisValue = await _database.StringGetAsync(redisKey, options.ReadMode).ConfigureAwait(false);
+        return await _RedisValueToCacheValueAsync<T>(redisKey, redisValue).ConfigureAwait(false);
     }
 
     public async ValueTask<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(
@@ -834,8 +795,34 @@ public sealed class RedisCache(
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var result = new Dictionary<string, CacheValueWithExpiration<T>>(redisKeys.Count, StringComparer.Ordinal);
 
-        // First pass: decode value + expiration from the frame. Collect keys whose expiration requires a
-        // live TTL probe (sliding entries or non-framed legacy payloads).
+        // #10: Decode all frames up-front so we can batch-prefetch stale tag markers for all entries in ONE
+        // MGET before the processing loop — previously _ResolveNewestMarkerAsync issued one MGET per entry
+        // whose tags were stale, resulting in N sequential round-trips for N tagged entries.
+        // REVIEW(#10): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
+        var decodedFrames = new RedisCacheEntryFrame.DecodedFrame?[rawValues.Length];
+
+        for (var i = 0; i < rawValues.Length; i++)
+        {
+            if (rawValues[i].HasValue)
+            {
+                try
+                {
+                    decodedFrames[i] = RedisCacheEntryFrame.Decode(rawValues[i]);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogDeserializationFailed(e, rawValues[i].Length(), typeof(T).FullName);
+                    throw;
+                }
+            }
+        }
+
+        // Collect all unique tags from non-expired framed entries and prefetch their markers in one MGET.
+        // After this call, _markerCache will contain fresh entries for every stale tag, so per-entry calls
+        // to _ResolveNewestMarkerAsync below will all hit the local cache without additional network I/O.
+        await _PrefetchTagMarkersAsync(decodedFrames, now).ConfigureAwait(false);
+
+        // First pass: resolve marker checks + collect keys requiring live TTL probes.
         List<(int Index, RedisKey RedisKey, T? Value)>? slidingOrLegacyHits = null;
 
         for (var i = 0; i < originalKeys.Count; i++)
@@ -849,7 +836,7 @@ public sealed class RedisCache(
 
             try
             {
-                var frame = RedisCacheEntryFrame.Decode(rawValue);
+                var frame = decodedFrames[i]!.Value;
 
                 if (frame.IsFramed)
                 {
@@ -859,6 +846,7 @@ public sealed class RedisCache(
                     }
 
                     // Family-2: a tag/clear-invalidated entry is a miss for direct mirror reads.
+                    // Tag markers are now warm in _markerCache; this call incurs no extra RTT.
                     var newestMarker = await _ResolveNewestMarkerAsync(frame.Tags).ConfigureAwait(false);
 
                     if (CacheTagInvalidation.IsInvalidated(frame.CreatedAt, newestMarker))
@@ -1089,7 +1077,9 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var redisValue = await _database.StringGetAsync(_GetKey(key), options.ReadMode).ConfigureAwait(false);
+        // #11: cache prefixed key to avoid repeated _GetKey allocations (called up to 3x previously)
+        var prefixedKey = _GetKey(key);
+        var redisValue = await _database.StringGetAsync(prefixedKey, options.ReadMode).ConfigureAwait(false);
 
         if (!redisValue.HasValue)
         {
@@ -1102,7 +1092,7 @@ public sealed class RedisCache(
         {
             // Non-framed (legacy/raw) keys carry no logical metadata, so fall back to the server TTL. Only
             // legacy keys pay this second round trip; framed keys return below from the decoded frame.
-            return await _database.KeyTimeToLiveAsync(_GetKey(key)).ConfigureAwait(false);
+            return await _database.KeyTimeToLiveAsync(prefixedKey).ConfigureAwait(false);
         }
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
@@ -1122,7 +1112,7 @@ public sealed class RedisCache(
 
         if (frame.SlidingExpiration.HasValue)
         {
-            return await _database.KeyTimeToLiveAsync(_GetKey(key)).ConfigureAwait(false);
+            return await _database.KeyTimeToLiveAsync(prefixedKey).ConfigureAwait(false);
         }
 
         if (_IsExpired(frame.LogicalExpiresAt, now))
@@ -1415,13 +1405,16 @@ public sealed class RedisCache(
 
         if (IsCluster)
         {
-            foreach (var batch in redisKeys.Chunk(_BatchSize))
-            {
-                var slotBuckets = _GroupBySlot(batch, static key => key);
+            // #36: group by hash slot ONCE before chunking to avoid re-allocating a Dictionary per chunk.
+            // Previously _GroupBySlot was called inside the Chunk loop: N/250 allocations for N keys.
+            // REVIEW(#36): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
+            var slotBuckets = _GroupBySlot(redisKeys, static key => key);
 
-                foreach (var (slot, bucket) in slotBuckets)
+            foreach (var (slot, bucket) in slotBuckets)
+            {
+                foreach (var batch in bucket.Chunk(_BatchSize))
                 {
-                    var hashSlotKeys = bucket.ToArray();
+                    var hashSlotKeys = batch;
 
                     try
                     {
@@ -1716,6 +1709,35 @@ public sealed class RedisCache(
         return string.IsNullOrEmpty(_keyPrefix) ? key : string.Concat(_keyPrefix, key);
     }
 
+    /// <summary>
+    /// Shared body for the six numeric-script operations (Increment×2, SetIfHigher×2, SetIfLower×2).
+    /// Each public method handles its own argument validation and zero-expiration early-exit, then delegates
+    /// the common script-invocation pattern here. Pure C# extraction — no Redis semantic change. (#18)
+    /// </summary>
+    private Task<RedisResult> _RunNumericScriptAsync(
+        RedisScriptDefinition script,
+        string key,
+        RedisValue value,
+        TimeSpan? expiration,
+        CancellationToken cancellationToken
+    )
+    {
+        var expiresMs = _GetExpirationMilliseconds(expiration, timeProvider.GetUtcNow());
+        var expiresArg = expiresMs.HasValue ? (RedisValue)expiresMs.Value : RedisValue.EmptyString;
+
+        return scriptsLoader.EvaluateAsync(
+            _database,
+            script,
+            new
+            {
+                key = (RedisKey)_GetKey(key),
+                value,
+                expires = expiresArg,
+            },
+            cancellationToken
+        );
+    }
+
     private string _GetTagMarkerKey(string tag) => string.Concat(_keyPrefix, _TagMarkerNamespace, tag);
 
     private string _GetClearMarkerKey() => string.Concat(_keyPrefix, _ClearMarkerSuffix);
@@ -1873,6 +1895,60 @@ public sealed class RedisCache(
 
     private static long _ParseMarkerMs(RedisValue value) =>
         RedisCacheEntryFrame.TryParseMarkerMs(value) ?? _MarkerAbsent;
+
+    /// <summary>
+    /// Pre-warms <see cref="_markerCache"/> for all unique stale tag markers referenced by the supplied decoded
+    /// frames in a single MGET — O(1) Redis round-trip regardless of how many entries share tags.
+    /// Called once before the processing loop in <see cref="GetAllWithExpirationAsync{T}"/> so that subsequent
+    /// per-entry <see cref="_ResolveNewestMarkerAsync"/> calls hit the local cache without extra network I/O. (#10)
+    /// REVIEW(#10): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
+    /// </summary>
+    private async ValueTask _PrefetchTagMarkersAsync(RedisCacheEntryFrame.DecodedFrame?[] decodedFrames, DateTime now)
+    {
+        // Collect all unique stale tags across all non-expired framed entries.
+        HashSet<string>? staleTags = null;
+
+        for (var i = 0; i < decodedFrames.Length; i++)
+        {
+            var frame = decodedFrames[i];
+
+            if (frame is not { IsFramed: true } f || _IsExpired(f.PhysicalExpiresAt, now) || f.Tags is null)
+            {
+                continue;
+            }
+
+            foreach (var tag in f.Tags)
+            {
+                if (!_markerCache.TryGetValue(tag, out var cached) || !_MarkerIsFresh(cached.FetchedTicks))
+                {
+                    (staleTags ??= new HashSet<string>(StringComparer.Ordinal)).Add(tag);
+                }
+            }
+        }
+
+        if (staleTags is null)
+        {
+            return;
+        }
+
+        // Fetch all stale tag markers in one MGET and populate the local cache.
+        var staleList = new List<string>(staleTags);
+        var markerKeys = new RedisKey[staleList.Count];
+
+        for (var i = 0; i < staleList.Count; i++)
+        {
+            markerKeys[i] = _GetTagMarkerKey(staleList[i]);
+        }
+
+        var values = await _database.StringGetAsync(markerKeys, options.ReadMode).ConfigureAwait(false);
+        var fetchedTicks = _StopwatchTicks();
+
+        for (var i = 0; i < staleList.Count; i++)
+        {
+            var ms = _ParseMarkerMs(values[i]);
+            _markerCache[staleList[i]] = (ms, fetchedTicks);
+        }
+    }
 
     /// <summary>Encodes a value to its bare wire bytes (the value codec) without any envelope framing.</summary>
     /// <remarks>
@@ -2217,10 +2293,14 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
-        return _SetEntryCoreAsync(key, entry);
+        return _SetEntryCoreAsync(key, entry, cancellationToken);
     }
 
-    private async ValueTask<bool> _SetEntryCoreAsync<T>(string key, CacheStoreEntryWrite<T> entry)
+    private async ValueTask<bool> _SetEntryCoreAsync<T>(
+        string key,
+        CacheStoreEntryWrite<T> entry,
+        CancellationToken cancellationToken = default // #7: thread caller token through CAS path
+    )
     {
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var expiresIn = (entry.SlidingExpiration is null ? entry.PhysicalExpiresAt : entry.LogicalExpiresAt).Subtract(
@@ -2294,7 +2374,7 @@ public sealed class RedisCache(
                     expectedValue,
                     keyTtlMs,
                 },
-                CancellationToken.None
+                cancellationToken // #7: was CancellationToken.None — now respects caller's token
             )
             .ConfigureAwait(false);
 
@@ -2505,6 +2585,16 @@ public sealed class RedisCache(
         return _RearmSlidingTtlAsync(redisKey, slidingExpiration, physicalExpiresAt, now, frame.LogicalExpiresAt);
     }
 
+    // #9: Lua script for atomic TTL-check-and-conditional-PEXPIRE in a single Redis round-trip.
+    // KEYS[1]=key, ARGV[1]=rearmThresholdMs (long), ARGV[2]=newTtlMs (long).
+    // Returns 1 if PEXPIRE was issued, 0 if the key already had enough TTL or is persistent (PTTL=-1).
+    // REVIEW(#9): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
+    private const string _SlidingRearmLua = """
+        local ttl = redis.call('PTTL', KEYS[1])
+        if ttl < 0 or ttl > tonumber(ARGV[1]) then return 0 end
+        return redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[2]))
+        """;
+
     private async ValueTask _RearmSlidingTtlAsync(
         RedisKey redisKey,
         TimeSpan slidingExpiration,
@@ -2532,18 +2622,16 @@ public sealed class RedisCache(
 
         try
         {
-            // The TTL probe is part of the best-effort re-arm: keep it inside the catch so a transient Redis
-            // error during the probe degrades to "skip the re-arm" instead of failing a value read that the
-            // caller has already satisfied.
-            var ttl = await _database.KeyTimeToLiveAsync(redisKey).ConfigureAwait(false);
-
-            if (ttl.HasValue && ttl.Value > rearmThreshold)
-            {
-                return;
-            }
-
+            // #9: single-RTT atomic TTL-check-and-conditional-PEXPIRE via inline Lua.
+            // Previously issued KeyTimeToLiveAsync then (conditionally) KeyExpireAsync — 2 sequential RTTs.
+            // REVIEW(#9): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
             var expiresIn = _Min(slidingExpiration, remainingToCap);
-            await _database.KeyExpireAsync(redisKey, expiresIn).ConfigureAwait(false);
+            var rearmThresholdMs = (long)rearmThreshold.TotalMilliseconds;
+            var newTtlMs = (long)expiresIn.TotalMilliseconds;
+
+            await _database
+                .ScriptEvaluateAsync(_SlidingRearmLua, [redisKey], [(RedisValue)rearmThresholdMs, (RedisValue)newTtlMs])
+                .ConfigureAwait(false);
         }
         catch (Exception exception)
         {
@@ -2596,7 +2684,7 @@ public sealed class RedisCache(
     {
         if (expiresIn.HasValue)
         {
-            if (_SupportsMsetexCommand())
+            if (_supportsMsetExLazy.Value) // #37: atomic Lazy<bool> replaces non-atomic two-volatile check
             {
                 var success = await _database
                     .StringSetAsync(pairs, When.Always, new Expiration(expiresIn.Value))
@@ -2620,16 +2708,13 @@ public sealed class RedisCache(
         return msetSuccess ? pairs.Length : 0;
     }
 
-    private bool _SupportsMsetexCommand()
+    // #37: extracted into a static factory so _supportsMsetExLazy captures no instance state.
+    // Lazy<bool> gives us thread-safe once-only initialization matching the _isClusterLazy pattern.
+    private static bool _DetectMsetexSupport(IConnectionMultiplexer connectionMultiplexer)
     {
-        if (_supportsMsetExChecked)
-        {
-            return _supportsMsetEx;
-        }
-
         // Redis 8.4 RC1 is internally versioned as 8.3.224
         var minVersion = new Version(8, 3, 224);
-        var endpoints = options.ConnectionMultiplexer.GetEndPoints();
+        var endpoints = connectionMultiplexer.GetEndPoints();
 
         if (endpoints.Length is 0)
         {
@@ -2640,7 +2725,7 @@ public sealed class RedisCache(
 
         foreach (var endpoint in endpoints)
         {
-            var server = options.ConnectionMultiplexer.GetServer(endpoint);
+            var server = connectionMultiplexer.GetServer(endpoint);
 
             if (server is { IsConnected: true, IsReplica: false })
             {
@@ -2648,21 +2733,12 @@ public sealed class RedisCache(
 
                 if (server.Version < minVersion)
                 {
-                    _supportsMsetEx = false;
-                    _supportsMsetExChecked = true;
                     return false;
                 }
             }
         }
 
-        if (foundConnectedPrimary)
-        {
-            _supportsMsetEx = true;
-            _supportsMsetExChecked = true;
-            return true;
-        }
-
-        return false;
+        return foundConnectedPrimary;
     }
 
     private TimeSpan? _NormalizeExpiration(TimeSpan? expiresIn)

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -592,47 +592,46 @@ public sealed class RedisCache(
         Argument.IsPositive(expiration);
         cancellationToken.ThrowIfCancellationRequested();
 
-        key = _GetKey(key);
-
         if (expiration is { Ticks: <= 0 })
         {
             await SetRemoveAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
             return 0;
         }
 
-        var expiresAt = expiration.HasValue
-            ? timeProvider.GetUtcNow().UtcDateTime.SafeAdd(expiration.Value)
-            : DateTime.MaxValue;
+        var now = timeProvider.GetUtcNow();
+        var expiresAt = expiration.HasValue ? now.UtcDateTime.SafeAdd(expiration.Value) : DateTime.MaxValue;
 
-        var redisValues = new List<SortedSetEntry>();
-        var expiresAtMilliseconds = expiresAt.ToUnixTimeMilliseconds();
+        var redisValues = new List<RedisValue>();
+        var expiresAtMilliseconds = expiration.HasValue
+            ? expiresAt.ToUnixTimeMilliseconds()
+            : RedisCacheEntryFrame.MaxUnixEpochMilliseconds;
 
         if (value is string stringValue)
         {
-            redisValues.Add(new SortedSetEntry(_ToRedisValue(stringValue), expiresAtMilliseconds));
+            redisValues.Add(_ToRedisValue(stringValue));
         }
         else
         {
-            redisValues.AddRange(
-                value.Where(v => v is not null).Select(v => new SortedSetEntry(_ToRedisValue(v), expiresAtMilliseconds))
-            );
+            redisValues.AddRange(value.Where(v => v is not null).Select(_ToRedisValue));
         }
-
-        await _RemoveExpiredListValuesAsync(key).ConfigureAwait(false);
 
         if (redisValues.Count is 0)
         {
             return 0;
         }
 
-        var added = await _database.SortedSetAddAsync(key, [.. redisValues]).ConfigureAwait(false);
+        var redisKey = _GetKey(key);
 
-        if (added > 0)
-        {
-            await _SetListExpirationAsync(key).ConfigureAwait(false);
-        }
-
-        return added;
+        return await _RunSetMutationScriptAsync(
+                redisKey,
+                redisKey,
+                [.. redisValues],
+                operation: "add",
+                expiresAtMilliseconds,
+                now.ToUnixTimeMilliseconds(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     #endregion
@@ -798,7 +797,6 @@ public sealed class RedisCache(
         // #10: Decode all frames up-front so we can batch-prefetch stale tag markers for all entries in ONE
         // MGET before the processing loop — previously _ResolveNewestMarkerAsync issued one MGET per entry
         // whose tags were stale, resulting in N sequential round-trips for N tagged entries.
-        // REVIEW(#10): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
         var decodedFrames = new RedisCacheEntryFrame.DecodedFrame?[rawValues.Length];
 
         for (var i = 0; i < rawValues.Length; i++)
@@ -1407,7 +1405,6 @@ public sealed class RedisCache(
         {
             // #36: group by hash slot ONCE before chunking to avoid re-allocating a Dictionary per chunk.
             // Previously _GroupBySlot was called inside the Chunk loop: N/250 allocations for N keys.
-            // REVIEW(#36): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
             var slotBuckets = _GroupBySlot(redisKeys, static key => key);
 
             foreach (var (slot, bucket) in slotBuckets)
@@ -1657,7 +1654,6 @@ public sealed class RedisCache(
         Argument.IsPositive(expiration);
         cancellationToken.ThrowIfCancellationRequested();
 
-        key = _GetKey(key);
         var redisValues = new List<RedisValue>();
 
         if (value is string stringValue)
@@ -1669,21 +1665,23 @@ public sealed class RedisCache(
             redisValues.AddRange(value.Where(v => v is not null).Select(_ToRedisValue));
         }
 
-        await _RemoveExpiredListValuesAsync(key).ConfigureAwait(false);
-
         if (redisValues.Count is 0)
         {
             return 0;
         }
 
-        var removed = await _database.SortedSetRemoveAsync(key, [.. redisValues]).ConfigureAwait(false);
+        var redisKey = _GetKey(key);
 
-        if (removed > 0)
-        {
-            await _SetListExpirationAsync(key).ConfigureAwait(false);
-        }
-
-        return removed;
+        return await _RunSetMutationScriptAsync(
+                redisKey,
+                redisKey,
+                [.. redisValues],
+                operation: "remove",
+                scoreMilliseconds: 0,
+                nowMilliseconds: timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)
@@ -1901,7 +1899,6 @@ public sealed class RedisCache(
     /// frames in a single MGET — O(1) Redis round-trip regardless of how many entries share tags.
     /// Called once before the processing loop in <see cref="GetAllWithExpirationAsync{T}"/> so that subsequent
     /// per-entry <see cref="_ResolveNewestMarkerAsync"/> calls hit the local cache without extra network I/O. (#10)
-    /// REVIEW(#10): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
     /// </summary>
     private async ValueTask _PrefetchTagMarkersAsync(RedisCacheEntryFrame.DecodedFrame?[] decodedFrames, DateTime now)
     {
@@ -2588,7 +2585,6 @@ public sealed class RedisCache(
     // #9: Lua script for atomic TTL-check-and-conditional-PEXPIRE in a single Redis round-trip.
     // KEYS[1]=key, ARGV[1]=rearmThresholdMs (long), ARGV[2]=newTtlMs (long).
     // Returns 1 if PEXPIRE was issued, 0 if the key already had enough TTL or is persistent (PTTL=-1).
-    // REVIEW(#9): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
     private const string _SlidingRearmLua = """
         local ttl = redis.call('PTTL', KEYS[1])
         if ttl < 0 or ttl > tonumber(ARGV[1]) then return 0 end
@@ -2624,7 +2620,6 @@ public sealed class RedisCache(
         {
             // #9: single-RTT atomic TTL-check-and-conditional-PEXPIRE via inline Lua.
             // Previously issued KeyTimeToLiveAsync then (conditionally) KeyExpireAsync — 2 sequential RTTs.
-            // REVIEW(#9): batched/consolidated — NEEDS INTEGRATION VERIFICATION (Docker)
             var expiresIn = _Min(slidingExpiration, remainingToCap);
             var rearmThresholdMs = (long)rearmThreshold.TotalMilliseconds;
             var newTtlMs = (long)expiresIn.TotalMilliseconds;
@@ -2780,41 +2775,59 @@ public sealed class RedisCache(
         return expiresAt == DateTime.MaxValue ? null : expiresAt;
     }
 
-    private async Task _SetListExpirationAsync(string key)
+    private async ValueTask<long> _RunSetMutationScriptAsync(
+        RedisKey key,
+        string logKey,
+        RedisValue[] values,
+        string operation,
+        long scoreMilliseconds,
+        long nowMilliseconds,
+        CancellationToken cancellationToken
+    )
     {
-        var items = await _database
-            .SortedSetRangeByRankWithScoresAsync(key, 0, 0, order: Order.Descending)
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var result = await SetAddWithExpireScriptDefinition
+            .EvaluateAsync(
+                _database,
+                key,
+                _GetSetMutationScriptValues(operation, scoreMilliseconds, nowMilliseconds, values)
+            )
             .ConfigureAwait(false);
 
-        if (items.Length is 0)
+        var valuesResult = (RedisResult[]?)result;
+
+        if (valuesResult is null || valuesResult.Length < 2)
         {
-            return;
+            throw new RedisServerException("Unexpected set mutation script result.");
         }
 
-        var highestExpirationInMs = (long)items.Single().Score;
+        var changed = (long)valuesResult[0];
+        var pruned = (long)valuesResult[1];
 
-        if (highestExpirationInMs >= RedisCacheEntryFrame.MaxUnixEpochMilliseconds)
+        if (pruned > 0)
         {
-            await _database.KeyPersistAsync(key).ConfigureAwait(false);
-            return;
+            _logger.LogExpiredValuesRemoved(pruned, logKey);
         }
 
-        var furthestExpirationUtc = DateTimeOffset.FromUnixTimeMilliseconds(highestExpirationInMs);
-        var expiresIn = furthestExpirationUtc - timeProvider.GetUtcNow();
-
-        await _database.KeyExpireAsync(key, expiresIn).ConfigureAwait(false);
+        return changed;
     }
 
-    private async Task _RemoveExpiredListValuesAsync(string key)
+    private static RedisValue[] _GetSetMutationScriptValues(
+        string operation,
+        long scoreMilliseconds,
+        long nowMilliseconds,
+        RedisValue[] values
+    )
     {
-        var expiredValues = await _database
-            .SortedSetRemoveRangeByScoreAsync(key, 0, timeProvider.GetUtcNow().ToUnixTimeMilliseconds())
-            .ConfigureAwait(false);
+        var scriptValues = new RedisValue[values.Length + 4];
+        scriptValues[0] = operation;
+        scriptValues[1] = scoreMilliseconds;
+        scriptValues[2] = nowMilliseconds;
+        scriptValues[3] = RedisCacheEntryFrame.MaxUnixEpochMilliseconds;
+        values.CopyTo(scriptValues, 4);
 
-        if (expiredValues > 0)
-        {
-            _logger.LogExpiredValuesRemoved(expiredValues, key);
-        }
+        return scriptValues;
     }
 
     private async Task<long> _DeleteKeysAsync(RedisKey[] keys, bool isCluster)

--- a/src/Headless.Caching.Redis/Scripts/CacheRemoveIfEqualScriptDefinition.cs
+++ b/src/Headless.Caching.Redis/Scripts/CacheRemoveIfEqualScriptDefinition.cs
@@ -40,7 +40,7 @@ internal sealed class CacheRemoveIfEqualScriptDefinition : RedisScriptDefinition
               local currentIsNull = flags % 2 == 1
               local len = string.len(currentVal)
 
-              -- Skip the optional v2 sections in frame layout order (sliding 0x08, eager-refresh 0x10,
+              -- Skip the optional v3 sections in frame layout order (sliding 0x08, eager-refresh 0x10,
               -- last-modified 0x40 fixed 8B each, then etag 0x20 and tags 0x80 as u16le-length-prefixed
               -- UTF-8) to find where the value segment starts.
               local valueStart = headerLen

--- a/src/Headless.Caching.Redis/Scripts/IncrementWithExpireScriptDefinition.cs
+++ b/src/Headless.Caching.Redis/Scripts/IncrementWithExpireScriptDefinition.cs
@@ -11,7 +11,6 @@ internal sealed class IncrementWithExpireScriptDefinition : RedisScriptDefinitio
 
     private IncrementWithExpireScriptDefinition()
         : base(
-            // REVIEW(#1): NEEDS INTEGRATION VERIFICATION (Docker)
             // math.modf returns (intpart, frac); branching on the first return value means the
             // condition was true only when intpart == 0 (i.e. |value| < 1), which is exactly
             // backwards. Fix: capture the fractional part and branch on it.

--- a/src/Headless.Caching.Redis/Scripts/IncrementWithExpireScriptDefinition.cs
+++ b/src/Headless.Caching.Redis/Scripts/IncrementWithExpireScriptDefinition.cs
@@ -11,8 +11,13 @@ internal sealed class IncrementWithExpireScriptDefinition : RedisScriptDefinitio
 
     private IncrementWithExpireScriptDefinition()
         : base(
+            // REVIEW(#1): NEEDS INTEGRATION VERIFICATION (Docker)
+            // math.modf returns (intpart, frac); branching on the first return value means the
+            // condition was true only when intpart == 0 (i.e. |value| < 1), which is exactly
+            // backwards. Fix: capture the fractional part and branch on it.
             """
-            if math.modf(@value) == 0 then
+            local intpart, frac = math.modf(@value)
+            if frac == 0 then
               redis.call('incrby', @key, @value)
             else
               redis.call('incrbyfloat', @key, @value)

--- a/src/Headless.Caching.Redis/Scripts/SetAddWithExpireScriptDefinition.cs
+++ b/src/Headless.Caching.Redis/Scripts/SetAddWithExpireScriptDefinition.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using StackExchange.Redis;
+
+namespace Headless.Caching;
+
+/// <summary>
+/// Atomically prunes expired set members, adds/removes members, and re-arms the sorted-set key expiration.
+/// </summary>
+internal static class SetAddWithExpireScriptDefinition
+{
+    private const string _Source = """
+        local key = KEYS[1]
+        local operation = ARGV[1]
+        local scoreMs = tonumber(ARGV[2])
+        local nowMs = tonumber(ARGV[3])
+        local maxExpirationMs = tonumber(ARGV[4])
+
+        local pruned = redis.call('zremrangebyscore', key, 0, nowMs)
+        local changed = 0
+
+        if operation == 'add' then
+          for i = 5, #ARGV do
+            changed = changed + redis.call('zadd', key, scoreMs, ARGV[i])
+          end
+        elseif operation == 'remove' then
+          for i = 5, #ARGV do
+            changed = changed + redis.call('zrem', key, ARGV[i])
+          end
+        else
+          return redis.error_reply('ERR unsupported set mutation operation')
+        end
+
+        if pruned > 0 or changed > 0 or operation == 'add' then
+          local highest = redis.call('zrevrange', key, 0, 0, 'WITHSCORES')
+
+          if #highest == 0 then
+            redis.call('del', key)
+          else
+            local highestExpirationMs = tonumber(highest[2])
+
+            if highestExpirationMs >= maxExpirationMs then
+              redis.call('persist', key)
+            else
+              redis.call('pexpireat', key, math.ceil(highestExpirationMs))
+            end
+          end
+        end
+
+        return { changed, pruned }
+        """;
+
+    public static Task<RedisResult> EvaluateAsync(IDatabaseAsync database, RedisKey key, RedisValue[] values)
+    {
+        return database.ScriptEvaluateAsync(_Source, [key], values);
+    }
+}

--- a/tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs
+++ b/tests/Headless.Caching.Core.Tests.Unit/FactoryCacheCoordinatorTests.cs
@@ -2885,6 +2885,220 @@ public sealed class FactoryCacheCoordinatorTests : TestBase
         observedKey.Should().Be(key);
     }
 
+    // #21 — _ObserveDiscardedSuccess: a factory that ignores its hard-timeout CancellationToken and completes
+    // successfully AFTER the hard-timeout window fires. The coordinator must return the stale/miss result at
+    // hard-timeout and must NOT write the discarded value to the store. EventId 16 must fire on the logger.
+    [Fact]
+    public async Task should_discard_late_factory_success_after_hard_timeout_and_log_event_id_16()
+    {
+        // given — stale entry as fail-safe reserve so the coordinator returns stale (not throws)
+        var key = Faker.Random.AlphaNumeric(8);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        _store.SetEntry(key, "stale", now.AddSeconds(-1), now.AddMinutes(5));
+        var logger = Substitute.For<ILogger<FactoryCacheCoordinator>>();
+        logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+        var coordinator = new FactoryCacheCoordinator(_timeProvider, logger);
+        var timeoutRegistered = _WaitForFactoryTimeoutRegistered(coordinator);
+        var factoryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Gate the factory: it ignores cancellation and only completes when we signal it
+        var factoryGate = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var options = _CreateOptions(isFailSafeEnabled: true, factoryHardTimeout: TimeSpan.FromSeconds(1));
+
+        async ValueTask<string?> IgnoresCancellationFactory(CancellationToken cancellationToken)
+        {
+            factoryStarted.SetResult();
+            // Deliberately ignore the cancellation token — factory keeps running past hard timeout
+            return await factoryGate.Task.ConfigureAwait(false);
+        }
+
+        // when — advance past hard timeout, coordinator returns stale
+        var resultTask = coordinator
+            .GetOrAddAsync(_store, key, IgnoresCancellationFactory, options, AbortToken)
+            .AsTask();
+        await factoryStarted.Task;
+        await timeoutRegistered;
+        _timeProvider.Advance(TimeSpan.FromSeconds(1)); // hard timeout fires
+        var result = await resultTask;
+
+        // then — stale is returned
+        result.Value.Should().Be("stale");
+        result.IsStale.Should().BeTrue();
+        // The coordinator may restamp the throttle window on hard-timeout with fail-safe (1 write allowed);
+        // the important invariant is that the discarded factory's value is never written.
+        var writesAtTimeout = _store.SetEntryCalls;
+
+        // now let the factory complete successfully (it ignored cancellation)
+        factoryGate.SetResult("discarded-fresh");
+        // poll briefly for the ContinueWith continuation to run (OnlyOnRanToCompletion on TaskScheduler.Default)
+        var observed = false;
+        for (var attempt = 0; attempt < 200 && !observed; attempt++)
+        {
+            observed = logger
+                .ReceivedCalls()
+                .Any(call =>
+                    call.GetMethodInfo().Name == nameof(ILogger.Log)
+                    && call.GetArguments()[1] is EventId { Id: 16, Name: "CacheFactoryDiscardedSuccess" }
+                );
+
+            if (!observed)
+            {
+                await Task.Delay(25, AbortToken);
+            }
+        }
+
+        // EventId 16 must fire (DiscardedSuccess observer)
+        observed
+            .Should()
+            .BeTrue("LogCacheFactoryDiscardedSuccess (EventId 16) must fire when the abandoned factory later resolves");
+        // No additional write must have occurred after the factory's discarded success — the discard path
+        // must not call SetEntryAsync. Any writes before this point are the coordinator's own restamp.
+        _store
+            .SetEntryCalls.Should()
+            .Be(writesAtTimeout, "the discarded factory result must never be written to the store");
+        // The store's value for this key must NOT be "discarded-fresh"
+        _store
+            .GetEntry(key)!
+            .Value.Should()
+            .NotBe("discarded-fresh", "discarded factory result must never be written to the store");
+    }
+
+    // #30 — _TryRestampStaleWithCeilingAsync ceiling-fires-before-restamp-write-completes branch.
+    // The restamp store write is gated behind a TaskCompletionSource; BackgroundFactoryCeiling is set shorter
+    // than the gate, so the ceiling fires first. Assert: coordinator returns control, the restamp is cancelled,
+    // and the stale entry's physical TTL is unchanged in the underlying store.
+    //
+    // NOTE: This test uses TimeProvider.System (real time) with a short ceiling (100ms) so the ceiling task
+    // is registered and fires by real time, avoiding FakeTimeProvider ordering races. The gated restamp write
+    // blocks indefinitely until the ceiling cancels it.
+    [Fact]
+    public async Task should_cancel_restamp_when_ceiling_fires_before_restamp_write_completes()
+    {
+        // given — stale entry; use a separate real-time store so FakeTimeProvider ordering is not an issue
+        var key = Faker.Random.AlphaNumeric(8);
+        var realStore = new FakeFactoryCacheStore();
+        var now = TimeProvider.System.GetUtcNow().UtcDateTime;
+        var stalePhysicalExpiry = now.AddMinutes(5);
+
+        // restampGate blocks the store write indefinitely so the ceiling can win the race
+        var restampGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gatedStore = new _GatedRestampStore(realStore, restampGate.Task);
+        realStore.SetEntry(key, "stale", now.AddSeconds(-1), stalePhysicalExpiry);
+
+        // Use TimeProvider.System so Task.Delay fires by wall time (avoids FakeTimeProvider advance races).
+        // Disposed manually after backgroundFinished to avoid CA2025 (task completes while Dispose is in flight).
+        var coordinator = new FactoryCacheCoordinator(
+            TimeProvider.System,
+            NullLogger<FactoryCacheCoordinator>.Instance
+        );
+        var backgroundFinished = _WaitForBackgroundFinished(coordinator);
+        var factoryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var factoryGate = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // ceiling = 150ms (real time); factory soft-times out at 50ms and then fails in background
+        var options = new CacheEntryOptions
+        {
+            Duration = TimeSpan.FromMinutes(5),
+            IsFailSafeEnabled = true,
+            FailSafeMaxDuration = TimeSpan.FromMinutes(10),
+            FailSafeThrottleDuration = TimeSpan.FromSeconds(30),
+            FactorySoftTimeout = TimeSpan.FromMilliseconds(50),
+            FactoryHardTimeout = TimeSpan.FromSeconds(10),
+            BackgroundFactoryCeiling = TimeSpan.FromMilliseconds(150),
+            LockTimeout = Timeout.InfiniteTimeSpan,
+        };
+
+        // Factory waits for its gate, then fails — background completion follows the failure path
+        // (not the ceiling-abandoned path) which calls _TryRestampStaleWithCeilingAsync
+        async ValueTask<string?> FailingFactory(CancellationToken cancellationToken)
+        {
+            factoryStarted.SetResult();
+            await factoryGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("background factory failed");
+        }
+
+        // when — soft timeout → stale returned, background completion starts
+        var first = coordinator.GetOrAddAsync(gatedStore, key, FailingFactory, options, AbortToken).AsTask();
+        await factoryStarted.Task;
+        // Wait for soft timeout to fire by real time (50ms ceiling)
+        var staleResult = await first;
+        staleResult.IsStale.Should().BeTrue();
+
+        // Release the factory gate so it fails → background catches the exception, calls _TryRestampStaleWithCeilingAsync.
+        // The restamp write blocks on restampGate indefinitely.
+        // The 150ms ceiling inside _TryRestampStaleWithCeilingAsync will fire by real time and cancel the restamp.
+        factoryGate.SetException(new InvalidOperationException("background factory failed"));
+
+        // Wait for the background operation to fully finish (ceiling cancels restamp → background unwinds)
+        await backgroundFinished.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        coordinator.Dispose(); // dispose after background task completes to avoid CA2025
+
+        // then — restamp was attempted but the ceiling cancelled it before the gate opened
+        gatedStore.RestampAttempts.Should().Be(1, "restamp was attempted once");
+        var storeEntry = realStore.GetEntry(key);
+        storeEntry.Should().NotBeNull();
+        // The restamp write was cancelled before mutating the store; physical TTL must be unchanged
+        storeEntry!
+            .PhysicalExpiresAt.Should()
+            .Be(stalePhysicalExpiry, "ceiling must cancel the restamp before it can mutate the store's physical TTL");
+    }
+
+    // Wraps FakeFactoryCacheStore and delays SetEntryAsync (restamp writes) behind a Task gate so the
+    // ceiling-fires-before-restamp branch in _TryRestampStaleWithCeilingAsync can be exercised.
+    // RestampStarted fires when the restamp write begins (before the gate blocks), so the test can advance
+    // the fake clock AFTER the restamp task is in-flight but BEFORE the ceiling Task.Delay is created.
+    // Note: Task.Delay for the second ceiling is created by _TryRestampStaleWithCeilingAsync AFTER
+    // restampTask starts, so we yield after RestampStarted to let that registration happen.
+    private sealed class _GatedRestampStore(FakeFactoryCacheStore inner, Task gate) : IFactoryCacheStore
+    {
+        private readonly TaskCompletionSource _restampStartedTcs = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        public int RestampAttempts { get; private set; }
+
+        /// <summary>Completes when a restamp write has started (entered the gate-wait).</summary>
+        public Task RestampStarted => _restampStartedTcs.Task;
+
+        public ValueTask<CacheStoreEntry<T>> TryGetEntryAsync<T>(string key, CancellationToken cancellationToken) =>
+            inner.TryGetEntryAsync<T>(key, cancellationToken);
+
+        public ValueTask<bool> SetEntryAsync<T>(
+            string key,
+            in CacheStoreEntryWrite<T> entry,
+            CancellationToken cancellationToken
+        )
+        {
+            // Copy the 'in' struct before entering the async state machine (async methods cannot have 'in' params).
+            var entryCopy = entry;
+            return _SetEntryAsyncCore(key, entryCopy, cancellationToken);
+        }
+
+        private async ValueTask<bool> _SetEntryAsyncCore<T>(
+            string key,
+            CacheStoreEntryWrite<T> entry,
+            CancellationToken cancellationToken
+        )
+        {
+            if (entry.IsRestamp)
+            {
+                RestampAttempts++;
+                _restampStartedTcs.TrySetResult(); // signal that the restamp is in-flight
+                // Block until the ceiling cancels us via cancellationToken (or gate is released)
+                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return await inner.SetEntryAsync(key, in entry, cancellationToken).ConfigureAwait(false);
+        }
+
+        public ValueTask TryRearmSlidingAsync(
+            string key,
+            TimeSpan slidingExpiration,
+            DateTime physicalExpiresAt,
+            DateTime now,
+            CancellationToken cancellationToken
+        ) => inner.TryRearmSlidingAsync(key, slidingExpiration, physicalExpiresAt, now, cancellationToken);
+    }
+
     // Models an actor that bypasses the coordinator (e.g. a direct RemoveAsync on the provider) while a factory
     // is in flight. Kept here (not on the fake) because only these interleaving tests need it.
     private static void _RemoveEntryDirectly(FakeFactoryCacheStore store, string key) => store.RemoveEntry(key);

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheTests.cs
@@ -1622,13 +1622,16 @@ public sealed class HybridCacheTests : TestBase
         // when
         var act = async () => await cache.RemoveAllAsync(keys, AbortToken);
 
-        // then — PINNED: the L2 failure propagates to the caller before L1 is touched, nothing is published,
-        // and nothing is queued (bulk removals are never captured by auto-recovery).
+        // then — the L2 failure propagates to the caller; L1 is cleaned before the rethrow to avoid leaving
+        // stale entries on this node (finding #4 fix). Nothing is published because L2 never confirmed the
+        // removal, and bulk removals are never captured by auto-recovery.
         await act.Should().ThrowAsync<InvalidOperationException>();
 
         foreach (var key in keys)
         {
-            (await l1.GetAsync<int>(key, AbortToken)).HasValue.Should().BeTrue("L1 is only cleared after L2 succeeds");
+            (await l1.GetAsync<int>(key, AbortToken))
+                .HasValue.Should()
+                .BeFalse("L1 is cleaned before the rethrow to avoid stale entries");
         }
 
         await publisher

--- a/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs
+++ b/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs
@@ -2040,6 +2040,63 @@ public sealed class InMemoryCacheTests : TestBase
         key1Exists.Should().BeTrue();
     }
 
+    // #31 — Concurrent LRU eviction stress: 50+ parallel tasks inserting random entries into a capacity-capped
+    // InMemoryCache (small MaxItems). After Task.WhenAll, CurrentMemorySize must be >= 0 and must equal the
+    // sum of sizes of surviving (live, non-expired) entries. Verifies that Interlocked.Add across 10+ call
+    // sites never leaves _currentMemorySize negative or inconsistent under contention.
+    [Fact]
+    public async Task should_keep_current_memory_size_non_negative_and_consistent_under_concurrent_lru_eviction()
+    {
+        // given — small MaxItems cap (10) to provoke heavy eviction under concurrent writes
+        const int maxItems = 10;
+        const long entrySize = 100;
+        const int parallelTasks = 60;
+        var options = new InMemoryCacheOptions
+        {
+            MaxItems = maxItems,
+            MaxMemorySize = maxItems * entrySize,
+            SizeCalculator = _ => entrySize,
+        };
+        using var cache = _CreateCache(options);
+
+        // when — 60 tasks each insert a unique random-key entry concurrently
+        var tasks = Enumerable
+            .Range(0, parallelTasks)
+            .Select(i =>
+                Task.Run(async () =>
+                {
+                    var key = Faker.Random.AlphaNumeric(20) + i;
+                    await cache.UpsertAsync(key, Faker.Random.AlphaNumeric(5), TimeSpan.FromMinutes(5));
+                })
+            )
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // Allow LRU background eviction to settle (eviction is async maintenance)
+        await Task.Delay(200, AbortToken);
+
+        // then — CurrentMemorySize must be non-negative
+        var reportedSize = cache.CurrentMemorySize;
+        reportedSize
+            .Should()
+            .BeGreaterThanOrEqualTo(0, "Interlocked.Add across concurrent evictions must never go negative");
+
+        // CurrentMemorySize must equal the sum of live surviving entries' sizes
+        // (surviving = not yet evicted; each entry has size = entrySize)
+        var survivingCount = await cache.GetCountAsync(cancellationToken: AbortToken);
+        var expectedSize = survivingCount * entrySize;
+        reportedSize
+            .Should()
+            .Be(
+                expectedSize,
+                $"CurrentMemorySize ({reportedSize}) must equal surviving entries ({survivingCount}) × entry size ({entrySize})"
+            );
+
+        // surviving count must not exceed the cap
+        survivingCount.Should().BeLessThanOrEqualTo(maxItems);
+    }
+
     #endregion
 
     #region CloneValues Option

--- a/tests/Headless.Caching.Redis.Tests.Integration/HybridCacheL2BehaviorTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/HybridCacheL2BehaviorTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Tests;
 
-// REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
 // Three Hybrid-over-real-Redis scenarios that were not covered by the existing single-test
 // DefaultHybridCacheTiersTests (which only verified composition + key existence in L2).
 //
@@ -51,7 +50,6 @@ public sealed class HybridCacheL2BehaviorTests(RedisCacheFixture fixture) : Test
         return new HybridCache(l1, l2, publisher, hybridOptions, NullLogger<HybridCache>.Instance, TimeProvider.System);
     }
 
-    // REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
     // FlushAll seed-order: after FlushAsync, a new upsert + read must return the new value, proving
     // that the L2 clear-marker was seeded before L1 was wiped (if the order were reversed, a concurrent
     // read in the gap would see a stale L2 hit; here we verify the net effect deterministically).
@@ -86,7 +84,6 @@ public sealed class HybridCacheL2BehaviorTests(RedisCacheFixture fixture) : Test
         result.Value.Should().Be("post-flush", "hybrid must return the post-flush value, not the pre-flush value");
     }
 
-    // REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
     // L1 TTL capping: when DefaultLocalExpiration (e.g. 30s) is less than the L2 logical TTL (e.g. 5min),
     // the L1 entry's effective expiration must be capped to DefaultLocalExpiration (30s), not the full L2 TTL.
     [Fact]
@@ -116,7 +113,6 @@ public sealed class HybridCacheL2BehaviorTests(RedisCacheFixture fixture) : Test
             );
     }
 
-    // REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
     // Backplane round-trip: an invalidation published by node A clears L1 on node B.
     // Node A upserts a key (both nodes can see it). Node B reads (populates node B's L1). Node A upserts
     // a new value + publishes invalidation. Node B's HandleInvalidationAsync must clear node B's L1 so

--- a/tests/Headless.Caching.Redis.Tests.Integration/HybridCacheL2BehaviorTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/HybridCacheL2BehaviorTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using Headless.Caching;
+using Headless.Messaging;
+using Headless.Redis;
+using Headless.Serializer;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Tests;
+
+// REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
+// Three Hybrid-over-real-Redis scenarios that were not covered by the existing single-test
+// DefaultHybridCacheTiersTests (which only verified composition + key existence in L2).
+//
+// (1) FlushAll seed-order: the L2 clear-marker is seeded before L1 is wiped — behavioral
+//     verification that FlushAsync clears both tiers and a subsequent write + read sees the fresh value.
+// (2) L1 TTL capping: L1 TTL is capped to the L2 logical expiry when DefaultLocalExpiration > L2 logical TTL.
+// (3) Backplane round-trip: an invalidation published by node A clears L1 on node B.
+
+[Collection(nameof(RedisCacheFixture))]
+public sealed class HybridCacheL2BehaviorTests(RedisCacheFixture fixture) : TestBase
+{
+    private HybridCache _CreateHybrid(
+        string keyPrefix = "",
+        HybridCacheOptions? hybridOptions = null,
+        _CapturingBus? bus = null
+    )
+    {
+        var l1 = new InMemoryCache(TimeProvider.System, new InMemoryCacheOptions());
+
+        var redisCacheOptions = new RedisCacheOptions
+        {
+            ConnectionMultiplexer = fixture.ConnectionMultiplexer,
+            KeyPrefix = keyPrefix,
+        };
+
+        var l2 = new RedisCache(
+            new SystemJsonSerializer(),
+            TimeProvider.System,
+            redisCacheOptions,
+            fixture.ScriptsLoader,
+            LoggerFactory.CreateLogger<RedisCache>()
+        );
+
+        var publisher = (IBus?)bus ?? _NoopBus.Instance;
+        hybridOptions ??= new HybridCacheOptions();
+
+        return new HybridCache(l1, l2, publisher, hybridOptions, NullLogger<HybridCache>.Instance, TimeProvider.System);
+    }
+
+    // REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
+    // FlushAll seed-order: after FlushAsync, a new upsert + read must return the new value, proving
+    // that the L2 clear-marker was seeded before L1 was wiped (if the order were reversed, a concurrent
+    // read in the gap would see a stale L2 hit; here we verify the net effect deterministically).
+    [Fact]
+    public async Task flush_all_clears_both_tiers_and_new_write_is_visible()
+    {
+        // given
+        await FlushAsync();
+        await using var hybrid = _CreateHybrid("hybrid-flush:");
+
+        var key = Faker.Random.AlphaNumeric(12);
+        await hybrid.UpsertAsync(key, "original", TimeSpan.FromMinutes(5), AbortToken);
+
+        // verify both tiers have the value before flush
+        var localBefore = await hybrid.LocalCache.GetAsync<string>(key, AbortToken);
+        localBefore.HasValue.Should().BeTrue("L1 must be populated before flush");
+        var db = fixture.ConnectionMultiplexer.GetDatabase();
+        (await db.KeyExistsAsync("hybrid-flush:" + key)).Should().BeTrue("L2 must be populated before flush");
+
+        // when — FlushAsync triggers the FlushAll invalidation path (seed L2 marker first, then wipe L1)
+        await hybrid.FlushAsync(AbortToken);
+
+        // then — both tiers must be empty
+        var localAfterFlush = await hybrid.LocalCache.GetAsync<string>(key, AbortToken);
+        localAfterFlush.HasValue.Should().BeFalse("L1 must be empty after flush");
+
+        // Write a new value after flush and read it back through both tiers
+        await hybrid.UpsertAsync(key, "post-flush", TimeSpan.FromMinutes(5), AbortToken);
+        var result = await hybrid.GetAsync<string>(key, AbortToken);
+
+        result.HasValue.Should().BeTrue("new write after flush must be readable");
+        result.Value.Should().Be("post-flush", "hybrid must return the post-flush value, not the pre-flush value");
+    }
+
+    // REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
+    // L1 TTL capping: when DefaultLocalExpiration (e.g. 30s) is less than the L2 logical TTL (e.g. 5min),
+    // the L1 entry's effective expiration must be capped to DefaultLocalExpiration (30s), not the full L2 TTL.
+    [Fact]
+    public async Task l1_ttl_is_capped_to_local_expiration_when_l2_ttl_is_longer()
+    {
+        // given
+        await FlushAsync();
+        var hybridOptions = new HybridCacheOptions { DefaultLocalExpiration = TimeSpan.FromSeconds(30) };
+        await using var hybrid = _CreateHybrid("hybrid-ttl:", hybridOptions);
+
+        var key = Faker.Random.AlphaNumeric(12);
+        // Upsert with a long TTL so L2 TTL (5min) > DefaultLocalExpiration (30s)
+        await hybrid.UpsertAsync(key, "value", TimeSpan.FromMinutes(5), AbortToken);
+
+        // when — read back to ensure L1 was populated
+        var result = await hybrid.GetAsync<string>(key, AbortToken);
+        result.HasValue.Should().BeTrue();
+
+        // then — L1 TTL must be <= DefaultLocalExpiration (30s), not 5min
+        var l1Expiration = await hybrid.LocalCache.GetExpirationAsync(key, AbortToken);
+        l1Expiration.Should().NotBeNull("L1 entry must exist");
+        l1Expiration!
+            .Value.Should()
+            .BeLessThanOrEqualTo(
+                TimeSpan.FromSeconds(31), // small grace for clock skew between write and read
+                "L1 TTL must be capped at DefaultLocalExpiration (30s), not the full L2 TTL (5min)"
+            );
+    }
+
+    // REVIEW(#26): NEEDS DOCKER (Testcontainers Redis)
+    // Backplane round-trip: an invalidation published by node A clears L1 on node B.
+    // Node A upserts a key (both nodes can see it). Node B reads (populates node B's L1). Node A upserts
+    // a new value + publishes invalidation. Node B's HandleInvalidationAsync must clear node B's L1 so
+    // the next read on node B returns the fresh value (not the stale L1 copy).
+    [Fact]
+    public async Task backplane_invalidation_from_node_a_clears_l1_on_node_b()
+    {
+        // given
+        await FlushAsync();
+        var bus = new _CapturingBus();
+
+        await using var hybridA = _CreateHybrid("hybrid-bp:", bus: bus);
+        await using var hybridB = _CreateHybrid("hybrid-bp:", bus: bus);
+
+        // Both nodes share the same Redis (L2); wire the bus so A's publishes invalidate B's L1
+        bus.Attach(hybridA);
+        bus.Attach(hybridB);
+
+        var key = Faker.Random.AlphaNumeric(12);
+
+        // Node A writes "v1" → L2 (Redis)
+        await hybridA.UpsertAsync(key, "v1", TimeSpan.FromMinutes(5), AbortToken);
+
+        // Node B reads — populates node B's L1 from L2
+        var readOnB = await hybridB.GetAsync<string>(key, AbortToken);
+        readOnB.HasValue.Should().BeTrue();
+        readOnB.Value.Should().Be("v1");
+
+        var bL1Before = await hybridB.LocalCache.GetAsync<string>(key, AbortToken);
+        bL1Before.HasValue.Should().BeTrue("node B L1 must be populated after first read");
+
+        // when — node A writes "v2" and publishes invalidation; the bus routes it to node B
+        await hybridA.UpsertAsync(key, "v2", TimeSpan.FromMinutes(5), AbortToken);
+
+        // then — node B's L1 must have been cleared by the backplane invalidation
+        var bL1After = await hybridB.LocalCache.GetAsync<string>(key, AbortToken);
+        bL1After.HasValue.Should().BeFalse("backplane invalidation must clear node B's L1 after node A's upsert");
+
+        // and a fresh read on node B must return "v2" from L2
+        var freshReadOnB = await hybridB.GetAsync<string>(key, AbortToken);
+        freshReadOnB.HasValue.Should().BeTrue();
+        freshReadOnB.Value.Should().Be("v2", "node B must read the updated value from L2 after L1 invalidation");
+    }
+
+    private async Task FlushAsync() => await fixture.ConnectionMultiplexer.FlushAllAsync();
+
+    // Minimal in-process backplane bus: routes CacheInvalidationMessage to all attached HybridCache instances.
+    // HandleInvalidationAsync is internal (InternalsVisibleTo is not granted to this project) so we invoke it
+    // via reflection — the same approach the real infrastructure's message consumer uses, but synchronous here.
+    private sealed class _CapturingBus : IBus
+    {
+        private readonly List<HybridCache> _subscribers = [];
+
+        public void Attach(HybridCache cache) => _subscribers.Add(cache);
+
+        public async Task PublishAsync<T>(
+            T? message,
+            PublishOptions? options = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (message is not CacheInvalidationMessage invalidation)
+            {
+                return;
+            }
+
+            foreach (var subscriber in _subscribers)
+            {
+                // HandleInvalidationAsync is internal; invoke via reflection so the test can route messages
+                // without InternalsVisibleTo being granted to this integration test project.
+                var method = typeof(HybridCache).GetMethod(
+                    "HandleInvalidationAsync",
+                    BindingFlags.Instance | BindingFlags.NonPublic
+                );
+                var task = (ValueTask)method!.Invoke(subscriber, [invalidation, cancellationToken])!;
+                await task.ConfigureAwait(false);
+            }
+        }
+    }
+
+    // No-op bus for tests that don't need cross-node invalidation routing.
+    private sealed class _NoopBus : IBus
+    {
+        public static readonly _NoopBus Instance = new();
+
+        public Task PublishAsync<T>(
+            T? message,
+            PublishOptions? options = null,
+            CancellationToken cancellationToken = default
+        ) => Task.CompletedTask;
+    }
+}

--- a/tests/Headless.Caching.Redis.Tests.Integration/IncrementTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/IncrementTests.cs
@@ -107,7 +107,6 @@ public sealed class IncrementTests(RedisCacheFixture fixture) : RedisCacheTestBa
         result.Should().Be(10.5);
     }
 
-    // REVIEW(#1): NEEDS DOCKER (Testcontainers Redis)
     // Regression test for the Lua math.modf fix: IncrementAsync(key, 0.5) must return 0.5 and must not throw.
     // Prior to the fix, math.modf(0.5) would mis-classify the fractional part and cause a Lua error.
     [Fact]
@@ -125,7 +124,6 @@ public sealed class IncrementTests(RedisCacheFixture fixture) : RedisCacheTestBa
         result.Should().Be(0.5);
     }
 
-    // REVIEW(#1): NEEDS DOCKER (Testcontainers Redis)
     // Negative fractional increment: ensures the Lua fractional branch handles negative fractions correctly.
     [Fact]
     public async Task should_increment_double_with_negative_fractional()
@@ -143,7 +141,6 @@ public sealed class IncrementTests(RedisCacheFixture fixture) : RedisCacheTestBa
         result.Should().BeApproximately(0.7, 1e-9);
     }
 
-    // REVIEW(#1): NEEDS DOCKER (Testcontainers Redis)
     // Integer-valued double: when the value is a whole number (no fractional part) the Lua modf integer branch
     // must be taken (HINCRBY path). Verifies both branches of the Lua fix.
     [Fact]

--- a/tests/Headless.Caching.Redis.Tests.Integration/IncrementTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/IncrementTests.cs
@@ -107,6 +107,60 @@ public sealed class IncrementTests(RedisCacheFixture fixture) : RedisCacheTestBa
         result.Should().Be(10.5);
     }
 
+    // REVIEW(#1): NEEDS DOCKER (Testcontainers Redis)
+    // Regression test for the Lua math.modf fix: IncrementAsync(key, 0.5) must return 0.5 and must not throw.
+    // Prior to the fix, math.modf(0.5) would mis-classify the fractional part and cause a Lua error.
+    [Fact]
+    public async Task should_increment_double_with_fractional_half()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        // when
+        var result = await cache.IncrementAsync(key, 0.5, TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().Be(0.5);
+    }
+
+    // REVIEW(#1): NEEDS DOCKER (Testcontainers Redis)
+    // Negative fractional increment: ensures the Lua fractional branch handles negative fractions correctly.
+    [Fact]
+    public async Task should_increment_double_with_negative_fractional()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.IncrementAsync(key, 1.0, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.IncrementAsync(key, -0.3, TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().BeApproximately(0.7, 1e-9);
+    }
+
+    // REVIEW(#1): NEEDS DOCKER (Testcontainers Redis)
+    // Integer-valued double: when the value is a whole number (no fractional part) the Lua modf integer branch
+    // must be taken (HINCRBY path). Verifies both branches of the Lua fix.
+    [Fact]
+    public async Task should_increment_double_with_integer_value()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        // when
+        var result = await cache.IncrementAsync(key, 2.0, TimeSpan.FromMinutes(5), AbortToken);
+
+        // then
+        result.Should().Be(2.0);
+    }
+
     [Fact]
     public async Task should_increment_double_existing_key()
     {

--- a/tests/Headless.Caching.Redis.Tests.Integration/SetOperationsTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/SetOperationsTests.cs
@@ -146,6 +146,73 @@ public sealed class SetOperationsTests(RedisCacheFixture fixture) : RedisCacheTe
         retrieved.Value.Should().HaveCount(2);
     }
 
+    [Fact]
+    public async Task should_extend_key_ttl_when_existing_set_member_is_readded_with_later_expiration()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var database = Fixture.ConnectionMultiplexer.GetDatabase();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.SetAddAsync(key, ["value"], TimeSpan.FromSeconds(1), AbortToken);
+
+        // when
+        var added = await cache.SetAddAsync(key, ["value"], TimeSpan.FromSeconds(5), AbortToken);
+
+        // then
+        added.Should().Be(0);
+
+        var ttl = await database.KeyTimeToLiveAsync(key);
+        ttl.Should().NotBeNull();
+        ttl!.Value.Should().BeCloseTo(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task should_rearm_key_ttl_after_removing_furthest_expiring_set_member()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var database = Fixture.ConnectionMultiplexer.GetDatabase();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.SetAddAsync(key, ["short"], TimeSpan.FromSeconds(3), AbortToken);
+        await cache.SetAddAsync(key, ["long"], TimeSpan.FromSeconds(20), AbortToken);
+
+        // when
+        var removed = await cache.SetRemoveAsync(key, ["long"], expiration: null, AbortToken);
+
+        // then
+        removed.Should().Be(1);
+
+        var ttl = await database.KeyTimeToLiveAsync(key);
+        ttl.Should().NotBeNull();
+        ttl!.Value.Should().BeLessThan(TimeSpan.FromSeconds(10));
+        ttl.Value.Should().BeCloseTo(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task should_persist_set_key_when_member_without_expiration_is_added()
+    {
+        // given
+        await FlushAsync();
+        using var cache = CreateCache();
+        var database = Fixture.ConnectionMultiplexer.GetDatabase();
+        var key = Faker.Random.AlphaNumeric(10);
+
+        await cache.SetAddAsync(key, ["expiring"], TimeSpan.FromSeconds(5), AbortToken);
+
+        // when
+        var added = await cache.SetAddAsync(key, ["immortal"], expiration: null, AbortToken);
+
+        // then
+        added.Should().Be(1);
+
+        var ttl = await database.KeyTimeToLiveAsync(key);
+        ttl.Should().BeNull();
+    }
+
     private sealed record TestSetObject
     {
         public int Id { get; init; }


### PR DESCRIPTION
## Summary

Applies the findings from a multi-agent code review of the `Headless.Caching.*` stack (run `20260622-093424`). The review found the stack already conformant to its design docs with no security issues, so this is hardening, not redesign: one real defect fixed plus reliability, performance, and structural improvements across the Hybrid, InMemory, Redis, and Core packages.

The functional bug: `IncrementAsync` with a fractional magnitude below 1 (e.g. `0.5`) previously threw `ERR value is not an integer` — the increment Lua tested `math.modf`'s integer part instead of its fractional part, routing fractional values to `INCRBY`. It now dispatches `INCRBY`/`INCRBYFLOAT` correctly.

Redis integration suite passes against Docker: `Headless.Caching.Redis.Tests.Integration` is green at 223/223.

## What changed

| Area | Change |
|---|---|
| Correctness | Fractional `IncrementAsync` no longer errors. `RemoveAllAsync` now rejects null keys and cleans L1 before rethrowing on L2 failure (was leaving stale L1 across nodes). Redis set keys now re-arm TTL atomically when members are added/removed, including existing-member score updates and no-expiration members. |
| Reliability | `TryInsert`/`TryReplace` now honor the L2 circuit breaker; `DisposeAsync` drains in-flight recovery-queue work; Remove/Expire recovery replay gained a stamp-aware staleness guard so it cannot delete a value written during an outage; CAS writes honor caller cancellation; L2-outage logs raised Debug -> Warning. |
| Performance | Sliding re-arm collapsed from 2 Redis round-trips to 1 (Lua); `GetAllWithExpirationAsync` batches tag-marker reads into a single `MGET` (was one per entry); Redis set add/remove prune + mutate + TTL re-arm now run in one Lua round-trip; `InMemoryCache` batches `UpsertAllAsync`, de-LINQs prefix scans, and reuses per-op key construction. |
| Structure | Extracted duplicated numeric-op and set-dispatch bodies into shared helpers; sealed `Cache<T>`; renamed `_AddCachingProviderCore` -> `_AddCachingCore`; documented the BCL adapter's sync-over-async constraint. |
| Tests | New unit tests for the coordinator hard-timeout discard path, ceiling-restamp cancellation, and InMemory LRU concurrency; new Docker-gated Redis integration tests for fractional increment, Hybrid L1/L2 scenarios, and Redis set TTL re-arm behavior. |

## Verification

- Docker available: `docker info` succeeded after restarting Docker Desktop once to recover a daemon HTTP 500.
- Redis integration: `make test-project TEST_PROJECT=tests/Headless.Caching.Redis.Tests.Integration/Headless.Caching.Redis.Tests.Integration.csproj` — 223/223 passed.
- BCL integration: `make test-project TEST_PROJECT=tests/Headless.Caching.Bcl.Tests.Integration/Headless.Caching.Bcl.Tests.Integration.csproj` — 9/9 passed.
- OutputCache integration: `make test-project TEST_PROJECT=tests/Headless.Caching.OutputCache.Tests.Integration/Headless.Caching.OutputCache.Tests.Integration.csproj` — 8/8 passed.
- Unit suites: Abstractions 47/47, Core 155/155, InMemory 216/216, Hybrid 214/214, BCL 11/11, OutputCache 22/22, Redis 17/17 passed.
- Formatting/build: `make format-check`, `git diff --check`, `BuildDashboardSpa=false make build`, and the pre-push hook format-check + clean Release build all passed.

## Deferred & out of scope

- Auto-registering the Hybrid invalidation consumer (multi-node L1 goes stale by default) is a default-behavior decision tracked in #511.
- God-class partial-splits of `RedisCache.cs` / `InMemoryCache.cs` were intentionally skipped.
- Copy-free frame decode remains dropped/parked: StackExchange.Redis 2.13.17 does not expose the proposed `RedisValue.TryGetBytes(ReadOnlyMemory)` API, and a real fix would be a larger `StringGetLeaseAsync` read-path refactor.
- Lua frame-preamble dedup remains dropped; the scripts are not byte-identical outside the inner block. The live typo in `CacheRemoveIfEqualScriptDefinition` was fixed from `v2` to `v3`.

One test (ceiling-restamp) is wall-clock-timed (~150 ms) because `FakeTimeProvider` cannot fire a timer registered on a background thread; revisit if CI proves flaky.

## Post-Deploy Monitoring & Validation

- Validation window: first 24 hours after package adoption in a Redis-backed service; owner: service owner consuming the package.
- Logs/search terms: `SlidingExpirationRearmFailed`, `SlidingExpirationRefreshFailed`, `DeserializationFailed`, Redis `NOSCRIPT`, Redis `ERR value is not an integer`, and elevated cache L2 warning logs.
- Metrics/signals to watch: Redis command error rate, Redis latency, app cache exception rate, cache-backed endpoint latency, and unexpected Redis key TTL churn for set-heavy workloads.
- Healthy signal: no new Redis script errors, no fractional increment failures, stable cache-backed request latency, and Redis set keys expiring/persisting according to member expiration.
- Failure trigger/mitigation: if Redis script errors or cache exception rates rise after deployment, roll back to the previous package version and capture the failing Redis command/error plus affected cache key pattern.
