### PR TITLE
test(dashboards): add Vitest unit tests for dependency-sensitive logic

### DIFF
--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -58,3 +58,7 @@ jobs:
       - name: "Build dashboard (type-check + vite build)"
         working-directory: ${{ matrix.dashboard }}
         run: npm run build
+
+      - name: "Unit tests (vitest)"
+        working-directory: ${{ matrix.dashboard }}
+        run: npm run test:unit

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -34,6 +34,7 @@
         "autoprefixer": "^10.5.0",
         "eslint": "^9.14.0",
         "eslint-plugin-vue": "^9.30.0",
+        "happy-dom": "^20.10.6",
         "npm-run-all2": "^7.0.2",
         "postcss": "^8.5.1",
         "prettier": "^3.8.4",
@@ -42,6 +43,7 @@
         "vite": "^6.4.3",
         "vite-plugin-dts": "^4.5.0",
         "vite-plugin-vue-devtools": "^7.6.8",
+        "vitest": "^3.2.6",
         "vue-tsc": "^3.3.5"
       }
     },
@@ -2206,6 +2208,24 @@
         "axios": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2227,6 +2247,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2484,6 +2521,131 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -3033,6 +3195,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3234,6 +3406,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -3248,6 +3433,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3304,6 +3499,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3319,6 +3531,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3540,6 +3762,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3757,6 +3989,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4270,6 +4509,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -4658,6 +4907,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5189,6 +5457,13 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5748,6 +6023,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -6377,6 +6662,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6441,6 +6733,20 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -6476,6 +6782,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -6628,6 +6954,20 @@
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6671,6 +7011,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6993,6 +7363,29 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-dts": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
@@ -7129,6 +7522,92 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7374,6 +7853,16 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -7398,6 +7887,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "lint": "eslint . --fix",
     "format": "prettier --write src/"
   },
@@ -39,6 +41,7 @@
     "autoprefixer": "^10.5.0",
     "eslint": "^9.14.0",
     "eslint-plugin-vue": "^9.30.0",
+    "happy-dom": "^20.10.6",
     "npm-run-all2": "^7.0.2",
     "postcss": "^8.5.1",
     "prettier": "^3.8.4",
@@ -47,6 +50,7 @@
     "vite": "^6.4.3",
     "vite-plugin-dts": "^4.5.0",
     "vite-plugin-vue-devtools": "^7.6.8",
+    "vitest": "^3.2.6",
     "vue-tsc": "^3.3.5"
   },
   "overrides": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CRUDCronJobDialog.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CRUDCronJobDialog.vue
@@ -6,7 +6,7 @@ import { jobsService } from '@/http/services/jobsService'
 import type { GetCronJobResponse } from '@/http/services/types/cronJobService.types'
 import { cronJobService } from '@/http/services/cronJobService'
 import { formatTime } from '@/utilities/dateTimeParser'
-import cronstrue from 'cronstrue'
+import { describeCron, isValidCronExpression } from '@/utilities/cron'
 const functionNamesStore = useFunctionNameStore()
 const getJobRequestData = jobsService.getRequestData()
 const updateCronJob = cronJobService.updateCronJob()
@@ -56,39 +56,13 @@ const formatJsonForDisplay = (json: string, isHtml: boolean = false) => {
   }
 }
 
-// Validate cron expression using cronstrue
-// Cronstrue will throw an error if the expression is invalid
-// We require 6-segment format (with seconds)
-const validateCronExpression = (value: string): boolean => {
-  if (!value) return false
-  
-  // Check if it has 6 segments (seconds included)
-  const segments = value.trim().split(/\s+/)
-  if (segments.length !== 6) {
-    return false
-  }
-  
-  try {
-    // Try to parse the expression with cronstrue
-    // If it's invalid, it will throw an error
-    cronstrue.toString(value)
-    return true
-  } catch (error) {
-    return false
-  }
-}
+// Validate cron expression: requires 6-segment (seconds) format that cronstrue can parse.
+const validateCronExpression = (value: string): boolean => isValidCronExpression(value)
 
 // Get readable expression for display
 const readableExpression = computed(() => {
   const expression = values.expression
-  if (!expression || !validateCronExpression(expression)) {
-    return ''
-  }
-  try {
-    return cronstrue.toString(expression)
-  } catch (error) {
-    return ''
-  }
+  return isValidCronExpression(expression) ? describeCron(expression) : ''
 })
 
 const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values } = useForm({

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/cron.spec.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/cron.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { describeCron, hasSecondsSegment, isValidCronExpression } from '@/utilities/cron'
+
+describe('hasSecondsSegment', () => {
+  it('accepts a 6-segment (seconds) expression', () => {
+    expect(hasSecondsSegment('0 0 12 * * *')).toBe(true)
+  })
+
+  it('trims surrounding whitespace before counting segments', () => {
+    expect(hasSecondsSegment('   0 0 12 * * *   ')).toBe(true)
+  })
+
+  it('rejects a 5-segment (no seconds) expression', () => {
+    expect(hasSecondsSegment('0 12 * * *')).toBe(false)
+  })
+
+  it('rejects empty / nullish input', () => {
+    expect(hasSecondsSegment('')).toBe(false)
+    expect(hasSecondsSegment(null)).toBe(false)
+    expect(hasSecondsSegment(undefined)).toBe(false)
+  })
+})
+
+describe('isValidCronExpression', () => {
+  it('is true for a parseable 6-segment expression', () => {
+    expect(isValidCronExpression('0 0 12 * * *')).toBe(true)
+    expect(isValidCronExpression('*/5 * * * * *')).toBe(true)
+  })
+
+  it('enforces the seconds rule: a parseable 5-segment expression is still invalid', () => {
+    expect(isValidCronExpression('0 12 * * *')).toBe(false)
+  })
+
+  it('is false for a 6-token but unparseable expression', () => {
+    expect(isValidCronExpression('foo bar baz qux quux corge')).toBe(false)
+  })
+})
+
+describe('describeCron', () => {
+  // Behavioral canary: a cronstrue bump that breaks seconds handling fails here.
+  it('renders the seconds frequency in human form', () => {
+    expect(describeCron('*/5 * * * * *').toLowerCase()).toContain('second')
+  })
+
+  it('produces a non-empty description for a valid expression', () => {
+    expect(describeCron('0 0 12 * * *')).not.toBe('')
+  })
+
+  it('returns the supplied fallback for an invalid expression', () => {
+    expect(describeCron('foo bar baz qux quux corge', 'Invalid cron expression')).toBe(
+      'Invalid cron expression',
+    )
+  })
+
+  it('defaults the fallback to an empty string', () => {
+    expect(describeCron('')).toBe('')
+    expect(describeCron(null)).toBe('')
+  })
+})

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/dateTimeParser.spec.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/dateTimeParser.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { formatDate, formatTime } from '@/utilities/dateTimeParser'
+
+describe('formatTime', () => {
+  it('renders sub-second values as milliseconds', () => {
+    expect(formatTime(250, true)).toBe('250ms')
+  })
+
+  it('rolls up >= 1000ms into seconds', () => {
+    expect(formatTime(1000, true)).toBe('1s')
+  })
+
+  it('renders bare seconds', () => {
+    expect(formatTime(45)).toBe('45s')
+  })
+
+  it('renders minutes (with and without remainder seconds)', () => {
+    expect(formatTime(90)).toBe('1m 30s')
+    expect(formatTime(120)).toBe('2m')
+  })
+
+  it('renders hours (with and without remainder minutes)', () => {
+    expect(formatTime(3661)).toBe('1h 1m')
+    expect(formatTime(7200)).toBe('2h')
+  })
+
+  it('renders days and hours', () => {
+    expect(formatTime(90000)).toBe('1d 1h')
+  })
+})
+
+describe('formatDate', () => {
+  it('formats a UTC instant in the requested time zone deterministically', () => {
+    expect(formatDate('2024-01-02T03:04:05Z', true, 'UTC')).toBe('02.01.2024 03:04:05')
+  })
+
+  it('omits the time component when includeTime is false', () => {
+    expect(formatDate('2024-01-02T03:04:05Z', false, 'UTC')).toBe('02.01.2024')
+  })
+
+  it('normalizes a space-separated, Z-less timestamp as UTC', () => {
+    expect(formatDate('2024-01-02 03:04:05', true, 'UTC')).toBe('02.01.2024 03:04:05')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(formatDate('')).toBe('')
+  })
+})

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  getApiBaseUrl,
+  getAuthMode,
+  getBackendUrl,
+  getBasePath,
+  resolveApiUrl,
+  resolvePath,
+} from '@/utilities/pathResolver'
+
+const baseConfig = {
+  basePath: '/jobs',
+  auth: { mode: 'none' as const, enabled: false, sessionTimeout: 0 },
+}
+
+afterEach(() => {
+  delete window.JobsConfig
+})
+
+describe('with basePath only (no backend domain)', () => {
+  beforeEach(() => {
+    window.JobsConfig = { ...baseConfig }
+  })
+
+  it('prefixes absolute paths with the base path', () => {
+    expect(resolvePath('/dashboard')).toBe('/jobs/dashboard')
+  })
+
+  it('joins relative paths under the base path', () => {
+    expect(resolvePath('dashboard')).toBe('/jobs/dashboard')
+  })
+
+  it('passes fully-qualified URLs through unchanged', () => {
+    expect(resolvePath('https://example.test/x')).toBe('https://example.test/x')
+  })
+
+  it('derives the API base from the base path', () => {
+    expect(getApiBaseUrl()).toBe('/jobs/api')
+  })
+
+  it('builds API endpoint URLs regardless of a leading slash', () => {
+    expect(resolveApiUrl('/auth/test')).toBe('/jobs/api/auth/test')
+    expect(resolveApiUrl('auth/test')).toBe('/jobs/api/auth/test')
+  })
+
+  it('has no standalone backend URL', () => {
+    expect(getBackendUrl()).toBeNull()
+  })
+})
+
+describe('with a plain backend domain', () => {
+  beforeEach(() => {
+    window.JobsConfig = { ...baseConfig, backendDomain: 'api.test.com' }
+  })
+
+  it('uses http and the domain for the API base', () => {
+    expect(getApiBaseUrl()).toBe('http://api.test.com/api')
+  })
+})
+
+describe('with an ssl: backend domain', () => {
+  beforeEach(() => {
+    window.JobsConfig = { ...baseConfig, backendDomain: 'ssl:api.test.com' }
+  })
+
+  it('upgrades to https and strips the ssl: prefix', () => {
+    expect(getApiBaseUrl()).toBe('https://api.test.com/api')
+    expect(getBackendUrl()).toBe('https://api.test.com')
+    expect(resolveApiUrl('users')).toBe('https://api.test.com/api/users')
+  })
+})
+
+describe('without configuration', () => {
+  it('falls back to sane defaults instead of throwing', () => {
+    expect(getBasePath()).toBe('/')
+    expect(getApiBaseUrl()).toBe('/api')
+    expect(getAuthMode()).toBe('none')
+    expect(resolvePath('foo')).toBe('foo')
+  })
+})

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/cron.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/cron.ts
@@ -1,0 +1,36 @@
+import cronstrue from 'cronstrue'
+
+/**
+ * Jobs cron expressions are required to be 6-segment (seconds included).
+ */
+export function hasSecondsSegment(expression: string | null | undefined): boolean {
+  if (!expression) return false
+  return expression.trim().split(/\s+/).length === 6
+}
+
+/**
+ * A cron expression is valid when it has the 6-segment shape AND cronstrue can parse it.
+ */
+export function isValidCronExpression(expression: string | null | undefined): boolean {
+  if (!hasSecondsSegment(expression)) return false
+
+  try {
+    cronstrue.toString(expression as string)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Human-readable description of a cron expression, or the fallback when it cannot be parsed.
+ */
+export function describeCron(expression: string | null | undefined, fallback = ''): string {
+  if (!expression) return fallback
+
+  try {
+    return cronstrue.toString(expression)
+  } catch {
+    return fallback
+  }
+}

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/CronJob.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/CronJob.vue
@@ -24,17 +24,11 @@ import {
   GridComponent,
 } from 'echarts/components'
 import VChart, { THEME_KEY } from 'vue-echarts'
-import cronstrue from 'cronstrue'
+import { describeCron } from '@/utilities/cron'
 
-// Helper function to get readable cron expression
-const getReadableCronExpression = (expression: string): string => {
-  try {
-    // cronstrue expects 6-part format with seconds
-    return cronstrue.toString(expression)
-  } catch (error) {
-    return 'Invalid cron expression'
-  }
-}
+// Helper function to get readable cron expression (6-part format with seconds)
+const getReadableCronExpression = (expression: string): string =>
+  describeCron(expression, 'Invalid cron expression')
 
 const getCronJobRangeGraphData = cronJobService.getTimeJobsGraphDataRange()
 const getCronJobsPaginated = cronJobService.getCronJobsPaginated()

--- a/src/Headless.Jobs.Dashboard/wwwroot/vitest.config.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// Tightly-scoped unit tests for pure, dependency-sensitive logic (cron parsing,
+// URL/path resolution, UTC/date formatting). No component mounting — those tests
+// are net-negative maintenance for internal dashboards. The Vite build + vue-tsc
+// already gate compilation; this gates *behavior* across dependency bumps.
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['src/**/*.spec.ts'],
+    globals: false,
+  },
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+  },
+})

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -32,6 +32,7 @@
         "autoprefixer": "^10.5.0",
         "eslint": "^9.14.0",
         "eslint-plugin-vue": "^9.30.0",
+        "happy-dom": "^20.10.6",
         "npm-run-all2": "^7.0.2",
         "postcss": "^8.5.1",
         "prettier": "^3.8.4",
@@ -39,6 +40,7 @@
         "vite": "^6.4.3",
         "vite-plugin-dts": "^4.5.0",
         "vite-plugin-vue-devtools": "^7.6.8",
+        "vitest": "^3.2.6",
         "vue-tsc": "^3.3.5"
       }
     },
@@ -2211,6 +2213,24 @@
         "axios": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2239,6 +2259,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2496,6 +2533,131 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -3005,6 +3167,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3202,6 +3374,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -3216,6 +3401,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3262,6 +3457,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3277,6 +3489,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -3439,6 +3661,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3644,6 +3876,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4126,6 +4365,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -4494,6 +4743,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4981,6 +5249,13 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5473,6 +5748,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -5911,6 +6196,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5975,6 +6267,20 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -6010,6 +6316,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/superjson": {
       "version": "2.2.6",
@@ -6072,6 +6398,20 @@
       "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6115,6 +6455,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6395,6 +6765,29 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-dts": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
@@ -6531,6 +6924,92 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6770,6 +7249,16 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6786,6 +7275,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6794,6 +7300,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/wsl-utils": {

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "lint": "eslint . --fix",
     "format": "prettier --write src/"
   },
@@ -37,6 +39,7 @@
     "autoprefixer": "^10.5.0",
     "eslint": "^9.14.0",
     "eslint-plugin-vue": "^9.30.0",
+    "happy-dom": "^20.10.6",
     "npm-run-all2": "^7.0.2",
     "postcss": "^8.5.1",
     "prettier": "^3.8.4",
@@ -44,6 +47,7 @@
     "vite": "^6.4.3",
     "vite-plugin-dts": "^4.5.0",
     "vite-plugin-vue-devtools": "^7.6.8",
+    "vitest": "^3.2.6",
     "vue-tsc": "^3.3.5"
   },
   "overrides": {

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/components/MessageDetailDialog.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/components/MessageDetailDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import JSONBig from 'json-bigint'
+import { parseJsonSafe } from '@/utilities/jsonBig'
 import { formatDateTime, timeAgo } from '@/utilities/dateTimeParser'
 
 export interface MessageDetail {
@@ -44,16 +44,6 @@ interface PlainText {
 
 type ContentKind = StructuredException | GenericException | PlainText
 
-const JSONBigParser = JSONBig({ storeAsString: true })
-
-function parseContent(raw: string): { parsed: unknown; isJson: boolean } {
-  try {
-    return { parsed: JSONBigParser.parse(raw), isJson: true }
-  } catch {
-    return { parsed: null, isJson: false }
-  }
-}
-
 function isExceptionObject(obj: unknown): boolean {
   if (!obj || typeof obj !== 'object') return false
   const o = obj as Record<string, unknown>
@@ -64,7 +54,7 @@ function isExceptionObject(obj: unknown): boolean {
 }
 
 function buildContentKind(raw: string): ContentKind {
-  const { parsed, isJson } = parseContent(raw)
+  const { parsed, isJson } = parseJsonSafe(raw)
 
   if (!isJson) return { type: 'plain', text: raw }
 
@@ -155,7 +145,7 @@ function highlightJson(jsonStr: string): string {
 
 const formattedJsonHtml = computed(() => {
   if (!props.message?.content) return ''
-  const { parsed, isJson } = parseContent(props.message.content)
+  const { parsed, isJson } = parseJsonSafe(props.message.content)
   if (!isJson) return props.message.content
   try {
     return highlightJson(JSON.stringify(parsed, null, 2))

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/dateTimeParser.spec.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/dateTimeParser.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { formatDateTime, timeAgo } from '@/utilities/dateTimeParser'
+
+describe('formatDateTime', () => {
+  it('returns an empty string for nullish input', () => {
+    expect(formatDateTime('')).toBe('')
+    expect(formatDateTime(null)).toBe('')
+    expect(formatDateTime(undefined)).toBe('')
+  })
+
+  it('produces a dd.MM.yyyy HH:mm:ss shape', () => {
+    expect(formatDateTime('2024-01-02T03:04:05Z')).toMatch(
+      /^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}:\d{2}$/,
+    )
+  })
+
+  it('normalizes a Z-less, space-separated timestamp to the same instant as its ISO form', () => {
+    // Time-zone independent: both inputs denote the same UTC instant, so they must render identically.
+    expect(formatDateTime('2024-01-02 03:04:05')).toBe(formatDateTime('2024-01-02T03:04:05Z'))
+  })
+})
+
+describe('timeAgo', () => {
+  it('returns an empty string for nullish input', () => {
+    expect(timeAgo('')).toBe('')
+  })
+
+  // Behavioral canary: a timeago.js bump that breaks relative formatting fails here.
+  it('describes a past instant relative to now', () => {
+    expect(timeAgo('2000-01-01T00:00:00Z').toLowerCase()).toContain('ago')
+  })
+})

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/jsonBig.spec.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/jsonBig.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { parseJsonSafe } from '@/utilities/jsonBig'
+
+describe('parseJsonSafe', () => {
+  // The reason json-bigint exists: int64 message ids must survive parsing intact.
+  it('preserves int64 ids beyond Number.MAX_SAFE_INTEGER as exact strings', () => {
+    const bigId = '9223372036854775807' // long.MaxValue
+    const { parsed, isJson } = parseJsonSafe(`{"messageId": ${bigId}}`)
+
+    expect(isJson).toBe(true)
+    const obj = parsed as Record<string, unknown>
+    expect(obj.messageId).toBe(bigId)
+    expect(typeof obj.messageId).toBe('string')
+  })
+
+  it('guards precisely the case native JSON.parse loses', () => {
+    const bigId = '9223372036854775807'
+    // Sanity contrast: native parse silently corrupts the value to a double.
+    expect(String(JSON.parse(`{"id": ${bigId}}`).id)).not.toBe(bigId)
+  })
+
+  it('parses ordinary JSON objects (small numbers stay numbers)', () => {
+    const { parsed, isJson } = parseJsonSafe('{"a":1,"b":"x"}')
+
+    expect(isJson).toBe(true)
+    expect(parsed).toMatchObject({ a: 1, b: 'x' })
+  })
+
+  it('reports invalid JSON without throwing', () => {
+    expect(parseJsonSafe('not json at all')).toEqual({ parsed: null, isJson: false })
+  })
+
+  it('treats a bare JSON string literal as valid JSON', () => {
+    const { parsed, isJson } = parseJsonSafe('"hello"')
+
+    expect(isJson).toBe(true)
+    expect(parsed).toBe('hello')
+  })
+})

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  getApiBaseUrl,
+  getAuthMode,
+  getBasePath,
+  getStatsPollingInterval,
+  resolveApiUrl,
+  resolvePath,
+} from '@/utilities/pathResolver'
+
+const baseConfig = {
+  basePath: '/messaging',
+  auth: { mode: 'none' as const, enabled: false, sessionTimeout: 0 },
+}
+
+afterEach(() => {
+  delete window.MessagingConfig
+})
+
+describe('with basePath only (no backend domain)', () => {
+  beforeEach(() => {
+    window.MessagingConfig = { ...baseConfig }
+  })
+
+  it('prefixes absolute paths with the base path', () => {
+    expect(resolvePath('/dashboard')).toBe('/messaging/dashboard')
+  })
+
+  it('joins relative paths under the base path', () => {
+    expect(resolvePath('dashboard')).toBe('/messaging/dashboard')
+  })
+
+  it('passes fully-qualified URLs through unchanged', () => {
+    expect(resolvePath('https://example.test/x')).toBe('https://example.test/x')
+  })
+
+  it('derives the API base from the base path', () => {
+    expect(getApiBaseUrl()).toBe('/messaging/api')
+  })
+
+  it('builds API endpoint URLs regardless of a leading slash', () => {
+    expect(resolveApiUrl('/published')).toBe('/messaging/api/published')
+    expect(resolveApiUrl('published')).toBe('/messaging/api/published')
+  })
+})
+
+describe('with an ssl: backend domain', () => {
+  beforeEach(() => {
+    window.MessagingConfig = { ...baseConfig, backendDomain: 'ssl:api.test.com' }
+  })
+
+  it('upgrades to https and strips the ssl: prefix', () => {
+    expect(getApiBaseUrl()).toBe('https://api.test.com/api')
+    expect(resolveApiUrl('nodes')).toBe('https://api.test.com/api/nodes')
+  })
+})
+
+describe('with a plain backend domain', () => {
+  beforeEach(() => {
+    window.MessagingConfig = { ...baseConfig, backendDomain: 'api.test.com' }
+  })
+
+  it('uses http and the domain for the API base', () => {
+    expect(getApiBaseUrl()).toBe('http://api.test.com/api')
+  })
+})
+
+describe('polling interval', () => {
+  it('returns the configured interval', () => {
+    window.MessagingConfig = { ...baseConfig, statsPollingInterval: 12000 }
+    expect(getStatsPollingInterval()).toBe(12000)
+  })
+
+  it('defaults to 5000ms when unset', () => {
+    window.MessagingConfig = { ...baseConfig }
+    expect(getStatsPollingInterval()).toBe(5000)
+  })
+})
+
+describe('without configuration', () => {
+  it('falls back to sane defaults instead of throwing', () => {
+    expect(getBasePath()).toBe('/')
+    expect(getApiBaseUrl()).toBe('/api')
+    expect(getAuthMode()).toBe('none')
+    expect(resolvePath('foo')).toBe('foo')
+  })
+})

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/jsonBig.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/jsonBig.ts
@@ -1,0 +1,22 @@
+import JSONBig from 'json-bigint'
+
+// storeAsString keeps int64 message ids / large numbers exact (as strings) instead of
+// letting JS coerce them to a lossy IEEE-754 double once they exceed Number.MAX_SAFE_INTEGER.
+const parser = JSONBig({ storeAsString: true })
+
+export interface ParsedJson {
+  parsed: unknown
+  isJson: boolean
+}
+
+/**
+ * Parse a raw string as JSON without losing large-integer precision.
+ * Returns { isJson: false } instead of throwing when the input is not valid JSON.
+ */
+export function parseJsonSafe(raw: string): ParsedJson {
+  try {
+    return { parsed: parser.parse(raw), isJson: true }
+  } catch {
+    return { parsed: null, isJson: false }
+  }
+}

--- a/src/Headless.Messaging.Dashboard/wwwroot/vitest.config.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// Tightly-scoped unit tests for pure, dependency-sensitive logic (json-bigint
+// precision, URL/path resolution, UTC/date formatting). No component mounting —
+// those tests are net-negative maintenance for internal dashboards. The Vite build
+// + vue-tsc already gate compilation; this gates *behavior* across dependency bumps.
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['src/**/*.spec.ts'],
+    globals: false,
+  },
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+  },
+})


### PR DESCRIPTION
## Why

Both SPA dashboards (Jobs, Messaging) had only a **compile gate** (`vue-tsc --build` + `vite build`) and **zero behavioral coverage**. A Dependabot bump to a behavior-bearing dependency — `axios`, `cronstrue`, `json-bigint`, `timeago.js` — could silently change runtime output while every CI check stayed green. This turns "did the bump break anything?" from a manual question into a CI answer.

Scope is deliberately tight: **pure logic only, no component mounting** (rendering tests are net-negative maintenance for internal tooling).

## What

**Extract dependency-sensitive logic out of components into testable utilities, then test it:**

- **Jobs** — new `utilities/cron.ts` (wraps `cronstrue`: 6-segment "seconds required" rule + human description) wired into `CRUDCronJobDialog.vue` and `CronJob.vue`. Specs for `cron`, `pathResolver`, `dateTimeParser`.
- **Messaging** — new `utilities/jsonBig.ts` (wraps `json-bigint` with `storeAsString` so int64 message ids survive parsing exactly) wired into `MessageDetailDialog.vue`. Specs for `jsonBig` (incl. an int64-precision canary vs native `JSON.parse`), `pathResolver`, `dateTimeParser`.

**Tooling:**
- Add `vitest@^3.2.6` + `happy-dom@^20.10.6` devDeps, a `test:unit` script, and `vitest.config.ts` (own config; tests live in `src/**/__tests__` which `tsconfig.app.json` already excludes from the production type-check).
- Add a **"Unit tests (vitest)"** step to the `Dashboards` workflow matrix.

## Verification

- `npm run test:unit`: **30 passed** (Jobs) + **20 passed** (Messaging) = 50.
- `npm run build` (type-check + vite build): green for both dashboards.
- Incremental .NET solution build: green (pre-push).

Tests assert stable semantics (URL/protocol resolution, UTC normalization, duration formatting, int64 preservation) rather than exact library wording, so they catch *breaking* dependency changes without false-positiving on cosmetic ones.