### PR TITLE
perf(messaging): drop per-publish payload copy (ASB) and LINQ attribute dict (SQS/SNS)

### DIFF
--- a/src/Headless.Messaging.Aws/AmazonSnsBusTransport.cs
+++ b/src/Headless.Messaging.Aws/AmazonSnsBusTransport.cs
@@ -35,13 +35,18 @@ internal sealed class AmazonSnsBusTransport(
                 // SNS requires a non-null message body; use empty string for empty bodies
                 var bodyJson = message.Body.Length > 0 ? Encoding.UTF8.GetString(message.Body.Span) : string.Empty;
 
-                var attributes = message
-                    .Headers.Where(x => x.Value != null)
-                    .ToDictionary(
-                        x => x.Key,
-                        x => new MessageAttributeValue { StringValue = x.Value, DataType = "String" },
-                        StringComparer.Ordinal
-                    );
+                var attributes = new Dictionary<string, MessageAttributeValue>(
+                    message.Headers.Count,
+                    StringComparer.Ordinal
+                );
+
+                foreach (var (key, value) in message.Headers)
+                {
+                    if (value is not null)
+                    {
+                        attributes[key] = new MessageAttributeValue { StringValue = value, DataType = "String" };
+                    }
+                }
 
                 var request = new PublishRequest(arn, bodyJson) { MessageAttributes = attributes };
 

--- a/src/Headless.Messaging.Aws/AmazonSqsQueueTransport.cs
+++ b/src/Headless.Messaging.Aws/AmazonSqsQueueTransport.cs
@@ -27,13 +27,18 @@ internal sealed class AmazonSqsQueueTransport(
             var queueName = message.GetName().NormalizeForSqsQueueName();
             var queueUrl = await _GetOrCreateQueueUrlAsync(queueName, cancellationToken).ConfigureAwait(false);
             var body = message.Body.Length > 0 ? Encoding.UTF8.GetString(message.Body.Span) : string.Empty;
-            var attributes = message
-                .Headers.Where(x => x.Value != null)
-                .ToDictionary(
-                    x => x.Key,
-                    x => new MessageAttributeValue { StringValue = x.Value, DataType = "String" },
-                    StringComparer.Ordinal
-                );
+            var attributes = new Dictionary<string, MessageAttributeValue>(
+                message.Headers.Count,
+                StringComparer.Ordinal
+            );
+
+            foreach (var (key, value) in message.Headers)
+            {
+                if (value is not null)
+                {
+                    attributes[key] = new MessageAttributeValue { StringValue = value, DataType = "String" };
+                }
+            }
 
             if (attributes.Count > _MaxMessageAttributes)
             {

--- a/src/Headless.Messaging.AzureServiceBus/AzureServiceBusMessageBuilder.cs
+++ b/src/Headless.Messaging.AzureServiceBus/AzureServiceBusMessageBuilder.cs
@@ -8,7 +8,9 @@ internal static class AzureServiceBusMessageBuilder
 {
     public static ServiceBusMessage Build(TransportMessage transportMessage, bool enableSessions)
     {
-        var message = new ServiceBusMessage(transportMessage.Body.ToArray())
+        // BinaryData.FromBytes wraps the ReadOnlyMemory without copying; ServiceBusMessage(byte[]) would force a
+        // full payload copy via Body.ToArray() on every publish.
+        var message = new ServiceBusMessage(BinaryData.FromBytes(transportMessage.Body))
         {
             MessageId = transportMessage.GetId(),
             Subject = transportMessage.GetName(),


### PR DESCRIPTION
Two verified, behavior-preserving per-publish allocation removals from the Round-4 catalog. One package per commit.

## Changes
- **`perf(messaging-asb)`** — `AzureServiceBusMessageBuilder.Build` did `new ServiceBusMessage(transportMessage.Body.ToArray())`, copying the whole payload every publish. `BinaryData.FromBytes(ReadOnlyMemory)` wraps the body **without copying**; identical bytes on the wire.
- **`perf(messaging-aws)`** — `AmazonSqsQueueTransport`/`AmazonSnsBusTransport` built `MessageAttributes` via `Headers.Where(...).ToDictionary(...)` per publish (a `Where` iterator + an un-presized dict that resizes as it fills). Replaced with a `foreach` into a capacity-hinted `Dictionary` — same contents, fewer allocations.

## Verification
- `Headless.Messaging.AzureServiceBus.Tests.Unit`: **82/82**.
- `Headless.Messaging.Aws.Tests.Unit`: **90/90**.
- Both packages build clean; full solution build via pre-push hook; CSharpier clean.
- Behavior-preserving: same payload bytes, same attribute contents.

## Context: what this batch deliberately excludes
The Round-4 catalog flagged several "Hi" items that did **not** survive verification as clean quick wins, deferred for separate, careful treatment:
- **Blobs.Azure `OpenReadStreamAsync`** (buffer→stream): real win but **behavior-changing** (streaming vs buffered: memory profile, seek, and not-found exception timing) — needs a deliberate change + integration test.
- **Messaging.Redis body base64→binary**: real, but a **breaking on-the-wire format change** — needs a backward-compatible read migration.
- **Pulsar `Body.ToArray()`**: `producer.NewMessage(byte[], …)` **requires** `byte[]` — not cleanly avoidable.
- **ORM audit double `ChangeTracker` walk**: **structural** refactor of the audit save pipeline — not a quick win.
- **Jobs OTel `enum.ToString()` / Serilog `Replace`**: re-verified as **non-findings** — modern .NET returns cached enum names and same-instance `Replace`/`Regex` on no-match, so no per-call allocation.

The two genuinely-real adjacent wins not in this PR (worth their own focused PR, mirroring the membership-store SQL precompute #517-style work): the **per-call `$"..."` SQL rebuild across both messaging storage providers** (~12 sites) — real per-row string allocations, behavior-preserving.