### PR TITLE
perf(serializer-json): cache derived options in CollectionItemJsonConverter

### DIFF
--- a/src/Headless.Serializer.Json/Converters/CollectionItemJsonConverter.cs
+++ b/src/Headless.Serializer.Json/Converters/CollectionItemJsonConverter.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Runtime.CompilerServices;
+
 namespace Headless.Serializer.Converters;
 
 /// <summary>
@@ -23,6 +25,10 @@ public sealed class CollectionItemJsonConverter<
 {
     public override bool HandleNull => true;
 
+    // Cache the derived options (source options with only TConverterType as converter) per source options
+    // instance, so Read/Write don't clone JsonSerializerOptions + Activator.CreateInstance on every call.
+    private static readonly ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions> _ItemOptions = [];
+
     public override IEnumerable<TDatatype>? Read(
         ref Utf8JsonReader reader,
         Type typeToConvert,
@@ -34,9 +40,7 @@ public sealed class CollectionItemJsonConverter<
             return null;
         }
 
-        JsonSerializerOptions serializerOptions = new(options);
-        serializerOptions.Converters.Clear();
-        serializerOptions.Converters.Add(Activator.CreateInstance<TConverterType>());
+        var serializerOptions = _ItemOptions.GetValue(options, _CreateItemOptions);
 
         List<TDatatype> returnValue = [];
 
@@ -62,9 +66,7 @@ public sealed class CollectionItemJsonConverter<
             return;
         }
 
-        JsonSerializerOptions serializerOptions = new(options);
-        serializerOptions.Converters.Clear();
-        serializerOptions.Converters.Add(Activator.CreateInstance<TConverterType>());
+        var serializerOptions = _ItemOptions.GetValue(options, _CreateItemOptions);
 
         writer.WriteStartArray();
 
@@ -74,5 +76,14 @@ public sealed class CollectionItemJsonConverter<
         }
 
         writer.WriteEndArray();
+    }
+
+    private static JsonSerializerOptions _CreateItemOptions(JsonSerializerOptions source)
+    {
+        var clone = new JsonSerializerOptions(source);
+        clone.Converters.Clear();
+        clone.Converters.Add(Activator.CreateInstance<TConverterType>());
+
+        return clone;
     }
 }


### PR DESCRIPTION
F-11 from the audit. `CollectionItemJsonConverter<TDatatype, TConverterType>` cloned `JsonSerializerOptions` (`new(options)` — a deep copy that discards the cached type-metadata resolver) **and** ran `Activator.CreateInstance<TConverterType>()` on **every** `Read` and `Write`.

## Change
Cache the derived options (source options with only `TConverterType` as the converter) per source-options instance via a static `ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions>`, built once by `_CreateItemOptions`. This mirrors the existing pattern in `EmptyStringAsNullJsonConverter`.

```csharp
var serializerOptions = _ItemOptions.GetValue(options, _CreateItemOptions);
```

## Behavior preservation
The derived options are identical to what the inline code produced (clone + clear converters + add `TConverterType`); they're now built once and reused instead of per-(de)serialize. `JsonSerializerOptions` is frozen on first use, so reusing the cached instance is correct (we never mutate after first use).

## Verification
- `Headless.Serializer.Tests.Unit`: **136/136** (incl. `CollectionItemJsonConverterTests`).
- Build clean; full solution build via pre-push hook; CSharpier clean.

## Note
The branch was originally cut for F-1 (Redis concurrency-stamp) and renamed after I found F-1 is **not** a quick win — it's a Core-abstraction + Lua-CAS concurrency change (the base64 stamp is the cross-component carrier through `CacheStoreEntry<T>.ConcurrencyStamp`), so it needs a focused, benchmark- + Docker-integration-test-gated pass, not a hasty ship.