### PR TITLE
perf: cache constant Connekio auth header; intern sitemap changefreq tokens

### DIFF
--- a/src/Headless.Sitemaps/SitemapUrls.cs
+++ b/src/Headless.Sitemaps/SitemapUrls.cs
@@ -256,6 +256,21 @@ public static class SitemapUrls
         }
     }
 
+    // Returns the interned lowercase sitemap token (no allocation), versus ToString().ToLowerInvariant()
+    // which allocates a new lowercased string per URL.
+    private static string _ToChangeFreqValue(ChangeFrequency frequency) =>
+        frequency switch
+        {
+            ChangeFrequency.Always => "always",
+            ChangeFrequency.Hourly => "hourly",
+            ChangeFrequency.Daily => "daily",
+            ChangeFrequency.Weekly => "weekly",
+            ChangeFrequency.Monthly => "monthly",
+            ChangeFrequency.Yearly => "yearly",
+            ChangeFrequency.Never => "never",
+            _ => frequency.ToString().ToLowerInvariant(),
+        };
+
     private static async Task _WriteOtherNodesAsync(XmlWriter writer, SitemapUrl sitemapUrl)
     {
         if (sitemapUrl.Priority is not null)
@@ -268,7 +283,7 @@ public static class SitemapUrls
 
         if (sitemapUrl.ChangeFrequency is not null)
         {
-            var value = sitemapUrl.ChangeFrequency.Value.ToString().ToLowerInvariant();
+            var value = _ToChangeFreqValue(sitemapUrl.ChangeFrequency.Value);
             await writer
                 .WriteElementStringAsync(prefix: null, localName: "changefreq", ns: null, value)
                 .ConfigureAwait(false);

--- a/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
+++ b/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Net.Http.Headers;
 using System.Text.Encodings.Web;
 using Headless.Checks;
 using Headless.Http;
@@ -24,6 +25,12 @@ internal sealed class ConnekioSmsSender(
     private readonly ConnekioSmsOptions _options = optionsAccessor.Value;
     private readonly Uri _singleSmsEndpoint = new(optionsAccessor.Value.SingleSmsEndpoint);
     private readonly Uri _batchSmsEndpoint = new(optionsAccessor.Value.BatchSmsEndpoint);
+
+    // Credentials are fixed at construction, so build the (immutable) Basic auth header once instead of
+    // re-interpolating + base64-encoding it on every send.
+    private readonly AuthenticationHeaderValue _basicAuthHeader = AuthenticationHeaderFactory.CreateBasic(
+        $"{optionsAccessor.Value.UserName}:{optionsAccessor.Value.Password}:{optionsAccessor.Value.AccountId}"
+    );
 
     public async ValueTask<SendSingleSmsResponse> SendAsync(
         SendSingleSmsRequest request,
@@ -61,9 +68,7 @@ internal sealed class ConnekioSmsSender(
 
         requestMessage.Content = new StringContent(_BuildPayload(request), Encoding.UTF8, "application/json");
 
-        requestMessage.Headers.Authorization = AuthenticationHeaderFactory.CreateBasic(
-            $"{_options.UserName}:{_options.Password}:{_options.AccountId}"
-        );
+        requestMessage.Headers.Authorization = _basicAuthHeader;
 
         using var httpClient = httpClientFactory.CreateClient(SetupConnekio.HttpClientName);
         var response = await httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Two clean, behavior-preserving allocation removals — the subset of the band-7 Lo/cold pile that actually survives cost-verification.

## Changes
- **`perf(sms-connekio)`** — `ConnekioSmsSender` rebuilt the Basic auth header on every send by interpolating + base64-encoding the fixed `User:Password:AccountId` credentials. Build the immutable `AuthenticationHeaderValue` once in a field and reuse it.
- **`perf(sitemaps)`** — `SitemapUrls` emitted `changefreq` as `ChangeFrequency.ToString().ToLowerInvariant()`, allocating a fresh lowercased string per URL (up to ~50K per generation). Mapped to interned lowercase literals via a switch — identical output, zero allocation.

## Verification
- `Headless.Sms.Connekio.Tests.Unit`: **7/7**.
- `Headless.Sitemaps.Tests.Unit`: **51/51** (changefreq output is test-covered — confirms identical tokens).
- Both build clean; full solution build via pre-push hook; CSharpier clean.

## Scope note
This was meant to be a sweep of the ~52 "Lo/cold" band-7 findings (blobs/emails/sms/push). On verification only these two are genuinely real **and** clean: the rest are either I/O-bound noise (a heap alloc next to a network/SMTP round trip), BCL non-findings (`string.Replace`/`Enum.ToString` don't allocate on no-match / for defined values), counter-productive heuristics (seeding `MemoryStream`/`StringBuilder` capacity from source size *over-allocates* for image downscale and PDF text extraction), or refactors rather than quick wins (Vodafone). Catalogued in the audit doc; not worth churning.