### PR TITLE
fix(ci): remove broken GitHub Actions MTP hook

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Headless.NET.Sdk": "0.0.116",
-    "Headless.NET.Sdk.Web": "0.0.116",
-    "Headless.NET.Sdk.Test": "0.0.116",
-    "Headless.NET.Sdk.Razor": "0.0.116",
-    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.116",
-    "Headless.NET.Sdk.WindowsDesktop": "0.0.116"
+    "Headless.NET.Sdk": "0.0.117",
+    "Headless.NET.Sdk.Web": "0.0.117",
+    "Headless.NET.Sdk.Test": "0.0.117",
+    "Headless.NET.Sdk.Razor": "0.0.117",
+    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.117",
+    "Headless.NET.Sdk.WindowsDesktop": "0.0.117"
   }
 }

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -4,4 +4,14 @@
     <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
+
+  <!--
+    GitHubActionsTestLogger is injected by Headless.NET.Sdk.Test for the VSTest path.
+    Its 3.x package also self-registers an MTP hook, but the net10.0 package has no
+    compile asset, so CI builds generate SelfRegisteredExtensions.cs with an unresolved
+    GitHubActionsTestLogger.MtpIntegration reference. MTP already emits GitHub annotations.
+  -->
+  <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <TestingPlatformBuilderHook Remove="708E03CB-DB8B-4A7B-98A0-477BADDFEFBE" />
+  </ItemGroup>
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -4,14 +4,4 @@
     <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
-
-  <!--
-    GitHubActionsTestLogger is injected by Headless.NET.Sdk.Test for the VSTest path.
-    Its 3.x package also self-registers an MTP hook, but the net10.0 package has no
-    compile asset, so CI builds generate SelfRegisteredExtensions.cs with an unresolved
-    GitHubActionsTestLogger.MtpIntegration reference. MTP already emits GitHub annotations.
-  -->
-  <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <TestingPlatformBuilderHook Remove="708E03CB-DB8B-4A7B-98A0-477BADDFEFBE" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove the GitHubActionsTestLogger MTP self-registration hook under GITHUB_ACTIONS
- keep the package available for the existing VSTest/logger path
- avoids generated SelfRegisteredExtensions.cs referencing GitHubActionsTestLogger.MtpIntegration without a compile asset

## Validation
- GITHUB_ACTIONS=true make build-project PROJECT=tests/Headless.Checks.Tests.Unit/Headless.Checks.Tests.Unit.csproj CONFIGURATION=Release
- make dashboards
- GITHUB_ACTIONS=true BuildDashboardSpa=false make ci-build
- pre-push hook: csharpier check + Release solution build, 0 warnings/errors