### PR TITLE
perf(messaging): cache consume-dispatch invoker and middleware service type

### DIFF
--- a/src/Headless.Messaging.Core/Internal/ConsumeMiddlewarePipeline.cs
+++ b/src/Headless.Messaging.Core/Internal/ConsumeMiddlewarePipeline.cs
@@ -3,7 +3,6 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using FastExpressionCompiler;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Messages;
@@ -32,6 +31,15 @@ internal sealed class ConsumeMiddlewarePipeline(
 {
     private static readonly ConcurrentDictionary<MiddlewareDispatchKey, ConsumeMiddlewareInvoker> _TypedInvokers =
         new();
+
+    // Caches a compiled delegate per message type that calls the strongly-typed
+    // IMessageDispatcher.DispatchInScopeAsync<TMessage>(...) overload, so the per-dispatch path avoids the
+    // reflective GetMethods().Single(...).MakeGenericMethod(...).Invoke(...) the fallback used to run per message.
+    private static readonly ConcurrentDictionary<Type, DispatchInvoker> _DispatchInvokers = new();
+
+    // Caches the IConsumeMiddleware<TContext> closed service type per concrete ConsumeContext type, so the
+    // resolution path avoids running MakeGenericType on every dispatch.
+    private static readonly ConcurrentDictionary<Type, Type> _TypedMiddlewareServiceTypes = new();
 
     private readonly ConcurrentDictionary<
         Type,
@@ -188,7 +196,8 @@ internal sealed class ConsumeMiddlewarePipeline(
 
     private object[] _ResolveMiddleware(IServiceProvider provider, ConsumeContext context, string? groupName)
     {
-        var directMiddleware = _ResolveDirectMiddleware(provider, context).ToArray();
+        // _ResolveDirectMiddleware already materializes a fresh array; reuse it directly instead of copying again.
+        var directMiddleware = _ResolveDirectMiddleware(provider, context);
 
         if (
             descriptorRegistry is not null
@@ -208,7 +217,10 @@ internal sealed class ConsumeMiddlewarePipeline(
 
     private static object[] _ResolveDirectMiddleware(IServiceProvider provider, ConsumeContext context)
     {
-        var typedServiceType = typeof(IConsumeMiddleware<>).MakeGenericType(context.GetType());
+        var typedServiceType = _TypedMiddlewareServiceTypes.GetOrAdd(
+            context.GetType(),
+            static contextType => typeof(IConsumeMiddleware<>).MakeGenericType(contextType)
+        );
         var busMiddleware = provider.GetServices<IConsumeMiddleware<ConsumeContext>>().Cast<object>();
         var typedMiddleware = provider
             .GetServices(typedServiceType)
@@ -402,7 +414,7 @@ internal sealed class ConsumeMiddlewarePipeline(
         return new DateTimeOffset(DateTime.SpecifyKind(added, DateTimeKind.Utc), TimeSpan.Zero);
     }
 
-    private static async Task _DispatchAsync(
+    private static Task _DispatchAsync(
         IMessageDispatcher dispatcher,
         IServiceProvider serviceProvider,
         ConsumerExecutorDescriptor descriptor,
@@ -411,6 +423,17 @@ internal sealed class ConsumeMiddlewarePipeline(
         CancellationToken cancellationToken
     )
     {
+        var invoker = _DispatchInvokers.GetOrAdd(messageType, _CompileDispatchInvoker);
+
+        // Calling the compiled delegate invokes the generic overload directly, so handler exceptions propagate
+        // unwrapped (no TargetInvocationException) — the same observable result the old reflective unwrap produced.
+        return invoker(dispatcher, serviceProvider, descriptor, consumeContext, cancellationToken);
+    }
+
+    private static DispatchInvoker _CompileDispatchInvoker(Type messageType)
+    {
+        var consumeContextType = typeof(ConsumeContext<>).MakeGenericType(messageType);
+
         var dispatchMethod = typeof(IMessageDispatcher)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Single(method =>
@@ -420,19 +443,31 @@ internal sealed class ConsumeMiddlewarePipeline(
             )
             .MakeGenericMethod(messageType);
 
-        Task task;
-        try
-        {
-            task = (Task)
-                dispatchMethod.Invoke(dispatcher, [serviceProvider, descriptor, consumeContext, cancellationToken])!;
-        }
-        catch (TargetInvocationException ex) when (ex.InnerException is not null)
-        {
-            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-            throw;
-        }
+        var dispatcherParam = Expression.Parameter(typeof(IMessageDispatcher), "dispatcher");
+        var serviceProviderParam = Expression.Parameter(typeof(IServiceProvider), "serviceProvider");
+        var descriptorParam = Expression.Parameter(typeof(ConsumerExecutorDescriptor), "descriptor");
+        var consumeContextParam = Expression.Parameter(typeof(object), "consumeContext");
+        var cancellationTokenParam = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
 
-        await task.ConfigureAwait(false);
+        var body = Expression.Call(
+            dispatcherParam,
+            dispatchMethod,
+            serviceProviderParam,
+            descriptorParam,
+            Expression.Convert(consumeContextParam, consumeContextType),
+            cancellationTokenParam
+        );
+
+        return Expression
+            .Lambda<DispatchInvoker>(
+                body,
+                dispatcherParam,
+                serviceProviderParam,
+                descriptorParam,
+                consumeContextParam,
+                cancellationTokenParam
+            )
+            .CompileFast();
     }
 
     private static void _ValidateIntentHeader(
@@ -479,5 +514,13 @@ internal sealed class ConsumeMiddlewarePipeline(
         object middleware,
         ConsumeContext context,
         Func<ValueTask> next
+    );
+
+    private delegate Task DispatchInvoker(
+        IMessageDispatcher dispatcher,
+        IServiceProvider serviceProvider,
+        ConsumerExecutorDescriptor descriptor,
+        object consumeContext,
+        CancellationToken cancellationToken
     );
 }


### PR DESCRIPTION
Two per-consume-dispatch allocation reductions in `ConsumeMiddlewarePipeline`, **validated by `Headless.Messaging.Benchmarks`** (added in the base PR #514). Stacked on #514 — retarget to `main` once that merges.

## Changes

- **F-3 — reflection dispatch fallback.** The `IConsume<T>` DI path (no runtime invoker) resolved + invoked `IMessageDispatcher.DispatchInScopeAsync<TMessage>` **reflectively per message**: `GetMethods().Single(...).MakeGenericMethod(...).Invoke(...)` + a boxed `object[]` args array + `CancellationToken` boxing. Replaced with a **compiled delegate cached per message type** (mirrors the existing `_TypedInvokers` / `_compiledConsumeContextFactories` + `CompileFast` pattern). Handler exceptions now propagate **unwrapped** directly — the same observable result the old `TargetInvocationException` unwrap produced.
- **F-2 — middleware resolution.** Cache the `IConsumeMiddleware<TContext>` closed service type per `ConsumeContext` type (no `MakeGenericType` per dispatch), and drop a redundant second `ToArray` over the already-materialized direct-middleware array.

## Measured (BenchmarkDotNet, ShortRun, MemoryDiagnoser; allocations deterministic)

| MiddlewareCount | Baseline | After F-3+F-2 | Δ Allocated |
|---|---|---|---|
| 0 | 1434 B / ~1.45 µs | **880 B / ~0.59 µs** | **−554 B (−39%)** |
| 1 | 1904 B | **1320 B** | −584 B (−31%) |
| 5 | 2867 B | **2256 B** | −611 B (−21%) |

F-3 accounts for ~485 B/op of that (and roughly halves latency); F-2 adds ~64–128 B/op.

## Verification
- `Headless.Messaging.Core.Tests.Unit`: **892/892 pass**, including the middleware-ordering and exception-propagation pipeline tests (the key behavior guards for F-3).
- Full solution build passes (pre-push hook); CSharpier clean.
- Behavior preserved: dispatch ordering, exception propagation (unwrapped), cancellation — all unchanged.

## Deliberately deferred
- **F-14** (per-dispatch `MessageHeader` copy, 376–656 B): lower value and changes `MessageHeader`'s public copy-isolation contract (aliasing risk across all consumers/middleware) — not worth it without broader consumer analysis.
- **F-2 descriptorRegistry worst case** (the per-dispatch `HashSet` rebuild in `_GetUntrackedDirectMiddleware`): real, but not on the path this benchmark covers and carries a "descriptors immutable post-startup" assumption — needs a dedicated benchmark variant first.