### PR TITLE
perf(domain)!: non-boxing typed equality hooks on EqualityBase

### DIFF
--- a/src/Headless.Domain/Domain/IAggregateRoot`T.cs
+++ b/src/Headless.Domain/Domain/IAggregateRoot`T.cs
@@ -25,7 +25,10 @@ public abstract class AggregateRoot<TId> : AggregateRoot, IAggregateRoot<TId>
     public override IReadOnlyList<object> GetKeys() => [Id];
 
     /// <inheritdoc/>
-    protected override IEnumerable<object?> EqualityComponents() => GetKeys();
+    protected override bool EqualityComponentsEqual(Entity other) => Id.Equals(((AggregateRoot<TId>)other).Id);
+
+    /// <inheritdoc/>
+    protected override void BuildHashCode(ref HashCode hash) => hash.Add(Id);
 
     /// <summary>Returns a diagnostic string of the form <c>[ENTITY: TypeName] Id = &lt;id&gt;</c>.</summary>
     public override string ToString() => $"[ENTITY: {GetType().Name}] Id = {Id}";

--- a/src/Headless.Domain/Domain/IEntity.cs
+++ b/src/Headless.Domain/Domain/IEntity.cs
@@ -23,7 +23,37 @@ public abstract class Entity : EqualityBase<Entity>, IEntity
     public abstract IReadOnlyList<object> GetKeys();
 
     /// <inheritdoc/>
-    protected override IEnumerable<object?> EqualityComponents() => GetKeys();
+    protected override bool EqualityComponentsEqual(Entity other)
+    {
+        var keys = GetKeys();
+        var otherKeys = other.GetKeys();
+
+        if (keys.Count != otherKeys.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < keys.Count; i++)
+        {
+            if (!Equals(keys[i], otherKeys[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    protected override void BuildHashCode(ref HashCode hash)
+    {
+        var keys = GetKeys();
+
+        for (var i = 0; i < keys.Count; i++)
+        {
+            hash.Add(keys[i]);
+        }
+    }
 
     /// <summary>Returns a diagnostic string of the form <c>[ENTITY: TypeName] Keys = k1, k2, ...</c>.</summary>
     public override string ToString() => $"[ENTITY: {GetType().Name}] Keys = {string.Join(", ", GetKeys())}";

--- a/src/Headless.Domain/Domain/IEntity`T.cs
+++ b/src/Headless.Domain/Domain/IEntity`T.cs
@@ -25,6 +25,12 @@ public abstract class Entity<TId> : Entity, IEntity<TId>
     /// <inheritdoc/>
     public override IReadOnlyList<object> GetKeys() => [Id];
 
+    /// <inheritdoc/>
+    protected override bool EqualityComponentsEqual(Entity other) => Id.Equals(((Entity<TId>)other).Id);
+
+    /// <inheritdoc/>
+    protected override void BuildHashCode(ref HashCode hash) => hash.Add(Id);
+
     /// <summary>Returns a diagnostic string of the form <c>[ENTITY: TypeName] Id = &lt;id&gt;</c>.</summary>
     public override string ToString() => $"[ENTITY: {GetType().Name}] Id = {Id}";
 }

--- a/src/Headless.Domain/Domain/ValueObject.cs
+++ b/src/Headless.Domain/Domain/ValueObject.cs
@@ -16,5 +16,12 @@ public interface IValueObject;
 /// (declared via <c>EqualityComponentsEqual</c> / <c>BuildHashCode</c>) are equal; neither instance needs a
 /// dedicated identity field.
 /// </summary>
+/// <remarks>
+/// Self-typed (<c>TSelf</c>) so the equality hooks receive the concrete type directly, e.g.
+/// <c>class Money : ValueObject&lt;Money&gt;</c> overrides <c>EqualityComponentsEqual(Money other)</c> with no
+/// cast. Use the non-generic <see cref="IValueObject"/> marker to reference value objects heterogeneously.
+/// </remarks>
+/// <typeparam name="TSelf">The concrete value-object type.</typeparam>
 [PublicAPI]
-public abstract class ValueObject : EqualityBase<ValueObject>, IValueObject;
+public abstract class ValueObject<TSelf> : EqualityBase<TSelf>, IValueObject
+    where TSelf : ValueObject<TSelf>;

--- a/src/Headless.Domain/Domain/ValueObject.cs
+++ b/src/Headless.Domain/Domain/ValueObject.cs
@@ -12,8 +12,9 @@ namespace Headless.Domain;
 public interface IValueObject;
 
 /// <summary>
-/// Base class for DDD value objects. Two instances are equal when all of their
-/// <c>EqualityComponents()</c> values are equal; neither instance needs a dedicated identity field.
+/// Base class for DDD value objects. Two instances are equal when all of their equality components
+/// (declared via <c>EqualityComponentsEqual</c> / <c>BuildHashCode</c>) are equal; neither instance needs a
+/// dedicated identity field.
 /// </summary>
 [PublicAPI]
 public abstract class ValueObject : EqualityBase<ValueObject>, IValueObject;

--- a/src/Headless.Domain/Helpers/EqualityBase.cs
+++ b/src/Headless.Domain/Helpers/EqualityBase.cs
@@ -5,12 +5,14 @@
 namespace Headless.Domain;
 
 /// <summary>
-/// Abstract base that implements structural equality for a type by delegating comparison
-/// to a sequence of <c>EqualityComponents()</c> values rather than reference identity.
+/// Abstract base that implements structural equality for a type by delegating comparison and hashing to
+/// strongly-typed hooks rather than reference identity.
 /// </summary>
 /// <remarks>
-/// Subclasses must override <c>EqualityComponents()</c> and return all fields that define equality.
-/// Two instances of the same concrete type are considered equal when every component compares equal in order.
+/// Subclasses override <see cref="EqualityComponentsEqual"/> (compare each equality-defining field to the
+/// other instance) and <see cref="BuildHashCode"/> (feed each equality-defining field into the hash). Both
+/// run without boxing value-type components, unlike an <c>IEnumerable&lt;object?&gt;</c> component sequence.
+/// Two instances of the same concrete type are equal when every component compares equal.
 /// </remarks>
 /// <typeparam name="T">The concrete subclass; used to constrain the typed <c>Equals</c> overload.</typeparam>
 [PublicAPI]
@@ -18,8 +20,8 @@ public abstract class EqualityBase<T> : IEquatable<T>
     where T : EqualityBase<T>
 {
     /// <summary>
-    /// Determines whether this instance is equal to <paramref name="other"/> by comparing
-    /// their runtime types and <c>EqualityComponents()</c> sequences.
+    /// Determines whether this instance is equal to <paramref name="other"/> by comparing their runtime
+    /// types and equality components.
     /// </summary>
     /// <param name="other">The instance to compare against, or <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if both instances have the same type and equal components; otherwise <see langword="false"/>.</returns>
@@ -35,7 +37,7 @@ public abstract class EqualityBase<T> : IEquatable<T>
             return true;
         }
 
-        return GetType() == other.GetType() && EqualityComponents().SequenceEqual(other.EqualityComponents());
+        return GetType() == other.GetType() && EqualityComponentsEqual(other);
     }
 
     /// <summary>Returns <see langword="true"/> when <paramref name="left"/> and <paramref name="right"/> are structurally equal.</summary>
@@ -60,23 +62,29 @@ public abstract class EqualityBase<T> : IEquatable<T>
         return Equals(obj as T);
     }
 
-    /// <summary>Computes a hash code from all <c>EqualityComponents()</c> values.</summary>
+    /// <summary>Computes a hash code from all equality components.</summary>
     /// <returns>A combined hash code consistent with <c>Equals</c>.</returns>
     public sealed override int GetHashCode()
     {
         var hash = new HashCode();
-
-        foreach (var component in EqualityComponents())
-        {
-            hash.Add(component);
-        }
+        BuildHashCode(ref hash);
 
         return hash.ToHashCode();
     }
 
     /// <summary>
-    /// Returns the ordered sequence of values that define equality for this instance.
-    /// Include every field or property that participates in identity; exclude transient or navigation state.
+    /// Compares this instance's equality components to <paramref name="other"/>. The caller guarantees
+    /// <paramref name="other"/> is non-null and has the same runtime type as this instance, so implementations
+    /// may cast it to the concrete type and compare fields directly without boxing.
     /// </summary>
-    protected abstract IEnumerable<object?> EqualityComponents();
+    /// <param name="other">The same-typed instance to compare against.</param>
+    /// <returns><see langword="true"/> when every equality component is equal; otherwise <see langword="false"/>.</returns>
+    protected abstract bool EqualityComponentsEqual(T other);
+
+    /// <summary>
+    /// Feeds each equality-defining component into <paramref name="hash"/>. Add the same components, in the
+    /// same set, that <see cref="EqualityComponentsEqual"/> compares, so equal instances hash equally.
+    /// </summary>
+    /// <param name="hash">The hash accumulator to add components to.</param>
+    protected abstract void BuildHashCode(ref HashCode hash);
 }

--- a/tests/Headless.Domain.Tests.Unit/Domain/ValueObjectTests.cs
+++ b/tests/Headless.Domain.Tests.Unit/Domain/ValueObjectTests.cs
@@ -6,18 +6,13 @@ namespace Tests.Domain;
 
 public sealed class ValueObjectTests
 {
-    private sealed class Address : ValueObject
+    private sealed class Address : ValueObject<Address>
     {
         public required string Street { get; init; }
 
         public required string City { get; init; }
 
-        protected override bool EqualityComponentsEqual(ValueObject other)
-        {
-            var o = (Address)other;
-
-            return Street == o.Street && City == o.City;
-        }
+        protected override bool EqualityComponentsEqual(Address other) => Street == other.Street && City == other.City;
 
         protected override void BuildHashCode(ref HashCode hash)
         {
@@ -31,7 +26,7 @@ public sealed class ValueObjectTests
     {
         var address = new Address { Street = "123 Main St", City = "Springfield" };
 
-        address.Should().BeAssignableTo<EqualityBase<ValueObject>>();
+        address.Should().BeAssignableTo<EqualityBase<Address>>();
     }
 
     [Fact]

--- a/tests/Headless.Domain.Tests.Unit/Domain/ValueObjectTests.cs
+++ b/tests/Headless.Domain.Tests.Unit/Domain/ValueObjectTests.cs
@@ -12,10 +12,17 @@ public sealed class ValueObjectTests
 
         public required string City { get; init; }
 
-        protected override IEnumerable<object?> EqualityComponents()
+        protected override bool EqualityComponentsEqual(ValueObject other)
         {
-            yield return Street;
-            yield return City;
+            var o = (Address)other;
+
+            return Street == o.Street && City == o.City;
+        }
+
+        protected override void BuildHashCode(ref HashCode hash)
+        {
+            hash.Add(Street);
+            hash.Add(City);
         }
     }
 

--- a/tests/Headless.Domain.Tests.Unit/Helpers/EqualityBaseTests.cs
+++ b/tests/Headless.Domain.Tests.Unit/Helpers/EqualityBaseTests.cs
@@ -12,10 +12,9 @@ public sealed class EqualityBaseTests
 
         public string? Description { get; init; }
 
-        protected override IEnumerable<object?> EqualityComponents()
-        {
-            yield return Id;
-        }
+        protected override bool EqualityComponentsEqual(IdEqualityItem other) => Id.Equals(other.Id);
+
+        protected override void BuildHashCode(ref HashCode hash) => hash.Add(Id);
     }
 
     private sealed class CompositeEqualityItem : EqualityBase<CompositeEqualityItem>
@@ -24,10 +23,13 @@ public sealed class EqualityBaseTests
 
         public int Value { get; init; }
 
-        protected override IEnumerable<object?> EqualityComponents()
+        protected override bool EqualityComponentsEqual(CompositeEqualityItem other) =>
+            Name == other.Name && Value == other.Value;
+
+        protected override void BuildHashCode(ref HashCode hash)
         {
-            yield return Name;
-            yield return Value;
+            hash.Add(Name);
+            hash.Add(Value);
         }
     }
 


### PR DESCRIPTION
Replaces the boxing `EqualityComponents()` contract on `EqualityBase<T>` with two strongly-typed hooks, and self-types `ValueObject` so overrides need no cast. This is the "Shape A" step of the equality de-boxing — the contained, no-EF-ripple part. The fuller typed-key `Entity<TId>` redesign (changing `GetKeys()`) remains a deliberate separate follow-up.

## Why
`EqualityBase<T>` exposed equality via `protected abstract IEnumerable<object?> EqualityComponents()`, so every `Equals`/`GetHashCode` **boxed** each value-type component, allocated **two `SequenceEqual` enumerators**, and re-enumerated with no hash memoization. It backs **both `ValueObject` and `Entity`**, so this fired on every dictionary/HashSet/EF-changetracker key probe.

## Change (commit 1) — typed hooks
```csharp
// before: protected abstract IEnumerable<object?> EqualityComponents();
// after:
protected abstract bool EqualityComponentsEqual(T other);   // typed compare, early-exit, no box
protected abstract void BuildHashCode(ref HashCode hash);   // typed hash, no box
```
- Value objects + any direct `EqualityBase<T>` subclass: compare/hash fields with zero boxing.
- `Entity<TId>` / `AggregateRoot<TId>`: compare/hash the typed `Id` directly (no box, no `GetKeys()` array). `GetKeys()` untouched — EF key mapping and `GetKey()` unaffected.
- Composite-key `Entity`: adapts over `GetKeys()` with an indexed loop + early-exit (no enumerator; keys stay boxed by the `GetKeys() : IReadOnlyList<object>` contract — the separate `Entity<TId>` follow-up).

## Change (commit 2) — no cast for value objects (CRTP)
```csharp
public abstract class ValueObject<TSelf> : EqualityBase<TSelf>, IValueObject where TSelf : ValueObject<TSelf>;

public sealed class Money : ValueObject<Money>
{
    protected override bool EqualityComponentsEqual(Money other) => Amount == other.Amount && Currency == other.Currency; // no cast
}
```
The non-generic `ValueObject` class is replaced by the existing `IValueObject` marker for heterogeneous references. The `Entity<TId>`/`AggregateRoot<TId>` cast stays — it's framework-internal (consumers inherit the hooks, never write it) and can't CRTP cleanly because of the `TId` axis plus the non-generic `Entity` base.

## Behavior preservation
Equality semantics and hash values preserved (`Id.Equals(other.Id)` via `IEquatable<TId>` matches the old boxed `object.Equals`; `HashCode.Add(Id)` feeds the same `Id.GetHashCode()`). Concrete framework records inherit the hooks unchanged. Full solution build clean; `Headless.Domain.Tests.Unit` 26/26; CSharpier clean.

## BREAKING CHANGE
- `Entity` subclasses that overrode `EqualityComponents()` move to `EqualityComponentsEqual` + `BuildHashCode`.
- Value objects derive from `ValueObject<TSelf>` (`class Money : ValueObject<Money>`) and override the typed hooks (no cast); use `IValueObject` for heterogeneous references.

Greenfield — breaking changes permitted per CLAUDE.md. Full composite-key entity de-box (the `Entity<TId>`/`GetKeys()` redesign) is a tracked separate follow-up.
