### PR TITLE
perf: assorted hot-path allocation fixes (slugs, local event bus)

### DIFF
--- a/src/Headless.Domain.LocalEventBus/ServiceProviderLocalEventBus.cs
+++ b/src/Headless.Domain.LocalEventBus/ServiceProviderLocalEventBus.cs
@@ -31,7 +31,14 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
         {
             try
             {
-                handler.HandleAsync(domainEvent).AsTask().WaitAndUnwrapException();
+                var pending = handler.HandleAsync(domainEvent);
+
+                // Avoid the ValueTask -> Task allocation for the common synchronously-completed handler; only
+                // fall back to AsTask() (to block / unwrap) when the handler did not finish synchronously.
+                if (!pending.IsCompletedSuccessfully)
+                {
+                    pending.AsTask().WaitAndUnwrapException();
+                }
             }
             catch (TargetInvocationException e)
             {
@@ -116,11 +123,13 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
         return _HandlerOrderCache.GetValue(handlerType, _ComputeHandlerOrder).Value;
     }
 
-    private static IEnumerable<IDomainEventHandler<T>> _OrderHandlers<T>(IEnumerable<IDomainEventHandler<T>> handlers)
+    private static IDomainEventHandler<T>[] _OrderHandlers<T>(IEnumerable<IDomainEventHandler<T>> handlers)
         where T : class, IDomainEvent
     {
-        // OrderBy is a stable sort but allocates a buffer on every publish. Skip it for the common 0/1-handler
-        // case, and for multi-handler sets where every handler keeps the default order (registration order wins).
+        // Return a concrete array so the foreach call sites iterate it with the array enumerator (no heap
+        // IEnumerator allocation). OrderBy is a stable sort but allocates a buffer on every publish, so skip
+        // it for the common 0/1-handler case and for multi-handler sets where every handler keeps the default
+        // order (registration order wins).
         var array = handlers as IDomainEventHandler<T>[] ?? handlers.ToArray();
 
         if (array.Length <= 1)
@@ -132,7 +141,7 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
         {
             if (_GetHandlerOrder(handler.GetType()) != 0)
             {
-                return array.OrderBy(handler => _GetHandlerOrder(handler.GetType()));
+                return array.OrderBy(ordered => _GetHandlerOrder(ordered.GetType())).ToArray();
             }
         }
 

--- a/src/Headless.Slugs/Slug.cs
+++ b/src/Headless.Slugs/Slug.cs
@@ -34,11 +34,22 @@ public static class Slug
         }
 
         options ??= new();
-        text = text.Normalize(NormalizationForm.FormD);
+
+        // Normalizing to NFD lets diacritic marks be stripped as non-spacing marks below. Skip the allocation
+        // when the input is already NFD (the common ASCII case) — IsNormalized is much cheaper than Normalize.
+        if (!text.IsNormalized(NormalizationForm.FormD))
+        {
+            text = text.Normalize(NormalizationForm.FormD);
+        }
 
         foreach (var (value, replacement) in options.Replacements)
         {
-            text = text.Replace(value, replacement, StringComparison.Ordinal);
+            // string.Replace allocates a new string even when the token is absent; most inputs contain none
+            // of the replacement tokens, so guard the (cheaper) Contains scan first.
+            if (text.Contains(value, StringComparison.Ordinal))
+            {
+                text = text.Replace(value, replacement, StringComparison.Ordinal);
+            }
         }
 
         var textLength = options.MaximumLength > 0 ? Math.Min(text.Length, options.MaximumLength) : text.Length;
@@ -47,8 +58,6 @@ public static class Slug
 
         foreach (var rune in text.EnumerateRunes())
         {
-            var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(rune.Value);
-
             if (options.IsAllowed(rune))
             {
                 var transformed = options.CasingTransformation switch
@@ -64,8 +73,9 @@ public static class Slug
                 sb.Append(transformed);
                 hasPreviousDash = false;
             }
+            // GetUnicodeCategory is only needed for disallowed runes, so compute it lazily here (not per rune).
             else if (
-                unicodeCategory != UnicodeCategory.NonSpacingMark
+                CharUnicodeInfo.GetUnicodeCategory(rune.Value) != UnicodeCategory.NonSpacingMark
                 && options.Separator is not null
                 && !_EndsWith(sb, options.Separator)
             )
@@ -93,7 +103,9 @@ public static class Slug
             }
         }
 
-        return text.Normalize(NormalizationForm.FormC);
+        // Skip the final NFC allocation when the result is already NFC (the common case once disallowed
+        // characters have been collapsed); IsNormalized short-circuits to the identical result.
+        return text.IsNormalized(NormalizationForm.FormC) ? text : text.Normalize(NormalizationForm.FormC);
     }
 
     private static bool _EndsWith(StringBuilder stringBuilder, string suffix)


### PR DESCRIPTION
Behavior-preserving per-call allocation reductions from a follow-up audit round over previously-uncovered packages (Slugs / MultiTenancy / Security / Domain event bus). One package per commit. MultiTenancy was confirmed entirely startup/DI (no per-request path) and Security crypto allocations are immaterial against PBKDF2 — so the wins land in `Slug.Create` and the local event bus.

## Changes

**`perf(slugs)` — `Slug.Create` (per content item / per generated URL):**
- Gate the NFD and final NFC `Normalize()` with `IsNormalized()` — the common already-normalized ASCII input skips the allocation `Normalize()` makes unconditionally.
- Guard each `options.Replacements` entry with `Contains()` before `string.Replace` (which allocates a new string per entry even when the token is absent; most inputs contain none of `& + . %`).
- Compute `CharUnicodeInfo.GetUnicodeCategory` lazily in the disallowed-rune branch instead of per rune.

**`perf(domain)` — `ServiceProviderLocalEventBus` (per domain-event publish):**
- Sync `Publish<T>` did `handler.HandleAsync(ev).AsTask().WaitAndUnwrapException()`, allocating a `Task` even when the handler completed synchronously (the common in-memory case). Now blocks via `AsTask()` only when the `ValueTask` didn't finish synchronously; exception unwrapping unchanged on the slow path.
- `_OrderHandlers` returned `IEnumerable<T>`, so the two `foreach` publish sites allocated a heap `IEnumerator` each publish. Now returns the concrete array (the common 0/1/default-order paths iterate it allocation-free).

## Verification
- `Headless.Slugs.Tests.Unit`: **72/72** (covers the normalization/replacement/diacritic edge cases — behavior preserved).
- `Headless.Domain.LocalEventBus.Tests.Unit`: **24/24**.
- Full solution build clean (pre-push hook); CSharpier clean.

## Not included
- `JsonInternalConverters` thread-safety + dead `IsInternalConverter` reflection (`Headless.Generator.Primitives.Abstractions`) — warmup/correctness rather than per-call perf, and dropping the reflection needs a dedicated serialization round-trip test. Tracked separately.