### PR TITLE
fix(dashboards): clear all eslint debt + enforce a lint CI gate

### DIFF
--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -62,3 +62,7 @@ jobs:
       - name: "Unit tests (vitest)"
         working-directory: ${{ matrix.dashboard }}
         run: npm run test:unit
+
+      - name: "Lint (eslint)"
+        working-directory: ${{ matrix.dashboard }}
+        run: npm run lint:check

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -12,6 +12,7 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "lint": "eslint . --fix",
+    "lint:check": "eslint .",
     "format": "prettier --write src/"
   },
   "dependencies": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/ChainJobsModal.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/ChainJobsModal.vue
@@ -748,33 +748,61 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useFunctionNameStore } from '@/stores/functionNames'
-import { jobsService } from '@/http/services/jobsService'
 import { timeJobService } from '@/http/services/timeJobService'
+import type { AddChainJobsRequest } from '@/http/services/types/timeJobService.types'
+
+// Domain types
+interface RetryIntervalOption {
+  id?: number
+  title: string
+  value?: number
+  header?: boolean
+}
+
+interface WizardStep {
+  id: string
+  title: string
+  description: string
+  icon: string
+  completed: boolean
+}
+
+interface ScheduledJob {
+  ignoreDateTime: boolean
+  executionDate: Date | undefined
+  executionTime: string
+}
+
+interface ChainJobPayload {
+  function: string
+  description: string
+  runCondition?: number | null
+  executionTime: string | null | undefined
+  retries: number
+  request: string | null
+  intervals: Array<number | undefined>
+  children: ChainJobPayload[]
+}
 
 // Props
 interface Props {
   modelValue: boolean
-  functionNames?: string[]
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  functionNames: () => []
-})
+const props = defineProps<Props>()
 
 // Emits
 interface Emits {
   (e: 'update:modelValue', value: boolean): void
-  (e: 'created', data: any): void
+  (e: 'created', data: object): void
 }
 
 const emit = defineEmits<Emits>()
 
 // Store
 const functionNamesStore = useFunctionNameStore()
-const getJobRequestData = jobsService.getRequestData()
-const addChainJobs = timeJobService.addChainJobs()
 
 // Reactive state
 const isOpen = computed({
@@ -802,29 +830,29 @@ const parentJob = ref({
   ignoreDateTime: false,
   retries: 0,
   requestData: '',
-  retryIntervals: [] as any[]
+  retryIntervals: [] as RetryIntervalOption[]
 })
 
 const children = ref([] as Array<{
   functionName: string
   description: string
-  runCondition: string | null
+  runCondition: number | null
   executionDate: Date | undefined
   executionTime: string
   ignoreDateTime: boolean
   retries: number
   requestData: string
-  retryIntervals: any[]
+  retryIntervals: RetryIntervalOption[]
   grandChildren: Array<{
     functionName: string
     description: string
-    runCondition: string | null
+    runCondition: number | null
     executionDate: Date | undefined
     executionTime: string
     ignoreDateTime: boolean
     retries: number
     requestData: string
-    retryIntervals: any[]
+    retryIntervals: RetryIntervalOption[]
   }>
 }>)
 
@@ -843,7 +871,7 @@ const runConditions = computed(() => [
   { title: 'In Progress (Parallel)', value: 5 }
 ])
 
-const retryIntervalItems = [
+const retryIntervalItems: RetryIntervalOption[] = [
   { header: true, title: 'Select suggested intervals or create one' },
   { id: 1, title: '1 min', value: 60 },
   { id: 2, title: '5 min', value: 300 },
@@ -954,7 +982,7 @@ const navigateToStep = (stepId: string) => {
   }
 }
 
-const getStepIconColor = (step: any) => {
+const getStepIconColor = (step: WizardStep) => {
   if (step.completed) return 'success'
   if (currentStep.value === step.id) return 'primary'
   return 'grey'
@@ -1035,7 +1063,7 @@ const formatJsonForDisplay = (json: string | null, isHtml: boolean = false) => {
   try {
     const formatted = JSON.stringify(JSON.parse(json), null, 2)
     return isHtml ? formatted.replace(/\n/g, '<br>').replace(/ /g, '&nbsp;') : formatted
-  } catch (error) {
+  } catch {
     return isHtml ? json.replace(/\n/g, '<br>').replace(/ /g, '&nbsp;') : json
   }
 }
@@ -1075,17 +1103,17 @@ const createNewChild = () => ({
   ignoreDateTime: false,
   retries: 0,
   requestData: '',
-  retryIntervals: [] as any[],
+  retryIntervals: [] as RetryIntervalOption[],
   grandChildren: [] as Array<{
     functionName: string
     description: string
-    runCondition: string | null
+    runCondition: number | null
     executionDate: Date | undefined
     executionTime: string
     ignoreDateTime: boolean
     retries: number
     requestData: string
-    retryIntervals: any[]
+    retryIntervals: RetryIntervalOption[]
   }>
 })
 
@@ -1098,7 +1126,7 @@ const createNewGrandChild = () => ({
   ignoreDateTime: false,
   retries: 0,
   requestData: '',
-  retryIntervals: [] as any[]
+  retryIntervals: [] as RetryIntervalOption[]
 })
 
 // Add/Remove children methods
@@ -1153,7 +1181,7 @@ const getConfiguredChildren = () => {
     .filter(child => child.functionName)
 }
 
-const formatExecutionTime = (job: any) => {
+const formatExecutionTime = (job: ScheduledJob) => {
   if (job.ignoreDateTime) return 'Immediate'
   if (job.executionDate && job.executionTime) {
     return `${job.executionDate.toLocaleDateString()} at ${job.executionTime}`
@@ -1165,7 +1193,7 @@ const createChainJobs = async () => {
   isCreating.value = true
   
   try {
-    const getExecutionTime = (job: any) => {
+    const getExecutionTime = (job: ScheduledJob) => {
       if (job.ignoreDateTime) return undefined
       if (job.executionDate && job.executionTime) {
         const [hours, minutes, seconds = 0] = job.executionTime.split(':').map(Number)
@@ -1182,7 +1210,7 @@ const createChainJobs = async () => {
       retries: parentJob.value.retries,
       request: parentJob.value.requestData || null,
       intervals: parentJob.value.retryIntervals?.map(item => typeof item === 'object' ? item.value : item) || [],
-      children: [] as any[]
+      children: [] as ChainJobPayload[]
     }
 
     children.value.forEach((child) => {
@@ -1195,7 +1223,7 @@ const createChainJobs = async () => {
           retries: child.retries,
           request: child.requestData || null,
           intervals: child.retryIntervals?.map(item => typeof item === 'object' ? item.value : item) || [],
-          children: [] as any[]
+          children: [] as ChainJobPayload[]
         }
 
         child.grandChildren.forEach((grandChild) => {
@@ -1217,7 +1245,7 @@ const createChainJobs = async () => {
     })
 
     const addChainJobs = timeJobService.addChainJobs()
-    addChainJobs.requestAsync(chainRoot)
+    addChainJobs.requestAsync(chainRoot as AddChainJobsRequest)
         .then((result) => {
             emit('created', result)
             closeModal()

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/TimeJobCharts.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/TimeJobCharts.vue
@@ -88,7 +88,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, type Ref } from 'vue'
 import VChart from 'vue-echarts'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
@@ -116,9 +116,25 @@ use([
 ])
 
 // Props
+interface GraphRangePoint {
+  date: string
+  count: number
+}
+
+interface GraphRangeSource {
+  loading?: Ref<boolean>
+  response?: Ref<GraphRangePoint[] | undefined>
+  requestAsync?: (min: number, max: number) => Promise<unknown>
+}
+
+interface GraphDataSource {
+  loading?: Ref<boolean>
+  response?: Ref<unknown[] | undefined>
+}
+
 interface Props {
-  getTimeJobsGraphDataRangeAndParseToGraph: any
-  getTimeJobsGraphData: any
+  getTimeJobsGraphDataRangeAndParseToGraph: GraphRangeSource
+  getTimeJobsGraphData: GraphDataSource
   range: number[]
 }
 
@@ -182,7 +198,7 @@ const lineChartOptions = computed(() => ({
   },
   xAxis: {
     type: 'category',
-    data: props.getTimeJobsGraphDataRangeAndParseToGraph?.response?.value?.map((item: any) => item.date) || [],
+    data: props.getTimeJobsGraphDataRangeAndParseToGraph?.response?.value?.map((item) => item.date) || [],
     axisLabel: {
       color: '#ffffff',
       rotate: 45
@@ -213,7 +229,7 @@ const lineChartOptions = computed(() => ({
     {
       name: 'Executions',
       type: 'line',
-      data: props.getTimeJobsGraphDataRangeAndParseToGraph?.response?.value?.map((item: any) => item.count) || [],
+      data: props.getTimeJobsGraphDataRangeAndParseToGraph?.response?.value?.map((item) => item.count) || [],
       smooth: true,
       lineStyle: {
         color: '#64b5f6',
@@ -287,9 +303,9 @@ const resetRange = () => {
 }
 
 // Debounce utility
-function debounce<T extends (...args: any[]) => void>(fn: T, delay: number): T {
+function debounce<T extends (...args: never[]) => void>(fn: T, delay: number): T {
   let timeout: ReturnType<typeof setTimeout>
-  return ((...args: any[]) => {
+  return ((...args: never[]) => {
     clearTimeout(timeout)
     timeout = setTimeout(() => fn(...args), delay)
   }) as T

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/common/AuthHeader.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/common/AuthHeader.vue
@@ -2,7 +2,6 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useAuth } from '../../composables/useAuth'
 import { useAuthStore } from '@/stores/authStore'
-import { authService } from '@/services/auth'
 
 // Props
 interface Props {
@@ -11,7 +10,7 @@ interface Props {
   showLogout?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   showLoginForm: true,
   showUserInfo: true,
   showLogout: true
@@ -30,14 +29,12 @@ const {
   username,
   isLoading,
   errorMessage,
-  login,
-  logout,
   clearError
 } = useAuth()
 
 // Import alert composable for demonstration
 import { useAlert } from '@/composables/useAlert'
-const { showSuccess, showError, showWarning, showInfo } = useAlert()
+const { showSuccess, showError, showInfo } = useAlert()
 
 // Local state
 const isLoginFormVisible = ref(false)

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/common/ConfirmDialog.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/common/ConfirmDialog.vue
@@ -23,17 +23,17 @@ export class ConfirmDialogProps {
 interface StructuredException {
   type: 'structured';
   message: string;
-  details: any;
+  details: unknown;
   stackTrace?: string;
   source?: string;
   helpLink?: string;
-  data?: any;
-  innerException?: any;
+  data?: unknown;
+  innerException?: unknown;
 }
 
 interface GenericException {
   type: 'generic';
-  details: any;
+  details: unknown;
 }
 
 interface PlainException {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/common/JobRequestDialog.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/common/JobRequestDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { jobsService } from '@/http/services/jobsService'
-import { computed, ref, toRef, watch, type PropType } from 'vue'
+import { computed, toRef, watch, type PropType } from 'vue'
 
 const getJobRequestData = jobsService.getRequestData()
 
@@ -18,9 +18,9 @@ const props = defineProps({
 
 const formattedJson = computed(() => {
   try {
-    const formatted = JSON.stringify(JSON.parse(getJobRequestData.response.value?.result!), null, 2);
+    const formatted = JSON.stringify(JSON.parse(getJobRequestData.response.value?.result ?? ''), null, 2);
     return formatted.replace(/\n/g, "<br>").replace(/ /g, "&nbsp;");
-  } catch (error) {
+  } catch {
     return "Invalid JSON";
   }
 });

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CRUDCronJobDialog.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CRUDCronJobDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, toRef, watch, type PropType } from 'vue'
+import type { FilterFunction } from 'vuetify'
 import { useFunctionNameStore } from '@/stores/functionNames'
 import { useForm } from '@/composables/useCustomForm'
 import { jobsService } from '@/http/services/jobsService'
@@ -51,7 +52,7 @@ const formatJsonForDisplay = (json: string, isHtml: boolean = false) => {
   try {
     const formatted = JSON.stringify(JSON.parse(json), null, 2)
     return isHtml ? formatted.replace(/\n/g, '<br>').replace(/ /g, '&nbsp;') : formatted
-  } catch (error) {
+  } catch {
     return undefined
   }
 }
@@ -135,7 +136,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
   },
   onSubmitForm: async (values, errors) => {
     if (!errors) {
-      var originalRequestData = values.requestData
+      const originalRequestData = values.requestData
       if (!props.dialogProps.isFromDuplicate) {
         await updateCronJob
           .requestAsync(props.dialogProps.id, {
@@ -144,7 +145,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
             request: values.requestData,
             retries: parseInt(`${values.retries}`),
             description: values.description,
-            intervals: comboBoxModel.value.map((item) => item.value),
+            intervals: comboBoxModel.value.map((item) => (item as ComboBoxInterval).value),
           })
           .then(() => {
             emit('close')
@@ -158,7 +159,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
             request: values.requestData,
             retries: parseInt(`${values.retries}`),
             description: values.description,
-            intervals: comboBoxModel.value.map((item) => item.value),
+            intervals: comboBoxModel.value.map((item) => (item as ComboBoxInterval).value),
           })
           .then(() => {
             emit('close')
@@ -185,17 +186,24 @@ const reqyestType = computed(() => {
   return requestType == '' ? 'No request data' : requestType
 })
 
-const comboBoxFilter = (_: any, queryText: any, item: any) => {
-  const toLowerCaseString = (val: any) => String(val != null ? val : '').toLowerCase()
+const comboBoxFilter: FilterFunction = (_, queryText, item) => {
+  const toLowerCaseString = (val: unknown) => String(val != null ? val : '').toLowerCase()
   const query = toLowerCaseString(queryText)
 
-  if (item.raw.header) return true
+  if (item?.raw.header) return true
 
-  const text = toLowerCaseString(item.raw.title)
+  const text = toLowerCaseString(item?.raw.title)
   return text.includes(query)
 }
 
-const comboBoxItems = [
+interface ComboBoxItem {
+  id?: string | number
+  title: string
+  value?: number
+  header?: boolean
+}
+
+const comboBoxItems: ComboBoxItem[] = [
   { header: true, title: 'Select suggested intervals or create one' },
   {
     id: 1,
@@ -214,7 +222,13 @@ const comboBoxItems = [
   },
 ]
 
-const comboBoxModel = ref<any[]>([])
+interface ComboBoxInterval {
+  id: string | number
+  title: string
+  value: number
+}
+
+const comboBoxModel = ref<(ComboBoxInterval | string)[]>([])
 const comboBoxSearch = ref<string | null>(null)
 
 watch(comboBoxSearch, () => {
@@ -247,7 +261,7 @@ watch(
   { deep: true },
 )
 
-const removeSelection = (index: any) => {
+const removeSelection = (index: number) => {
   comboBoxModel.value.splice(index, 1)
 }
 
@@ -399,7 +413,7 @@ defineExpose({
                         ></v-list-subheader>
                         <v-list-item
                           v-if="!item.raw.header && comboBoxModel.length < values.retries"
-                          @click="props.onClick as any"
+                          @click="props.onClick as (() => void) | undefined"
                         >
                           <v-chip :text="item.raw.title" variant="flat" label></v-chip>
                         </v-list-item>

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CronOccurrenceDialog.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CronOccurrenceDialog.vue
@@ -99,7 +99,7 @@ const addHubListeners = async () => {
         response.items[itemIndex] = {
           ...currentItem,
           ...val,
-          status: Status[val.status as any],
+          status: Status[val.status as number],
           executedAt: `${format(val.executedAt)} (took ${formatTime(val.elapsedTime as number, true)})`,
           retryIntervals: currentItem.retryIntervals,
           lockedAt: currentItem.lockedAt, // Preserve existing lockedAt
@@ -116,7 +116,7 @@ const addHubListeners = async () => {
     }
   });
 
-  props.jobNotificationHub.onReceiveAddCronJobOccurrence((val:GetCronJobOccurrenceResponse) => {
+  props.jobNotificationHub.onReceiveAddCronJobOccurrence(() => {
     // Reload current page when new item is added
     loadPageData();
   });
@@ -166,7 +166,7 @@ const requestCancel = async (id: string) => {
 const onSubmitConfirmDialog = async () => {
   confirmDialog.close()
   await deleteCronOccurrence
-    .requestAsync(confirmDialog.propData?.data!)
+    .requestAsync(confirmDialog.propData?.data ?? '')
     .then(async () => await sleep(100))
     .then(async () => {
       await loadPageData()
@@ -204,7 +204,7 @@ const getStatusIcon = (status: string | number) => {
   }
 }
 
-const formatRetryIntervals = (item: any) => {
+const formatRetryIntervals = (item: GetCronJobOccurrenceResponse) => {
   if (!item.retryIntervals || item.retryIntervals.length === 0) {
     return []
   }
@@ -235,7 +235,7 @@ const formatRetryIntervals = (item: any) => {
   return intervals
 }
 
-const setRowProp = (propContext: any) => {
+const setRowProp = (propContext: { item: GetCronJobOccurrenceResponse }) => {
   const status = propContext.item.status;
   const statusStr = typeof status === 'string' ? status : (status !== null && status !== undefined ? String(status) : 'Unknown');
   return { 
@@ -312,7 +312,7 @@ const setRowProp = (propContext: any) => {
             fixed-header
           >
             <!-- Status Column -->
-            <template v-slot:item.status="{ item }">
+            <template #[`item.status`]="{ item }">
               <div class="status-cell">
                 <div class="status-badge" :style="{ backgroundColor: getStatusColor(item.status) }">
                   <v-icon size="14" color="white">{{ getStatusIcon(item.status) }}</v-icon>
@@ -344,7 +344,7 @@ const setRowProp = (propContext: any) => {
             </template>
 
             <!-- Executed At Column -->
-            <template v-slot:item.ExecutedAt="{ item }">
+            <template #[`item.ExecutedAt`]="{ item }">
               <div class="executed-at-cell">
                 <div v-if="hasStatus(item.status, Status.InProgress)" class="executing-indicator">
                   <v-icon size="16" class="spinning">mdi-loading</v-icon>
@@ -360,7 +360,7 @@ const setRowProp = (propContext: any) => {
             </template>
 
             <!-- Retry Intervals Column -->
-            <template v-slot:item.retryIntervals="{ item }">
+            <template #[`item.retryIntervals`]="{ item }">
               <div class="retry-intervals-cell">
                 <div v-if="!item.retryIntervals || item.retryIntervals.length === 0" class="no-retries">
                   <span class="na-text">N/A</span>
@@ -405,7 +405,7 @@ const setRowProp = (propContext: any) => {
             </template>
 
             <!-- Actions Column -->
-            <template v-slot:item.actions="{ item }">
+            <template #[`item.actions`]="{ item }">
               <div class="actions-cell">
                 <v-btn
                   @click="requestCancel(item.id)"

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/layout/DashboardLayout.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/layout/DashboardLayout.vue
@@ -41,14 +41,15 @@ const isAuthEnabled = computed(() => window.JobsConfig?.auth?.enabled ?? false)
 const router = useRouter()
 
 // Lazy-loaded stores and services
-let jobsService: any = null
+type JobsService = typeof import('../../http/services/jobsService').jobsService
+let jobsService: JobsService = null!
 
 // Lazy-loaded service functions
-let getOptions: any = null
-let getJobHostStatus: any = null
-let startJobHost: any = null
-let restartJobHost: any = null
-let stopJobHost: any = null
+let getOptions: ReturnType<JobsService['getOptions']> = null!
+let getJobHostStatus: ReturnType<JobsService['getJobHostStatus']> = null!
+let startJobHost: ReturnType<JobsService['startJobHost']> = null!
+let restartJobHost: ReturnType<JobsService['restartJobHost']> = null!
+let stopJobHost: ReturnType<JobsService['stopJobHost']> = null!
 
 
 
@@ -69,7 +70,7 @@ const initializeServices = async () => {
           try {
             await connectionStore.initializeConnectionWithRetry()
             connectionStore.setupVisibilityHandling()
-          } catch (error) {
+          } catch {
             // Connection initialization failed after retry
           }
         }, 2000)
@@ -77,7 +78,7 @@ const initializeServices = async () => {
       }
 
       await connectionStore.initializeConnection()
-    } catch (error) {
+    } catch {
       // Failed to initialize WebSocket connection
     }
 
@@ -96,7 +97,7 @@ const initializeServices = async () => {
 
     // Mark services as ready
     isServicesReady.value = true
-  } catch (error) {
+  } catch {
     // Failed to initialize services
     // Even if there's an error, mark as ready to prevent infinite loading
     isServicesReady.value = true
@@ -133,7 +134,7 @@ const loadInitialData = async () => {
     if (getJobHostStatus.response?.value) {
       tickerHostStatus.value = getJobHostStatus.response.value.isRunning
     }
-  } catch (error) {
+  } catch {
     // Failed to load initial data
     currentMachine.value = 'Error'
     tickerHostStatus.value = false
@@ -153,7 +154,7 @@ onMounted(async () => {
         try {
           await connectionStore.initializeConnectionWithRetry()
           connectionStore.setupVisibilityHandling()
-        } catch (error) {
+        } catch {
           // Connection initialization failed after retry
         }
       }, 2000)
@@ -164,7 +165,7 @@ onMounted(async () => {
 
     // After connection is established, initialize services and load data
     await initializeServices()
-  } catch (error) {
+  } catch {
     // Error initializing connection
   }
 })
@@ -214,7 +215,7 @@ async function handleReconnect() {
     // Force UI update
     connectionStore.forceUIUpdate()
 
-  } catch (error) {
+  } catch {
     // Reconnection failed
   }
 }
@@ -239,42 +240,6 @@ function handleAuthLogout() {
     window.location.reload()
   }
 }
-
-// Connection status display
-const getConnectionStatus = computed(() => {
-  if (connectionStore.isConnected) {
-    return 'Connected'
-  } else if (connectionStore.isConnecting) {
-    return 'Connecting...'
-  } else {
-    return 'Disconnected'
-  }
-})
-
-// Connection management methods
-const handleForceReconnection = async () => {
-  if (!connectionStore) return
-
-  try {
-    await connectionStore.forceReconnection()
-  } catch (error) {
-    // Force reconnection failed
-  }
-}
-
-const handleManualHealthCheck = async () => {
-  try {
-    await connectionStore.performManualHealthCheck()
-    await connectionStore.refreshConnectionStatus()
-  } catch (error) {
-    // Manual health check failed
-  }
-}
-
-const handleForceUIUpdate = () => {
-  connectionStore.forceUIUpdate()
-}
-
 
 </script>
 

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/timeJobComponents/CRUDTimeJobDialogComponent.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/timeJobComponents/CRUDTimeJobDialogComponent.vue
@@ -54,7 +54,7 @@ const formatJsonForDisplay = (json: string, isHtml: boolean = false) => {
   try {
     const formatted = JSON.stringify(JSON.parse(json), null, 2)
     return isHtml ? formatted.replace(/\n/g, '<br>').replace(/ /g, '&nbsp;') : formatted
-  } catch (error) {
+  } catch {
     return undefined
   }
 }
@@ -144,7 +144,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
   }),
   onFieldUpdate: {
     executionTime: (value, update) => {
-      let cleaned = value.replace(/[^0-9]/g, '')
+      const cleaned = value.replace(/[^0-9]/g, '')
 
       if (!cleaned) {
         update('')
@@ -195,7 +195,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
     functionName: (value, update) => {
       setFieldValue(
         'exampleData',
-        functionNamesStore.data!.find((fn) => fn.functionName === value)?.functionRequestType!,
+        functionNamesStore.data!.find((fn) => fn.functionName === value)?.functionRequestType ?? '',
       )
 
       if (props.dialogProps.id == undefined || props.dialogProps.function != value)
@@ -203,7 +203,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
       else
         setFieldValue(
           'requestData',
-          formatJsonForDisplay(getJobRequestData.response.value?.result!, false)!,
+          formatJsonForDisplay(getJobRequestData.response.value?.result ?? '', false)!,
         )
 
       update(value)
@@ -270,7 +270,9 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
             executionTime: executionDateTime,
             retries: parseInt(`${values.retries}`),
             description: values.description,
-            intervals: comboBoxModel.value.map((item) => item.value),
+            intervals: comboBoxModel.value.map((item) =>
+              typeof item === 'string' ? parseInt(item) : (item.value ?? 0),
+            ),
           }, schedulingTimeZone)
           .then(() => {
             emit('confirm')
@@ -283,7 +285,9 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
             executionTime: executionDateTime,
             retries: parseInt(`${values.retries}`),
             description: values.description,
-            intervals: comboBoxModel.value.map((item) => item.value),
+            intervals: comboBoxModel.value.map((item) =>
+              typeof item === 'string' ? parseInt(item) : (item.value ?? 0),
+            ),
           }, schedulingTimeZone)
           .then(() => {
             emit('confirm')
@@ -292,7 +296,7 @@ const { resetForm, handleSubmit, bindField, setFieldValue, getFieldValue, values
     }
   },
 })
-const comboBoxItems = [
+const comboBoxItems: ComboBoxOption[] = [
   { header: true, title: 'Select suggested intervals or create one' },
   {
     id: 1,
@@ -311,17 +315,28 @@ const comboBoxItems = [
   },
 ]
 
-const comboBoxFilter = (_: any, queryText: any, item: any) => {
-  const toLowerCaseString = (val: any) => String(val != null ? val : '').toLowerCase()
+const comboBoxFilter = (
+  _: string,
+  queryText: string,
+  item?: { raw: { header?: boolean; title?: string } },
+) => {
+  const toLowerCaseString = (val: unknown) => String(val != null ? val : '').toLowerCase()
   const query = toLowerCaseString(queryText)
 
-  if (item.raw.header) return true
+  if (item?.raw.header) return true
 
-  const text = toLowerCaseString(item.raw.title)
+  const text = toLowerCaseString(item?.raw.title)
   return text.includes(query)
 }
 
-const comboBoxModel = ref<any[]>([])
+interface ComboBoxOption {
+  id?: string | number
+  title: string
+  value?: number
+  header?: boolean
+}
+
+const comboBoxModel = ref<ComboBoxOption[]>([])
 const comboBoxSearch = ref<string | null>(null)
 
 watch(comboBoxSearch, () => {
@@ -339,14 +354,15 @@ watch(
     if (values.retries < comboBoxModel.value.length) {
       comboBoxModel.value.pop()
     } else {
-      let lastItem = comboBoxModel.value[comboBoxModel.value.length - 1]
+      const lastItem = comboBoxModel.value[comboBoxModel.value.length - 1]
       if (typeof lastItem === 'string') {
-        if (parseInt(lastItem) > 86400) lastItem = '86400'
-        else if (parseInt(lastItem) < 0) lastItem = '0'
+        let seconds = parseInt(lastItem)
+        if (seconds > 86400) seconds = 86400
+        else if (seconds < 0) seconds = 0
         comboBoxModel.value.splice(-1, 1, {
           id: Date.now(),
-          title: formatTime(parseInt(lastItem)),
-          value: parseInt(lastItem),
+          title: formatTime(seconds),
+          value: seconds,
         })
       }
     }
@@ -354,7 +370,7 @@ watch(
   { deep: true },
 )
 
-const removeSelection = (index: any) => {
+const removeSelection = (index: number) => {
   comboBoxModel.value.splice(index, 1)
 }
 
@@ -507,7 +523,7 @@ defineExpose({
                         ></v-list-subheader>
                         <v-list-item
                           v-if="!item.raw.header && comboBoxModel.length < values.retries"
-                          @click="props.onClick as any"
+                          @click="props.onClick as (() => void) | undefined"
                         >
                           <v-chip :text="item.raw.title" variant="flat" label></v-chip>
                         </v-list-item>

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/composables/useAlert.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/composables/useAlert.ts
@@ -45,7 +45,7 @@ export function useAlert() {
   /**
    * Show an HTTP error alert with intelligent error parsing
    */
-  const showHttpError = (error: any, customMessage?: string) => {
+  const showHttpError = (error: unknown, customMessage?: string) => {
     return alertStore.showHttpError(error, customMessage)
   }
 

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/composables/useCustomForm.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/composables/useCustomForm.ts
@@ -2,7 +2,7 @@ import { reactive, type UnwrapRef } from 'vue';
 import * as yup from 'yup';
 import { type Path, type PathWithSuffix, type PathValue } from '@/utilities/pathTypes';
 
-export interface ExtendedFormOptions<TData extends Record<string, any>> {
+export interface ExtendedFormOptions<TData extends Record<string, unknown>> {
   initialValues: TData;
   validationSchema?:
   | yup.ObjectSchema<TData>
@@ -16,8 +16,8 @@ export interface ExtendedFormOptions<TData extends Record<string, any>> {
 
 /* -------------------- Utility Functions -------------------- */
 
-function getAllPaths(obj: any, prefix = ''): string[] {
-  return Object.entries(obj).flatMap(([key, value]) => {
+function getAllPaths(obj: unknown, prefix = ''): string[] {
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) => {
     const path = prefix ? `${prefix}.${key}` : key;
     return value && typeof value === 'object' && !Array.isArray(value)
       ? getAllPaths(value, path)
@@ -25,15 +25,18 @@ function getAllPaths(obj: any, prefix = ''): string[] {
   });
 }
 
-function getValue(obj: any, path: string): any {
-  return path.split('.').reduce((acc, key) => acc?.[key], obj);
+function getValue(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => (acc as Record<string, unknown> | undefined)?.[key], obj);
 }
 
-function setValue(obj: any, path: string, newValue: any): void {
+function setValue(obj: unknown, path: string, newValue: unknown): void {
   const keys = path.split('.');
   const lastKey = keys.pop();
   if (!lastKey) return;
-  const target = keys.reduce((acc, key) => (acc[key] ??= {}), obj);
+  const target = keys.reduce<Record<string, unknown>>(
+    (acc, key) => (acc[key] ??= {}) as Record<string, unknown>,
+    obj as Record<string, unknown>,
+  );
   target[lastKey] = newValue;
 }
 
@@ -43,14 +46,14 @@ function deepClone<T>(obj: T): T {
 
 /* -------------------- Core Form Implementation -------------------- */
 
-interface CustomForm<TData extends Record<string, any>> {
+interface CustomForm<TData extends Record<string, unknown>> {
   values: UnwrapRef<TData>;
   errors: Record<string, string>;
   validate: () => Promise<void>;
   validateField: (path: string) => Promise<void>;
 }
 
-function useCustomForm<TData extends Record<string, any>>(options: ExtendedFormOptions<TData>): CustomForm<TData> {
+function useCustomForm<TData extends Record<string, unknown>>(options: ExtendedFormOptions<TData>): CustomForm<TData> {
   const values = reactive(options.initialValues) as UnwrapRef<TData>;
   const errors = reactive<Record<string, string>>({});
 
@@ -72,8 +75,12 @@ function useCustomForm<TData extends Record<string, any>>(options: ExtendedFormO
     if (schema) {
       try {
         await schema.validate(values, { abortEarly: false });
-      } catch (e: any) {
-        e.inner?.forEach((err: any) => (errors[err.path] = err.message));
+      } catch (e) {
+        if (e instanceof yup.ValidationError) {
+          e.inner.forEach((err) => {
+            if (err.path) errors[err.path] = err.message;
+          });
+        }
       }
     }
   }
@@ -89,8 +96,8 @@ function useCustomForm<TData extends Record<string, any>>(options: ExtendedFormO
 
       try {
         await schema.validateAt(path, values);
-      } catch (err: any) {
-        errors[path] = err.message;
+      } catch (err) {
+        errors[path] = err instanceof Error ? err.message : String(err);
       }
     }
   }
@@ -101,7 +108,7 @@ function useCustomForm<TData extends Record<string, any>>(options: ExtendedFormO
 
 /* -------------------- Exposed Composable -------------------- */
 
-export function useForm<TData extends Record<string, any>>(options: ExtendedFormOptions<TData>) {
+export function useForm<TData extends Record<string, unknown>>(options: ExtendedFormOptions<TData>) {
   const initialValuesClone = deepClone(options.initialValues);
   const { values, errors, validate, validateField } = useCustomForm(options);
   const allPaths: Path<TData>[] = getAllPaths(options.initialValues) as Path<TData>[];
@@ -123,7 +130,7 @@ export function useForm<TData extends Record<string, any>>(options: ExtendedForm
 
   function resetForm() {
     allPaths.forEach((path: Path<TData>) => {
-      setFieldValue(path, getValue(initialValuesClone, path));
+      setFieldValue(path, getValue(initialValuesClone, path) as PathValue<TData, Path<TData>>);
       touched[path] = false;
     });
 
@@ -132,10 +139,10 @@ export function useForm<TData extends Record<string, any>>(options: ExtendedForm
 
   function resetField(path: Path<TData>, forceUpdateInitialValue?: PathValue<TData, Path<TData>>) {
     if (forceUpdateInitialValue) {
-      initialValuesClone[path] = forceUpdateInitialValue;
+      setValue(initialValuesClone, path, forceUpdateInitialValue);
     }
 
-    setFieldValue(path, getValue(initialValuesClone, path));
+    setFieldValue(path, getValue(initialValuesClone, path) as PathValue<TData, Path<TData>>);
 
     touched[path] = false;
   }
@@ -155,21 +162,23 @@ export function useForm<TData extends Record<string, any>>(options: ExtendedForm
   }
 
   function getFieldValue<P extends Path<TData>>(path: P): PathValue<TData, P> {
-    return getValue(values, path);
+    return getValue(values, path) as PathValue<TData, P>;
   }
 
-  function bindField<P extends Path<TData>>(path: P, modelValueTransformer?: (value: any) => PathValue<TData, P>) {
+  function bindField<P extends Path<TData>>(path: P, modelValueTransformer?: (value: string | number | Date) => PathValue<TData, P>) {
     return {
       modelValue: getFieldValue(path),
-      'onUpdate:modelValue': async (val: any) => {
-        let newValue: PathValue<TData, P> = modelValueTransformer ? modelValueTransformer(val) : val;
+      'onUpdate:modelValue': async (val: unknown) => {
+        const newValue: PathValue<TData, P> = modelValueTransformer
+          ? modelValueTransformer(val as string | number | Date)
+          : (val as PathValue<TData, P>);
 
         const updateFn = options.onFieldUpdate?.[path] as
           | ((value: PathValue<TData, P>, update: (newValue: PathValue<TData, P>) => void) => PathValue<TData, P>)
           | undefined;
 
         if (updateFn) {
-          updateFn(val, (updatedValue) => setFieldValue(path, updatedValue));
+          updateFn(val as PathValue<TData, P>, (updatedValue) => setFieldValue(path, updatedValue));
         } else {
           setFieldValue(path, newValue);
         }
@@ -179,7 +188,7 @@ export function useForm<TData extends Record<string, any>>(options: ExtendedForm
       },
       onBlur: async () => {
         touched[path] = true;
-        let finalValue = getValue(values, path);
+        let finalValue: PathValue<TData, P> = getValue(values, path) as PathValue<TData, P>;
 
         const blurUpdateFn = options.onFieldUpdate?.[`${path}__blur` as PathWithSuffix<TData>] as
           | ((value: PathValue<TData, P>, update: (newValue: PathValue<TData, P>) => void) => PathValue<TData, P>)

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/base/axiosConfig.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/base/axiosConfig.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from '@/stores/authStore';
 import { useAlertStore } from '@/stores/alertStore';
-import axios, { AxiosError, type AxiosInstance, type AxiosResponse } from 'axios';
-import { getApiBaseUrl, getAuthMode } from '@/utilities/pathResolver';
+import axios, { AxiosError, type AxiosInstance, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import { getApiBaseUrl } from '@/utilities/pathResolver';
 
 const axiosInstance: AxiosInstance = axios.create({
   baseURL: getApiBaseUrl(),
@@ -9,7 +9,7 @@ const axiosInstance: AxiosInstance = axios.create({
 
 // Request Interceptor: Set Authorization header
 axiosInstance.interceptors.request.use(
-  (config: any) => {
+  (config: InternalAxiosRequestConfig) => {
     // Get auth headers from localStorage (using correct keys)
     const apiKey = localStorage.getItem('jobs_api_key');
     const basicAuth = localStorage.getItem('jobs_basic_auth');

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/base/baseHttpService.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/base/baseHttpService.ts
@@ -1,6 +1,6 @@
 // useBaseHttpService.ts
 
-import axios, { type Method } from "axios";
+import axios, { type Canceler, type Method } from "axios";
 import { type Ref, ref } from "vue";
 import http from "./axiosConfig";
 import type { Path, PathValue } from "@/utilities/pathTypes";
@@ -55,7 +55,7 @@ export interface BaseHttpServiceSingle<TRequest, TSingle extends object> {
     url: string,
     options?: {
       bodyData?: TRequest;
-      paramData?: Record<string, any>;
+      paramData?: Record<string, unknown>;
       suppressAlert?: boolean; // Set to false to force show alert (default: axios interceptor handles it)
     }
   ): Promise<TSingle>;
@@ -99,7 +99,7 @@ export interface BaseHttpServiceArray<TRequest, TItem extends object> {
     url: string,
     options?: {
       bodyData?: TRequest;
-      paramData?: Record<string, any>;
+      paramData?: Record<string, unknown>;
       suppressAlert?: boolean; // Set to false to force show alert (default: axios interceptor handles it)
     }
   ): Promise<TItem[]>;
@@ -160,16 +160,16 @@ export function useBaseHttpService<TRequest extends object, TItem extends object
  */
 export function useBaseHttpService(
   mode: "single" | "array"
-): BaseHttpServiceSingle<any, any> | BaseHttpServiceArray<any, any> {
+): BaseHttpServiceSingle<object, object> | BaseHttpServiceArray<object, object> {
 
-  const cancelRequest: Ref<Function | undefined> = ref(undefined);
+  const cancelRequest: Ref<Canceler | undefined> = ref(undefined);
   const loader = ref(false);
   const { showHttpError } = useAlert();
 
   // Will be set if you call FixToResponseModel
   const responseModelKeys: Ref<string[] | undefined> = ref([]);
-  let transformFn: ((item: any) => any) | undefined;
-  let reOrganizeFn: ((response: any) => any) | undefined;
+  let transformFn: ((item: object) => object) | undefined;
+  let reOrganizeFn: ((response: object[]) => object[] | undefined) | undefined;
 
   /**
    * A helper to process raw data from the server:
@@ -177,7 +177,7 @@ export function useBaseHttpService(
    * - Then apply `transformFn` if present
    */
   function processResponse<T extends object>(
-    data: any,
+    data: unknown,
     keys?: string[],
     transform?: (x: T) => T
   ): T | T[] {
@@ -188,7 +188,7 @@ export function useBaseHttpService(
   }
 
   function processOneItem<T extends object>(
-    item: any,
+    item: unknown,
     keys?: string[],
     transform?: (x: T) => T
   ): T {
@@ -196,21 +196,23 @@ export function useBaseHttpService(
       return {} as T;
     }
 
+    const source = item as Record<string, unknown>;
+
     let filtered: Partial<T>;
     if (keys && keys.length > 0) {
       filtered = {};
       // For each model key (case-insensitive), find the property in `item`
       for (const modelKey of keys) {
-        const foundItemKey = Object.keys(item).find(
+        const foundItemKey = Object.keys(source).find(
           (k) => k.toLowerCase() === modelKey.toLowerCase()
         );
         if (foundItemKey) {
-          filtered[modelKey as keyof T] = item[foundItemKey];
+          filtered[modelKey as keyof T] = source[foundItemKey] as T[keyof T];
         }
       }
     } else {
       // If no keys specified, clone entire item
-      filtered = { ...item };
+      filtered = { ...source } as Partial<T>;
     }
 
     return transform ? transform(filtered as T) : (filtered as T);
@@ -220,14 +222,14 @@ export function useBaseHttpService(
      "single" mode
      -------------------------------------------------------------- */
   if (mode === "single") {
-    const response = ref<any>();
+    const response = ref<object>();
     const headers = ref<TableHeader[] | undefined>(undefined);
 
     const sendAsync = async (
       methodType: Method,
       url: string,
-      options?: { bodyData?: any; paramData?: Record<string, any>; suppressAlert?: boolean }
-    ): Promise<any> => {
+      options?: { bodyData?: object; paramData?: Record<string, unknown>; suppressAlert?: boolean }
+    ): Promise<object> => {
       if (cancelRequest.value) cancelRequest.value();
       loader.value = true;
       try {
@@ -250,12 +252,12 @@ export function useBaseHttpService(
         const processed = processResponse(res.data, responseModelKeys.value, transformFn);
 
         if (reOrganizeFn) {
-          response.value = reOrganizeFn(processed) as any;
+          response.value = reOrganizeFn(processed as object[]);
         } else {
-          response.value = processed as any;
+          response.value = processed;
         }
 
-        return response.value;
+        return response.value as object;
       } catch (error) {
         // Don't show error alert here since axios interceptor handles it
         // Only show if explicitly requested and not suppressed
@@ -268,13 +270,13 @@ export function useBaseHttpService(
       }
     };
 
-    const FixToResponseModel = (model: new () => any, transform?: (item: any) => any) => {
+    const FixToResponseModel = (model: new () => object, transform?: (item: object) => object) => {
       responseModelKeys.value = Object.keys(new model());
       transformFn = transform;
       return baseHttpService;
     };
 
-    const updateResponse = (newResponse: any) => {
+    const updateResponse = (newResponse: object | undefined) => {
       const processed = processResponse(newResponse, responseModelKeys.value, transformFn);
       response.value = processed;
     };
@@ -312,11 +314,11 @@ export function useBaseHttpService(
     };
 
 
-    const updateProperty = (property: string, value: any) => {
-      response.value[property] = value;
+    const updateProperty = (property: string, value: unknown) => {
+      (response.value as Record<string, unknown>)[property] = value;
     };
 
-    const baseHttpService: BaseHttpServiceSingle<any, any> = {
+    const baseHttpService: BaseHttpServiceSingle<object, object> = {
       loader,
       response,
       headers,
@@ -334,18 +336,18 @@ export function useBaseHttpService(
      "array" mode
      -------------------------------------------------------------- */
   else {
-    const response = ref<any[]>();
+    const response = ref<object[]>();
     const headers = ref<TableHeader[] | undefined>(undefined);
 
     const sendAsync = async (
       methodType: Method,
       url: string,
-      options?: { bodyData?: any; paramData?: Record<string, any>; suppressAlert?: boolean }
-    ): Promise<any[]> => {
+      options?: { bodyData?: object; paramData?: Record<string, unknown>; suppressAlert?: boolean }
+    ): Promise<object[]> => {
       if (cancelRequest.value) cancelRequest.value(); // Cancel existing request
       loader.value = true;
       try {
-        const res = await http.request<any[]>({
+        const res = await http.request<object[]>({
           url,
           method: methodType,
           params: options?.paramData,
@@ -356,9 +358,10 @@ export function useBaseHttpService(
           }),
         });
 
-        res.data = res.data.map((item: any) => {
-          if (item.status != undefined) {
-            item.status = getStatusValueSafe(item.status);
+        res.data = res.data.map((item) => {
+          const record = item as Record<string, unknown>;
+          if (record.status != undefined) {
+            record.status = getStatusValueSafe(record.status as string | number);
           }
           return item;
         });
@@ -367,9 +370,9 @@ export function useBaseHttpService(
 
         const processed = processResponse(organized, responseModelKeys.value, transformFn);
 
-        response.value = processed as any[];
+        response.value = processed as object[];
 
-        return response.value;
+        return response.value as object[];
 
       } catch (error) {
         // Don't show error alert here since axios interceptor handles it
@@ -383,34 +386,34 @@ export function useBaseHttpService(
       }
     };
 
-    const FixToResponseModel = (model: new () => any, transform?: (item: any) => any) => {
+    const FixToResponseModel = (model: new () => object, transform?: (item: object) => object) => {
       responseModelKeys.value = Object.keys(new model());
       transformFn = transform;
       return baseHttpService;
     };
 
-    const updateResponse = (newResponse: any[] | undefined) => {
+    const updateResponse = (newResponse: object[] | undefined) => {
       if (reOrganizeFn) {
-        newResponse = reOrganizeFn(newResponse);
+        newResponse = reOrganizeFn(newResponse as object[]);
       }
       const processed = processResponse(newResponse, responseModelKeys.value, transformFn);
-      response.value = processed;
+      response.value = processed as object[];
     };
 
-    const addToResponse = (newItem: any) => {
+    const addToResponse = (newItem: object) => {
       const processed = processResponse(newItem, responseModelKeys.value, transformFn);
-      response.value?.push(processed);
+      response.value?.push(processed as object);
       if (reOrganizeFn) {
-        response.value = reOrganizeFn(response.value);
+        response.value = reOrganizeFn(response.value as object[]);
       }
     };
 
-    const removeFromResponse = (key: any, value: any) => {
+    const removeFromResponse = (key: string, value: unknown) => {
       if (!response.value) return;
 
       // Handle both string and GUID comparisons for better reliability
       const filtered = response.value.filter(item => {
-        const itemValue = item[key];
+        const itemValue = (item as Record<string, unknown>)[key];
         // Convert both values to strings for comparison to handle GUID/string mismatches
         return String(itemValue) !== String(value);
       });
@@ -419,27 +422,30 @@ export function useBaseHttpService(
 
       // Apply reorganization if needed
       if (reOrganizeFn) {
-        response.value = reOrganizeFn(response.value);
+        response.value = reOrganizeFn(response.value as object[]);
       }
     };
 
-      const updateByNestedKey = (nestedObjectKey: string, key: string, value: any, ignoreKeys: string[] = []) => {
+      const updateByNestedKey = (nestedObjectKey: string, key: string, value: object, ignoreKeys: string[] = []) => {
+        const valueRecord = value as Record<string, unknown>;
         // First try to find at root level
-        let itemToUpdate = response.value?.find(item => item[key] == value[key]);
-        
+        let itemToUpdate: object | null | undefined = response.value?.find(item => (item as Record<string, unknown>)[key] == valueRecord[key]);
+
         // Recursive function to search in nested children at any depth
-        const findInNestedChildren = (items: any[], nestedKey: string): any => {
+        const findInNestedChildren = (items: object[], nestedKey: string): object | null => {
           for (const item of items) {
+            const record = item as Record<string, unknown>;
             // Check if this item has the nested property (e.g., 'children')
-            if (item[nestedKey] && Array.isArray(item[nestedKey])) {
+            if (record[nestedKey] && Array.isArray(record[nestedKey])) {
+              const children = record[nestedKey] as object[];
               // Search in direct children
-              const foundChild = item[nestedKey].find((child: any) => child[key] == value[key]);
+              const foundChild = children.find((child) => (child as Record<string, unknown>)[key] == valueRecord[key]);
               if (foundChild) {
                 return foundChild;
               }
-              
+
               // Recursively search in grandchildren, great-grandchildren, etc.
-              const foundInDeeper = findInNestedChildren(item[nestedKey], nestedKey);
+              const foundInDeeper = findInNestedChildren(children, nestedKey);
               if (foundInDeeper) {
                 return foundInDeeper;
               }
@@ -447,7 +453,7 @@ export function useBaseHttpService(
           }
           return null;
         };
-        
+
         // If not found at root, search recursively in nested children
         if (!itemToUpdate && response.value) {
           itemToUpdate = findInNestedChildren(response.value, nestedObjectKey);
@@ -461,17 +467,18 @@ export function useBaseHttpService(
 
         Object.keys(processed).forEach((itemKey) => {
           if (!ignoreKeys.includes(itemKey)) {
-            (itemToUpdate as any)[itemKey] = processed[itemKey] as any;
+            (itemToUpdate as Record<string, unknown>)[itemKey] = (processed as Record<string, unknown>)[itemKey];
           }
         });
 
         if (reOrganizeFn) {
-          response.value = reOrganizeFn(response.value);
+          response.value = reOrganizeFn(response.value as object[]);
         }
       }
 
-    const updateByKey = (key: string, value: any, ignoreKeys: string[] = []) => {
-      const item = response.value?.find(item => item[key] == value[key]);
+    const updateByKey = (key: string, value: object, ignoreKeys: string[] = []) => {
+      const valueRecord = value as Record<string, unknown>;
+      const item = response.value?.find(item => (item as Record<string, unknown>)[key] == valueRecord[key]);
 
       if (!item) {
         return; // Exit early if no matching item found
@@ -481,29 +488,29 @@ export function useBaseHttpService(
 
       Object.keys(processed).forEach((itemKey) => {
         if (!ignoreKeys.includes(itemKey)) {
-          (item as any)[itemKey] = processed[itemKey] as any;
+          (item as Record<string, unknown>)[itemKey] = (processed as Record<string, unknown>)[itemKey];
         }
       });
 
       if (reOrganizeFn) {
-        response.value = reOrganizeFn(response.value);
+        response.value = reOrganizeFn(response.value as object[]);
       }
     };
 
-    const updatePropertyByKey = (key: string, keyValue: any, property: string, value: any) => {
-      const item = response.value?.find(item => item[key] === keyValue);
+    const updatePropertyByKey = (key: string, keyValue: unknown, property: string, value: unknown) => {
+      const item = response.value?.find(item => (item as Record<string, unknown>)[key] === keyValue);
       if (item) {
-        item[property] = value;
+        (item as Record<string, unknown>)[property] = value;
       }
     };
 
-    const updateProperty = (property: string, value: any) => {
+    const updateProperty = (property: string, value: unknown) => {
       response.value?.forEach(x => {
-        x[property] = value
+        (x as Record<string, unknown>)[property] = value
       })
     };
 
-    const ReOrganizeResponse = (transform: (response: any[]) => any[]) => {
+    const ReOrganizeResponse = (transform: (response: object[]) => object[] | undefined) => {
       reOrganizeFn = transform;
       return baseHttpService;
     };
@@ -540,7 +547,7 @@ export function useBaseHttpService(
       return baseHttpService;
     };
 
-    const baseHttpService: BaseHttpServiceArray<any, any> = {
+    const baseHttpService: BaseHttpServiceArray<object, object> = {
       loader,
       response,
       headers,

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/cronJobOccurrenceService.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/cronJobOccurrenceService.ts
@@ -24,7 +24,7 @@ const getByCronJobId = () => {
             
             // Safely set status with null check
             if (response.status !== undefined && response.status !== null) {
-                response.status = Status[response.status as any];
+                response.status = Status[response.status as number];
             }
 
             if (response.executedAt != null || response.executedAt != undefined) {
@@ -76,7 +76,7 @@ const getByCronJobIdPaginated = () => {
                     
                     // Safely set status with null check and ensure it's always a string
                     if (item.status !== undefined && item.status !== null) {
-                        const statusValue = Status[item.status as any];
+                        const statusValue = Status[item.status as number];
                         item.status = statusValue !== undefined ? statusValue : String(item.status);
                     } else {
                         item.status = 'Unknown';

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/cronJobService.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/cronJobService.ts
@@ -28,7 +28,7 @@ const getCronJobs = () => {
             else if ((response.retryIntervals == null || response.retryIntervals.length == 0) && (response.retries != null && (response.retries as number) > 0))
                 response.retryIntervals = Array(1).fill(`${30}s`);
             else 
-                response.retryIntervals = (response.retryIntervals as string[]).map((x: any) => formatTime(x as number, false));
+                response.retryIntervals = (response.retryIntervals as string[]).map((x: string) => formatTime(x as unknown as number, false));
             
             return response;
         })
@@ -69,7 +69,7 @@ const getCronJobsPaginated = () => {
                     else if ((item.retryIntervals == null || item.retryIntervals.length == 0) && (item.retries != null && (item.retries as number) > 0))
                         item.retryIntervals = Array(1).fill(`${30}s`);
                     else 
-                        item.retryIntervals = (item.retryIntervals as string[]).map((x: any) => formatTime(x as number, false));
+                        item.retryIntervals = (item.retryIntervals as string[]).map((x: string) => formatTime(x as unknown as number, false));
                     
                     return item;
                 });

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/timeJobService.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/timeJobService.ts
@@ -37,7 +37,7 @@ const getTimeJobs = () => {
             const processItem = (item: GetTimeJobResponse): GetTimeJobResponse => {
                 // Safely set status with null check
                 if (item.status !== undefined && item.status !== null) {
-                    item.status = Status[item.status as any];
+                    item.status = Status[item.status as number];
                 }
 
                 if (item.executedAt != null || item.executedAt != undefined)
@@ -49,7 +49,7 @@ const getTimeJobs = () => {
                 if (item.retryIntervals == null || item.retryIntervals.length == 0 && item.retries != null && (item.retries as number) > 0)
                     item.retryIntervals = Array(1).fill(`${30}s`);
                 else
-                    item.retryIntervals = (item.retryIntervals as string[]).map((x: any) => formatTime(x as number, false));
+                    item.retryIntervals = (item.retryIntervals as string[]).map((x: string) => formatTime(x as unknown as number, false));
 
                 item.lockHolder = item.lockHolder ?? '-';
 
@@ -109,7 +109,7 @@ const getTimeJobsPaginated = () => {
                 response.items = response.items.map((item: GetTimeJobResponse) => {
                     const processItem = (item: GetTimeJobResponse): GetTimeJobResponse => {
                         if (item.status !== undefined && item.status !== null) {
-                            item.status = Status[item.status as any];
+                            item.status = Status[item.status as number];
                         }
                         
                         if (item.executedAt != null || item.executedAt != undefined)
@@ -121,7 +121,7 @@ const getTimeJobsPaginated = () => {
                         if (item.retryIntervals == null || item.retryIntervals.length == 0 && item.retries != null && (item.retries as number) > 0)
                             item.retryIntervals = Array(1).fill(`${30}s`);
                         else
-                            item.retryIntervals = (item.retryIntervals as string[]).map((x: any) => formatTime(x as number, false));
+                            item.retryIntervals = (item.retryIntervals as string[]).map((x: string) => formatTime(x as unknown as number, false));
                         
                         item.lockHolder = item.lockHolder ?? '-';
                         
@@ -213,7 +213,7 @@ const addTimeJob = () => {
     const baseHttp = useBaseHttpService<AddTimeJobRequest, object>('single');
 
     const requestAsync = async (data: AddTimeJobRequest, timeZoneId?: string | null) => {
-        const paramData: Record<string, any> = {};
+        const paramData: Record<string, string> = {};
         if (timeZoneId) {
             paramData.timeZoneId = timeZoneId;
         }
@@ -230,7 +230,7 @@ const updateTimeJob = () => {
     const baseHttp = useBaseHttpService<UpdateTimeJobRequest, object>('single');
 
     const requestAsync = async (id: string, data: UpdateTimeJobRequest, timeZoneId?: string | null) => {
-        const paramData: Record<string, any> = { id };
+        const paramData: Record<string, string> = { id };
         if (timeZoneId) {
             paramData.timeZoneId = timeZoneId;
         }

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/hub/base/baseHub.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/hub/base/baseHub.ts
@@ -41,7 +41,7 @@ class BaseHub {
                 
                 // No auth configured or no token available
                 return null;
-            } catch (error) {
+            } catch {
                 // Could not access auth token
                 return null;
             }
@@ -66,7 +66,7 @@ class BaseHub {
         
         if (useWebSocketsOnly) {
             // WebSocket transport - use access_token query parameter for auth
-            const connectionOptions: any = {
+            const connectionOptions: signalR.IHttpConnectionOptions = {
                 transport: signalR.HttpTransportType.WebSockets
             };
             
@@ -95,7 +95,7 @@ class BaseHub {
                 .build();
         } else {
             // Allow fallback transports - use headers for auth
-            const connectionOptions: any = {};
+            const connectionOptions: signalR.IHttpConnectionOptions = {};
             
             if (authInfo) {
                 connectionOptions.headers = {
@@ -135,7 +135,7 @@ class BaseHub {
         if (this.connection.state === signalR.HubConnectionState.Connected) {
             try {
                 await this.connection.invoke(methodName);
-            } catch (err) {
+            } catch {
                 // Error sending message
             }
         } else {
@@ -157,13 +157,14 @@ class BaseHub {
             console.log('🔗 SignalR: Starting connection...');
             await this.connection.start();
             console.log('✅ SignalR: Connection established successfully');
-        } catch (err: any) {
+        } catch (err) {
             console.error('🚨 SignalR Connection Error:', err);
             
             // Check if it's an authentication error
-            if (err?.message?.includes('401') || 
-                err?.message?.includes('Unauthorized') ||
-                err?.message?.includes('Authentication failed')) {
+            const message = err instanceof Error ? err.message : '';
+            if (message.includes('401') ||
+                message.includes('Unauthorized') ||
+                message.includes('Authentication failed')) {
                 console.error('🚫 SignalR: Authentication failed - connection will not retry');
                 // Don't rethrow authentication errors to prevent infinite retry
                 return;
@@ -177,7 +178,7 @@ class BaseHub {
     async stopConnectionAsync(): Promise<void> {
         try {
             await this.connection.stop();
-        } catch (err) {
+        } catch {
             // Error stopping SignalR connection
         }
     }
@@ -192,13 +193,13 @@ class BaseHub {
 
     // Subscribe to messages from the server
     onReceiveMessageAsSingle<T>(methodName: string, callback: (response: T) => void): void {
-        this.connection.on(methodName, (responseFromHub: any) => {
+        this.connection.on(methodName, (responseFromHub: unknown) => {
             if (Array.isArray(responseFromHub)) {
                 responseFromHub.forEach((response) => {
-                    callback(response);
+                    callback(response as T);
                 });
             } else {
-                callback(responseFromHub);
+                callback(responseFromHub as T);
             }
         });
     }

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/hub/jobNotificationHub.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/hub/jobNotificationHub.ts
@@ -33,31 +33,31 @@ class JobNotificationHub extends BaseHub {
   }
 
   onReceiveAddCronJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveAddCronJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveAddCronJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveUpdateCronJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveUpdateCronJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveUpdateCronJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveDeleteCronJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveDeleteCronJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveDeleteCronJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveUpdateCronJobOccurrence<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveUpdateCronJobOccurrence, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveUpdateCronJobOccurrence, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveAddCronJobOccurrence<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveAddCronJobOccurrence, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveAddCronJobOccurrence, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
@@ -70,56 +70,56 @@ class JobNotificationHub extends BaseHub {
   }
 
   onReceiveAddTimeJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveAddTimeJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveAddTimeJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveUpdateTimeJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveUpdateTimeJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveUpdateTimeJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveCanceledJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveCanceledJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveCanceledJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveDeleteTimeJob<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveDeleteTimeJob, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveDeleteTimeJob, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveThreadsActive<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveThreadsActive, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveThreadsActive, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveNextOccurrence<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveNextOccurrence, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveNextOccurrence, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveHostStatus<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveHostStatus, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveHostStatus, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   onReceiveHostExceptionMessage<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveHostExceptionMessage, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveHostExceptionMessage, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }
 
   // Live-nodes delta pushed by the membership dashboard bridge (one node-state change per event).
   onReceiveNodesUpdate<T>(callback: (response: T) => void): void {
-    this.onReceiveMessageAsSingle<T>(methodName.onReceiveNodesUpdate, (responseFromHub: any) => {
+    this.onReceiveMessageAsSingle<T>(methodName.onReceiveNodesUpdate, (responseFromHub: T) => {
       callback(responseFromHub);
     });
   }

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/services/http.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/services/http.ts
@@ -22,14 +22,14 @@ class HttpService {
   /**
    * POST request
    */
-  async post<T>(endpoint: string, data?: any): Promise<T> {
+  async post<T>(endpoint: string, data?: unknown): Promise<T> {
     return this.request<T>('POST', endpoint, data);
   }
 
   /**
    * PUT request
    */
-  async put<T>(endpoint: string, data?: any): Promise<T> {
+  async put<T>(endpoint: string, data?: unknown): Promise<T> {
     return this.request<T>('PUT', endpoint, data);
   }
 
@@ -43,7 +43,7 @@ class HttpService {
   /**
    * Generic request method
    */
-  private async request<T>(method: string, endpoint: string, data?: any): Promise<T> {
+  private async request<T>(method: string, endpoint: string, data?: unknown): Promise<T> {
     const url = `${this.baseUrl}/api${endpoint}`;
     
     const headers: Record<string, string> = {
@@ -85,7 +85,7 @@ class HttpService {
         return response.json();
       }
       
-      return response.text() as any;
+      return response.text() as unknown as T;
     } catch (error) {
       console.error(`HTTP ${method} ${endpoint} failed:`, error);
       throw error;

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/services/signalr.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/services/signalr.ts
@@ -14,10 +14,12 @@ export interface SignalRStatus {
   error?: string;
 }
 
+type EventCallback = (...args: unknown[]) => void;
+
 class SignalRService {
   private connection: signalR.HubConnection | null = null;
   private state: ConnectionState = 'disconnected';
-  private listeners: Map<string, Function[]> = new Map();
+  private listeners: Map<string, EventCallback[]> = new Map();
 
   /**
    * Initialize and start SignalR connection
@@ -99,7 +101,7 @@ class SignalRService {
   /**
    * Add event listener
    */
-  on(event: string, callback: Function): void {
+  on(event: string, callback: EventCallback): void {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, []);
     }
@@ -109,7 +111,7 @@ class SignalRService {
   /**
    * Remove event listener
    */
-  off(event: string, callback?: Function): void {
+  off(event: string, callback?: EventCallback): void {
     if (!callback) {
       this.listeners.delete(event);
       return;
@@ -245,7 +247,7 @@ class SignalRService {
     }
   }
 
-  private emit(event: string, ...args: any[]): void {
+  private emit(event: string, ...args: unknown[]): void {
     const callbacks = this.listeners.get(event);
     if (callbacks) {
       callbacks.forEach(callback => {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/stores/alertStore.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/stores/alertStore.ts
@@ -23,6 +23,16 @@ export interface Alert extends Required<Omit<AlertOptions, 'actions'>> {
   createdAt: number
 }
 
+interface HttpErrorLike {
+  response?: {
+    status?: number
+    statusText?: string
+    data?: string | { message?: string; error?: string; title?: string } | null
+  }
+  request?: unknown
+  message?: string
+}
+
 export const useAlertStore = defineStore('alert', () => {
   const alerts = ref<Alert[]>([])
   
@@ -128,26 +138,28 @@ export const useAlertStore = defineStore('alert', () => {
   }
 
   // HTTP Error specific method
-  const showHttpError = (error: any, customMessage?: string) => {
+  const showHttpError = (error: unknown, customMessage?: string) => {
     let message = customMessage || 'An error occurred'
     let title = 'HTTP Error'
 
-    if (error?.response) {
-      const status = error.response.status
-      const statusText = error.response.statusText || 'Unknown Error'
-      
+    const err = error as HttpErrorLike
+
+    if (err?.response) {
+      const status = err.response.status
+      const statusText = err.response.statusText || 'Unknown Error'
+
       title = `HTTP ${status} Error`
-      
+
       // Try to extract error message from response
-      if (error.response.data) {
-        if (typeof error.response.data === 'string') {
-          message = error.response.data
-        } else if (error.response.data.message) {
-          message = error.response.data.message
-        } else if (error.response.data.error) {
-          message = error.response.data.error
-        } else if (error.response.data.title) {
-          message = error.response.data.title
+      if (err.response.data) {
+        if (typeof err.response.data === 'string') {
+          message = err.response.data
+        } else if (err.response.data.message) {
+          message = err.response.data.message
+        } else if (err.response.data.error) {
+          message = err.response.data.error
+        } else if (err.response.data.title) {
+          message = err.response.data.title
         } else {
           message = statusText
         }
@@ -173,11 +185,11 @@ export const useAlertStore = defineStore('alert', () => {
           message = 'Service is temporarily unavailable. Please try again later.'
           break
       }
-    } else if (error?.request) {
+    } else if (err?.request) {
       title = 'Network Error'
       message = 'Unable to connect to the server. Please check your internet connection.'
-    } else if (error?.message) {
-      message = error.message
+    } else if (err?.message) {
+      message = err.message
     }
 
     return showError(message, {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/stores/authStore.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/stores/authStore.ts
@@ -24,7 +24,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   // Computed properties
   const isLoggedIn = computed(() => {
-    forceUpdate.value; // Force reactivity
+    void forceUpdate.value; // Force reactivity
     if (!isInitialized.value) return false;
     return authStatus.value.authenticated;
   });

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/stores/connectionStore.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/stores/connectionStore.ts
@@ -92,7 +92,7 @@ export const useConnectionStore = defineStore('connection', () => {
       setConnectionState('Connected')
       setBackendHealthy(true)
       _startHealthCheck()
-    } catch (error) {
+    } catch {
       // Failed to initialize WebSocket connection
       setConnectionState('Disconnected')
       setBackendHealthy(false)
@@ -114,7 +114,7 @@ export const useConnectionStore = defineStore('connection', () => {
         setBackendHealthy(true)
         _startHealthCheck()
         return
-      } catch (error) {
+      } catch {
         // Connection attempt failed
         if (attempt === maxRetries) {
           // All connection attempts failed. WebSocket will not be available.
@@ -128,43 +128,6 @@ export const useConnectionStore = defineStore('connection', () => {
         const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000)
         await new Promise(resolve => setTimeout(resolve, delay))
       }
-    }
-  }
-
-  async function _establishConnection(): Promise<void> {
-    try {
-      // Add timeout to prevent hanging
-      const connectionPromise = JobNotificationHub.startConnection()
-      const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('Connection timeout after 10 seconds')), 10000)
-      })
-      
-      await Promise.race([connectionPromise, timeoutPromise])
-      
-      // Update connection state to connected
-      setConnecting(false)
-      setConnectionState('Connected')
-      setBackendHealthy(true)
-      _isInitialized.value = true
-      
-      // Set up connection event handlers
-      _setupConnectionHandlers()
-      
-      // Sync state with actual SignalR connection
-      _syncConnectionState()
-      
-      // Force UI update to ensure reactivity
-      forceUIUpdate()
-      
-      // Start health check after successful connection
-      _startHealthCheck()
-    } catch (error) {
-      // Ensure connecting state is reset on failure
-      setConnecting(false)
-      setConnectionState('Disconnected')
-      setBackendHealthy(false)
-      _isInitialized.value = false
-      throw error
     }
   }
 
@@ -202,62 +165,6 @@ export const useConnectionStore = defineStore('connection', () => {
     }
   }
 
-  function _setupConnectionHandlers(): void {
-    const connection = JobNotificationHub.connection
-    
-    if (!connection) {
-      return
-    }
-
-    // Handle connection state changes
-    connection.onclose((error) => {
-      _isInitialized.value = false
-      setBackendHealthy(false)
-      setConnecting(false)
-      setConnectionState('Disconnected')
-      _stopHealthCheck()
-      
-      // Attempt to reconnect after a delay if it wasn't a manual close
-      if (error) {
-        setTimeout(() => {
-          _attemptReconnection()
-        }, 3000)
-      }
-    })
-
-    connection.onreconnecting((error) => {
-      setBackendHealthy(false)
-      setConnecting(true)
-      setConnectionState('Connecting')
-    })
-
-    connection.onreconnected((connectionId) => {
-      _isInitialized.value = true
-      setConnecting(false)
-      setBackendHealthy(true)
-      setConnectionState('Connected')
-      // Start health check after reconnection
-      _startHealthCheck()
-    })
-
-    // Handle initial connection
-    connection.on('connected', () => {
-      _isInitialized.value = true
-      setConnecting(false)
-      setBackendHealthy(true)
-      setConnectionState('Connected')
-      _startHealthCheck()
-    })
-
-    // Also set up the 'connected' event for initial connection
-    connection.on('connected', () => {
-      _isInitialized.value = true
-      setConnecting(false)
-      setBackendHealthy(true)
-      setConnectionState('Connected')
-    })
-  }
-
   // Attempt reconnection
   async function _attemptReconnection(): Promise<void> {
     if (_isConnecting.value || _isInitialized.value) {
@@ -267,7 +174,7 @@ export const useConnectionStore = defineStore('connection', () => {
     _isConnecting.value = true
     try {
       await initializeConnection()
-    } catch (error) {
+    } catch {
       // Reconnection failed
     } finally {
       _isConnecting.value = false
@@ -284,7 +191,7 @@ export const useConnectionStore = defineStore('connection', () => {
     // Stop current connection if it exists
     try {
       await JobNotificationHub.stopConnection()
-    } catch (error) {
+    } catch {
       // Error stopping connection during force reconnection
     }
     
@@ -323,7 +230,7 @@ export const useConnectionStore = defineStore('connection', () => {
   }
 
   // Update connection with new auth token
-  async function updateAuthToken(newAuthToken: string): Promise<void> {
+  async function updateAuthToken(): Promise<void> {
     // Stop current connection
     if (_isInitialized.value) {
       await JobNotificationHub.stopConnection()
@@ -398,7 +305,7 @@ export const useConnectionStore = defineStore('connection', () => {
         // Sync state even when not connected
         _syncConnectionState()
       }
-    } catch (error) {
+    } catch {
       setBackendHealthy(false)
       setLastHealthCheck(new Date())
     }
@@ -444,9 +351,9 @@ export const useConnectionStore = defineStore('connection', () => {
     }
     
     // Trigger all computed properties by accessing them
-    isConnected.value
-    isWebSocketConnected.value
-    connectionState.value
+    void isConnected.value
+    void isWebSocketConnected.value
+    void connectionState.value
     
     // Force a reactive update by temporarily changing and restoring values
     const tempConnecting = _isConnecting.value

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/stores/functionNames.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/stores/functionNames.ts
@@ -19,7 +19,7 @@ export const useFunctionNameStore = defineStore('functionNames', () => {
     const data = computed(() => getFunctionData.response.value);
 
     const getNamespaceOrNull = (functionName: string) : string | null => {
-        var result = data.value?.find(x => x.functionName == functionName)?.functionRequestNamespace ?? null;
+        const result = data.value?.find(x => x.functionName == functionName)?.functionRequestNamespace ?? null;
 
         if(result == '' || result == null)
             return null;

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/nameof.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/nameof.ts
@@ -1,31 +1,31 @@
 // nameof.ts
 
 // Overload for a single property selector
-export function nameof<T>(expr: (obj: T) => any): string;
+export function nameof<T>(expr: (obj: T) => unknown): string;
 
 // Overload for two property selectors
 export function nameof<T>(
-    expr1: (obj: T) => any,
-    expr2: (obj: T) => any
+    expr1: (obj: T) => unknown,
+    expr2: (obj: T) => unknown
 ): [string, string];
 
 // Overload for multiple property selectors
 export function nameof<T>(
-    expr1: (obj: T) => any,
-    expr2: (obj: T) => any,
-    ...exprs: Array<(obj: T) => any>
+    expr1: (obj: T) => unknown,
+    expr2: (obj: T) => unknown,
+    ...exprs: Array<(obj: T) => unknown>
 ): string[];
 
 // Implementation Signature
 export function nameof<T>(
-    ...exprs: Array<(obj: T) => any>
+    ...exprs: Array<(obj: T) => unknown>
 ): string | [string, string] | string[] {
     const paths: string[] = [];
 
     exprs.forEach(expr => {
         const path: string[] = [];
 
-        const handler: ProxyHandler<any> = {
+        const handler: ProxyHandler<object> = {
             get(target, prop, receiver) {
                 if (typeof prop === 'symbol') {
                     return receiver;
@@ -35,7 +35,7 @@ export function nameof<T>(
             }
         };
 
-        const proxy = new Proxy({}, handler);
+        const proxy = new Proxy({}, handler) as T;
         expr(proxy);
 
         paths.push(path.join('.'));

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/CronJob.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/CronJob.vue
@@ -8,6 +8,9 @@ import PaginationFooter from '@/components/PaginationFooter.vue'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { LineChart, PieChart } from 'echarts/charts'
+import type { LineSeriesOption } from 'echarts/charts'
+import type { LegendComponentOption } from 'echarts/components'
+import type { CallbackDataParams } from 'echarts/types/dist/shared'
 import { sleep } from '@/utilities/sleep'
 import {
   GetCronJobGraphDataRangeResponse,
@@ -29,6 +32,12 @@ import { describeCron } from '@/utilities/cron'
 // Helper function to get readable cron expression (6-part format with seconds)
 const getReadableCronExpression = (expression: string): string =>
   describeCron(expression, 'Invalid cron expression')
+
+// Helper to detect aborted/cancelled HTTP request errors
+const isCanceledError = (error: unknown): boolean => {
+  const err = error as { name?: string; code?: string }
+  return err?.name === 'CanceledError' || err?.code === 'ERR_CANCELED'
+}
 
 const getCronJobRangeGraphData = cronJobService.getTimeJobsGraphDataRange()
 const getCronJobsPaginated = cronJobService.getCronJobsPaginated()
@@ -90,20 +99,24 @@ const timeZoneStore = useTimeZoneStore()
 
 const onSubmitConfirmDialog = async () => {
   try {
-    const deletedId = confirmDialog.propData?.id!
+    const deletedId = confirmDialog.propData?.id
     confirmDialog.close()
-    
+
+    if (deletedId == undefined) {
+      return
+    }
+
     // Immediately remove from UI for better UX
     // Reload page after deletion
-    
+
     // Perform the actual deletion
     await deleteCronJob.requestAsync(deletedId)
     
     // Update charts to reflect the deletion
     await updateChartsAfterDeletion(deletedId)
     
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
     // If deletion failed, we might want to refresh the data to restore the item
@@ -134,8 +147,8 @@ const updateChartsAfterDataChange = async (changedId?: string) => {
       const res = await getCronJobRangeGraphData.requestAsync(-3, 3)
       GetCronJobRangeGraphData(res)
     }
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
     console.error('Error updating charts after data change:', error)
@@ -167,8 +180,8 @@ const updateChartsAfterDeletion = async (deletedId: string) => {
       const res = await getCronJobRangeGraphData.requestAsync(-3, 3)
       GetCronJobRangeGraphData(res)
     }
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
     console.error('Error updating charts after deletion:', error)
@@ -205,8 +218,8 @@ const getTimeJobsGraphDataAndParseToGraph = async () => {
     // Force pie chart re-render by updating the key
     pieChartKey.value++
     
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
   }
@@ -237,8 +250,8 @@ const updatePieChartForSelectedTicker = async (jobId: string, min: number, max: 
     
     // Convert to pie chart format
     const chartData = Array.from(statusCounts.entries())
-      .filter(([_, count]) => count > 0) // Only show statuses with data
-      .sort(([_, a], [__, b]) => b - a) // Sort by count descending
+      .filter(([, count]) => count > 0) // Only show statuses with data
+      .sort(([, a], [, b]) => b - a) // Sort by count descending
       .map(([statusId, count]) => {
         const statusName = Status[statusId] || `Status ${statusId}`
         const color = statusColors[statusId] || '#999999'
@@ -266,8 +279,8 @@ const updatePieChartForSelectedTicker = async (jobId: string, min: number, max: 
     // Force pie chart re-render by updating the key
     pieChartKey.value++
     
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
   }
@@ -318,7 +331,7 @@ const GetCronJobRangeGraphData = (res: GetCronJobGraphDataRangeResponse[]) => {
     const composedData = Array.from(seriesMap.entries()).map(([item1, dataArray]) => ({
       data: dataArray,
       name: Status[item1] || `Unknown ${item1}`,
-      type: 'line',
+      type: 'line' as const,
       smooth: true,
       symbol: 'circle',
       symbolSize: 6,
@@ -339,7 +352,7 @@ const GetCronJobRangeGraphData = (res: GetCronJobGraphDataRangeResponse[]) => {
       },
       areaStyle: {
         color: {
-          type: 'linear',
+          type: 'linear' as const,
           x: 0,
           y: 0,
           x2: 0,
@@ -398,8 +411,8 @@ const GetCronJobRangeGraphData = (res: GetCronJobGraphDataRangeResponse[]) => {
     // Force chart re-render by updating the key
     chartKey.value++
     
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
   }
@@ -420,8 +433,8 @@ const ShowCronJobOccurrenceGraphData = async (functionName: string, id: string, 
         
         // Refresh pie chart with all jobs data
         await getTimeJobsGraphDataAndParseToGraph()
-      } catch (error: any) {
-        if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+      } catch (error: unknown) {
+        if (isCanceledError(error)) {
           return
         }
       }
@@ -436,8 +449,8 @@ const ShowCronJobOccurrenceGraphData = async (functionName: string, id: string, 
         
         // Update pie chart with selected job's data
         await updatePieChartForSelectedTicker(id, min, max)
-      } catch (error: any) {
-        if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+      } catch (error: unknown) {
+        if (isCanceledError(error)) {
           return
         }
       }
@@ -450,7 +463,7 @@ const ShowCronJobOccurrenceGraphData = async (functionName: string, id: string, 
     setTimeout(() => {
     }, 100)
     
-  } catch (error: any) {
+  } catch {
   } finally {
     chartLoading.value = false
   }
@@ -471,8 +484,8 @@ onMounted(async () => {
       if (!connectionStore.isInitialized) {
         await connectionStore.initializeConnectionWithRetry()
       }
-    } 
-    catch (error: any) {}
+    }
+    catch {}
     
     // Check if still mounted before continuing
     if (!isMounted.value) return
@@ -480,7 +493,7 @@ onMounted(async () => {
     // Load cron jobs data
     try {
       await loadPageData()
-    } catch (error: any) {
+    } catch {
     }
     
     // Check if still mounted before continuing
@@ -490,8 +503,8 @@ onMounted(async () => {
     try {
       const res = await getCronJobRangeGraphData.requestAsync(-3, 3)
       GetCronJobRangeGraphData(res)
-    } catch (error: any) {
-      if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+    } catch (error: unknown) {
+      if (isCanceledError(error)) {
         return
       }
     }
@@ -502,7 +515,7 @@ onMounted(async () => {
     // Load status distribution data
     try {
       await getTimeJobsGraphDataAndParseToGraph()
-    } catch (error: any) {
+    } catch {
     }
     
     // Check if still mounted before continuing
@@ -511,10 +524,10 @@ onMounted(async () => {
     // Add hub listeners
     try {
       await addHubListeners()
-    } catch (error: any) {
+    } catch {
     }
-    
-  } catch (error: any) {
+
+  } catch {
   }
 })
 
@@ -602,8 +615,8 @@ provide(THEME_KEY, 'dark')
 
 const chartData = ref({
   xAxisData: [] as string[],
-  series: [] as any[],
-  legend: {} as any,
+  series: [] as LineSeriesOption[],
+  legend: {} as LegendComponentOption,
   title: 'Job statuses for all Cron Jobs'
 })
 
@@ -746,7 +759,7 @@ const totalOption = computed(() => ({
   },
   tooltip: {
     trigger: 'item',
-    formatter: function (params: any) {
+    formatter: function (params: CallbackDataParams) {
       const percentage = params.percent || 0
       const value = params.value || 0
       return `<div style="
@@ -811,7 +824,7 @@ const totalOption = computed(() => ({
         color: '#ffffff',
         fontSize: 12,
         fontWeight: 'bold',
-        formatter: function (params: any) {
+        formatter: function (params: CallbackDataParams) {
           const percentage = params.percent || 0
           return percentage > 5 ? `${params.name}\n${params.value}` : ''
         },
@@ -898,24 +911,10 @@ const safeRange = computed({
   },
 })
 
-const safeMin = computed({
-  get: () => safeRange.value[0],
-  set: (val) => {
-    safeRange.value = [val || -1, safeRange.value[1]]
-  },
-})
-
-const safeMax = computed({
-  get: () => safeRange.value[1],
-  set: (val) => {
-    safeRange.value = [safeRange.value[0], val || 1]
-  },
-})
-
 // ✅ Debounce utility
-function debounce<T extends (...args: any[]) => void>(fn: T, delay: number): T {
+function debounce<T extends (...args: never[]) => void>(fn: T, delay: number): T {
   let timeout: ReturnType<typeof setTimeout>
-  return ((...args: any[]) => {
+  return ((...args: Parameters<T>) => {
     clearTimeout(timeout)
     timeout = setTimeout(() => fn(...args), delay)
   }) as T
@@ -934,8 +933,8 @@ const fetchGraphData = debounce(async ([min, max]: number[]) => {
       // Also update the pie chart for the selected job
       await updatePieChartForSelectedTicker(selectedCronJobGraphData.value!, min, max)
     }
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
   }
@@ -956,7 +955,7 @@ watch(
 // Debug watcher for chart data changes
 watch(
   () => chartData.value,
-  (newData) => {
+  () => {
   },
   { deep: true }
 )
@@ -964,7 +963,7 @@ watch(
 // Debug watcher for pie chart data changes
 watch(
   () => pieChartData.value,
-  (newData) => {
+  () => {
   },
   { deep: true }
 )
@@ -1001,8 +1000,8 @@ const refreshData = async () => {
     
     // Update charts using the helper function
     await updateChartsAfterDataChange()
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error: unknown) {
+    if (isCanceledError(error)) {
       return
     }
   }
@@ -1202,7 +1201,7 @@ const refreshData = async () => {
             hide-default-footer
             class="enhanced-table"
           >
-            <template v-slot:item.expression="{ item }">
+            <template #[`item.expression`]="{ item }">
               <v-tooltip location="top">
                 <template #activator="{ props }">
                   <span v-bind="props" class="expression-tooltip">
@@ -1213,7 +1212,7 @@ const refreshData = async () => {
               </v-tooltip>
             </template>
 
-            <template v-slot:item.retryIntervals="{ item }">
+            <template #[`item.retryIntervals`]="{ item }">
               <div class="retry-display" v-if="item.retryIntervals?.length || (item.retries && item.retries > 0)">
                 <div class="retry-header" v-if="item.retries > 0">
                   <span class="retry-count-label">Max Retries: {{ item.retries }}</span>
@@ -1228,7 +1227,7 @@ const refreshData = async () => {
               <span v-else class="no-retries">—</span>
             </template>
 
-            <template v-slot:item.actions="{ item }">
+            <template #[`item.actions`]="{ item }">
               <div class="action-buttons-container">
                 <!-- Chart Button -->
                 <div class="action-btn-wrapper">

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/Dashboard.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/Dashboard.vue
@@ -9,6 +9,8 @@ import { useTimeZoneStore } from '@/stores/timeZoneStore'
 import { Status } from '@/http/services/types/base/baseHttpResponse.types'
 import LiveNodesPanel from '@/components/LiveNodesPanel.vue'
 
+defineOptions({ name: 'DashboardView' })
+
 const getNextPlannedJob = jobsService.getNextPlannedJob()
 const getOptions = jobsService.getOptions()
 const getMachineJobs = jobsService.getMachineJobs()
@@ -35,7 +37,7 @@ onMounted(async () => {
     const total = res.reduce((sum, item) => sum + item.item2, 0)
 
     res.forEach((item) => {
-      const status = statuses.value.find((x) => x.name === Status[item.item1 as any])
+      const status = statuses.value.find((x) => x.name === Status[Number(item.item1)])
 
       if (status) {
         status.count = item.item2
@@ -213,13 +215,9 @@ const functionHeaders = [
   { title: 'Priority', key: 'priority', sortable: true },
 ]
 
-// Computed properties for pagination
-const totalFunctionsPages = computed(() =>
-  Math.ceil(functionItems.value.length / functionsPerPage.value),
-)
 
 // Handle Vuetify table options update
-const handleTableOptionsUpdate = (options: any) => {
+const handleTableOptionsUpdate = (options: { page?: number; itemsPerPage?: number }) => {
   if (options.itemsPerPage !== undefined) {
     functionsPerPage.value = options.itemsPerPage
   }
@@ -228,31 +226,6 @@ const handleTableOptionsUpdate = (options: any) => {
   }
 }
 
-// Function to get visible page numbers for pagination
-const getVisiblePageNumbers = () => {
-  const total = totalFunctionsPages.value
-  const current = currentFunctionsPage.value
-  const delta = 2 // Number of pages to show on each side of current page
-
-  let start = Math.max(1, current - delta)
-  let end = Math.min(total, current + delta)
-
-  // Adjust start and end to always show delta*2 + 1 pages when possible
-  if (end - start < delta * 2) {
-    if (start === 1) {
-      end = Math.min(total, start + delta * 2)
-    } else {
-      start = Math.max(1, end - delta * 2)
-    }
-  }
-
-  const pages = []
-  for (let i = start; i <= end; i++) {
-    pages.push(i)
-  }
-
-  return pages
-}
 </script>
 <template>
   <div class="dashboard-container">
@@ -463,19 +436,19 @@ const getVisiblePageNumbers = () => {
               @update:options="handleTableOptionsUpdate"
             >
               <!-- Function Name Column -->
-              <template v-slot:item.function="{ item }">
+              <template #[`item.function`]="{ item }">
                 <span class="function-name">{{ item.function }}</span>
               </template>
 
               <!-- Request Namespace Column -->
-              <template v-slot:item.request="{ item }">
+              <template #[`item.request`]="{ item }">
                 <span class="namespace-text" :title="item.request">
                   {{ item.request }}
                 </span>
               </template>
 
               <!-- Priority Column -->
-              <template v-slot:item.priority="{ item }">
+              <template #[`item.priority`]="{ item }">
                 <div
                   class="priority-badge"
                   :class="`priority-${item.priority.toLowerCase().replace('longrunning', 'long')}`"

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/Login.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/Login.vue
@@ -179,6 +179,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'LoginView' })
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/TimeJob.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/TimeJob.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { onMounted, ref, provide, computed, onUnmounted, nextTick, watch } from 'vue'
+import { onMounted, ref, provide, computed, onUnmounted, watch } from 'vue'
 import { timeJobService } from '@/http/services/timeJobService'
 import type { GetTimeJobResponse } from '@/http/services/types/timeJobService.types'
 import { Status } from '@/http/services/types/base/baseHttpResponse.types'
@@ -24,7 +24,11 @@ import {
   DataZoomComponent,
 } from 'echarts/components'
 import VChart, { THEME_KEY } from 'vue-echarts'
-import type { GetTimeJobGraphDataRangeResponse } from '@/http/services/types/timeJobService.types'
+import type { LineSeriesOption, PieSeriesOption, LegendComponentOption } from 'echarts'
+import type {
+  GetTimeJobGraphDataRangeResponse,
+  GetTimeJobGraphDataResponse,
+} from '@/http/services/types/timeJobService.types'
 
 use([
   CanvasRenderer,
@@ -88,11 +92,11 @@ const chartLoading = ref(false)
 const chartKey = ref(0)
 const chartData = ref({
   xAxisData: [] as string[],
-  series: [] as any[],
-  legend: {} as any,
+  series: [] as LineSeriesOption[],
+  legend: {} as LegendComponentOption,
   title: 'Job statuses for all Time Jobs',
 })
-const pieChartData = ref<any[]>([])
+const pieChartData = ref<PieSeriesOption['data']>([])
 const pieChartKey = ref(0)
 
 // Provide theme for charts
@@ -107,12 +111,12 @@ onMounted(async () => {
     if (!connectionStore.isInitialized) {
       await connectionStore.initializeConnectionWithRetry()
     }
-  } catch (error: any) {}
+  } catch {}
 
   // Load initial data with pagination
   try {
     await loadPageData()
-  } catch (error) {
+  } catch {
     // Failed to load time jobs
   }
   
@@ -127,7 +131,7 @@ onMounted(async () => {
   // Add hub listeners
   try {
     await addHubListeners()
-  } catch (error) {
+  } catch {
     // Failed to add hub listeners
   }
 })
@@ -184,8 +188,9 @@ const loadTimeSeriesChartData = async (min: number, max: number) => {
     chartLoading.value = true
     const res = await getTimeJobsGraphDataRange.requestAsync(min, max)
     processTimeSeriesData(res)
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error) {
+    const err = error as { name?: string; code?: string } | undefined
+    if (err?.name === 'CanceledError' || err?.code === 'ERR_CANCELED') {
       return
     }
     console.error('Failed to load time series chart data:', error)
@@ -198,8 +203,9 @@ const loadPieChartData = async () => {
   try {
     const res = await getTimeJobsGraphData.requestAsync()
     processPieChartData(res)
-  } catch (error: any) {
-    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+  } catch (error) {
+    const err = error as { name?: string; code?: string } | undefined
+    if (err?.name === 'CanceledError' || err?.code === 'ERR_CANCELED') {
       return
     }
     console.error('Failed to load pie chart data:', error)
@@ -219,7 +225,7 @@ const processTimeSeriesData = (data: GetTimeJobGraphDataRangeResponse[]) => {
 
   data.forEach((item) => {
     if (!item.results) return
-    item.results.forEach((result: any) => {
+    item.results.forEach((result) => {
       allStatuses.add(result.item1)
       if (!dateMap.has(item.date)) {
         dateMap.set(item.date, new Map())
@@ -243,7 +249,7 @@ const processTimeSeriesData = (data: GetTimeJobGraphDataRangeResponse[]) => {
     7: '#BA68C8', // Skipped - Medium Orchid (Purple)
   }
 
-  const composedData = statusArray.map((status) => ({
+  const composedData = statusArray.map((status): LineSeriesOption => ({
     name: Status[status] || `Status ${status}`,
     type: 'line',
     smooth: true,
@@ -276,14 +282,14 @@ const processTimeSeriesData = (data: GetTimeJobGraphDataRangeResponse[]) => {
   chartData.value = {
     xAxisData: uniqueDates,
     series: composedData,
-    legend: { data: composedData.map(s => s.name) },
+    legend: { data: composedData.map((s) => String(s.name ?? '')) },
     title: chartData.value.title
   }
   
   chartKey.value++
 }
 
-const processPieChartData = (data: any[]) => {
+const processPieChartData = (data: GetTimeJobGraphDataResponse[]) => {
   if (!data || !Array.isArray(data)) {
     pieChartData.value = []
     return
@@ -330,9 +336,9 @@ const processPieChartData = (data: any[]) => {
 
 const addHubListeners = async () => {
   // Debounce utility for view refreshes
-  function debounce<T extends (...args: any[]) => void>(fn: T, delay: number): T {
+  function debounce<T extends (...args: unknown[]) => void>(fn: T, delay: number): T {
     let timeout: ReturnType<typeof setTimeout>
-    return ((...args: any[]) => {
+    return ((...args: unknown[]) => {
       clearTimeout(timeout)
       timeout = setTimeout(() => fn(...args), delay)
     }) as T
@@ -351,7 +357,7 @@ const addHubListeners = async () => {
     debouncedRefresh()
   })
 
-  JobNotificationHub.onReceiveDeleteTimeJob<string>((id) => {
+  JobNotificationHub.onReceiveDeleteTimeJob<string>(() => {
     // Reload current page when item is deleted
     loadPageData()
     // Update charts
@@ -549,17 +555,31 @@ const pieChartOption = computed(() => ({
   animationEasing: 'cubicOut' as const,
 }))
 
+// Tree row shape: a time job enriched with tree-rendering metadata
+interface TreeTimeJob extends GetTimeJobResponse {
+  depth: number
+  isParent: boolean
+  isChild: boolean
+  isExpanded: boolean
+  hasChildren: boolean
+  childrenCount: number
+  treePath: string
+  isFirstChild: boolean
+  isLastChild: boolean
+  children: GetTimeJobResponse[]
+}
+
 // Process data to create tree table structure with proper hierarchy
 const processedTableData = computed(() => {
   const paginatedData = getTimeJobsPaginated.response.value
   const rawData = paginatedData?.items || []
-  const result: any[] = []
+  const result: TreeTimeJob[] = []
 
   // Recursive function to build tree structure with proper indentation
-  const buildTreeData = (items: any[], depth: number = 0, parentPath: string = '') => {
+  const buildTreeData = (items: GetTimeJobResponse[], depth: number = 0, parentPath: string = '') => {
     items.forEach((item, index) => {
       const currentPath = parentPath ? `${parentPath}.${index}` : `${index}`
-      const hasChildren = item.children && item.children.length > 0
+      const hasChildren = !!(item.children && item.children.length > 0)
       const isExpanded = expandedParents.value.has(item.id)
 
       // Add the current item with tree metadata
@@ -583,7 +603,7 @@ const processedTableData = computed(() => {
 
       // If this item is expanded and has children, add them recursively
       if (isExpanded && hasChildren) {
-        buildTreeData(item.children, depth + 1, currentPath)
+        buildTreeData(item.children ?? [], depth + 1, currentPath)
       }
     })
   }
@@ -662,7 +682,7 @@ const openChainJobsModal = () => {
   chainJobsModal.value.isOpen = true
 }
 
-const onChainJobsCreated = async (result: any) => {
+const onChainJobsCreated = async (result: object) => {
   console.log('Chain jobs created successfully!', result)
   await loadPageData()
 }
@@ -700,9 +720,9 @@ const expandToLevel = (maxDepth: number) => {
 }
 
 // Row props function to style rows based on tree depth and type
-const getRowProps = (item: any) => {
+const getRowProps = () => {
   const classes = []
-  const styles: any = {}
+  const styles: Record<string, string> = {}
 
   classes.push('tree-leaf-row')
   classes.push('tree-root-row')
@@ -714,7 +734,7 @@ const getRowProps = (item: any) => {
 }
 
 // Enhanced tree table helper functions
-const getTreeIcon = (item: any) => {
+const getTreeIcon = (item: TreeTimeJob) => {
   // Parent nodes - folder icons
   if (item.depth === 0) {
     return item.isExpanded ? 'mdi-folder-open-outline' : 'mdi-folder-outline'
@@ -723,7 +743,7 @@ const getTreeIcon = (item: any) => {
   }
 }
 
-const getTreeIconColor = (item: any) => {
+const getTreeIconColor = (item: TreeTimeJob) => {
   // Parent nodes - different colors by depth
   if (item.depth === 0) {
     return 'amber'
@@ -747,7 +767,7 @@ const pushRequestMatchType = (matchType: number) => {
 }
 
 const getRequestMatchType = computed(() => {
-  return Array.from(requestMatchType.value.entries()).map((item, index) => {
+  return Array.from(requestMatchType.value.entries()).map((item) => {
     if (item[1] == 0)
       return { id: item[0], icon: 'mdi-delete-alert', color: '#212121', class: 'grey-badge' }
     else if (item[1] == 1)
@@ -795,7 +815,7 @@ const getRetryIntervalsArray = (retryIntervals: string[] | string | null): strin
   return []
 }
 
-const getDisplayIntervals = (item: any) => {
+const getDisplayIntervals = (item: TreeTimeJob) => {
   const intervals = getRetryIntervalsArray(item.retryIntervals)
   if (intervals.length <= 3) {
     // Show all if 3 or fewer
@@ -823,7 +843,7 @@ const getDisplayIntervals = (item: any) => {
   }
 }
 
-const getHiddenCount = (item: any) => {
+const getHiddenCount = (item: TreeTimeJob) => {
   const intervals = getRetryIntervalsArray(item.retryIntervals)
   if (intervals.length <= 3) return 0
 
@@ -840,7 +860,7 @@ const getHiddenCount = (item: any) => {
   }
 }
 
-const getRetryStatus = (index: number, item: any) => {
+const getRetryStatus = (index: number, item: TreeTimeJob) => {
   if (!item.retryCount) return 'pending'
 
   const currentRetryIndex = item.retryCount - 1
@@ -863,7 +883,7 @@ const requestCancel = async (id: string) => {
 
 const onSubmitConfirmDialog = async () => {
   confirmDialog.close()
-  await deleteTimeJob.requestAsync(confirmDialog.propData?.id!)
+  await deleteTimeJob.requestAsync(confirmDialog.propData.id)
 }
 
 const canBeForceDeleted = ref<string[]>([])
@@ -1115,7 +1135,7 @@ const canBeForceDeleted = ref<string[]>([])
             :item-height="32"
           >
             <!-- Selection Column -->
-            <template v-slot:item.selection="{ item }">
+            <template #[`item.selection`]="{ item }">
               <v-checkbox
                 v-if="!item.isChild"
                 :model-value="selectedItems.has(item.id)"
@@ -1127,7 +1147,7 @@ const canBeForceDeleted = ref<string[]>([])
               />
             </template>
 
-            <template v-slot:item.function="{ item }">
+            <template #[`item.function`]="{ item }">
               <div class="tree-cell" :style="{ paddingLeft: item.depth * 28 + 'px' }">
                 <!-- Tree Structure with improved lines -->
                 <div class="tree-structure" v-if="item.depth > 0">
@@ -1194,7 +1214,7 @@ const canBeForceDeleted = ref<string[]>([])
               </div>
             </template>
 
-            <template v-slot:item.status="{ item }">
+            <template #[`item.status`]="{ item }">
               <div class="d-flex align-center">
                 <v-chip
                   :style="{ 
@@ -1228,7 +1248,7 @@ const canBeForceDeleted = ref<string[]>([])
                 </v-chip>
               </div>
             </template>
-            <template v-slot:item.RequestType="{ item }">
+            <template #[`item.RequestType`]="{ item }">
               <v-badge
                 v-bind="
                   getRequestMatchType.find((y) => y!.id == item.id) ?? {
@@ -1248,7 +1268,7 @@ const canBeForceDeleted = ref<string[]>([])
               </v-badge>
             </template>
 
-            <template v-slot:item.ExecutedAt="{ item }">
+            <template #[`item.ExecutedAt`]="{ item }">
               <div
                 v-if="hasStatus(item.status, Status.InProgress)"
                 class="snippet"
@@ -1267,9 +1287,9 @@ const canBeForceDeleted = ref<string[]>([])
               </div>
             </template>
 
-            <template v-slot:item.retryIntervals="{ item }">
-              <div class="retry-display" v-if="getRetryIntervalsArray(item.retryIntervals)?.length || (item.retries && item.retries > 0)">
-                <div class="retry-header" v-if="item.retries > 0">
+            <template #[`item.retryIntervals`]="{ item }">
+              <div class="retry-display" v-if="getRetryIntervalsArray(item.retryIntervals)?.length || (item.retries && Number(item.retries) > 0)">
+                <div class="retry-header" v-if="Number(item.retries) > 0">
                   <span class="retry-count-label">Attempt {{ item.retryCount || 0 }}/{{ item.retries }}</span>
                 </div>
                 <span class="retry-sequence" v-if="getRetryIntervalsArray(item.retryIntervals)?.length">
@@ -1287,14 +1307,14 @@ const canBeForceDeleted = ref<string[]>([])
               <span v-else class="no-retries">—</span>
             </template>
 
-            <template v-slot:item.lockHolder="{ item }">
+            <template #[`item.lockHolder`]="{ item }">
               <span class="text-caption">{{ item.lockHolder }}</span>
               <v-tooltip v-if="item.lockHolder != ''" activator="parent" location="left">
                 <span>Locked At: {{ formatDate(item.lockedAt) }}</span>
               </v-tooltip>
             </template>
 
-            <template v-slot:item.actions="{ item }">
+            <template #[`item.actions`]="{ item }">
               <div class="action-buttons-container">
                 <!-- Cancel Button -->
                 <div
@@ -1405,7 +1425,7 @@ const canBeForceDeleted = ref<string[]>([])
             </template>
 
             <!-- Tree Marker Column -->
-            <template v-slot:item.treeMarker="{ item }">
+            <template #[`item.treeMarker`]="{ item }">
               <div class="tree-marker">
                 <svg width="32" height="32" viewBox="0 0 32 32" class="tree-marker-svg">
                   <!-- Mirror the left side tree structure on the right -->

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -12,6 +12,7 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "lint": "eslint . --fix",
+    "lint:check": "eslint .",
     "format": "prettier --write src/"
   },
   "dependencies": {

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/stores/authStore.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/stores/authStore.ts
@@ -24,7 +24,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   // Computed properties
   const isLoggedIn = computed(() => {
-    forceUpdate.value // Force reactivity
+    void forceUpdate.value // Force reactivity
     if (!isInitialized.value) return false
     return authStatus.value.authenticated
   })

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Dashboard.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Dashboard.vue
@@ -99,6 +99,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'DashboardView' })
 import { onMounted, onUnmounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMessagingStore } from '@/stores/messagingStore'

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Login.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Login.vue
@@ -172,6 +172,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'LoginView' })
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Nodes.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Nodes.vue
@@ -135,6 +135,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'NodesView' })
 import { ref, reactive, onMounted } from 'vue'
 import { httpService } from '@/services/http'
 import { useAlertStore } from '@/stores/alertStore'

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Published.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Published.vue
@@ -171,6 +171,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'PublishedView' })
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { httpService } from '@/services/http'
@@ -334,7 +335,7 @@ async function viewMessage(storageId: string) {
     const dto = await httpService.get<MessageDetail>(`/published/message/${storageId}`)
     detailMessage.value = dto
     detailDialogOpen.value = true
-  } catch (error) {
+  } catch {
     alertStore.showError('Failed to load message detail')
   }
 }
@@ -345,7 +346,7 @@ function handleBatchRequeue() {
       await httpService.post('/published/requeue', [...selectedIds.value])
       alertStore.showSuccess(`${selectedIds.value.length} messages requeued`)
       await loadMessages()
-    } catch (error) {
+    } catch {
       alertStore.showError('Failed to requeue messages')
     }
   }
@@ -365,7 +366,7 @@ function handleBatchDelete() {
       await httpService.post('/published/delete', [...selectedIds.value])
       alertStore.showSuccess(`${selectedIds.value.length} messages deleted`)
       await loadMessages()
-    } catch (error) {
+    } catch {
       alertStore.showError('Failed to delete messages')
     }
   }

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Received.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Received.vue
@@ -181,6 +181,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'ReceivedView' })
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { httpService } from '@/services/http'
@@ -342,7 +343,7 @@ async function viewMessage(storageId: string) {
     const dto = await httpService.get<MessageDetail>(`/received/message/${storageId}`)
     detailMessage.value = dto
     detailDialogOpen.value = true
-  } catch (error) {
+  } catch {
     alertStore.showError('Failed to load message detail')
   }
 }
@@ -353,7 +354,7 @@ function handleBatchReexecute() {
       await httpService.post('/received/reexecute', [...selectedIds.value])
       alertStore.showSuccess(`${selectedIds.value.length} messages re-executed`)
       await loadMessages()
-    } catch (error) {
+    } catch {
       alertStore.showError('Failed to re-execute messages')
     }
   }
@@ -373,7 +374,7 @@ function handleBatchDelete() {
       await httpService.post('/received/delete', [...selectedIds.value])
       alertStore.showSuccess(`${selectedIds.value.length} messages deleted`)
       await loadMessages()
-    } catch (error) {
+    } catch {
       alertStore.showError('Failed to delete messages')
     }
   }

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Subscribers.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Subscribers.vue
@@ -68,6 +68,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'SubscribersView' })
 import { ref, reactive, onMounted } from 'vue'
 import { httpService } from '@/services/http'
 import { useAlertStore } from '@/stores/alertStore'

--- a/src/Headless.Messaging.Dashboard/wwwroot/vite.config.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/vite.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from 'node:url'
-import { defineConfig, type PluginOption } from 'vite'
+import { defineConfig, type PluginOption, type ProxyOptions } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { dynamicBase } from 'vite-plugin-dynamic-base'
 
@@ -112,14 +112,14 @@ export default defineConfig(async ({ command, mode }) => {
           target: DEMO_BACKEND,
           changeOrigin: true,
           secure: false,
-          configure: (proxy: { on: Function }) => {
-            proxy.on('proxyReq', (proxyReq: { setHeader: Function }) => {
+          configure: (proxy) => {
+            proxy.on('proxyReq', (proxyReq) => {
               if (devToken) {
                 proxyReq.setHeader('Authorization', `Bearer ${devToken}`)
               }
             })
           },
-        },
+        } satisfies ProxyOptions,
       },
     },
   }


### PR DESCRIPTION
Clears the **317 pre-existing ESLint errors** across both dashboards (Jobs 302, Messaging 15) with real code fixes — **no `eslint-disable`, no `as any`, no rule relaxation** — and adds a lint gate so it can't regrow.

## Approach
The bulk (201 `no-explicit-any` in Jobs) was properly typed with real domain types (`src/http/services/types/**`), ECharts types, SignalR types, axios response generics, or generics / `unknown`+narrowing where genuinely dynamic. The rest fixed by category:

| rule | fix |
|---|---|
| `no-explicit-any` (216) | real types / generics / `unknown`+narrowing |
| `no-unused-vars` (67) | remove dead imports/vars/params; `catch {}` for unused bindings |
| `vue/valid-v-slot` (19) | Vuetify dotted slots → dynamic `#[\`item.x\`]` syntax |
| `vue/multi-word-component-names` (8) | `defineOptions({ name: '…View' })` on route views |
| `no-non-null-asserted-optional-chain` (6) | real guards / `?? fallback` |
| `no-unsafe-function-type` (6) | explicit signatures (axios `Canceler`, SignalR, etc.) |
| `no-unused-expressions` (5) | `void` on intentional reactivity touches |
| `no-var`/`prefer-const` (4) | `let`/`const` |
| `vue/no-dupe-keys` (1) | removed a dead duplicated prop (real bug) |

Two genuine bugs surfaced and were fixed in passing:
- `useCustomForm.resetField` did a direct `obj[path] = …` on a **nested** path (only "worked" because `any` masked it) → now uses the nested-aware `setValue`.
- `ChainJobsModal` had a duplicated `functionNames` prop shadowed by a computed.

## Durability
Added `lint:check` (`eslint .`, no `--fix`) to both dashboards and a **"Lint (eslint)" step to the Dashboards workflow** — lint now joins build + vitest as a PR gate.

## Verified (both dashboards)
- `npm run lint:check` → **0 problems**
- `npm run build` (vue-tsc + vite) → green
- `npm run test:unit` → 30 (Jobs) / 20 (Messaging) pass
- `npm ci` → clean
- Zero `any`, `eslint-disable`, or `@ts-ignore` remain in `src/`

Most fixes were produced by 6 parallel subagents over disjoint file sets, then verified centrally (full build + lint + tests + a cheat scan).