### PR TITLE
perf: dedupe cron normalization (jobs) and drop per-message LINQ in consumer matching

### DIFF
--- a/src/Headless.Jobs.Core/CronScheduleCache.cs
+++ b/src/Headless.Jobs.Core/CronScheduleCache.cs
@@ -31,7 +31,9 @@ internal static partial class CronScheduleCache
 
     public static DateTime? GetNextOccurrenceOrDefault(string expression, DateTime dateTime)
     {
-        var parsed = Get(_Normalize(expression));
+        // Get(...) already normalizes its argument, so passing the raw expression normalizes once instead of
+        // twice (the regex replace + Trim ran an extra time on the already-normalized string).
+        var parsed = Get(expression);
 
         if (parsed == null)
         {

--- a/src/Headless.Messaging.Core/Internal/IConsumerServiceSelector.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerServiceSelector.cs
@@ -203,7 +203,19 @@ public sealed class ConsumerServiceSelector : IConsumerServiceSelector
     {
         Argument.IsNotNull(key);
 
-        return executeDescriptor.FirstOrDefault(x => x.MessageName.Equals(key, StringComparison.OrdinalIgnoreCase));
+        // Indexed scan instead of FirstOrDefault(closure): same first-match semantics with no per-message
+        // closure + iterator allocation (this runs per transport-dispatched message).
+        for (var i = 0; i < executeDescriptor.Count; i++)
+        {
+            var descriptor = executeDescriptor[i];
+
+            if (descriptor.MessageName.Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                return descriptor;
+            }
+        }
+
+        return null;
     }
 
     private ConsumerExecutorDescriptor? _MatchWildcardUsingRegex(


### PR DESCRIPTION
Two in-process, behavior-preserving per-call allocation removals — chosen because they're validatable by unit tests (no Docker) and not I/O-adjacent, unlike the remaining SQL/Redis items.

## Changes
- **`perf(jobs)`** (F-18b) — `CronScheduleCache.GetNextOccurrenceOrDefault` called `Get(_Normalize(expression))`, but `Get` already normalizes its argument, so the compiled-regex whitespace replace + `Trim` ran **twice** per next-occurrence lookup (two normalized strings). `_Normalize` is idempotent, so pass the raw expression — normalizes once. Runs per cron definition per scheduler poll.
- **`perf(messaging)`** (F-23) — `ConsumerServiceSelector._MatchUsingName` used `FirstOrDefault(x => x.MessageName.Equals(key, …))`, allocating a `key`-capturing closure + a LINQ iterator per transport-dispatched message. Replaced with an indexed `for` loop — identical first-match `OrdinalIgnoreCase` semantics, no per-message allocation. (Kept the existing match cache; did not restructure it into a dictionary — the candidate set is small, so removing the allocation is the win.)

## Verification
- `Headless.Jobs.Tests.Unit`: **159/159**.
- `Headless.Messaging.Core.Tests.Unit`: **892/892**.
- Both build clean; full solution build via pre-push hook; CSharpier clean.
- Behavior-preserving: identical cron schedule resolution; identical consumer name-match result.