### PR TITLE
perf: behavior-preserving hot-path quick wins (5 packages)

### DIFF
--- a/src/Headless.Api.Core/Middlewares/ServerTimingMiddleware.cs
+++ b/src/Headless.Api.Core/Middlewares/ServerTimingMiddleware.cs
@@ -38,7 +38,12 @@ internal sealed class ServerTimingMiddleware : IMiddleware
         await next(context).ConfigureAwait(false);
         var elapsedTime = Stopwatch.GetElapsedTime(timestamp);
 
-        FormattableString serverTiming = $"app;dur={(long)elapsedTime.TotalMicroseconds}.0";
-        context.Response.AppendTrailer(_ServerTimingHttpHeader, serverTiming.ToString(CultureInfo.InvariantCulture));
+        // string.Create with the interpolated-string handler formats directly into a pooled buffer with
+        // invariant culture, avoiding the FormattableString object + boxed object[] args allocation.
+        var serverTiming = string.Create(
+            CultureInfo.InvariantCulture,
+            $"app;dur={(long)elapsedTime.TotalMicroseconds}.0"
+        );
+        context.Response.AppendTrailer(_ServerTimingHttpHeader, serverTiming);
     }
 }

--- a/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Primitives;
 namespace Headless.Api;
 
 internal sealed partial class IdempotencyMiddleware(
-    IOptionsSnapshot<IdempotencyOptions> optionsSnapshot,
+    IOptionsMonitor<IdempotencyOptions> optionsMonitor,
     ICache cache,
     ICurrentTenant currentTenant,
     ICurrentUser currentUser,
@@ -59,7 +59,9 @@ internal sealed partial class IdempotencyMiddleware(
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         var ct = cancellationTokenProvider.Token;
-        var appOptions = optionsSnapshot.Value;
+        // IOptionsMonitor.CurrentValue is a cached singleton read that still observes reloads, avoiding the
+        // per-request options rebuild + FluentValidation pass that IOptionsSnapshot.Value forces per scope.
+        var appOptions = optionsMonitor.CurrentValue;
 
         // Read the idempotency-key header using the app-level HeaderName *before* resolving
         // endpoint metadata. HeaderName overrides via WithIdempotency are deliberately ignored —
@@ -682,7 +684,7 @@ internal sealed partial class IdempotencyMiddleware(
         }
 
         // Clone + merge per request. A static cache keyed by metadata captured `appOptions` from
-        // the first observation, which silently ignored subsequent IOptionsSnapshot reloads for
+        // the first observation, which silently ignored subsequent IOptionsMonitor reloads for
         // endpoints with WithIdempotency(...) while plain endpoints honored reloads — an
         // asymmetric drift that was very hard to debug. Cloning per request costs a struct copy
         // plus two HashSet allocations (Methods, ReplayHeaderAllowlist), well below request-flow

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -685,8 +685,9 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var redisValue = await _database.StringGetAsync(_GetKey(key), options.ReadMode).ConfigureAwait(false);
-        return await _RedisValueToCacheValueAsync<T>(_GetKey(key), redisValue).ConfigureAwait(false);
+        var redisKey = _GetKey(key);
+        var redisValue = await _database.StringGetAsync(redisKey, options.ReadMode).ConfigureAwait(false);
+        return await _RedisValueToCacheValueAsync<T>(redisKey, redisValue).ConfigureAwait(false);
     }
 
     public async ValueTask<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(

--- a/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
+++ b/src/Headless.Coordination.SqlServer/SqlServerMembershipStore.cs
@@ -23,6 +23,15 @@ internal sealed class SqlServerMembershipStore(
     private const int _MaxDeadlockRetryAttempts = 2;
     private readonly ResiliencePipeline _deadlockRetryPipeline = _BuildDeadlockRetryPipeline(timeProvider, logger);
 
+    // Membership SQL is invariant after construction (the schema is fixed in IOptions and the store is a DI
+    // singleton), so the per-tick paths (heartbeat, liveness reads, retention prune) precompute their command
+    // text once instead of rebuilding ~40-line strings every beat. The lifecycle paths (allocate/upsert/leave)
+    // run once per node and keep building inline.
+    private readonly string _heartbeatSql = _BuildHeartbeatSql(providerOptions.Value.Schema);
+    private readonly string _readLivenessSql = _BuildReadLivenessSql(providerOptions.Value.Schema);
+    private readonly string _readNodeLivenessSql = _BuildReadNodeLivenessSql(providerOptions.Value.Schema);
+    private readonly string _pruneExpiredRowsSql = _BuildPruneExpiredRowsSql(providerOptions.Value.Schema);
+
     protected override async ValueTask<NodeIncarnation> AllocateIncarnationCoreAsync(
         string clusterName,
         NodeId nodeId,
@@ -205,51 +214,6 @@ internal sealed class SqlServerMembershipStore(
         CancellationToken cancellationToken
     )
     {
-        var generationTable = _Qualified(SqlServerMembershipSchema.Generation.Table);
-        var livenessTable = _Qualified(SqlServerMembershipSchema.Liveness.Table);
-        var sql = $$"""
-            DECLARE @currentIncarnation bigint;
-
-            SELECT @currentIncarnation = [{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}]
-            FROM {{generationTable}} WITH (UPDLOCK, HOLDLOCK)
-            WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-              AND [{{SqlServerMembershipSchema.NodeId}}] = @NodeId;
-
-            IF @currentIncarnation IS NULL OR @currentIncarnation <> @Incarnation
-            BEGIN
-                SELECT CAST(0 AS bit);
-                RETURN;
-            END;
-
-            UPDATE {{livenessTable}} WITH (UPDLOCK, HOLDLOCK)
-            SET [{{SqlServerMembershipSchema.Liveness.LastBeat}}] = SYSUTCDATETIME(),
-                [{{SqlServerMembershipSchema.Liveness.LeftAt}}] = NULL
-            WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-              AND [{{SqlServerMembershipSchema.NodeId}}] = @NodeId
-              AND [{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation;
-
-            IF @@ROWCOUNT = 0
-            BEGIN
-                INSERT INTO {{livenessTable}} (
-                    [{{SqlServerMembershipSchema.ClusterName}}],
-                    [{{SqlServerMembershipSchema.NodeId}}],
-                    [{{SqlServerMembershipSchema.Incarnation}}],
-                    [{{SqlServerMembershipSchema.Liveness.LastBeat}}],
-                    [{{SqlServerMembershipSchema.Liveness.LeftAt}}]
-                )
-                SELECT @ClusterName, @NodeId, @Incarnation, SYSUTCDATETIME(), NULL
-                WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM {{livenessTable}} WITH (UPDLOCK, HOLDLOCK)
-                    WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-                      AND [{{SqlServerMembershipSchema.NodeId}}] = @NodeId
-                      AND [{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation
-                );
-            END;
-
-            SELECT CAST(1 AS bit);
-            """;
-
         return await _ExecuteWithDeadlockRetryAsync(
                 "Heartbeat",
                 async ct =>
@@ -258,7 +222,7 @@ internal sealed class SqlServerMembershipStore(
                     await connection.OpenAsync(ct).ConfigureAwait(false);
                     await using var transaction = (SqlTransaction)
                         await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
-                    await using var command = _CreateCommand(connection, sql, transaction);
+                    await using var command = _CreateCommand(connection, _heartbeatSql, transaction);
                     command.Parameters.AddWithValue("ClusterName", clusterName);
                     command.Parameters.AddWithValue("NodeId", identity.NodeId.Value);
                     command.Parameters.AddWithValue("Incarnation", identity.Incarnation.Value);
@@ -304,39 +268,11 @@ internal sealed class SqlServerMembershipStore(
         CancellationToken cancellationToken
     )
     {
-        var generationTable = _Qualified(SqlServerMembershipSchema.Generation.Table);
-        var descriptorTable = _Qualified(SqlServerMembershipSchema.Descriptor.Table);
-        var livenessTable = _Qualified(SqlServerMembershipSchema.Liveness.Table);
-        var sql = $$"""
-            SELECT
-                l.[{{SqlServerMembershipSchema.NodeId}}],
-                l.[{{SqlServerMembershipSchema.Incarnation}}],
-                d.[{{SqlServerMembershipSchema.Descriptor.Role}}],
-                d.[{{SqlServerMembershipSchema.Descriptor.Metadata}}],
-                CASE
-                    WHEN l.[{{SqlServerMembershipSchema.Liveness.LeftAt}}] IS NOT NULL THEN @DeadState
-                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @DeadThresholdMs THEN @DeadState
-                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @SuspicionThresholdMs THEN @SuspectedState
-                    ELSE @AliveState
-                END AS [state]
-            FROM {{livenessTable}} l
-            JOIN {{generationTable}} g
-              ON g.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
-             AND g.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
-             AND g.[{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
-            LEFT JOIN {{descriptorTable}} d
-              ON d.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
-             AND d.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
-             AND d.[{{SqlServerMembershipSchema.Incarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
-            WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-            ORDER BY l.[{{SqlServerMembershipSchema.NodeId}}], l.[{{SqlServerMembershipSchema.Incarnation}}];
-            """;
-
         await using var connection = providerOptions.Value.CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         // Pruning is best-effort cleanup; do not abort it on the caller's read cancellation.
         await _PruneExpiredRowsAsync(connection, clusterName, CancellationToken.None).ConfigureAwait(false);
-        await using var command = _CreateCommand(connection, sql);
+        await using var command = _CreateCommand(connection, _readLivenessSql);
         command.Parameters.AddWithValue("ClusterName", clusterName);
         command.Parameters.AddWithValue("DeadThresholdMs", _ToMilliseconds(DeadThreshold));
         command.Parameters.AddWithValue("SuspicionThresholdMs", _ToMilliseconds(SuspicionThreshold));
@@ -361,35 +297,9 @@ internal sealed class SqlServerMembershipStore(
         CancellationToken cancellationToken
     )
     {
-        var generationTable = _Qualified(SqlServerMembershipSchema.Generation.Table);
-        var livenessTable = _Qualified(SqlServerMembershipSchema.Liveness.Table);
-
-        // Targeted single-row read: join to the generation authority so a non-current incarnation yields no
-        // row (absent -> null), classify with the store clock identically to ReadCurrentLivenessCoreAsync, and
-        // exclude retention-expired rows in the WHERE so they read as absent (null) exactly as the snapshot's
-        // prune would remove them. Plain read: no SERIALIZABLE transaction, no deadlock retry, no prune.
-        var sql = $$"""
-            SELECT
-                CASE
-                    WHEN l.[{{SqlServerMembershipSchema.Liveness.LeftAt}}] IS NOT NULL THEN @DeadState
-                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @DeadThresholdMs THEN @DeadState
-                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @SuspicionThresholdMs THEN @SuspectedState
-                    ELSE @AliveState
-                END AS [state]
-            FROM {{livenessTable}} l
-            JOIN {{generationTable}} g
-              ON g.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
-             AND g.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
-             AND g.[{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
-            WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-              AND l.[{{SqlServerMembershipSchema.NodeId}}] = @NodeId
-              AND l.[{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation
-              AND DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) < @RetentionThresholdMs;
-            """;
-
         await using var connection = providerOptions.Value.CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var command = _CreateCommand(connection, sql);
+        await using var command = _CreateCommand(connection, _readNodeLivenessSql);
         command.Parameters.AddWithValue("ClusterName", clusterName);
         command.Parameters.AddWithValue("NodeId", identity.NodeId.Value);
         command.Parameters.AddWithValue("Incarnation", identity.Incarnation.Value);
@@ -411,27 +321,7 @@ internal sealed class SqlServerMembershipStore(
         CancellationToken cancellationToken
     )
     {
-        var descriptorTable = _Qualified(SqlServerMembershipSchema.Descriptor.Table);
-        var livenessTable = _Qualified(SqlServerMembershipSchema.Liveness.Table);
-        var sql = $$"""
-            DELETE FROM {{livenessTable}}
-            WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-              AND DATEDIFF_BIG(millisecond, [{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @RetentionThresholdMs;
-
-            DELETE d
-            FROM {{descriptorTable}} d
-            WHERE d.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
-              AND DATEDIFF_BIG(millisecond, d.[{{SqlServerMembershipSchema.DateCreated}}], SYSUTCDATETIME()) >= @RetentionThresholdMs
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM {{livenessTable}} l
-                  WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = d.[{{SqlServerMembershipSchema.ClusterName}}]
-                    AND l.[{{SqlServerMembershipSchema.NodeId}}] = d.[{{SqlServerMembershipSchema.NodeId}}]
-                    AND l.[{{SqlServerMembershipSchema.Incarnation}}] = d.[{{SqlServerMembershipSchema.Incarnation}}]
-              );
-            """;
-
-        await using var command = _CreateCommand(connection, sql);
+        await using var command = _CreateCommand(connection, _pruneExpiredRowsSql);
         command.Parameters.AddWithValue("ClusterName", clusterName);
         command.Parameters.AddWithValue("RetentionThresholdMs", _ToMilliseconds(DeadThreshold + DeadRetentionWindow));
 
@@ -450,6 +340,155 @@ internal sealed class SqlServerMembershipStore(
     private string _Qualified(string table)
     {
         return SqlServerCoordinationIdentifier.Qualified(providerOptions.Value.Schema, table);
+    }
+
+    private static string _BuildHeartbeatSql(string schema)
+    {
+        var generationTable = SqlServerCoordinationIdentifier.Qualified(
+            schema,
+            SqlServerMembershipSchema.Generation.Table
+        );
+        var livenessTable = SqlServerCoordinationIdentifier.Qualified(schema, SqlServerMembershipSchema.Liveness.Table);
+
+        return $$"""
+            DECLARE @currentIncarnation bigint;
+
+            SELECT @currentIncarnation = [{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}]
+            FROM {{generationTable}} WITH (UPDLOCK, HOLDLOCK)
+            WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+              AND [{{SqlServerMembershipSchema.NodeId}}] = @NodeId;
+
+            IF @currentIncarnation IS NULL OR @currentIncarnation <> @Incarnation
+            BEGIN
+                SELECT CAST(0 AS bit);
+                RETURN;
+            END;
+
+            UPDATE {{livenessTable}} WITH (UPDLOCK, HOLDLOCK)
+            SET [{{SqlServerMembershipSchema.Liveness.LastBeat}}] = SYSUTCDATETIME(),
+                [{{SqlServerMembershipSchema.Liveness.LeftAt}}] = NULL
+            WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+              AND [{{SqlServerMembershipSchema.NodeId}}] = @NodeId
+              AND [{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO {{livenessTable}} (
+                    [{{SqlServerMembershipSchema.ClusterName}}],
+                    [{{SqlServerMembershipSchema.NodeId}}],
+                    [{{SqlServerMembershipSchema.Incarnation}}],
+                    [{{SqlServerMembershipSchema.Liveness.LastBeat}}],
+                    [{{SqlServerMembershipSchema.Liveness.LeftAt}}]
+                )
+                SELECT @ClusterName, @NodeId, @Incarnation, SYSUTCDATETIME(), NULL
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM {{livenessTable}} WITH (UPDLOCK, HOLDLOCK)
+                    WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+                      AND [{{SqlServerMembershipSchema.NodeId}}] = @NodeId
+                      AND [{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation
+                );
+            END;
+
+            SELECT CAST(1 AS bit);
+            """;
+    }
+
+    private static string _BuildReadLivenessSql(string schema)
+    {
+        var generationTable = SqlServerCoordinationIdentifier.Qualified(
+            schema,
+            SqlServerMembershipSchema.Generation.Table
+        );
+        var descriptorTable = SqlServerCoordinationIdentifier.Qualified(
+            schema,
+            SqlServerMembershipSchema.Descriptor.Table
+        );
+        var livenessTable = SqlServerCoordinationIdentifier.Qualified(schema, SqlServerMembershipSchema.Liveness.Table);
+
+        return $$"""
+            SELECT
+                l.[{{SqlServerMembershipSchema.NodeId}}],
+                l.[{{SqlServerMembershipSchema.Incarnation}}],
+                d.[{{SqlServerMembershipSchema.Descriptor.Role}}],
+                d.[{{SqlServerMembershipSchema.Descriptor.Metadata}}],
+                CASE
+                    WHEN l.[{{SqlServerMembershipSchema.Liveness.LeftAt}}] IS NOT NULL THEN @DeadState
+                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @DeadThresholdMs THEN @DeadState
+                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @SuspicionThresholdMs THEN @SuspectedState
+                    ELSE @AliveState
+                END AS [state]
+            FROM {{livenessTable}} l
+            JOIN {{generationTable}} g
+              ON g.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
+             AND g.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
+             AND g.[{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
+            LEFT JOIN {{descriptorTable}} d
+              ON d.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
+             AND d.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
+             AND d.[{{SqlServerMembershipSchema.Incarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
+            WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+            ORDER BY l.[{{SqlServerMembershipSchema.NodeId}}], l.[{{SqlServerMembershipSchema.Incarnation}}];
+            """;
+    }
+
+    private static string _BuildReadNodeLivenessSql(string schema)
+    {
+        var generationTable = SqlServerCoordinationIdentifier.Qualified(
+            schema,
+            SqlServerMembershipSchema.Generation.Table
+        );
+        var livenessTable = SqlServerCoordinationIdentifier.Qualified(schema, SqlServerMembershipSchema.Liveness.Table);
+
+        // Targeted single-row read: join to the generation authority so a non-current incarnation yields no
+        // row (absent -> null), classify with the store clock identically to ReadCurrentLivenessCoreAsync, and
+        // exclude retention-expired rows in the WHERE so they read as absent (null) exactly as the snapshot's
+        // prune would remove them. Plain read: no SERIALIZABLE transaction, no deadlock retry, no prune.
+        return $$"""
+            SELECT
+                CASE
+                    WHEN l.[{{SqlServerMembershipSchema.Liveness.LeftAt}}] IS NOT NULL THEN @DeadState
+                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @DeadThresholdMs THEN @DeadState
+                    WHEN DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @SuspicionThresholdMs THEN @SuspectedState
+                    ELSE @AliveState
+                END AS [state]
+            FROM {{livenessTable}} l
+            JOIN {{generationTable}} g
+              ON g.[{{SqlServerMembershipSchema.ClusterName}}] = l.[{{SqlServerMembershipSchema.ClusterName}}]
+             AND g.[{{SqlServerMembershipSchema.NodeId}}] = l.[{{SqlServerMembershipSchema.NodeId}}]
+             AND g.[{{SqlServerMembershipSchema.Generation.CurrentIncarnation}}] = l.[{{SqlServerMembershipSchema.Incarnation}}]
+            WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+              AND l.[{{SqlServerMembershipSchema.NodeId}}] = @NodeId
+              AND l.[{{SqlServerMembershipSchema.Incarnation}}] = @Incarnation
+              AND DATEDIFF_BIG(millisecond, l.[{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) < @RetentionThresholdMs;
+            """;
+    }
+
+    private static string _BuildPruneExpiredRowsSql(string schema)
+    {
+        var descriptorTable = SqlServerCoordinationIdentifier.Qualified(
+            schema,
+            SqlServerMembershipSchema.Descriptor.Table
+        );
+        var livenessTable = SqlServerCoordinationIdentifier.Qualified(schema, SqlServerMembershipSchema.Liveness.Table);
+
+        return $$"""
+            DELETE FROM {{livenessTable}}
+            WHERE [{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+              AND DATEDIFF_BIG(millisecond, [{{SqlServerMembershipSchema.Liveness.LastBeat}}], SYSUTCDATETIME()) >= @RetentionThresholdMs;
+
+            DELETE d
+            FROM {{descriptorTable}} d
+            WHERE d.[{{SqlServerMembershipSchema.ClusterName}}] = @ClusterName
+              AND DATEDIFF_BIG(millisecond, d.[{{SqlServerMembershipSchema.DateCreated}}], SYSUTCDATETIME()) >= @RetentionThresholdMs
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM {{livenessTable}} l
+                  WHERE l.[{{SqlServerMembershipSchema.ClusterName}}] = d.[{{SqlServerMembershipSchema.ClusterName}}]
+                    AND l.[{{SqlServerMembershipSchema.NodeId}}] = d.[{{SqlServerMembershipSchema.NodeId}}]
+                    AND l.[{{SqlServerMembershipSchema.Incarnation}}] = d.[{{SqlServerMembershipSchema.Incarnation}}]
+              );
+            """;
     }
 
     private static long _ToMilliseconds(TimeSpan value)

--- a/src/Headless.Mediator/Behaviors/RequestLoggingBehavior.cs
+++ b/src/Headless.Mediator/Behaviors/RequestLoggingBehavior.cs
@@ -28,6 +28,13 @@ public sealed class RequestLoggingBehavior<TMessage, TResponse>(
     /// <returns>A completed <see cref="ValueTask"/> because logging is synchronous.</returns>
     protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
     {
+        // Gate before building args: LoggerMessage.Define checks IsEnabled inside the delegate, but C#
+        // evaluates _currentUser.UserId?.ToString() (a string allocation) first. Skip it when Debug is off.
+        if (!_logger.IsEnabled(LogLevel.Debug))
+        {
+            return ValueTask.CompletedTask;
+        }
+
         _LogMediatorMessage(
             _logger,
             userId: _currentUser.UserId?.ToString(),

--- a/src/Headless.Mediator/Behaviors/ResponseLoggingBehavior.cs
+++ b/src/Headless.Mediator/Behaviors/ResponseLoggingBehavior.cs
@@ -29,6 +29,13 @@ public sealed class ResponseLoggingBehavior<TMessage, TResponse>(
     /// <returns>A completed <see cref="ValueTask"/> because logging is synchronous.</returns>
     protected override ValueTask Handle(TMessage message, TResponse response, CancellationToken cancellationToken)
     {
+        // Gate before building args: LoggerMessage.Define checks IsEnabled inside the delegate, but C#
+        // evaluates _currentUser.UserId?.ToString() (a string allocation) first. Skip it when Debug is off.
+        if (!_logger.IsEnabled(LogLevel.Debug))
+        {
+            return ValueTask.CompletedTask;
+        }
+
         _LogMediatorResponse(
             _logger,
             userId: _currentUser.UserId?.ToString(),

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareCustomHooksTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareCustomHooksTests.cs
@@ -21,8 +21,8 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
         ICurrentTenant? tenant = null
     )
     {
-        var snapshot = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        snapshot.Value.Returns(options);
+        var monitor = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        monitor.CurrentValue.Returns(options);
 
         // Default to a present tenant so the default key derivation produces a non-empty key;
         // tests that exercise pass-through-by-missing-identity supply their own substitutes.
@@ -32,7 +32,7 @@ public sealed class IdempotencyMiddlewareCustomHooksTests : IdempotencyMiddlewar
             tenant.Id.Returns("t1");
         }
 
-        return CreateMiddleware(options: snapshot, cache: cache, currentTenant: tenant);
+        return CreateMiddleware(options: monitor, cache: cache, currentTenant: tenant);
     }
 
     private static DefaultHttpContext _CreateLocalContext(

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTestBase.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTestBase.cs
@@ -23,7 +23,7 @@ namespace Tests;
 public abstract class IdempotencyMiddlewareTestBase : TestBase
 {
     internal IdempotencyMiddleware CreateMiddleware(
-        IOptionsSnapshot<IdempotencyOptions>? options = null,
+        IOptionsMonitor<IdempotencyOptions>? options = null,
         ICache? cache = null,
         ICurrentTenant? currentTenant = null,
         ICurrentUser? currentUser = null,
@@ -36,8 +36,8 @@ public abstract class IdempotencyMiddlewareTestBase : TestBase
     {
         if (options is null)
         {
-            var snapshot = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-            snapshot.Value.Returns(new IdempotencyOptions());
+            var snapshot = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+            snapshot.CurrentValue.Returns(new IdempotencyOptions());
             options = snapshot;
         }
 

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
@@ -305,8 +305,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         // With RequireUserIdentity=false the middleware permits tenant-only anonymous traffic.
         // The user segment in the cache key is empty (rather than a literal "anon") so a real
         // UserId equal to "anon" cannot collide with the anonymous bucket.
-        var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions { RequireUserIdentity = false });
+        var opts = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        opts.CurrentValue.Returns(new IdempotencyOptions { RequireUserIdentity = false });
 
         var cache = Substitute.For<ICache>();
         cache
@@ -541,8 +541,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
             .Conflict(Arg.Any<IReadOnlyCollection<ErrorDescriptor>>())
             .Returns(new ProblemDetails { Status = 409 });
 
-        var options = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        options.Value.Returns(new IdempotencyOptions { MismatchStatusCode = 409 });
+        var options = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        options.CurrentValue.Returns(new IdempotencyOptions { MismatchStatusCode = 409 });
 
         var middleware = CreateMiddleware(options: options, cache: cache, problemDetailsCreator: problemDetailsCreator);
         var context = CreateContext(idempotencyKey: "k1", body: body);
@@ -711,8 +711,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     {
         var sp = new ServiceCollection().AddLogging().AddSingleton(lockProvider).BuildServiceProvider();
 
-        var options = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        options.Value.Returns(new IdempotencyOptions { InFlightStrategy = InFlightStrategy.WaitAndReplay });
+        var options = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        options.CurrentValue.Returns(new IdempotencyOptions { InFlightStrategy = InFlightStrategy.WaitAndReplay });
 
         return CreateMiddleware(
             options: options,
@@ -1013,13 +1013,13 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
 
     // ── U8: oversize body (AE6) ───────────────────────────────────────────────
 
-    private static IOptionsSnapshot<IdempotencyOptions> _OptionsWithCap(
+    private static IOptionsMonitor<IdempotencyOptions> _OptionsWithCap(
         int cap,
         OversizeBehavior behavior = OversizeBehavior.Reject
     )
     {
-        var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions { MaxBodySizeForHashing = cap, OversizeBehavior = behavior });
+        var opts = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        opts.CurrentValue.Returns(new IdempotencyOptions { MaxBodySizeForHashing = cap, OversizeBehavior = behavior });
         return opts;
     }
 
@@ -1255,8 +1255,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     public async Task should_honor_consumer_overridden_cache_predicate()
     {
         // given — consumer says _ => true (cache everything), response is 503
-        var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions { ShouldCacheResponse = _ => true });
+        var opts = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        opts.CurrentValue.Returns(new IdempotencyOptions { ShouldCacheResponse = _ => true });
 
         byte[] body = [1, 2, 3];
         var cache = Substitute.For<ICache>();
@@ -1567,8 +1567,10 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
         byte[] body = [1, 2, 3];
         byte[] fakeFingerprint = [0xDE, 0xAD, 0xBE, 0xEF];
 
-        var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions { RequestFingerprint = _ => new ValueTask<byte[]>(fakeFingerprint) });
+        var opts = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        opts.CurrentValue.Returns(
+            new IdempotencyOptions { RequestFingerprint = _ => new ValueTask<byte[]>(fakeFingerprint) }
+        );
 
         var cache = Substitute.For<ICache>();
         cache
@@ -1620,8 +1622,8 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     [Fact]
     public async Task should_pass_inflight_marker_ttl_equal_to_key_expiration()
     {
-        var opts = Substitute.For<IOptionsSnapshot<IdempotencyOptions>>();
-        opts.Value.Returns(new IdempotencyOptions { IdempotencyKeyExpiration = TimeSpan.FromHours(7) });
+        var opts = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        opts.CurrentValue.Returns(new IdempotencyOptions { IdempotencyKeyExpiration = TimeSpan.FromHours(7) });
 
         TimeSpan? capturedMarkerTtl = null;
         var cache = Substitute.For<ICache>();


### PR DESCRIPTION
Five behavior-preserving runtime-perf fixes from the hot-path audit (`.context/docs/perf-audit-22-06-2026.md`), one package per commit. All verified-building; unit tests pass where they exist. No observable-behavior changes (ordering, retry, cancellation, threading, defaults, SQL text, log output all preserved). The Hi-impact findings that need benchmark-gating are intentionally **not** in this PR.

## Changes

| Finding | Package | Change |
|---|---|---|
| F-7 | Mediator | `RequestLoggingBehavior`/`ResponseLoggingBehavior` evaluated `_currentUser.UserId?.ToString()` before `LoggerMessage`'s internal `IsEnabled` gate — wasted string alloc per send/response when Debug is off (prod default). Now short-circuits on `!IsEnabled(Debug)`. |
| F-8 | Caching.Redis | `GetAsync` called `_GetKey(key)` (a `string.Concat`) twice per get — build the prefixed key once. |
| F-13 | Api.Core | `ServerTimingMiddleware` used `FormattableString` + `ToString(InvariantCulture)`. Switched to `string.Create` + interpolated handler — drops the `FormattableString` object + boxed `object[]` args, keeps invariant culture. |
| F-9 | Api.Idempotency | `IdempotencyMiddleware` read `IOptionsSnapshot.Value` per request, forcing a per-scope options rebuild + FluentValidation pass on every request (incl. the common no-key pass-through). Now `IOptionsMonitor.CurrentValue` — cached singleton read that still observes reloads. Tests updated to substitute `IOptionsMonitor`. |
| F-10 | Coordination.SqlServer | Heartbeat, liveness reads, and retention prune rebuilt ~40-line interpolated SQL every call (runtime-qualified table names). Schema is fixed in `IOptions` + the store is a DI singleton, so precompute via static builders at construction (matching the Postgres provider, whose SQL is a compile-time `const`). One-time lifecycle paths (allocate/upsert/leave) left inline. |

## Verification
- All 5 projects build clean (0 warnings / 0 errors).
- Mediator: 19/19 unit tests. Api.Core: 291/291. Idempotency: 190/190.
- Redis + SqlServer integration tests need Docker (not run here); their changes are text-/key-identical by construction.
- CSharpier clean.

## Notes
- F-9 touched 3 idempotency test files: the middleware now genuinely depends on `IOptionsMonitor`, so the white-box test helpers were updated to substitute it (rather than bridging).
- F-10 scoped to the per-tick hot paths only; once-per-node lifecycle SQL is left inline (one-time cost, down-ranked by the audit).

## Deliberately excluded
Hi-impact findings (F-1 Redis concurrency-stamp base64, F-2/F-3 messaging dispatch, F-4 ORM nav-tracker O(N²), F-5 jobs poll projections) — these change risk profile / need BenchmarkDotNet gating, and several paths have no benchmark harness yet. F-6 (messaging default-serializer-options deserialize) is a correctness fix that changes observable behavior, so it's tracked separately.