### PR TITLE
feat(sms)!: single-recipient core + IBulkSmsSender capability

### DIFF
--- a/docs/llms/sms.md
+++ b/docs/llms/sms.md
@@ -107,9 +107,10 @@ Register exactly one provider via `AddHeadlessSms(setup => setup.Use{Provider}(.
 - Always use `Headless.Sms.Dev` in development/test environments to avoid sending real SMS messages. Use `AddHeadlessSms(setup => setup.UseDev("sms-log.txt"))` for file logging or `AddHeadlessSms(setup => setup.UseNoop())` for silent discard.
 - Code against `ISmsSender` from `Headless.Sms.Abstractions` — never against provider-specific sender types.
 - Register exactly one provider with `services.AddHeadlessSms(setup => setup.Use{Provider}(...))` (for example `UseTwilio`, `UseAwsSns`, `UseCequens`, `UseDev`). The registration enforces an exactly-one-provider gate and throws on zero or multiple providers.
-- `SendSingleSmsRequest` uses `Destinations` (a list of `SmsRequestDestination`) and `Text` — not `To`/`Message`. Destination requires a country calling code (`Code`) and the local number (`Number`) as separate fields.
+- `SendSingleSmsRequest` targets exactly one recipient via `Destination` (a single `SmsRequestDestination`) plus `Text` — not `To`/`Message`. A destination requires a country calling code (`Code`) and the local number (`Number`) as separate fields.
+- For one message to many recipients in a single provider call, use `IBulkSmsSender.SendBulkAsync(SendBulkSmsRequest)`. It is an optional capability: Cequens, Connekio, Infobip, VictoryLink, Vodafone, and the Dev/Noop senders implement it; Twilio and AWS SNS do not (one recipient per API call), so resolving `IBulkSmsSender` for them fails. Loop `SendAsync` to fan out over a single-recipient provider.
 - `SendSingleSmsResponse` exposes `Success` (bool), optional `ProviderMessageId` (string? — the backend's message id on success when it returns one), `FailureError` (string? — non-null when `Success` is false), and `FailureKind` (the `SmsFailureKind` enum classifying failures). It does NOT have `IsSuccess` or `ErrorMessage`.
-- `ISmsSender.SendAsync` returns `ValueTask<SendSingleSmsResponse>` and never throws for provider/transport failures — only `OperationCanceledException` (on cancellation) and argument-validation exceptions (for a null request, no destinations, or an empty body) propagate. Always check `response.Success`.
+- `ISmsSender.SendAsync` returns `ValueTask<SendSingleSmsResponse>` and never throws for provider/transport failures — only `OperationCanceledException` (on cancellation) and argument-validation exceptions (for a null request, a null destination, or an empty body) propagate. Always check `response.Success`.
 - HTTP-backed providers (Cequens, Connekio, Infobip, Twilio, VictoryLink, Vodafone) disable auto-retry by default to prevent duplicate SMS delivery. Opt back in via the `configureResilience` parameter if the provider supports idempotency keys.
 - Exactly one provider is allowed: `AddHeadlessSms` throws an `InvalidOperationException` if zero or multiple providers are selected, or if it is called more than once on the same service collection.
 - For Twilio, the option property for the sender number is `PhoneNumber` (not `From`) and the account identifier is `Sid` (not `AccountSid`). There is no `MessagingServiceSid` option in the current API.
@@ -121,13 +122,13 @@ Register exactly one provider via `AddHeadlessSms(setup => setup.Use{Provider}(.
 
 ### Message model
 
-`SendSingleSmsRequest` is the single message type for all providers:
+`SendSingleSmsRequest` is the single-recipient message type used by `ISmsSender`:
 
 ```csharp
 new SendSingleSmsRequest
 {
     MessageId = "optional-idempotency-id",          // optional, provider-specific use
-    Destinations = [new SmsRequestDestination(20, "1234567890")], // Code = country calling code
+    Destination = new SmsRequestDestination(20, "1234567890"), // Code = country calling code
     Text = "Your OTP is 123456",
     Properties = null                               // optional, provider-specific metadata
 }
@@ -135,7 +136,7 @@ new SendSingleSmsRequest
 
 `SmsRequestDestination(int Code, string Number)` models a phone number split into country calling code and subscriber number. `ToString()` returns `"{Code}{Number}"` without a plus sign; `ToString(hasPlusPrefix: true)` returns `"+{Code}{Number}"`.
 
-`IsBatch` on the request is `true` when `Destinations.Count > 1`. Batch support varies by provider.
+For multi-recipient sends, `SendBulkSmsRequest` carries a `Destinations` list (plus `Text` and optional `MessageId`/`Properties`) and is sent via `IBulkSmsSender.SendBulkAsync`, returning a `SendBulkSmsResponse`. Bulk support varies by provider (see the capability note above).
 
 ### Result model
 
@@ -149,7 +150,9 @@ SendSingleSmsResponse.Failed("reason", SmsFailureKind.Transient)  // classified 
 SendSingleSmsResponse.FromException(exception)                    // failure with a non-empty message, classified via SmsFailureKinds.FromException
 ```
 
-Check `response.Success` after every send. `FailureError` is guaranteed non-null when `Success` is false (enforced by `[MemberNotNullWhen(false, nameof(FailureError))]`); `Failed` throws on a null/empty reason. `ProviderMessageId` carries the backend's message id on success when the provider returns one (Twilio SID, AWS SNS message id, Infobip bulk id), and is `null` otherwise. `FailureKind` (`SmsFailureKind`: `None`, `Unknown`, `Transient`, `RateLimited`, `InvalidRecipient`, `AuthFailure`, `OutOfCredit`, `Unsupported`) classifies failures so callers can decide whether to retry or switch providers — transport/network faults are reported as `Transient`, and a request a provider cannot fulfill (for example a multi-destination batch on a single-recipient provider such as Twilio or AWS SNS) is `Unsupported`. Providers classify failures consistently with the shared `SmsFailureKinds` helper (`FromHttpStatusCode`, `FromException`); `SendSingleSmsResponse.FromException` pairs that classification with a guaranteed non-empty message.
+Check `response.Success` after every send. `FailureError` is guaranteed non-null when `Success` is false (enforced by `[MemberNotNullWhen(false, nameof(FailureError))]`); `Failed` throws on a null/empty reason. `ProviderMessageId` carries the backend's message id on success when the provider returns one (Twilio SID, AWS SNS message id, Infobip bulk id), and is `null` otherwise. `FailureKind` (`SmsFailureKind`: `None`, `Unknown`, `Transient`, `RateLimited`, `InvalidRecipient`, `AuthFailure`, `OutOfCredit`) classifies failures so callers can decide whether to retry or switch providers — transport/network faults are reported as `Transient`. Providers classify failures consistently with the shared `SmsFailureKinds` helper (`FromHttpStatusCode`, `FromException`); `SendSingleSmsResponse.FromException` pairs that classification with a guaranteed non-empty message.
+
+`IBulkSmsSender.SendBulkAsync` returns a `SendBulkSmsResponse` with one `SmsRecipientResult` (`Destination` + a per-recipient `SendSingleSmsResponse`) per recipient, plus `AllSucceeded`/`AnySucceeded` and an optional `ProviderBatchId`. Providers that return per-recipient detail (Infobip) populate each result individually; providers whose API reports a single batch status (Cequens, Connekio, VictoryLink, Vodafone) apply that one outcome to every recipient.
 
 ### Retry safety
 
@@ -182,10 +185,13 @@ Provides a provider-agnostic SMS sending API so application code stays decoupled
 
 ### Key Features
 
-- `ISmsSender` — single method `SendAsync(SendSingleSmsRequest, CancellationToken) : ValueTask<SendSingleSmsResponse>`.
-- `SendSingleSmsRequest` — message contract with `Destinations` (list of `SmsRequestDestination`), `Text`, optional `MessageId`, and optional `Properties`.
+- `ISmsSender` — single-recipient send: `SendAsync(SendSingleSmsRequest, CancellationToken) : ValueTask<SendSingleSmsResponse>`.
+- `IBulkSmsSender` — optional capability for multi-recipient sends: `SendBulkAsync(SendBulkSmsRequest, CancellationToken) : ValueTask<SendBulkSmsResponse>`. Only implemented by providers with native bulk support.
+- `SendSingleSmsRequest` — single-recipient message contract with `Destination` (one `SmsRequestDestination`), `Text`, optional `MessageId`, and optional `Properties`.
+- `SendBulkSmsRequest` — bulk message contract with `Destinations` (list), `Text`, optional `MessageId`/`Properties`.
 - `SmsRequestDestination(int Code, string Number)` — phone number with separate country calling code and subscriber number.
 - `SendSingleSmsResponse` — closed result type; `Success` (bool), optional `ProviderMessageId`, `FailureError` (string? non-null on failure), and `FailureKind` (`SmsFailureKind`). Built via `Succeeded`, `Failed`, or `FromException` (which guarantees a non-empty message and classifies the failure).
+- `SendBulkSmsResponse` — per-recipient bulk result; `Results` (one `SmsRecipientResult` each), `AllSucceeded`/`AnySucceeded`, optional `ProviderBatchId`. Built via `FromResults` or `FromAggregate`.
 - `SmsFailureKinds` — shared classifier (`FromHttpStatusCode`, `FromException`) so every provider maps transport signals to the same `SmsFailureKind`.
 - `AddHeadlessSms(setup => setup.Use{Provider}(...))` — root registration entry with an exactly-one-provider gate; each provider package contributes a `Use{Provider}` builder member.
 - Never throws for provider errors — only `OperationCanceledException` and argument-validation exceptions (malformed request) propagate.
@@ -205,7 +211,7 @@ public sealed class OtpService(ISmsSender smsSender)
     {
         var request = new SendSingleSmsRequest
         {
-            Destinations = [new SmsRequestDestination(20, phoneNumber)], // 20 = Egypt calling code
+            Destination = new SmsRequestDestination(20, phoneNumber), // 20 = Egypt calling code
             Text = $"Your verification code is: {code}",
         };
 
@@ -413,7 +419,7 @@ Provides SMS sending via the Connekio API using basic username/password/accountI
 ### Key Features
 
 - `ConnekioSmsSender` — `ISmsSender` implementation backed by the Connekio REST API.
-- Separate `SingleSmsEndpoint` and `BatchSmsEndpoint` (auto-selected based on `IsBatch`).
+- Separate `SingleSmsEndpoint` (used by `SendAsync`) and `BatchSmsEndpoint` (used by `IBulkSmsSender.SendBulkAsync`).
 - Basic auth: `UserName` + `Password` + `AccountId`.
 - Standard resilience pipeline with auto-retry **disabled** by default.
 - Optional `configureClient` and `configureResilience` hooks.

--- a/src/Headless.Sms.Abstractions/Contracts/SendBulkSmsRequest.cs
+++ b/src/Headless.Sms.Abstractions/Contracts/SendBulkSmsRequest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Headless.Sms;
+
+/// <summary>Describes a single SMS message delivered to many recipients in one provider call.</summary>
+/// <remarks>
+/// Used with <see cref="IBulkSmsSender"/>. The same <see cref="Text"/> is sent to every entry in
+/// <see cref="Destinations"/>. The outcome is a <see cref="SendBulkSmsResponse"/> with one result per
+/// recipient; providers whose API cannot report per-recipient outcomes apply the same aggregate result to
+/// every recipient.
+/// </remarks>
+[PublicAPI]
+public sealed class SendBulkSmsRequest
+{
+    /// <summary>
+    /// Caller-supplied correlation id for the batch. Providers that accept a client message id forward it
+    /// (deriving per-recipient ids where required); others ignore it. May be <see langword="null"/>.
+    /// </summary>
+    public string? MessageId { get; init; }
+
+    /// <summary>The recipients. Must contain at least one destination.</summary>
+    public required IReadOnlyList<SmsRequestDestination> Destinations { get; init; }
+
+    /// <summary>The plain-text body of the SMS message.</summary>
+    public required string Text { get; init; }
+
+    /// <summary>
+    /// Optional provider-specific or application-specific metadata. Providers may read well-known keys from
+    /// this dictionary; unrecognized keys are ignored.
+    /// </summary>
+    public IDictionary<string, object>? Properties { get; init; }
+}

--- a/src/Headless.Sms.Abstractions/Contracts/SendBulkSmsResponse.cs
+++ b/src/Headless.Sms.Abstractions/Contracts/SendBulkSmsResponse.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Checks;
+
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Headless.Sms;
+
+/// <summary>The outcome of a bulk send: one <see cref="SmsRecipientResult"/> per recipient, in request order.</summary>
+/// <remarks>
+/// Providers that return per-recipient detail (for example Infobip) populate each result individually.
+/// Providers whose API reports a single status for the whole batch use <see cref="FromAggregate"/> to apply
+/// that one outcome to every recipient — in that case <see cref="AllSucceeded"/> reflects the batch status,
+/// but the per-recipient breakdown is identical for all entries.
+/// </remarks>
+[PublicAPI]
+public sealed class SendBulkSmsResponse
+{
+    private SendBulkSmsResponse(IReadOnlyList<SmsRecipientResult> results, string? providerBatchId)
+    {
+        Results = results;
+        ProviderBatchId = providerBatchId;
+    }
+
+    /// <summary>Per-recipient outcomes, in the order recipients were supplied in the request.</summary>
+    public IReadOnlyList<SmsRecipientResult> Results { get; }
+
+    /// <summary>
+    /// Provider-assigned identifier for the batch when the backend returns one (for example the Infobip
+    /// bulk id). May be <see langword="null"/> when the provider does not expose one.
+    /// </summary>
+    public string? ProviderBatchId { get; }
+
+    /// <summary>Whether every recipient was accepted by the provider.</summary>
+    public bool AllSucceeded => Results.All(static r => r.Result.Success);
+
+    /// <summary>Whether at least one recipient was accepted by the provider.</summary>
+    public bool AnySucceeded => Results.Any(static r => r.Result.Success);
+
+    /// <summary>Creates a response from explicit per-recipient results.</summary>
+    /// <param name="results">One result per recipient. Must not be <see langword="null"/>.</param>
+    /// <param name="providerBatchId">The provider-assigned batch id, when available.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="results"/> is <see langword="null"/>.</exception>
+    public static SendBulkSmsResponse FromResults(
+        IReadOnlyList<SmsRecipientResult> results,
+        string? providerBatchId = null
+    )
+    {
+        Argument.IsNotNull(results);
+
+        return new SendBulkSmsResponse(results, providerBatchId);
+    }
+
+    /// <summary>
+    /// Creates a response that applies one aggregate <paramref name="outcome"/> to every recipient. Used by
+    /// providers whose API reports a single status for the whole batch rather than per-recipient detail.
+    /// </summary>
+    /// <param name="destinations">The recipients the outcome applies to. Must not be <see langword="null"/>.</param>
+    /// <param name="outcome">The single outcome to mirror onto every recipient. Must not be <see langword="null"/>.</param>
+    /// <param name="providerBatchId">The provider-assigned batch id, when available.</param>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    public static SendBulkSmsResponse FromAggregate(
+        IEnumerable<SmsRequestDestination> destinations,
+        SendSingleSmsResponse outcome,
+        string? providerBatchId = null
+    )
+    {
+        Argument.IsNotNull(destinations);
+        Argument.IsNotNull(outcome);
+
+        var results = destinations.Select(destination => new SmsRecipientResult(destination, outcome)).ToList();
+
+        return new SendBulkSmsResponse(results, providerBatchId);
+    }
+}
+
+/// <summary>The outcome for one recipient within a <see cref="SendBulkSmsResponse"/>.</summary>
+/// <param name="Destination">The recipient this outcome belongs to.</param>
+/// <param name="Result">The single-send outcome for this recipient.</param>
+[PublicAPI]
+public sealed record SmsRecipientResult(SmsRequestDestination Destination, SendSingleSmsResponse Result);

--- a/src/Headless.Sms.Abstractions/Contracts/SendBulkSmsResponse.cs
+++ b/src/Headless.Sms.Abstractions/Contracts/SendBulkSmsResponse.cs
@@ -37,15 +37,17 @@ public sealed class SendBulkSmsResponse
     public bool AnySucceeded => Results.Any(static r => r.Result.Success);
 
     /// <summary>Creates a response from explicit per-recipient results.</summary>
-    /// <param name="results">One result per recipient. Must not be <see langword="null"/>.</param>
+    /// <param name="results">One result per recipient. Must not be <see langword="null"/> or empty.</param>
     /// <param name="providerBatchId">The provider-assigned batch id, when available.</param>
     /// <exception cref="ArgumentNullException"><paramref name="results"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="results"/> is empty.</exception>
     public static SendBulkSmsResponse FromResults(
         IReadOnlyList<SmsRecipientResult> results,
         string? providerBatchId = null
     )
     {
         Argument.IsNotNull(results);
+        Argument.IsNotEmpty(results);
 
         return new SendBulkSmsResponse(results, providerBatchId);
     }

--- a/src/Headless.Sms.Abstractions/Contracts/SendSingleSmsRequest.cs
+++ b/src/Headless.Sms.Abstractions/Contracts/SendSingleSmsRequest.cs
@@ -3,11 +3,11 @@
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Headless.Sms;
 
-/// <summary>Describes a single SMS message to be sent through <see cref="ISmsSender"/>.</summary>
+/// <summary>Describes a single SMS message to one recipient, sent through <see cref="ISmsSender"/>.</summary>
 /// <remarks>
-/// A request targets one or more recipients via <see cref="Destinations"/>. When more than one destination
-/// is specified the request is treated as a batch send (<see cref="IsBatch"/> is <see langword="true"/>);
-/// providers that do not support batch sends natively will reject such requests with a failed response.
+/// Each request targets exactly one recipient (<see cref="Destination"/>). To send the same text to many
+/// recipients in one provider call, use a provider that implements <see cref="IBulkSmsSender"/> and its
+/// <see cref="SendBulkSmsRequest"/> instead.
 /// </remarks>
 [PublicAPI]
 public sealed class SendSingleSmsRequest
@@ -20,10 +20,10 @@ public sealed class SendSingleSmsRequest
     public string? MessageId { get; init; }
 
     /// <summary>
-    /// One or more recipients. Each entry contains a dial-code (<see cref="SmsRequestDestination.Code"/>) and
-    /// a local subscriber number (<see cref="SmsRequestDestination.Number"/>).
+    /// The single recipient: a dial-code (<see cref="SmsRequestDestination.Code"/>) and a local subscriber
+    /// number (<see cref="SmsRequestDestination.Number"/>).
     /// </summary>
-    public required IReadOnlyList<SmsRequestDestination> Destinations { get; init; }
+    public required SmsRequestDestination Destination { get; init; }
 
     /// <summary>The plain-text body of the SMS message.</summary>
     public required string Text { get; init; }
@@ -33,13 +33,6 @@ public sealed class SendSingleSmsRequest
     /// from this dictionary; unrecognized keys are ignored.
     /// </summary>
     public IDictionary<string, object>? Properties { get; init; }
-
-    /// <summary>
-    /// <see langword="true"/> when the request targets more than one recipient; <see langword="false"/> for
-    /// single-recipient sends. Providers that do not support batch sends natively will return a failed
-    /// response for batch requests.
-    /// </summary>
-    public bool IsBatch => Destinations.Count > 1;
 }
 
 /// <summary>A single SMS recipient identified by a dial code and a subscriber number.</summary>

--- a/src/Headless.Sms.Abstractions/Contracts/SendSingleSmsResponse.cs
+++ b/src/Headless.Sms.Abstractions/Contracts/SendSingleSmsResponse.cs
@@ -100,12 +100,4 @@ public enum SmsFailureKind
 
     /// <summary>The provider account has insufficient credit or balance.</summary>
     OutOfCredit,
-
-    /// <summary>
-    /// The provider does not support the requested operation (for example a multi-destination batch send on a
-    /// provider that only sends to one recipient per call). Retrying or switching the same request to another
-    /// instance of the same provider will not help; the caller must change the request or route to a different
-    /// provider.
-    /// </summary>
-    Unsupported,
 }

--- a/src/Headless.Sms.Abstractions/IBulkSmsSender.cs
+++ b/src/Headless.Sms.Abstractions/IBulkSmsSender.cs
@@ -25,7 +25,9 @@ public interface IBulkSmsSender
     /// propagate. Providers whose API reports a single status for the whole batch apply that aggregate outcome
     /// to every recipient.
     /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> or its <see cref="SendBulkSmsRequest.Destinations"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="request"/> has no destinations or an empty message body.
     /// </exception>

--- a/src/Headless.Sms.Abstractions/IBulkSmsSender.cs
+++ b/src/Headless.Sms.Abstractions/IBulkSmsSender.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Sms;
+
+/// <summary>
+/// Optional capability implemented by SMS providers that can deliver one message to many recipients in a
+/// single provider call.
+/// </summary>
+/// <remarks>
+/// Resolve it from DI directly, or check <c>sender is IBulkSmsSender</c> on an <see cref="ISmsSender"/>.
+/// Providers without native bulk support (for example Twilio and AWS SNS, which send to one recipient per
+/// API call) do not register or implement this interface — resolving it will fail, signalling the capability
+/// is unavailable. To fan a message out over such a provider, loop <see cref="ISmsSender.SendAsync"/>.
+/// </remarks>
+[PublicAPI]
+public interface IBulkSmsSender
+{
+    /// <summary>Sends the message described by <paramref name="request"/> to all of its recipients.</summary>
+    /// <param name="request">The message, recipients, and optional metadata to send.</param>
+    /// <param name="cancellationToken">A token to cancel the send.</param>
+    /// <returns>
+    /// A <see cref="SendBulkSmsResponse"/> carrying one <see cref="SmsRecipientResult"/> per recipient.
+    /// As with <see cref="ISmsSender"/>, provider and transport failures are returned rather than thrown;
+    /// only argument-validation exceptions (for a malformed request) and <see cref="OperationCanceledException"/>
+    /// propagate. Providers whose API reports a single status for the whole batch apply that aggregate outcome
+    /// to every recipient.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="request"/> has no destinations or an empty message body.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// The send was canceled through <paramref name="cancellationToken"/>.
+    /// </exception>
+    ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Headless.Sms.Abstractions/ISmsSender.cs
+++ b/src/Headless.Sms.Abstractions/ISmsSender.cs
@@ -2,12 +2,16 @@
 
 namespace Headless.Sms;
 
-/// <summary>Sends SMS messages through a configured provider backend.</summary>
+/// <summary>Sends SMS messages to a single recipient through a configured provider backend.</summary>
+/// <remarks>
+/// To send the same message to many recipients in one provider call, resolve <see cref="IBulkSmsSender"/>
+/// (implemented by providers with native bulk support).
+/// </remarks>
 [PublicAPI]
 public interface ISmsSender
 {
-    /// <summary>Sends an SMS message described by <paramref name="request"/>.</summary>
-    /// <param name="request">The message, destination(s), and optional metadata to send.</param>
+    /// <summary>Sends an SMS message described by <paramref name="request"/> to its single recipient.</summary>
+    /// <param name="request">The message, recipient, and optional metadata to send.</param>
     /// <param name="cancellationToken">A token to cancel the send.</param>
     /// <returns>
     /// A <see cref="SendSingleSmsResponse"/> describing the outcome. Implementations return
@@ -21,10 +25,10 @@ public interface ISmsSender
     /// <see cref="OperationCanceledException"/> when the send is canceled. Every other failure is returned as
     /// <see cref="SendSingleSmsResponse.Failed"/>.
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException">
-    /// <paramref name="request"/> has no destinations or an empty message body.
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> or its <see cref="SendSingleSmsRequest.Destination"/> is <see langword="null"/>.
     /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="request"/> has an empty message body.</exception>
     /// <exception cref="OperationCanceledException">
     /// The send was canceled through <paramref name="cancellationToken"/>.
     /// </exception>

--- a/src/Headless.Sms.Abstractions/README.md
+++ b/src/Headless.Sms.Abstractions/README.md
@@ -8,11 +8,14 @@ Provides a provider-agnostic SMS sending API so application code stays decoupled
 
 ## Key Features
 
-- `ISmsSender` — single method `SendAsync(SendSingleSmsRequest, CancellationToken) : ValueTask<SendSingleSmsResponse>`.
-- `SendSingleSmsRequest` — message contract with `Destinations` (list of `SmsRequestDestination`), `Text`, optional `MessageId`, and optional `Properties`.
+- `ISmsSender` — single-recipient send: `SendAsync(SendSingleSmsRequest, CancellationToken) : ValueTask<SendSingleSmsResponse>`.
+- `IBulkSmsSender` — optional capability for multi-recipient sends: `SendBulkAsync(SendBulkSmsRequest, CancellationToken) : ValueTask<SendBulkSmsResponse>`. Implemented only by providers with native bulk support.
+- `SendSingleSmsRequest` — single-recipient contract with `Destination` (one `SmsRequestDestination`), `Text`, optional `MessageId`, and optional `Properties`.
+- `SendBulkSmsRequest` — bulk contract with `Destinations` (list), `Text`, optional `MessageId`/`Properties`.
 - `SmsRequestDestination(int Code, string Number)` — phone number with separate country calling code and subscriber number.
 - `SendSingleSmsResponse` — closed result type; `Success` (bool), optional `ProviderMessageId`, `FailureError` (string? non-null on failure), and `FailureKind` (`SmsFailureKind`). Built via `Succeeded`, `Failed`, or `FromException`.
-- `SmsFailureKinds` — shared classifier (`FromHttpStatusCode`, `FromException`) so every provider maps transport signals to the same `SmsFailureKind` (`None`, `Unknown`, `Transient`, `RateLimited`, `InvalidRecipient`, `AuthFailure`, `OutOfCredit`, `Unsupported`).
+- `SendBulkSmsResponse` — per-recipient bulk result; `Results` (one `SmsRecipientResult` each), `AllSucceeded`/`AnySucceeded`, optional `ProviderBatchId`. Built via `FromResults` or `FromAggregate`.
+- `SmsFailureKinds` — shared classifier (`FromHttpStatusCode`, `FromException`) so every provider maps transport signals to the same `SmsFailureKind` (`None`, `Unknown`, `Transient`, `RateLimited`, `InvalidRecipient`, `AuthFailure`, `OutOfCredit`).
 - Never throws for provider errors — only `OperationCanceledException` and argument-validation exceptions (malformed request) propagate.
 
 ## Installation
@@ -30,7 +33,7 @@ public sealed class OtpService(ISmsSender smsSender)
     {
         var request = new SendSingleSmsRequest
         {
-            Destinations = [new SmsRequestDestination(20, phoneNumber)], // 20 = Egypt calling code
+            Destination = new SmsRequestDestination(20, phoneNumber), // 20 = Egypt calling code
             Text = $"Your verification code is: {code}",
         };
 

--- a/src/Headless.Sms.Aws/AwsSnsSmsSender.cs
+++ b/src/Headless.Sms.Aws/AwsSnsSmsSender.cs
@@ -23,16 +23,8 @@ internal sealed class AwsSnsSmsSender(
     )
     {
         Argument.IsNotNull(request);
-        Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotNull(request.Destination);
         Argument.IsNotEmpty(request.Text);
-
-        if (request.Destinations.Count > 1)
-        {
-            return SendSingleSmsResponse.Failed(
-                "AWS SNS does not support sending SMS to multiple destinations",
-                SmsFailureKind.Unsupported
-            );
-        }
 
         var attributes = new Dictionary<string, MessageAttributeValue>(StringComparer.Ordinal)
         {
@@ -60,7 +52,7 @@ internal sealed class AwsSnsSmsSender(
 
         var publishRequest = new PublishRequest
         {
-            PhoneNumber = request.Destinations[0].ToString(hasPlusPrefix: true),
+            PhoneNumber = request.Destination.ToString(hasPlusPrefix: true),
             Message = request.Text,
             MessageAttributes = attributes,
         };
@@ -74,7 +66,7 @@ internal sealed class AwsSnsSmsSender(
                 return SendSingleSmsResponse.Succeeded(publishResponse.MessageId);
             }
 
-            logger.LogSmsSendFailed(request.Destinations.Count, publishResponse.HttpStatusCode);
+            logger.LogSmsSendFailed(destinationCount: 1, publishResponse.HttpStatusCode);
 
             return SendSingleSmsResponse.Failed(
                 $"Failed to send SMS using AWS with status code {publishResponse.HttpStatusCode}",
@@ -87,7 +79,7 @@ internal sealed class AwsSnsSmsSender(
         }
         catch (Exception e)
         {
-            logger.LogSmsSendException(e, request.Destinations.Count);
+            logger.LogSmsSendException(e, destinationCount: 1);
 
             return SendSingleSmsResponse.FromException(e);
         }

--- a/src/Headless.Sms.Aws/README.md
+++ b/src/Headless.Sms.Aws/README.md
@@ -8,7 +8,7 @@ Provides SMS sending via Amazon Simple Notification Service (SNS), reusing exist
 
 ## Key Features
 
-- `AwsSnsSmsSender` — `ISmsSender` implementation backed by AWS SNS.
+- `AwsSnsSmsSender` — `ISmsSender` implementation backed by AWS SNS. Single recipient per send; does not implement `IBulkSmsSender` (SNS publishes to one phone number per call).
 - `SenderId` — alphanumeric sender ID displayed to recipients (support varies by country).
 - `MaxPrice` — optional per-message USD price cap; SNS rejects sends that would exceed it.
 - Accepts any AWS credential source: environment, instance metadata, `appsettings.json` via `AWSOptions`, or explicit `BasicAWSCredentials`.

--- a/src/Headless.Sms.Cequens/CequensSmsSender.cs
+++ b/src/Headless.Sms.Cequens/CequensSmsSender.cs
@@ -19,7 +19,7 @@ internal sealed class CequensSmsSender(
     TimeProvider timeProvider,
     IOptions<CequensSmsOptions> optionsAccessor,
     ILogger<CequensSmsSender> logger
-) : ISmsSender, IDisposable
+) : ISmsSender, IBulkSmsSender, IDisposable
 {
     private static readonly JsonSerializerOptions _JsonOptions = new()
     {
@@ -36,12 +36,54 @@ internal sealed class CequensSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destination);
+        Argument.IsNotEmpty(request.Text);
+
+        return await _SendAsync(
+                request.Destination.ToString(),
+                request.MessageId,
+                request.Text,
+                destinationCount: 1,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 
+        // Cequens accepts a comma-separated recipient list and reports a single status, so the same outcome
+        // applies to every recipient.
+        var outcome = await _SendAsync(
+                string.Join(',', request.Destinations),
+                request.MessageId,
+                request.Text,
+                request.Destinations.Count,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
+    }
+
+    private async ValueTask<SendSingleSmsResponse> _SendAsync(
+        string recipients,
+        string? messageId,
+        string text,
+        int destinationCount,
+        CancellationToken cancellationToken
+    )
+    {
         try
         {
-            return await _SendCoreAsync(request, cancellationToken).ConfigureAwait(false);
+            return await _SendCoreAsync(recipients, messageId, text, destinationCount, cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -49,14 +91,17 @@ internal sealed class CequensSmsSender(
         }
         catch (Exception e)
         {
-            logger.LogSmsSendException(e, request.Destinations.Count);
+            logger.LogSmsSendException(e, destinationCount);
 
             return SendSingleSmsResponse.FromException(e);
         }
     }
 
     private async ValueTask<SendSingleSmsResponse> _SendCoreAsync(
-        SendSingleSmsRequest request,
+        string recipients,
+        string? messageId,
+        string text,
+        int destinationCount,
         CancellationToken cancellationToken
     )
     {
@@ -65,13 +110,10 @@ internal sealed class CequensSmsSender(
         var apiRequest = new SendSmsRequest
         {
             ClientMessageId =
-                request.MessageId is not null
-                && int.TryParse(request.MessageId, CultureInfo.InvariantCulture, out var id)
-                    ? id
-                    : null,
+                messageId is not null && int.TryParse(messageId, CultureInfo.InvariantCulture, out var id) ? id : null,
             SenderName = _options.SenderName,
-            MessageText = request.Text,
-            Recipients = request.IsBatch ? string.Join(',', request.Destinations) : request.Destinations[0].ToString(),
+            MessageText = text,
+            Recipients = recipients,
         };
 
         // At most two attempts: a 401 invalidates a stale cached token so the retry re-authenticates.
@@ -95,7 +137,7 @@ internal sealed class CequensSmsSender(
 
             if (response.IsSuccessStatusCode)
             {
-                logger.LogSmsSentSuccessfully(request.Destinations.Count, response.StatusCode);
+                logger.LogSmsSentSuccessfully(destinationCount, response.StatusCode);
 
                 return SendSingleSmsResponse.Succeeded();
             }
@@ -107,7 +149,7 @@ internal sealed class CequensSmsSender(
                 continue;
             }
 
-            logger.LogFailedToSendSms(request.Destinations.Count, response.StatusCode);
+            logger.LogFailedToSendSms(destinationCount, response.StatusCode);
 
             var rawContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var error = string.IsNullOrEmpty(rawContent) ? "Failed to send SMS using Cequens API" : rawContent;

--- a/src/Headless.Sms.Cequens/CequensSmsSender.cs
+++ b/src/Headless.Sms.Cequens/CequensSmsSender.cs
@@ -55,6 +55,7 @@ internal sealed class CequensSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 

--- a/src/Headless.Sms.Cequens/README.md
+++ b/src/Headless.Sms.Cequens/README.md
@@ -8,7 +8,7 @@ Provides SMS sending via the Cequens API, a regional MENA gateway that authentic
 
 ## Key Features
 
-- `CequensSmsSender` — `ISmsSender` implementation backed by the Cequens REST API.
+- `CequensSmsSender` — implements `ISmsSender` (single recipient) and `IBulkSmsSender` (multi-recipient bulk), backed by the Cequens REST API.
 - JWT token-based auth with automatic token acquisition from `TokenEndpoint`.
 - Optional pre-configured `Token` to skip the sign-in flow.
 - Configurable `SingleSmsEndpoint` and `TokenEndpoint` (defaults point to the Cequens production API).

--- a/src/Headless.Sms.Cequens/Setup.cs
+++ b/src/Headless.Sms.Cequens/Setup.cs
@@ -124,6 +124,7 @@ public static class SetupCequens
         {
             _configureOptions(services);
             services.AddSingleton<ISmsSender, CequensSmsSender>();
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
 
             var httpClientBuilder = _configureClient is null
                 ? services.AddHttpClient(HttpClientName)

--- a/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
+++ b/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
@@ -66,6 +66,7 @@ internal sealed class ConnekioSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 

--- a/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
+++ b/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
@@ -41,32 +41,23 @@ internal sealed class ConnekioSmsSender(
         Argument.IsNotNull(request.Destination);
         Argument.IsNotEmpty(request.Text);
 
-        try
-        {
-            var payload = JsonSerializer.Serialize(
-                new ConnekioSingleSmsRequest
-                {
-                    AccountId = _options.AccountId,
-                    Sender = _options.Sender,
-                    Text = request.Text,
-                    Msisdn = request.Destination.ToString(),
-                },
-                _JsonOptions
-            );
-
-            return await _PostAsync(_singleSmsEndpoint, payload, destinationCount: 1, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception e)
-        {
-            logger.LogSmsSendException(e, destinationCount: 1);
-
-            return SendSingleSmsResponse.FromException(e);
-        }
+        return await _SendAsync(
+                _singleSmsEndpoint,
+                () =>
+                    JsonSerializer.Serialize(
+                        new ConnekioSingleSmsRequest
+                        {
+                            AccountId = _options.AccountId,
+                            Sender = _options.Sender,
+                            Text = request.Text,
+                            Msisdn = request.Destination.ToString(),
+                        },
+                        _JsonOptions
+                    ),
+                destinationCount: 1,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
@@ -80,25 +71,44 @@ internal sealed class ConnekioSmsSender(
 
         // Connekio has a dedicated batch endpoint that returns a single status, so the same outcome applies to
         // every recipient.
+        var outcome = await _SendAsync(
+                _batchSmsEndpoint,
+                () =>
+                    JsonSerializer.Serialize(
+                        new ConnekioBatchSmsRequest
+                        {
+                            AccountId = _options.AccountId,
+                            Sender = _options.Sender,
+                            Text = request.Text,
+                            MobileList = request
+                                .Destinations.Select(r => new ConnekioRecipient { Msisdn = r.ToString() })
+                                .ToList(),
+                        },
+                        _JsonOptions
+                    ),
+                request.Destinations.Count,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
+    }
+
+    // Both entry points share one try/catch so the never-throw contract (only OperationCanceledException and
+    // argument-validation propagate) lives in a single place. The payload is built inside the guarded region so
+    // a serialization fault is reported as a failed response rather than thrown.
+    private async ValueTask<SendSingleSmsResponse> _SendAsync(
+        Uri endpoint,
+        [InstantHandle] Func<string> payloadFactory,
+        int destinationCount,
+        CancellationToken cancellationToken
+    )
+    {
         try
         {
-            var payload = JsonSerializer.Serialize(
-                new ConnekioBatchSmsRequest
-                {
-                    AccountId = _options.AccountId,
-                    Sender = _options.Sender,
-                    Text = request.Text,
-                    MobileList = request
-                        .Destinations.Select(r => new ConnekioRecipient { Msisdn = r.ToString() })
-                        .ToList(),
-                },
-                _JsonOptions
-            );
+            var payload = payloadFactory();
 
-            var outcome = await _PostAsync(_batchSmsEndpoint, payload, request.Destinations.Count, cancellationToken)
-                .ConfigureAwait(false);
-
-            return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
+            return await _PostAsync(endpoint, payload, destinationCount, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -106,9 +116,9 @@ internal sealed class ConnekioSmsSender(
         }
         catch (Exception e)
         {
-            logger.LogSmsSendException(e, request.Destinations.Count);
+            logger.LogSmsSendException(e, destinationCount);
 
-            return SendBulkSmsResponse.FromAggregate(request.Destinations, SendSingleSmsResponse.FromException(e));
+            return SendSingleSmsResponse.FromException(e);
         }
     }
 

--- a/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
+++ b/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
@@ -14,7 +14,7 @@ internal sealed class ConnekioSmsSender(
     IHttpClientFactory httpClientFactory,
     IOptions<ConnekioSmsOptions> optionsAccessor,
     ILogger<ConnekioSmsSender> logger
-) : ISmsSender
+) : ISmsSender, IBulkSmsSender
 {
     private static readonly JsonSerializerOptions _JsonOptions = new()
     {
@@ -38,12 +38,67 @@ internal sealed class ConnekioSmsSender(
     )
     {
         Argument.IsNotNull(request);
-        Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotNull(request.Destination);
         Argument.IsNotEmpty(request.Text);
 
         try
         {
-            return await _SendCoreAsync(request, cancellationToken).ConfigureAwait(false);
+            var payload = JsonSerializer.Serialize(
+                new ConnekioSingleSmsRequest
+                {
+                    AccountId = _options.AccountId,
+                    Sender = _options.Sender,
+                    Text = request.Text,
+                    Msisdn = request.Destination.ToString(),
+                },
+                _JsonOptions
+            );
+
+            return await _PostAsync(_singleSmsEndpoint, payload, destinationCount: 1, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            logger.LogSmsSendException(e, destinationCount: 1);
+
+            return SendSingleSmsResponse.FromException(e);
+        }
+    }
+
+    public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
+        Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotEmpty(request.Text);
+
+        // Connekio has a dedicated batch endpoint that returns a single status, so the same outcome applies to
+        // every recipient.
+        try
+        {
+            var payload = JsonSerializer.Serialize(
+                new ConnekioBatchSmsRequest
+                {
+                    AccountId = _options.AccountId,
+                    Sender = _options.Sender,
+                    Text = request.Text,
+                    MobileList = request
+                        .Destinations.Select(r => new ConnekioRecipient { Msisdn = r.ToString() })
+                        .ToList(),
+                },
+                _JsonOptions
+            );
+
+            var outcome = await _PostAsync(_batchSmsEndpoint, payload, request.Destinations.Count, cancellationToken)
+                .ConfigureAwait(false);
+
+            return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
         }
         catch (OperationCanceledException)
         {
@@ -53,21 +108,19 @@ internal sealed class ConnekioSmsSender(
         {
             logger.LogSmsSendException(e, request.Destinations.Count);
 
-            return SendSingleSmsResponse.FromException(e);
+            return SendBulkSmsResponse.FromAggregate(request.Destinations, SendSingleSmsResponse.FromException(e));
         }
     }
 
-    #region Helpers
-
-    private async ValueTask<SendSingleSmsResponse> _SendCoreAsync(
-        SendSingleSmsRequest request,
+    private async ValueTask<SendSingleSmsResponse> _PostAsync(
+        Uri endpoint,
+        string payload,
+        int destinationCount,
         CancellationToken cancellationToken
     )
     {
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, _GetEndpoint(request.IsBatch));
-
-        requestMessage.Content = new StringContent(_BuildPayload(request), Encoding.UTF8, "application/json");
-
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        requestMessage.Content = new StringContent(payload, Encoding.UTF8, "application/json");
         requestMessage.Headers.Authorization = _basicAuthHeader;
 
         using var httpClient = httpClientFactory.CreateClient(SetupConnekio.HttpClientName);
@@ -87,44 +140,11 @@ internal sealed class ConnekioSmsSender(
         }
         else
         {
-            logger.LogFailedToSendSms(request.Destinations.Count, response.StatusCode);
+            logger.LogFailedToSendSms(destinationCount, response.StatusCode);
         }
 
         var error = string.IsNullOrWhiteSpace(rawContent) ? "Failed to send SMS using Connekio API" : rawContent;
 
         return SendSingleSmsResponse.Failed(error, SmsFailureKinds.FromHttpStatusCode(response.StatusCode));
     }
-
-    private string _BuildPayload(SendSingleSmsRequest request)
-    {
-        if (request.IsBatch)
-        {
-            var batchRequest = new ConnekioBatchSmsRequest
-            {
-                AccountId = _options.AccountId,
-                Sender = _options.Sender,
-                Text = request.Text,
-                MobileList = request.Destinations.Select(r => new ConnekioRecipient { Msisdn = r.ToString() }).ToList(),
-            };
-
-            return JsonSerializer.Serialize(batchRequest, _JsonOptions);
-        }
-
-        var singleRequest = new ConnekioSingleSmsRequest
-        {
-            AccountId = _options.AccountId,
-            Sender = _options.Sender,
-            Text = request.Text,
-            Msisdn = request.Destinations[0].ToString(),
-        };
-
-        return JsonSerializer.Serialize(singleRequest, _JsonOptions);
-    }
-
-    private Uri _GetEndpoint(bool isBatch)
-    {
-        return isBatch ? _batchSmsEndpoint : _singleSmsEndpoint;
-    }
-
-    #endregion
 }

--- a/src/Headless.Sms.Connekio/README.md
+++ b/src/Headless.Sms.Connekio/README.md
@@ -8,8 +8,8 @@ Provides SMS sending via the Connekio API using basic username/password/accountI
 
 ## Key Features
 
-- `ConnekioSmsSender` — `ISmsSender` implementation backed by the Connekio REST API.
-- Separate `SingleSmsEndpoint` and `BatchSmsEndpoint` (auto-selected based on `IsBatch`).
+- `ConnekioSmsSender` — implements `ISmsSender` (single recipient) and `IBulkSmsSender` (multi-recipient bulk).
+- Separate `SingleSmsEndpoint` (used by `SendAsync`) and `BatchSmsEndpoint` (used by `SendBulkAsync`).
 - Basic auth: `UserName` + `Password` + `AccountId`.
 - Standard resilience pipeline with auto-retry **disabled** by default to prevent duplicate SMS.
 - Optional `configureClient` and `configureResilience` hooks for fine-grained `HttpClient` control.

--- a/src/Headless.Sms.Connekio/Setup.cs
+++ b/src/Headless.Sms.Connekio/Setup.cs
@@ -123,6 +123,7 @@ public static class SetupConnekio
         {
             _configureOptions(services);
             services.AddSingleton<ISmsSender, ConnekioSmsSender>();
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
 
             var httpClientBuilder = _configureClient is null
                 ? services.AddHttpClient(HttpClientName)

--- a/src/Headless.Sms.Dev/DevSmsSender.cs
+++ b/src/Headless.Sms.Dev/DevSmsSender.cs
@@ -5,7 +5,7 @@ using Headless.Sms.Dev.Internals;
 
 namespace Headless.Sms.Dev;
 
-internal sealed class DevSmsSender(string filePath) : ISmsSender, IDisposable
+internal sealed class DevSmsSender(string filePath) : ISmsSender, IBulkSmsSender, IDisposable
 {
     private const string _Separator = "--------------------";
     private readonly string _filePath = Argument.IsNotNullOrEmpty(filePath);
@@ -22,24 +22,65 @@ internal sealed class DevSmsSender(string filePath) : ISmsSender, IDisposable
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destination);
+        Argument.IsNotEmpty(request.Text);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return await _WriteAsync(
+                request.MessageId,
+                request.Destination.ToString(),
+                request.Text,
+                request.Properties,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        var outcome = await _WriteAsync(
+                request.MessageId,
+                request.Destinations.JoinAsString(", "),
+                request.Text,
+                request.Properties,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
+    }
+
+    private async ValueTask<SendSingleSmsResponse> _WriteAsync(
+        string? messageId,
+        string recipients,
+        string text,
+        IDictionary<string, object>? properties,
+        CancellationToken cancellationToken
+    )
+    {
         var sb = new StringBuilder();
 
-        if (!string.IsNullOrEmpty(request.MessageId))
+        if (!string.IsNullOrEmpty(messageId))
         {
-            sb.Append("MessageId: ").AppendLine(request.MessageId);
+            sb.Append("MessageId: ").AppendLine(messageId);
         }
 
-        sb.Append("To: ").AppendLine(request.Destinations.JoinAsString(", "));
-        sb.Append("Text: ").AppendLine(request.Text);
+        sb.Append("To: ").AppendLine(recipients);
+        sb.Append("Text: ").AppendLine(text);
 
-        if (request.Properties is not null)
+        if (properties is not null)
         {
-            sb.Append("Properties: ").AppendLine(JsonSerializer.Serialize(request.Properties, _JsonOptions));
+            sb.Append("Properties: ").AppendLine(JsonSerializer.Serialize(properties, _JsonOptions));
         }
 
         sb.AppendLine(_Separator);

--- a/src/Headless.Sms.Dev/DevSmsSender.cs
+++ b/src/Headless.Sms.Dev/DevSmsSender.cs
@@ -43,6 +43,7 @@ internal sealed class DevSmsSender(string filePath) : ISmsSender, IBulkSmsSender
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 

--- a/src/Headless.Sms.Dev/NoopSmsSender.cs
+++ b/src/Headless.Sms.Dev/NoopSmsSender.cs
@@ -11,6 +11,10 @@ internal sealed class NoopSmsSender : ISmsSender, IBulkSmsSender
         CancellationToken cancellationToken = default
     )
     {
+        Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destination);
+        Argument.IsNotEmpty(request.Text);
+
         cancellationToken.ThrowIfCancellationRequested();
 
         return ValueTask.FromResult(SendSingleSmsResponse.Succeeded());
@@ -23,6 +27,7 @@ internal sealed class NoopSmsSender : ISmsSender, IBulkSmsSender
     {
         Argument.IsNotNull(request);
         Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotEmpty(request.Text);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Headless.Sms.Dev/NoopSmsSender.cs
+++ b/src/Headless.Sms.Dev/NoopSmsSender.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Checks;
+
 namespace Headless.Sms.Dev;
 
-internal sealed class NoopSmsSender : ISmsSender
+internal sealed class NoopSmsSender : ISmsSender, IBulkSmsSender
 {
     public ValueTask<SendSingleSmsResponse> SendAsync(
         SendSingleSmsRequest request,
@@ -10,6 +12,22 @@ internal sealed class NoopSmsSender : ISmsSender
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+
         return ValueTask.FromResult(SendSingleSmsResponse.Succeeded());
+    }
+
+    public ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
+        Argument.IsNotEmpty(request.Destinations);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(
+            SendBulkSmsResponse.FromAggregate(request.Destinations, SendSingleSmsResponse.Succeeded())
+        );
     }
 }

--- a/src/Headless.Sms.Dev/NoopSmsSender.cs
+++ b/src/Headless.Sms.Dev/NoopSmsSender.cs
@@ -26,6 +26,7 @@ internal sealed class NoopSmsSender : ISmsSender, IBulkSmsSender
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 

--- a/src/Headless.Sms.Dev/README.md
+++ b/src/Headless.Sms.Dev/README.md
@@ -8,8 +8,8 @@ Provides no-op and file-logging SMS senders for development and test environment
 
 ## Key Features
 
-- `DevSmsSender` — appends formatted SMS details to a local file for inspection.
-- `NoopSmsSender` — silently discards all messages and returns `SendSingleSmsResponse.Succeeded()`.
+- `DevSmsSender` — implements `ISmsSender` and `IBulkSmsSender`; appends formatted SMS details to a local file for inspection.
+- `NoopSmsSender` — implements `ISmsSender` and `IBulkSmsSender`; silently discards all messages and returns a success response.
 - No external dependencies, no HTTP calls, no API credentials needed.
 
 ## Installation
@@ -52,5 +52,5 @@ No configuration required.
 
 ## Side Effects
 
-- Registers `ISmsSender` as singleton
+- Registers `ISmsSender` and `IBulkSmsSender` as singleton (the bulk sender forwards to the same instance)
 - `DevSmsSender` writes to the specified file path

--- a/src/Headless.Sms.Dev/Setup.cs
+++ b/src/Headless.Sms.Dev/Setup.cs
@@ -38,6 +38,7 @@ public static class SetupDevSms
         public void AddServices(IServiceCollection services)
         {
             services.AddSingleton<ISmsSender>(_ => new DevSmsSender(filePath));
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
         }
     }
 
@@ -46,6 +47,7 @@ public static class SetupDevSms
         public void AddServices(IServiceCollection services)
         {
             services.AddSingleton<ISmsSender, NoopSmsSender>();
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
         }
     }
 }

--- a/src/Headless.Sms.Infobip/InfobipSmsSender.cs
+++ b/src/Headless.Sms.Infobip/InfobipSmsSender.cs
@@ -124,8 +124,8 @@ internal sealed class InfobipSmsSender(
         return await smsApi.SendSmsMessagesAsync(smsRequest, cancellationToken).ConfigureAwait(false);
     }
 
-    // Infobip returns one entry per recipient (in request order) carrying its own message id. When that
-    // detail is present we map it per recipient; otherwise we fall back to the bulk id for every recipient.
+    // Infobip returns one entry per recipient (in request order) carrying its own message id and status.
+    // When that detail is present we map it per recipient; otherwise we fall back to the bulk id.
     private static SendBulkSmsResponse _MapBulkResponse(
         IReadOnlyList<SmsRequestDestination> destinations,
         SmsResponse response
@@ -144,12 +144,59 @@ internal sealed class InfobipSmsSender(
 
         for (var i = 0; i < destinations.Count; i++)
         {
-            results.Add(
-                new SmsRecipientResult(destinations[i], SendSingleSmsResponse.Succeeded(messages[i].MessageId))
-            );
+            results.Add(new SmsRecipientResult(destinations[i], _MapMessageResponse(messages[i])));
         }
 
         return SendBulkSmsResponse.FromResults(results, response.BulkId);
+    }
+
+    private static SendSingleSmsResponse _MapMessageResponse(SmsResponseDetails message)
+    {
+        var status = message.Status;
+        var groupName = status?.GroupName;
+
+        if (
+            groupName is MessageGeneralStatus.Accepted or MessageGeneralStatus.Pending or MessageGeneralStatus.Delivered
+        )
+        {
+            return SendSingleSmsResponse.Succeeded(message.MessageId);
+        }
+
+        var failure = string.IsNullOrWhiteSpace(status?.Description)
+            ? $"Infobip message status {status?.Name ?? groupName?.ToString() ?? "unknown"}"
+            : status.Description;
+
+        return SendSingleSmsResponse.Failed(failure, _MapMessageFailureKind(status));
+    }
+
+    private static SmsFailureKind _MapMessageFailureKind(SmsMessageStatus? status)
+    {
+        if (status is null)
+        {
+            return SmsFailureKind.Unknown;
+        }
+
+        if (status.Name?.Contains("BALANCE", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return SmsFailureKind.OutOfCredit;
+        }
+
+        if (status.Name?.Contains("AUTH", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return SmsFailureKind.AuthFailure;
+        }
+
+        if (status.Name?.Contains("RATE", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return SmsFailureKind.RateLimited;
+        }
+
+        return status.GroupName switch
+        {
+            MessageGeneralStatus.Undeliverable or MessageGeneralStatus.Expired or MessageGeneralStatus.Rejected =>
+                SmsFailureKind.InvalidRecipient,
+            _ => SmsFailureKind.Unknown,
+        };
     }
 
     private static string _FormatApiError(ApiException exception)

--- a/src/Headless.Sms.Infobip/InfobipSmsSender.cs
+++ b/src/Headless.Sms.Infobip/InfobipSmsSender.cs
@@ -133,11 +133,30 @@ internal sealed class InfobipSmsSender(
     {
         var messages = response.Messages;
 
-        if (messages is null || messages.Count != destinations.Count)
+        if (messages is null)
         {
-            var aggregate = SendSingleSmsResponse.Succeeded(response.BulkId);
+            // A 200 with a bulk id but no per-recipient breakdown: the batch was accepted, so mirror the
+            // aggregate success to every recipient.
+            return SendBulkSmsResponse.FromAggregate(
+                destinations,
+                SendSingleSmsResponse.Succeeded(response.BulkId),
+                response.BulkId
+            );
+        }
 
-            return SendBulkSmsResponse.FromAggregate(destinations, aggregate, response.BulkId);
+        if (messages.Count != destinations.Count)
+        {
+            // The provider returned a per-recipient breakdown whose count does not match the request, so
+            // positional mapping is unsafe. Do not fabricate success: report the outcome as Unknown for every
+            // recipient so callers can retry or investigate rather than treat unconfirmed sends as accepted.
+            return SendBulkSmsResponse.FromAggregate(
+                destinations,
+                SendSingleSmsResponse.Failed(
+                    $"Infobip returned {messages.Count} message result(s) for {destinations.Count} recipient(s)",
+                    SmsFailureKind.Unknown
+                ),
+                response.BulkId
+            );
         }
 
         var results = new List<SmsRecipientResult>(destinations.Count);

--- a/src/Headless.Sms.Infobip/InfobipSmsSender.cs
+++ b/src/Headless.Sms.Infobip/InfobipSmsSender.cs
@@ -13,7 +13,7 @@ internal sealed class InfobipSmsSender(
     IHttpClientFactory httpClientFactory,
     IOptions<InfobipSmsOptions> optionsAccessor,
     ILogger<InfobipSmsSender> logger
-) : ISmsSender
+) : ISmsSender, IBulkSmsSender
 {
     private readonly InfobipSmsOptions _options = optionsAccessor.Value;
 
@@ -23,56 +23,76 @@ internal sealed class InfobipSmsSender(
     )
     {
         Argument.IsNotNull(request);
-        Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotNull(request.Destination);
         Argument.IsNotEmpty(request.Text);
 
-        var destinations = request.IsBatch
-            ? request
-                .Destinations.Select(
-                    (item, index) =>
-                    {
-                        var messageId = request.MessageId is null
-                            ? null
-                            : request.MessageId + (index + 1).ToString(CultureInfo.InvariantCulture);
-
-                        return new SmsDestination(to: item.ToString(hasPlusPrefix: false), messageId: messageId);
-                    }
-                )
-                .ToList()
-            :
-            [
-                new SmsDestination(
-                    to: request.Destinations[0].ToString(hasPlusPrefix: false),
-                    messageId: request.MessageId
-                ),
-            ];
-
-        var smsMessage = new SmsMessage(
-            _options.Sender,
-            destinations,
-            new SmsMessageContent(new SmsTextContent(request.Text))
-        );
-        var smsRequest = new SmsRequest([smsMessage]);
-
-        using var httpClient = httpClientFactory.CreateClient(SetupInfobip.HttpClientName);
-        using var smsApi = new SmsApi(
-            httpClient,
-            new Configuration { BasePath = _options.BasePath, ApiKey = _options.ApiKey }
+        var destination = new SmsDestination(
+            to: request.Destination.ToString(hasPlusPrefix: false),
+            messageId: request.MessageId
         );
 
         try
         {
-            var smsResponse = await smsApi.SendSmsMessagesAsync(smsRequest, cancellationToken).ConfigureAwait(false);
-            logger.LogSmsSentSuccessfully(request.Destinations.Count);
+            var smsResponse = await _SendAsync([destination], request.Text, cancellationToken).ConfigureAwait(false);
+            logger.LogSmsSentSuccessfully(destinationCount: 1);
 
             return SendSingleSmsResponse.Succeeded(smsResponse.BulkId);
         }
         catch (ApiException e)
         {
-            logger.LogSmsSendFailed(e, request.Destinations.Count, e.ErrorCode);
-            FormattableString error = $"ErrorCode: {e.ErrorCode} {e.Message}";
+            logger.LogSmsSendFailed(e, destinationCount: 1, e.ErrorCode);
 
-            return SendSingleSmsResponse.Failed(error.ToInvariantString());
+            return SendSingleSmsResponse.Failed(_FormatApiError(e));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            logger.LogSmsSendException(e, destinationCount: 1);
+
+            return SendSingleSmsResponse.FromException(e);
+        }
+    }
+
+    public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
+        Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotEmpty(request.Text);
+
+        var destinations = request
+            .Destinations.Select(
+                (item, index) =>
+                {
+                    var messageId = request.MessageId is null
+                        ? null
+                        : request.MessageId + (index + 1).ToString(CultureInfo.InvariantCulture);
+
+                    return new SmsDestination(to: item.ToString(hasPlusPrefix: false), messageId: messageId);
+                }
+            )
+            .ToList();
+
+        try
+        {
+            var smsResponse = await _SendAsync(destinations, request.Text, cancellationToken).ConfigureAwait(false);
+            logger.LogSmsSentSuccessfully(request.Destinations.Count);
+
+            return _MapBulkResponse(request.Destinations, smsResponse);
+        }
+        catch (ApiException e)
+        {
+            logger.LogSmsSendFailed(e, request.Destinations.Count, e.ErrorCode);
+
+            return SendBulkSmsResponse.FromAggregate(
+                request.Destinations,
+                SendSingleSmsResponse.Failed(_FormatApiError(e))
+            );
         }
         catch (OperationCanceledException)
         {
@@ -82,7 +102,60 @@ internal sealed class InfobipSmsSender(
         {
             logger.LogSmsSendException(e, request.Destinations.Count);
 
-            return SendSingleSmsResponse.FromException(e);
+            return SendBulkSmsResponse.FromAggregate(request.Destinations, SendSingleSmsResponse.FromException(e));
         }
+    }
+
+    private async Task<SmsResponse> _SendAsync(
+        List<SmsDestination> destinations,
+        string text,
+        CancellationToken cancellationToken
+    )
+    {
+        var smsMessage = new SmsMessage(_options.Sender, destinations, new SmsMessageContent(new SmsTextContent(text)));
+        var smsRequest = new SmsRequest([smsMessage]);
+
+        using var httpClient = httpClientFactory.CreateClient(SetupInfobip.HttpClientName);
+        using var smsApi = new SmsApi(
+            httpClient,
+            new Configuration { BasePath = _options.BasePath, ApiKey = _options.ApiKey }
+        );
+
+        return await smsApi.SendSmsMessagesAsync(smsRequest, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Infobip returns one entry per recipient (in request order) carrying its own message id. When that
+    // detail is present we map it per recipient; otherwise we fall back to the bulk id for every recipient.
+    private static SendBulkSmsResponse _MapBulkResponse(
+        IReadOnlyList<SmsRequestDestination> destinations,
+        SmsResponse response
+    )
+    {
+        var messages = response.Messages;
+
+        if (messages is null || messages.Count != destinations.Count)
+        {
+            var aggregate = SendSingleSmsResponse.Succeeded(response.BulkId);
+
+            return SendBulkSmsResponse.FromAggregate(destinations, aggregate, response.BulkId);
+        }
+
+        var results = new List<SmsRecipientResult>(destinations.Count);
+
+        for (var i = 0; i < destinations.Count; i++)
+        {
+            results.Add(
+                new SmsRecipientResult(destinations[i], SendSingleSmsResponse.Succeeded(messages[i].MessageId))
+            );
+        }
+
+        return SendBulkSmsResponse.FromResults(results, response.BulkId);
+    }
+
+    private static string _FormatApiError(ApiException exception)
+    {
+        FormattableString error = $"ErrorCode: {exception.ErrorCode} {exception.Message}";
+
+        return error.ToInvariantString();
     }
 }

--- a/src/Headless.Sms.Infobip/InfobipSmsSender.cs
+++ b/src/Headless.Sms.Infobip/InfobipSmsSender.cs
@@ -35,9 +35,20 @@ internal sealed class InfobipSmsSender(
         try
         {
             var smsResponse = await _SendAsync([destination], request.Text, cancellationToken).ConfigureAwait(false);
-            logger.LogSmsSentSuccessfully(destinationCount: 1);
 
-            return SendSingleSmsResponse.Succeeded(smsResponse.BulkId);
+            // A single send returns one message entry; honor its per-recipient status so a rejection delivered
+            // inside a 200 response is reported as a failure (matching the bulk path) instead of a blanket
+            // success. The success id stays the bulk id, as documented.
+            var message = smsResponse.Messages is { Count: > 0 } ? smsResponse.Messages[0] : null;
+
+            if (message is null || _IsAccepted(message.Status))
+            {
+                logger.LogSmsSentSuccessfully(destinationCount: 1);
+
+                return SendSingleSmsResponse.Succeeded(smsResponse.BulkId);
+            }
+
+            return _MapMessageResponse(message);
         }
         catch (ApiException e)
         {
@@ -66,6 +77,7 @@ internal sealed class InfobipSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 
@@ -176,20 +188,24 @@ internal sealed class InfobipSmsSender(
         return SendBulkSmsResponse.FromResults(results, response.BulkId);
     }
 
+    // Infobip's PENDING/ACCEPTED/DELIVERED groups mean the message was taken for delivery; everything else is
+    // a rejection the caller should treat as a failed send.
+    private static bool _IsAccepted(SmsMessageStatus? status) =>
+        status?.GroupName
+            is MessageGeneralStatus.Accepted
+                or MessageGeneralStatus.Pending
+                or MessageGeneralStatus.Delivered;
+
     private static SendSingleSmsResponse _MapMessageResponse(SmsResponseDetails message)
     {
-        var status = message.Status;
-        var groupName = status?.GroupName;
-
-        if (
-            groupName is MessageGeneralStatus.Accepted or MessageGeneralStatus.Pending or MessageGeneralStatus.Delivered
-        )
+        if (_IsAccepted(message.Status))
         {
             return SendSingleSmsResponse.Succeeded(message.MessageId);
         }
 
+        var status = message.Status;
         var failure = string.IsNullOrWhiteSpace(status?.Description)
-            ? $"Infobip message status {status?.Name ?? groupName?.ToString() ?? "unknown"}"
+            ? $"Infobip message status {status?.Name ?? status?.GroupName?.ToString() ?? "unknown"}"
             : status.Description;
 
         return SendSingleSmsResponse.Failed(failure, _MapMessageFailureKind(status));

--- a/src/Headless.Sms.Infobip/InfobipSmsSender.cs
+++ b/src/Headless.Sms.Infobip/InfobipSmsSender.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Net;
 using Headless.Checks;
 using Infobip.Api.Client;
 using Infobip.Api.Client.Api;
@@ -54,10 +53,7 @@ internal sealed class InfobipSmsSender(
         {
             logger.LogSmsSendFailed(e, destinationCount: 1, e.ErrorCode);
 
-            return SendSingleSmsResponse.Failed(
-                _FormatApiError(e),
-                SmsFailureKinds.FromHttpStatusCode((HttpStatusCode)e.ErrorCode)
-            );
+            return SendSingleSmsResponse.Failed(_FormatApiError(e));
         }
         catch (OperationCanceledException)
         {
@@ -107,10 +103,7 @@ internal sealed class InfobipSmsSender(
 
             return SendBulkSmsResponse.FromAggregate(
                 request.Destinations,
-                SendSingleSmsResponse.Failed(
-                    _FormatApiError(e),
-                    SmsFailureKinds.FromHttpStatusCode((HttpStatusCode)e.ErrorCode)
-                )
+                SendSingleSmsResponse.Failed(_FormatApiError(e))
             );
         }
         catch (OperationCanceledException)
@@ -211,29 +204,18 @@ internal sealed class InfobipSmsSender(
         return SendSingleSmsResponse.Failed(failure, _MapMessageFailureKind(status));
     }
 
-    private static SmsFailureKind _MapMessageFailureKind(SmsMessageStatus? status)
-    {
-        if (status is null)
-        {
-            return SmsFailureKind.Unknown;
-        }
-
-        // Infobip exposes the specific reason only as a free-form per-message status name (for example
-        // "REJECTED_NOT_ENOUGH_CREDITS"). Authentication (401) and rate-limit (429) failures surface at the
-        // request level as an ApiException, not as per-message statuses, so out-of-credit is the only kind that
-        // can be refined here; every other rejection falls back to the delivery group.
-        if (status.Name?.Contains("CREDIT", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return SmsFailureKind.OutOfCredit;
-        }
-
-        return status.GroupName switch
+    // Infobip's only reliably-typed failure signal is the delivery group (MessageGeneralStatus); the specific
+    // status name is a free-form string, so classify by group rather than parsing names. A rejected,
+    // undeliverable, or expired message is reported as InvalidRecipient (the framework's kind for a recipient
+    // "rejected by the provider"); any other non-accepted status is Unknown. The raw provider status text is
+    // preserved in FailureError for callers that need the specific reason.
+    private static SmsFailureKind _MapMessageFailureKind(SmsMessageStatus? status) =>
+        status?.GroupName switch
         {
             MessageGeneralStatus.Undeliverable or MessageGeneralStatus.Expired or MessageGeneralStatus.Rejected =>
                 SmsFailureKind.InvalidRecipient,
             _ => SmsFailureKind.Unknown,
         };
-    }
 
     private static string _FormatApiError(ApiException exception)
     {

--- a/src/Headless.Sms.Infobip/InfobipSmsSender.cs
+++ b/src/Headless.Sms.Infobip/InfobipSmsSender.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Net;
 using Headless.Checks;
 using Infobip.Api.Client;
 using Infobip.Api.Client.Api;
@@ -42,7 +43,10 @@ internal sealed class InfobipSmsSender(
         {
             logger.LogSmsSendFailed(e, destinationCount: 1, e.ErrorCode);
 
-            return SendSingleSmsResponse.Failed(_FormatApiError(e));
+            return SendSingleSmsResponse.Failed(
+                _FormatApiError(e),
+                SmsFailureKinds.FromHttpStatusCode((HttpStatusCode)e.ErrorCode)
+            );
         }
         catch (OperationCanceledException)
         {
@@ -91,7 +95,10 @@ internal sealed class InfobipSmsSender(
 
             return SendBulkSmsResponse.FromAggregate(
                 request.Destinations,
-                SendSingleSmsResponse.Failed(_FormatApiError(e))
+                SendSingleSmsResponse.Failed(
+                    _FormatApiError(e),
+                    SmsFailureKinds.FromHttpStatusCode((HttpStatusCode)e.ErrorCode)
+                )
             );
         }
         catch (OperationCanceledException)
@@ -195,19 +202,13 @@ internal sealed class InfobipSmsSender(
             return SmsFailureKind.Unknown;
         }
 
-        if (status.Name?.Contains("BALANCE", StringComparison.OrdinalIgnoreCase) == true)
+        // Infobip exposes the specific reason only as a free-form per-message status name (for example
+        // "REJECTED_NOT_ENOUGH_CREDITS"). Authentication (401) and rate-limit (429) failures surface at the
+        // request level as an ApiException, not as per-message statuses, so out-of-credit is the only kind that
+        // can be refined here; every other rejection falls back to the delivery group.
+        if (status.Name?.Contains("CREDIT", StringComparison.OrdinalIgnoreCase) == true)
         {
             return SmsFailureKind.OutOfCredit;
-        }
-
-        if (status.Name?.Contains("AUTH", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return SmsFailureKind.AuthFailure;
-        }
-
-        if (status.Name?.Contains("RATE", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return SmsFailureKind.RateLimited;
         }
 
         return status.GroupName switch

--- a/src/Headless.Sms.Infobip/README.md
+++ b/src/Headless.Sms.Infobip/README.md
@@ -8,7 +8,7 @@ Provides SMS sending via Infobip's REST API, a global messaging platform with de
 
 ## Key Features
 
-- `InfobipSmsSender` — `ISmsSender` implementation backed by the Infobip REST API.
+- `InfobipSmsSender` — implements `ISmsSender` (single recipient) and `IBulkSmsSender` (multi-recipient bulk, with per-recipient message ids), backed by the Infobip REST API.
 - API key authentication via HTTP `Authorization` header.
 - `BasePath` — Infobip-assigned base URL for your account (varies per account; not a shared endpoint).
 - `Sender` — alphanumeric or numeric sender shown to recipients.

--- a/src/Headless.Sms.Infobip/Setup.cs
+++ b/src/Headless.Sms.Infobip/Setup.cs
@@ -123,6 +123,7 @@ public static class SetupInfobip
         {
             _configureOptions(services);
             services.AddSingleton<ISmsSender, InfobipSmsSender>();
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
 
             var httpClientBuilder = _configureClient is null
                 ? services.AddHttpClient(HttpClientName)

--- a/src/Headless.Sms.Twilio/README.md
+++ b/src/Headless.Sms.Twilio/README.md
@@ -8,7 +8,7 @@ Provides SMS sending via Twilio's REST API, the most widely supported internatio
 
 ## Key Features
 
-- `TwilioSmsSender` — `ISmsSender` implementation using `ITwilioRestClient`.
+- `TwilioSmsSender` — `ISmsSender` implementation using `ITwilioRestClient`. Single recipient per send; does not implement `IBulkSmsSender` (Twilio creates one message per recipient).
 - `Sid` + `AuthToken` — Twilio account credentials.
 - `PhoneNumber` — E.164 sender number validated by `InternationalPhoneNumber` rule.
 - `MaxPrice` — optional per-message USD price cap.

--- a/src/Headless.Sms.Twilio/TwilioSmsSender.cs
+++ b/src/Headless.Sms.Twilio/TwilioSmsSender.cs
@@ -30,16 +30,8 @@ internal sealed class TwilioSmsSender(
     )
     {
         Argument.IsNotNull(request);
-        Argument.IsNotEmpty(request.Destinations);
+        Argument.IsNotNull(request.Destination);
         Argument.IsNotEmpty(request.Text);
-
-        if (request.Destinations.Count > 1)
-        {
-            return SendSingleSmsResponse.Failed(
-                "Twilio only supports sending to one destination at a time",
-                SmsFailureKind.Unsupported
-            );
-        }
 
         try
         {
@@ -49,7 +41,7 @@ internal sealed class TwilioSmsSender(
 
             var response = await MessageResource
                 .CreateAsync(
-                    to: new PhoneNumber(request.Destinations[0].ToString(hasPlusPrefix: true)),
+                    to: new PhoneNumber(request.Destination.ToString(hasPlusPrefix: true)),
                     from: new PhoneNumber(_options.PhoneNumber),
                     body: request.Text,
                     maxPrice: _options.MaxPrice,
@@ -62,7 +54,7 @@ internal sealed class TwilioSmsSender(
                 return SendSingleSmsResponse.Succeeded(response.Sid);
             }
 
-            logger.LogFailedToSendSms(request.Destinations.Count, response.ErrorCode);
+            logger.LogFailedToSendSms(destinationCount: 1, response.ErrorCode);
 
             return SendSingleSmsResponse.Failed(
                 response.ErrorMessage
@@ -75,7 +67,7 @@ internal sealed class TwilioSmsSender(
         }
         catch (Exception e)
         {
-            logger.LogSmsSendException(e, request.Destinations.Count);
+            logger.LogSmsSendException(e, destinationCount: 1);
 
             return SendSingleSmsResponse.FromException(e);
         }

--- a/src/Headless.Sms.VictoryLink/README.md
+++ b/src/Headless.Sms.VictoryLink/README.md
@@ -8,7 +8,7 @@ Provides SMS sending via the VictoryLink API, a regional gateway serving the Mid
 
 ## Key Features
 
-- `VictoryLinkSmsSender` — `ISmsSender` implementation backed by the VictoryLink REST API.
+- `VictoryLinkSmsSender` — implements `ISmsSender` (single recipient) and `IBulkSmsSender` (multi-recipient bulk), backed by the VictoryLink REST API.
 - Username + password authentication.
 - Configurable `Sender` name and `Endpoint` URL.
 - Response-code-based error detection.

--- a/src/Headless.Sms.VictoryLink/Setup.cs
+++ b/src/Headless.Sms.VictoryLink/Setup.cs
@@ -126,6 +126,7 @@ public static class SetupVictoryLink
         {
             _configureOptions(services);
             services.AddSingleton<ISmsSender, VictoryLinkSmsSender>();
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
 
             var httpClientBuilder = _configureClient is null
                 ? services.AddHttpClient(HttpClientName)

--- a/src/Headless.Sms.VictoryLink/VictoryLinkSmsSender.cs
+++ b/src/Headless.Sms.VictoryLink/VictoryLinkSmsSender.cs
@@ -13,7 +13,7 @@ internal sealed class VictoryLinkSmsSender(
     IHttpClientFactory httpClientFactory,
     IOptions<VictoryLinkSmsOptions> optionsAccessor,
     ILogger<VictoryLinkSmsSender> logger
-) : ISmsSender
+) : ISmsSender, IBulkSmsSender
 {
     private static readonly JsonSerializerOptions _JsonOptions = new()
     {
@@ -30,12 +30,40 @@ internal sealed class VictoryLinkSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destination);
+        Argument.IsNotEmpty(request.Text);
+
+        return await _SendAsync([request.Destination], request.Text, request.MessageId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 
+        // VictoryLink accepts a comma-separated receiver list and returns a single response code, so the same
+        // outcome applies to every recipient.
+        var outcome = await _SendAsync(request.Destinations, request.Text, request.MessageId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
+    }
+
+    private async ValueTask<SendSingleSmsResponse> _SendAsync(
+        IReadOnlyList<SmsRequestDestination> destinations,
+        string text,
+        string? messageId,
+        CancellationToken cancellationToken
+    )
+    {
         try
         {
-            return await _SendCoreAsync(request, cancellationToken).ConfigureAwait(false);
+            return await _SendCoreAsync(destinations, text, messageId, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -43,28 +71,28 @@ internal sealed class VictoryLinkSmsSender(
         }
         catch (Exception e)
         {
-            logger.LogSmsSendException(e, request.Destinations.Count);
+            logger.LogSmsSendException(e, destinations.Count);
 
             return SendSingleSmsResponse.FromException(e);
         }
     }
 
     private async ValueTask<SendSingleSmsResponse> _SendCoreAsync(
-        SendSingleSmsRequest request,
+        IReadOnlyList<SmsRequestDestination> destinations,
+        string text,
+        string? messageId,
         CancellationToken cancellationToken
     )
     {
         var victoryLinkRequest = new VictoryLinkRequest
         {
-            SmsId = request.MessageId ?? Guid.NewGuid().ToString(),
+            SmsId = messageId ?? Guid.NewGuid().ToString(),
             UserName = _options.UserName,
             Password = _options.Password,
-            SmsText = request.Text,
-            SmsLang = request.Text.IsRtlText() ? "a" : "e",
+            SmsText = text,
+            SmsLang = text.IsRtlText() ? "a" : "e",
             SmsSender = _options.Sender,
-            SmsReceiver = request.IsBatch
-                ? string.Join(',', request.Destinations.Select(x => x.ToString()))
-                : request.Destinations[0].ToString(),
+            SmsReceiver = string.Join(',', destinations.Select(x => x.ToString())),
         };
 
         using var httpClient = httpClientFactory.CreateClient(SetupVictoryLink.HttpClientName);
@@ -90,7 +118,7 @@ internal sealed class VictoryLinkSmsSender(
 
         var responseMessage = VictoryLinkResponseCodes.GetCodeMeaning(code);
 
-        logger.LogFailedToSendSms(request.Destinations.Count, responseMessage);
+        logger.LogFailedToSendSms(destinations.Count, responseMessage);
 
         return SendSingleSmsResponse.Failed(responseMessage, VictoryLinkResponseCodes.GetFailureKind(code));
     }

--- a/src/Headless.Sms.VictoryLink/VictoryLinkSmsSender.cs
+++ b/src/Headless.Sms.VictoryLink/VictoryLinkSmsSender.cs
@@ -43,6 +43,7 @@ internal sealed class VictoryLinkSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 

--- a/src/Headless.Sms.Vodafone/README.md
+++ b/src/Headless.Sms.Vodafone/README.md
@@ -8,7 +8,7 @@ Provides SMS sending via the Vodafone Egypt enterprise messaging API, which uses
 
 ## Key Features
 
-- `VodafoneSmsSender` — `ISmsSender` implementation backed by the Vodafone Egypt REST API.
+- `VodafoneSmsSender` — implements `ISmsSender` (single recipient) and `IBulkSmsSender` (multi-recipient bulk), backed by the Vodafone Egypt REST API.
 - Account credentials: `AccountId` + `Password` + `SecureHash`.
 - Configurable `Sender` name and `SendSmsEndpoint`.
 - Standard resilience pipeline with auto-retry **disabled** by default to prevent duplicate SMS.

--- a/src/Headless.Sms.Vodafone/Setup.cs
+++ b/src/Headless.Sms.Vodafone/Setup.cs
@@ -123,6 +123,7 @@ public static class SetupVodafone
         {
             _configureOptions(services);
             services.AddSingleton<ISmsSender, VodafoneSmsSender>();
+            services.AddSingleton<IBulkSmsSender>(static sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>());
 
             var httpClientBuilder = _configureClient is null
                 ? services.AddHttpClient(HttpClientName)

--- a/src/Headless.Sms.Vodafone/VodafoneSmsSender.cs
+++ b/src/Headless.Sms.Vodafone/VodafoneSmsSender.cs
@@ -12,7 +12,7 @@ internal sealed class VodafoneSmsSender(
     IHttpClientFactory httpClientFactory,
     IOptions<VodafoneSmsOptions> optionsAccessor,
     ILogger<VodafoneSmsSender> logger
-) : ISmsSender
+) : ISmsSender, IBulkSmsSender
 {
     private readonly VodafoneSmsOptions _options = optionsAccessor.Value;
     private readonly Uri _uri = new(optionsAccessor.Value.SendSmsEndpoint);
@@ -24,12 +24,37 @@ internal sealed class VodafoneSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destination);
+        Argument.IsNotEmpty(request.Text);
+
+        return await _SendAsync([request.Destination], request.Text, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<SendBulkSmsResponse> SendBulkAsync(
+        SendBulkSmsRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Argument.IsNotNull(request);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 
+        // Vodafone Egypt accepts a comma-separated recipient list and reports a single batch status, so the
+        // same outcome applies to every recipient.
+        var outcome = await _SendAsync(request.Destinations, request.Text, cancellationToken).ConfigureAwait(false);
+
+        return SendBulkSmsResponse.FromAggregate(request.Destinations, outcome);
+    }
+
+    private async ValueTask<SendSingleSmsResponse> _SendAsync(
+        IReadOnlyList<SmsRequestDestination> destinations,
+        string text,
+        CancellationToken cancellationToken
+    )
+    {
         try
         {
-            return await _SendCoreAsync(request, cancellationToken).ConfigureAwait(false);
+            return await _SendCoreAsync(destinations, text, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -37,20 +62,21 @@ internal sealed class VodafoneSmsSender(
         }
         catch (Exception e)
         {
-            logger.LogSmsSendException(e, request.Destinations.Count);
+            logger.LogSmsSendException(e, destinations.Count);
 
             return SendSingleSmsResponse.FromException(e);
         }
     }
 
     private async ValueTask<SendSingleSmsResponse> _SendCoreAsync(
-        SendSingleSmsRequest request,
+        IReadOnlyList<SmsRequestDestination> destinations,
+        string text,
         CancellationToken cancellationToken
     )
     {
         using var httpClient = httpClientFactory.CreateClient(SetupVodafone.HttpClientName);
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, _uri);
-        requestMessage.Content = new StringContent(_BuildPayload(request), Encoding.UTF8, "application/xml");
+        requestMessage.Content = new StringContent(_BuildPayload(destinations, text), Encoding.UTF8, "application/xml");
 
         using var response = await httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
         var rawContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -69,20 +95,17 @@ internal sealed class VodafoneSmsSender(
             return SendSingleSmsResponse.Succeeded();
         }
 
-        logger.LogFailedToSendSms(request.Destinations.Count, response.StatusCode);
+        logger.LogFailedToSendSms(destinations.Count, response.StatusCode);
 
         // Vodafone reports logical failures inside a 200 body, so the HTTP status is not a reliable signal;
         // surface the raw response so callers can see the provider's actual error.
         return SendSingleSmsResponse.Failed(rawContent);
     }
 
-    private string _BuildPayload(SendSingleSmsRequest request)
+    private string _BuildPayload(IReadOnlyList<SmsRequestDestination> destinations, string text)
     {
-        var hashableKey = _BuildHashableKey(request);
-        var secureHash = _ComputeHash(hashableKey);
-        var recipients = request.IsBatch
-            ? string.Join(',', request.Destinations.Select(d => SecurityElement.Escape(d.ToString())))
-            : SecurityElement.Escape(request.Destinations[0].ToString());
+        var secureHash = _ComputeHash(_BuildHashableKey(destinations, text));
+        var recipients = string.Join(',', destinations.Select(d => SecurityElement.Escape(d.ToString())));
 
         return "<Payload>"
             + $"<AccountId>{SecurityElement.Escape(_options.AccountId)}</AccountId>"
@@ -90,11 +113,11 @@ internal sealed class VodafoneSmsSender(
             + $"<SenderName>{SecurityElement.Escape(_options.Sender)}</SenderName>"
             + $"<SecureHash>{secureHash}</SecureHash>"
             + $"<Recipients>{recipients}</Recipients>"
-            + $"<Message>{SecurityElement.Escape(request.Text)}</Message>"
+            + $"<Message>{SecurityElement.Escape(text)}</Message>"
             + "</Payload>";
     }
 
-    private string _BuildHashableKey(SendSingleSmsRequest request)
+    private string _BuildHashableKey(IReadOnlyList<SmsRequestDestination> destinations, string text)
     {
         var hashableKey = new StringBuilder();
 
@@ -103,21 +126,11 @@ internal sealed class VodafoneSmsSender(
             $"AccountId={_options.AccountId}&Password={_options.Password}"
         );
 
-        if (request.IsBatch)
-        {
-            foreach (var recipient in request.Destinations)
-            {
-                hashableKey.Append(
-                    CultureInfo.InvariantCulture,
-                    $"&SenderName={_options.Sender}&ReceiverMSISDN={recipient}&SMSText={request.Text}"
-                );
-            }
-        }
-        else
+        foreach (var recipient in destinations)
         {
             hashableKey.Append(
                 CultureInfo.InvariantCulture,
-                $"&SenderName={_options.Sender}&ReceiverMSISDN={request.Destinations[0]}&SMSText={request.Text}"
+                $"&SenderName={_options.Sender}&ReceiverMSISDN={recipient}&SMSText={text}"
             );
         }
 

--- a/src/Headless.Sms.Vodafone/VodafoneSmsSender.cs
+++ b/src/Headless.Sms.Vodafone/VodafoneSmsSender.cs
@@ -36,6 +36,7 @@ internal sealed class VodafoneSmsSender(
     )
     {
         Argument.IsNotNull(request);
+        Argument.IsNotNull(request.Destinations);
         Argument.IsNotEmpty(request.Destinations);
         Argument.IsNotEmpty(request.Text);
 

--- a/tests/Headless.Sms.Abstractions.Tests.Unit/AddHeadlessSmsTests.cs
+++ b/tests/Headless.Sms.Abstractions.Tests.Unit/AddHeadlessSmsTests.cs
@@ -23,6 +23,34 @@ public sealed class AddHeadlessSmsTests
     }
 
     [Fact]
+    public void should_register_bulk_sender_for_noop_provider()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddHeadlessSms(setup => setup.UseNoop());
+
+        // then
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    [Fact]
+    public void should_register_bulk_sender_for_dev_provider()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddHeadlessSms(setup => setup.UseDev(Path.Combine(Path.GetTempPath(), "sms.txt")));
+
+        // then
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    [Fact]
     public void should_throw_when_no_provider_is_selected()
     {
         // given

--- a/tests/Headless.Sms.Abstractions.Tests.Unit/SendBulkSmsResponseTests.cs
+++ b/tests/Headless.Sms.Abstractions.Tests.Unit/SendBulkSmsResponseTests.cs
@@ -60,6 +60,14 @@ public sealed class SendBulkSmsResponseTests
     }
 
     [Fact]
+    public void should_reject_empty_results()
+    {
+        var act = () => SendBulkSmsResponse.FromResults([]);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
     public void should_reject_null_aggregate_arguments()
     {
         var actDestinations = () => SendBulkSmsResponse.FromAggregate(null!, SendSingleSmsResponse.Succeeded());

--- a/tests/Headless.Sms.Abstractions.Tests.Unit/SendBulkSmsResponseTests.cs
+++ b/tests/Headless.Sms.Abstractions.Tests.Unit/SendBulkSmsResponseTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+
+namespace Tests;
+
+public sealed class SendBulkSmsResponseTests
+{
+    private static readonly SmsRequestDestination _A = new(20, "1001");
+    private static readonly SmsRequestDestination _B = new(20, "1002");
+
+    [Fact]
+    public void should_build_from_explicit_per_recipient_results()
+    {
+        var results = new[]
+        {
+            new SmsRecipientResult(_A, SendSingleSmsResponse.Succeeded("id-a")),
+            new SmsRecipientResult(_B, SendSingleSmsResponse.Failed("nope", SmsFailureKind.InvalidRecipient)),
+        };
+
+        var response = SendBulkSmsResponse.FromResults(results, "batch-1");
+
+        response.Results.Should().HaveCount(2);
+        response.ProviderBatchId.Should().Be("batch-1");
+        response.AllSucceeded.Should().BeFalse();
+        response.AnySucceeded.Should().BeTrue();
+        response.Results[0].Result.ProviderMessageId.Should().Be("id-a");
+        response.Results[1].Result.FailureKind.Should().Be(SmsFailureKind.InvalidRecipient);
+    }
+
+    [Fact]
+    public void should_apply_one_aggregate_outcome_to_every_recipient()
+    {
+        var outcome = SendSingleSmsResponse.Failed("down", SmsFailureKind.Transient);
+
+        var response = SendBulkSmsResponse.FromAggregate([_A, _B], outcome);
+
+        response.Results.Should().HaveCount(2);
+        response.AllSucceeded.Should().BeFalse();
+        response.AnySucceeded.Should().BeFalse();
+        response.Results.Should().AllSatisfy(r => r.Result.Should().BeSameAs(outcome));
+        response.Results.Select(r => r.Destination).Should().Equal(_A, _B);
+    }
+
+    [Fact]
+    public void should_report_all_succeeded_when_every_recipient_succeeds()
+    {
+        var response = SendBulkSmsResponse.FromAggregate([_A, _B], SendSingleSmsResponse.Succeeded());
+
+        response.AllSucceeded.Should().BeTrue();
+        response.AnySucceeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_reject_null_results()
+    {
+        var act = () => SendBulkSmsResponse.FromResults(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void should_reject_null_aggregate_arguments()
+    {
+        var actDestinations = () => SendBulkSmsResponse.FromAggregate(null!, SendSingleSmsResponse.Succeeded());
+        var actOutcome = () => SendBulkSmsResponse.FromAggregate([_A], null!);
+
+        actDestinations.Should().Throw<ArgumentNullException>();
+        actOutcome.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSetupTests.cs
+++ b/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSetupTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.Aws;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class AwsSnsSetupTests
+{
+    [Fact]
+    public void should_not_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessSms(setup => setup.UseAwsSns(_Config(("SenderId", "SENDER"))));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<IBulkSmsSender>().Should().BeNull();
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}

--- a/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsConformanceTests.cs
@@ -56,8 +56,7 @@ public sealed class AwsSnsSmsConformanceTests : SmsSenderConformanceTests
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_request_without_destinations() =>
-        base.should_reject_a_request_without_destinations();
+    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>

--- a/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsSenderTests.cs
+++ b/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsSenderTests.cs
@@ -3,7 +3,6 @@
 using System.Net;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
-using Headless.Sms;
 using Headless.Sms.Aws;
 using Headless.Sms.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -47,18 +46,6 @@ public sealed class AwsSnsSmsSenderTests
         await client
             .Received(1)
             .PublishAsync(Arg.Is<PublishRequest>(r => r.PhoneNumber == "+201001234567"), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task should_reject_multiple_destinations_as_unsupported_without_calling_aws()
-    {
-        var client = Substitute.For<IAmazonSimpleNotificationService>();
-
-        var result = await CreateSender(client).SendAsync(SmsRequests.Batch("hi", (20, "1"), (20, "2")));
-
-        result.Success.Should().BeFalse();
-        result.FailureKind.Should().Be(SmsFailureKind.Unsupported);
-        await client.DidNotReceive().PublishAsync(Arg.Any<PublishRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Headless.Sms.Cequens.Tests.Unit/CequensBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Cequens.Tests.Unit/CequensBulkSmsConformanceTests.cs
@@ -12,22 +12,18 @@ using WireMock.ResponseBuilders;
 
 namespace Tests;
 
-/// <summary>
-/// Runs the cross-provider <see cref="SmsSenderConformanceTests"/> contract against the Cequens sender.
-/// Cequens-specific behavior (token acquisition, caching, 401 re-auth, static-token fallback) lives in
-/// <see cref="CequensSmsSenderTests"/>.
-/// </summary>
-public sealed class CequensSmsConformanceTests : SmsSenderConformanceTests, IClassFixture<SmsWireMockFixture>
+/// <summary>Runs the <see cref="SmsBulkSenderConformanceTests"/> contract against the Cequens bulk sender.</summary>
+public sealed class CequensBulkSmsConformanceTests : SmsBulkSenderConformanceTests, IClassFixture<SmsWireMockFixture>
 {
     private readonly SmsWireMockFixture _fixture;
 
-    public CequensSmsConformanceTests(SmsWireMockFixture fixture)
+    public CequensBulkSmsConformanceTests(SmsWireMockFixture fixture)
     {
         _fixture = fixture;
         _fixture.Reset();
     }
 
-    protected override ISmsSender CreateSuccessfulSender()
+    protected override IBulkSmsSender CreateSuccessfulSender()
     {
         _fixture
             .Server.Given(Request.Create().WithPath("/auth").UsingPost())
@@ -41,12 +37,8 @@ public sealed class CequensSmsConformanceTests : SmsSenderConformanceTests, ICla
         return _CreateSender(_fixture.BaseUrl, staticToken: null);
     }
 
-    protected override ISmsSender CreateFaultingSender()
-    {
-        // Closed endpoints plus a static token: the token fetch fails fast and falls back to the static token,
-        // so it is the send itself that faults at the transport layer (→ Transient), matching the contract.
-        return _CreateSender("http://localhost:1", staticToken: "static-token");
-    }
+    protected override IBulkSmsSender CreateFaultingSender() =>
+        _CreateSender("http://localhost:1", staticToken: "static-token");
 
     private CequensSmsSender _CreateSender(string baseUrl, string? staticToken)
     {
@@ -74,14 +66,16 @@ public sealed class CequensSmsConformanceTests : SmsSenderConformanceTests, ICla
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
+    public override Task should_reject_a_request_without_destinations() =>
+        base.should_reject_a_request_without_destinations();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 
     [Fact]
-    public override Task should_succeed_for_a_single_destination() => base.should_succeed_for_a_single_destination();
+    public override Task should_return_a_result_for_every_recipient() =>
+        base.should_return_a_result_for_every_recipient();
 
     [Fact]
     public override Task should_report_a_transient_failure_on_a_transport_fault() =>

--- a/tests/Headless.Sms.Cequens.Tests.Unit/CequensBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Cequens.Tests.Unit/CequensBulkSmsConformanceTests.cs
@@ -70,6 +70,9 @@ public sealed class CequensBulkSmsConformanceTests : SmsBulkSenderConformanceTes
         base.should_reject_a_request_without_destinations();
 
     [Fact]
+    public override Task should_reject_null_destinations() => base.should_reject_null_destinations();
+
+    [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 

--- a/tests/Headless.Sms.Cequens.Tests.Unit/CequensSetupTests.cs
+++ b/tests/Headless.Sms.Cequens.Tests.Unit/CequensSetupTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.Cequens;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class CequensSetupTests
+{
+    [Fact]
+    public void should_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+        services.AddHeadlessSms(setup =>
+            setup.UseCequens(
+                _Config(
+                    ("SingleSmsEndpoint", "https://example.test/sms"),
+                    ("TokenEndpoint", "https://example.test/auth"),
+                    ("ApiKey", "api-key"),
+                    ("UserName", "user"),
+                    ("SenderName", "SENDER")
+                )
+            )
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioBulkSmsConformanceTests.cs
@@ -11,31 +11,28 @@ using WireMock.ResponseBuilders;
 
 namespace Tests;
 
-/// <summary>
-/// Runs the cross-provider <see cref="SmsSenderConformanceTests"/> contract against the Connekio sender.
-/// Connekio-specific behavior (batch routing, Basic auth header, surfaced failure body) lives in
-/// <see cref="ConnekioSmsSenderTests"/>.
-/// </summary>
-public sealed class ConnekioSmsConformanceTests : SmsSenderConformanceTests, IClassFixture<SmsWireMockFixture>
+/// <summary>Runs the <see cref="SmsBulkSenderConformanceTests"/> contract against the Connekio bulk sender.</summary>
+public sealed class ConnekioBulkSmsConformanceTests : SmsBulkSenderConformanceTests, IClassFixture<SmsWireMockFixture>
 {
     private readonly SmsWireMockFixture _fixture;
 
-    public ConnekioSmsConformanceTests(SmsWireMockFixture fixture)
+    public ConnekioBulkSmsConformanceTests(SmsWireMockFixture fixture)
     {
         _fixture = fixture;
         _fixture.Reset();
     }
 
-    protected override ISmsSender CreateSuccessfulSender()
+    protected override IBulkSmsSender CreateSuccessfulSender()
     {
+        // Bulk sends route to the dedicated batch endpoint.
         _fixture
-            .Server.Given(Request.Create().WithPath("/single").UsingPost())
+            .Server.Given(Request.Create().WithPath("/batch").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK).WithBody("{}"));
 
         return _CreateSender(_fixture.BaseUrl);
     }
 
-    protected override ISmsSender CreateFaultingSender() => _CreateSender("http://localhost:1");
+    protected override IBulkSmsSender CreateFaultingSender() => _CreateSender("http://localhost:1");
 
     private ConnekioSmsSender _CreateSender(string baseUrl)
     {
@@ -58,14 +55,16 @@ public sealed class ConnekioSmsConformanceTests : SmsSenderConformanceTests, ICl
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
+    public override Task should_reject_a_request_without_destinations() =>
+        base.should_reject_a_request_without_destinations();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 
     [Fact]
-    public override Task should_succeed_for_a_single_destination() => base.should_succeed_for_a_single_destination();
+    public override Task should_return_a_result_for_every_recipient() =>
+        base.should_return_a_result_for_every_recipient();
 
     [Fact]
     public override Task should_report_a_transient_failure_on_a_transport_fault() =>

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioBulkSmsConformanceTests.cs
@@ -59,6 +59,9 @@ public sealed class ConnekioBulkSmsConformanceTests : SmsBulkSenderConformanceTe
         base.should_reject_a_request_without_destinations();
 
     [Fact]
+    public override Task should_reject_null_destinations() => base.should_reject_null_destinations();
+
+    [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSetupTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSetupTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.Connekio;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class ConnekioSetupTests
+{
+    [Fact]
+    public void should_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHeadlessSms(setup =>
+            setup.UseConnekio(
+                _Config(
+                    ("SingleSmsEndpoint", "https://example.test/sms/single"),
+                    ("BatchSmsEndpoint", "https://example.test/sms/batch"),
+                    ("Sender", "SENDER"),
+                    ("AccountId", "account"),
+                    ("UserName", "user"),
+                    ("Password", "password")
+                )
+            )
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsSenderTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsSenderTests.cs
@@ -80,13 +80,14 @@ public sealed class ConnekioSmsSenderTests : IClassFixture<SmsWireMockFixture>
     }
 
     [Fact]
-    public async Task should_route_batch_requests_to_the_batch_endpoint()
+    public async Task should_route_bulk_requests_to_the_batch_endpoint()
     {
         Stub("/batch", HttpStatusCode.OK, "{}");
 
-        var result = await CreateSender().SendAsync(SmsRequests.Batch("hi", (20, "1001"), (20, "1002")));
+        var result = await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001"), (20, "1002")));
 
-        result.Success.Should().BeTrue();
+        result.AllSucceeded.Should().BeTrue();
+        result.Results.Should().HaveCount(2);
         _fixture.Server.FindLogEntries(Request.Create().WithPath("/batch").UsingPost()).Should().ContainSingle();
     }
 

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsSenderTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsSenderTests.cs
@@ -92,6 +92,32 @@ public sealed class ConnekioSmsSenderTests : IClassFixture<SmsWireMockFixture>
     }
 
     [Fact]
+    public async Task should_mirror_a_bulk_failure_kind_to_every_recipient()
+    {
+        // Connekio's batch endpoint reports one status, so a 401 must classify every recipient as an auth failure.
+        Stub("/batch", HttpStatusCode.Unauthorized, "nope");
+
+        var result = await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001"), (20, "1002")));
+
+        result.AllSucceeded.Should().BeFalse();
+        result.AnySucceeded.Should().BeFalse();
+        result.Results.Should().HaveCount(2);
+        result.Results.Should().AllSatisfy(r => r.Result.FailureKind.Should().Be(SmsFailureKind.AuthFailure));
+    }
+
+    [Fact]
+    public async Task should_send_every_recipient_in_the_bulk_payload()
+    {
+        Stub("/batch", HttpStatusCode.OK, "{}");
+
+        await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001"), (20, "1002")));
+
+        var body = _fixture.Server.LogEntries.Single().RequestMessage?.Body;
+        body.Should().NotBeNull();
+        body.Should().Contain("201001").And.Contain("201002");
+    }
+
+    [Fact]
     public async Task should_send_a_basic_authorization_header()
     {
         Stub("/single", HttpStatusCode.OK, "{}");

--- a/tests/Headless.Sms.Dev.Tests.Unit/DevSmsSenderTests.cs
+++ b/tests/Headless.Sms.Dev.Tests.Unit/DevSmsSenderTests.cs
@@ -26,6 +26,27 @@ public sealed class DevSmsSenderTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public async Task should_append_a_bulk_message_for_every_recipient()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sms-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevSmsSender(path);
+
+        try
+        {
+            var response = await sender.SendBulkAsync(SmsRequests.Bulk("bulk dev", (20, "1001"), (20, "1002")));
+
+            response.AllSucceeded.Should().BeTrue();
+            response.Results.Should().HaveCount(2);
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain("bulk dev").And.Contain("201001").And.Contain("201002");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }
 
 public sealed class NoopSmsSenderTests

--- a/tests/Headless.Sms.Dev.Tests.Unit/DevSmsSenderTests.cs
+++ b/tests/Headless.Sms.Dev.Tests.Unit/DevSmsSenderTests.cs
@@ -106,6 +106,16 @@ public sealed class NoopSmsSenderTests
     }
 
     [Fact]
+    public async Task should_reject_a_bulk_request_without_destinations()
+    {
+        var request = new SendBulkSmsRequest { Destinations = null!, Text = "Hello world" };
+
+        var act = async () => await new NoopSmsSender().SendBulkAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
     public async Task should_honor_cancellation()
     {
         using var cts = new CancellationTokenSource();

--- a/tests/Headless.Sms.Dev.Tests.Unit/DevSmsSenderTests.cs
+++ b/tests/Headless.Sms.Dev.Tests.Unit/DevSmsSenderTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Sms;
 using Headless.Sms.Dev;
 using Headless.Sms.Testing;
 
@@ -60,12 +61,69 @@ public sealed class NoopSmsSenderTests
     }
 
     [Fact]
+    public async Task should_reject_a_null_single_request()
+    {
+        var act = async () => await new NoopSmsSender().SendAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task should_reject_a_single_request_without_destination()
+    {
+        var request = new SendSingleSmsRequest { Destination = null!, Text = "Hello world" };
+
+        var act = async () => await new NoopSmsSender().SendAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task should_reject_a_single_request_with_an_empty_body()
+    {
+        var act = async () => await new NoopSmsSender().SendAsync(SmsRequests.Single(text: ""));
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task should_report_bulk_success()
+    {
+        var response = await new NoopSmsSender().SendBulkAsync(SmsRequests.Bulk("Hello world", (20, "1001")));
+
+        response.AllSucceeded.Should().BeTrue();
+        response.Results.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task should_reject_a_bulk_request_with_an_empty_body()
+    {
+        var request = SmsRequests.Bulk("", (20, "1001"));
+
+        var act = async () => await new NoopSmsSender().SendBulkAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
     public async Task should_honor_cancellation()
     {
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
         var act = async () => await new NoopSmsSender().SendAsync(SmsRequests.Single(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task should_honor_bulk_cancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = async () =>
+            await new NoopSmsSender().SendBulkAsync(SmsRequests.Bulk("Hello world", (20, "1001")), cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipBulkSmsConformanceTests.cs
@@ -11,35 +11,29 @@ using WireMock.ResponseBuilders;
 
 namespace Tests;
 
-/// <summary>
-/// Runs the cross-provider <see cref="SmsSenderConformanceTests"/> contract against the Infobip sender.
-/// Infobip-specific behavior (bulk id, per-message ids, API error mapping) lives in
-/// <see cref="InfobipSmsSenderTests"/>.
-/// </summary>
-public sealed class InfobipSmsConformanceTests : SmsSenderConformanceTests, IClassFixture<SmsWireMockFixture>
+/// <summary>Runs the <see cref="SmsBulkSenderConformanceTests"/> contract against the Infobip bulk sender.</summary>
+public sealed class InfobipBulkSmsConformanceTests : SmsBulkSenderConformanceTests, IClassFixture<SmsWireMockFixture>
 {
+    // Two messages so the per-recipient mapping matches the two-recipient conformance request.
     private const string _SuccessBody = """
         {
           "bulkId": "bulk-1",
           "messages": [
-            {
-              "to": "201001234567",
-              "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "queued" },
-              "messageId": "m1"
-            }
+            { "to": "201001234567", "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "queued" }, "messageId": "m1" },
+            { "to": "201009876543", "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "queued" }, "messageId": "m2" }
           ]
         }
         """;
 
     private readonly SmsWireMockFixture _fixture;
 
-    public InfobipSmsConformanceTests(SmsWireMockFixture fixture)
+    public InfobipBulkSmsConformanceTests(SmsWireMockFixture fixture)
     {
         _fixture = fixture;
         _fixture.Reset();
     }
 
-    protected override ISmsSender CreateSuccessfulSender()
+    protected override IBulkSmsSender CreateSuccessfulSender()
     {
         _fixture
             .Server.Given(Request.Create().UsingPost())
@@ -54,7 +48,7 @@ public sealed class InfobipSmsConformanceTests : SmsSenderConformanceTests, ICla
         return _CreateSender(_fixture.BaseUrl);
     }
 
-    protected override ISmsSender CreateFaultingSender() => _CreateSender("http://localhost:1");
+    protected override IBulkSmsSender CreateFaultingSender() => _CreateSender("http://localhost:1");
 
     private InfobipSmsSender _CreateSender(string basePath)
     {
@@ -74,14 +68,16 @@ public sealed class InfobipSmsConformanceTests : SmsSenderConformanceTests, ICla
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
+    public override Task should_reject_a_request_without_destinations() =>
+        base.should_reject_a_request_without_destinations();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 
     [Fact]
-    public override Task should_succeed_for_a_single_destination() => base.should_succeed_for_a_single_destination();
+    public override Task should_return_a_result_for_every_recipient() =>
+        base.should_return_a_result_for_every_recipient();
 
     [Fact]
     public override Task should_report_a_transient_failure_on_a_transport_fault() =>

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipBulkSmsConformanceTests.cs
@@ -72,6 +72,9 @@ public sealed class InfobipBulkSmsConformanceTests : SmsBulkSenderConformanceTes
         base.should_reject_a_request_without_destinations();
 
     [Fact]
+    public override Task should_reject_null_destinations() => base.should_reject_null_destinations();
+
+    [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSetupTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSetupTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.Infobip;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class InfobipSetupTests
+{
+    [Fact]
+    public void should_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHeadlessSms(setup =>
+            setup.UseInfobip(_Config(("Sender", "SENDER"), ("ApiKey", "api-key"), ("BasePath", "https://example.test")))
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -184,4 +184,54 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
         response.Results.Should().HaveCount(2);
         response.Results.Should().AllSatisfy(r => r.Result.FailureKind.Should().Be(SmsFailureKind.Unknown));
     }
+
+    [Fact]
+    public async Task should_classify_a_not_enough_credits_recipient_as_out_of_credit()
+    {
+        // Infobip reports out-of-credit only as a per-message status name ("REJECTED_NOT_ENOUGH_CREDITS").
+        const string body = """
+            {
+              "bulkId": "bulk-12",
+              "messages": [
+                { "to": "201001110000", "status": { "groupId": 5, "groupName": "REJECTED", "id": 6, "name": "REJECTED_NOT_ENOUGH_CREDITS", "description": "Not enough credits" }, "messageId": "m-a" }
+              ]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var response = await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000")));
+
+        response.AllSucceeded.Should().BeFalse();
+        response.Results[0].Result.FailureKind.Should().Be(SmsFailureKind.OutOfCredit);
+    }
+
+    [Fact]
+    public async Task should_classify_an_unauthorized_response_as_an_auth_failure()
+    {
+        // Authentication failures surface at the request level (HTTP 401), not as a per-message status.
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.Unauthorized)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(
+                        """{"requestError":{"serviceException":{"messageId":"UNAUTHORIZED","text":"invalid api key"}}}"""
+                    )
+            );
+
+        var result = await CreateSender().SendAsync(SmsRequests.Single());
+
+        result.Success.Should().BeFalse();
+        result.FailureKind.Should().Be(SmsFailureKind.AuthFailure);
+    }
 }

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -84,4 +84,36 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
 
         result.Success.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task should_carry_per_recipient_message_ids_for_a_bulk_send()
+    {
+        const string body = """
+            {
+              "bulkId": "bulk-9",
+              "messages": [
+                { "to": "201001110000", "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "q" }, "messageId": "m-a" },
+                { "to": "201002220000", "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "q" }, "messageId": "m-b" }
+              ]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var response = await CreateSender()
+            .SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000"), (20, "1002220000")));
+
+        response.AllSucceeded.Should().BeTrue();
+        response.ProviderBatchId.Should().Be("bulk-9");
+        response.Results.Should().HaveCount(2);
+        response.Results[0].Result.ProviderMessageId.Should().Be("m-a");
+        response.Results[1].Result.ProviderMessageId.Should().Be("m-b");
+    }
 }

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -151,4 +151,37 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
         response.Results[1].Result.FailureError.Should().Be("Invalid destination");
         response.Results[1].Result.FailureKind.Should().Be(SmsFailureKind.InvalidRecipient);
     }
+
+    [Fact]
+    public async Task should_not_report_success_when_the_bulk_response_count_does_not_match()
+    {
+        // Two recipients requested, but Infobip returns only one message result: the response cannot be
+        // attributed per recipient, so the send must not be reported as all-succeeded.
+        const string body = """
+            {
+              "bulkId": "bulk-11",
+              "messages": [
+                { "to": "201001110000", "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "q" }, "messageId": "m-a" }
+              ]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var response = await CreateSender()
+            .SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000"), (20, "1002220000")));
+
+        response.AllSucceeded.Should().BeFalse();
+        response.AnySucceeded.Should().BeFalse();
+        response.ProviderBatchId.Should().Be("bulk-11");
+        response.Results.Should().HaveCount(2);
+        response.Results.Should().AllSatisfy(r => r.Result.FailureKind.Should().Be(SmsFailureKind.Unknown));
+    }
 }

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -234,4 +234,86 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
         result.Success.Should().BeFalse();
         result.FailureKind.Should().Be(SmsFailureKind.AuthFailure);
     }
+
+    [Fact]
+    public async Task should_fail_a_single_send_when_the_message_is_rejected_in_a_200()
+    {
+        // Infobip can accept the request (HTTP 200) but reject the individual message; a single send must
+        // surface that as a failure rather than reporting success.
+        const string body = """
+            {
+              "bulkId": "bulk-13",
+              "messages": [
+                { "to": "201001234567", "status": { "groupId": 5, "groupName": "REJECTED", "id": 99, "name": "REJECTED_DESTINATION", "description": "Invalid destination" }, "messageId": "m1" }
+              ]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var result = await CreateSender().SendAsync(SmsRequests.Single());
+
+        result.Success.Should().BeFalse();
+        result.FailureError.Should().Be("Invalid destination");
+        result.FailureKind.Should().Be(SmsFailureKind.InvalidRecipient);
+    }
+
+    [Fact]
+    public async Task should_classify_a_missing_status_as_unknown_for_a_bulk_recipient()
+    {
+        const string body = """
+            {
+              "bulkId": "bulk-14",
+              "messages": [{ "to": "201001110000", "messageId": "m-a" }]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var response = await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000")));
+
+        response.Results[0].Result.Success.Should().BeFalse();
+        response.Results[0].Result.FailureKind.Should().Be(SmsFailureKind.Unknown);
+    }
+
+    [Fact]
+    public async Task should_use_the_status_name_when_the_failure_description_is_blank()
+    {
+        const string body = """
+            {
+              "bulkId": "bulk-15",
+              "messages": [
+                { "to": "201001110000", "status": { "groupId": 5, "groupName": "REJECTED", "id": 99, "name": "REJECTED_DESTINATION", "description": "" }, "messageId": "m-a" }
+              ]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var response = await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000")));
+
+        response.Results[0].Result.Success.Should().BeFalse();
+        response.Results[0].Result.FailureError.Should().Be("Infobip message status REJECTED_DESTINATION");
+    }
 }

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -116,4 +116,39 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
         response.Results[0].Result.ProviderMessageId.Should().Be("m-a");
         response.Results[1].Result.ProviderMessageId.Should().Be("m-b");
     }
+
+    [Fact]
+    public async Task should_preserve_per_recipient_failure_status_for_a_bulk_send()
+    {
+        const string body = """
+            {
+              "bulkId": "bulk-10",
+              "messages": [
+                { "to": "201001110000", "status": { "groupId": 1, "groupName": "PENDING", "id": 7, "name": "PENDING_ENROUTE", "description": "queued" }, "messageId": "m-a" },
+                { "to": "201002220000", "status": { "groupId": 5, "groupName": "REJECTED", "id": 99, "name": "REJECTED_DESTINATION", "description": "Invalid destination" }, "messageId": "m-b" }
+              ]
+            }
+            """;
+        _fixture
+            .Server.Given(Request.Create().UsingPost())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody(body)
+            );
+
+        var response = await CreateSender()
+            .SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000"), (20, "1002220000")));
+
+        response.AllSucceeded.Should().BeFalse();
+        response.AnySucceeded.Should().BeTrue();
+        response.ProviderBatchId.Should().Be("bulk-10");
+        response.Results[0].Result.Success.Should().BeTrue();
+        response.Results[0].Result.ProviderMessageId.Should().Be("m-a");
+        response.Results[1].Result.Success.Should().BeFalse();
+        response.Results[1].Result.FailureError.Should().Be("Invalid destination");
+        response.Results[1].Result.FailureKind.Should().Be(SmsFailureKind.InvalidRecipient);
+    }
 }

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -186,9 +186,11 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
     }
 
     [Fact]
-    public async Task should_classify_a_not_enough_credits_recipient_as_out_of_credit()
+    public async Task should_classify_a_rejected_recipient_by_group_not_by_status_name()
     {
-        // Infobip reports out-of-credit only as a per-message status name ("REJECTED_NOT_ENOUGH_CREDITS").
+        // Deliberate: classify by Infobip's typed delivery group, not by parsing the free-form status name, so
+        // even a "REJECTED_NOT_ENOUGH_CREDITS" rejection maps to InvalidRecipient (REJECTED group). The specific
+        // reason is preserved in FailureError.
         const string body = """
             {
               "bulkId": "bulk-12",
@@ -210,13 +212,16 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
         var response = await CreateSender().SendBulkAsync(SmsRequests.Bulk("hi", (20, "1001110000")));
 
         response.AllSucceeded.Should().BeFalse();
-        response.Results[0].Result.FailureKind.Should().Be(SmsFailureKind.OutOfCredit);
+        response.Results[0].Result.FailureKind.Should().Be(SmsFailureKind.InvalidRecipient);
+        response.Results[0].Result.FailureError.Should().Be("Not enough credits");
     }
 
     [Fact]
-    public async Task should_classify_an_unauthorized_response_as_an_auth_failure()
+    public async Task should_not_infer_a_failure_kind_from_the_http_status()
     {
-        // Authentication failures surface at the request level (HTTP 401), not as a per-message status.
+        // Deliberate: Infobip's HTTP status is not a reliable per-provider kind signal (its real error lives in
+        // the response body), so a request-level rejection is reported without a guessed kind (Unknown) rather
+        // than run through the generic HTTP-status mapping.
         _fixture
             .Server.Given(Request.Create().UsingPost())
             .RespondWith(
@@ -232,7 +237,7 @@ public sealed class InfobipSmsSenderTests : IClassFixture<SmsWireMockFixture>
         var result = await CreateSender().SendAsync(SmsRequests.Single());
 
         result.Success.Should().BeFalse();
-        result.FailureKind.Should().Be(SmsFailureKind.AuthFailure);
+        result.FailureKind.Should().Be(SmsFailureKind.Unknown);
     }
 
     [Fact]

--- a/tests/Headless.Sms.Tests.Harness/SmsBulkSenderConformanceTests.cs
+++ b/tests/Headless.Sms.Tests.Harness/SmsBulkSenderConformanceTests.cs
@@ -60,7 +60,7 @@ public abstract class SmsBulkSenderConformanceTests
 
         response.AllSucceeded.Should().BeTrue();
         response.Results.Should().HaveCount(2);
-        response.Results.Select(r => r.Destination).Should().BeEquivalentTo(request.Destinations);
+        response.Results.Select(r => r.Destination).Should().Equal(request.Destinations);
     }
 
     public virtual async Task should_report_a_transient_failure_on_a_transport_fault()

--- a/tests/Headless.Sms.Tests.Harness/SmsBulkSenderConformanceTests.cs
+++ b/tests/Headless.Sms.Tests.Harness/SmsBulkSenderConformanceTests.cs
@@ -37,6 +37,16 @@ public abstract class SmsBulkSenderConformanceTests
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
+    public virtual async Task should_reject_null_destinations()
+    {
+        var sender = CreateSuccessfulSender();
+        var request = new SendBulkSmsRequest { Destinations = null!, Text = "Hello world" };
+
+        var act = async () => await sender.SendBulkAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
     public virtual async Task should_reject_a_request_with_an_empty_body()
     {
         var sender = CreateSuccessfulSender();

--- a/tests/Headless.Sms.Tests.Harness/SmsBulkSenderConformanceTests.cs
+++ b/tests/Headless.Sms.Tests.Harness/SmsBulkSenderConformanceTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Sms.Testing;
+
+/// <summary>
+/// Cross-provider conformance contract that every <see cref="IBulkSmsSender"/> implementation must satisfy.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="SmsSenderConformanceTests"/> for the bulk capability. Concrete provider test classes
+/// derive from this, wire the provider through <see cref="CreateSuccessfulSender"/> and
+/// <see cref="CreateFaultingSender"/>, and re-expose each scenario as an xUnit <c>[Fact]</c> override.
+/// </remarks>
+public abstract class SmsBulkSenderConformanceTests
+{
+    /// <summary>Wires the provider so that a multi-recipient bulk send succeeds.</summary>
+    protected abstract IBulkSmsSender CreateSuccessfulSender();
+
+    /// <summary>Wires the provider so that the bulk send faults at the transport layer.</summary>
+    protected abstract IBulkSmsSender CreateFaultingSender();
+
+    public virtual async Task should_reject_a_null_request()
+    {
+        var sender = CreateSuccessfulSender();
+
+        var act = async () => await sender.SendBulkAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    public virtual async Task should_reject_a_request_without_destinations()
+    {
+        var sender = CreateSuccessfulSender();
+        var request = new SendBulkSmsRequest { Destinations = [], Text = "Hello world" };
+
+        var act = async () => await sender.SendBulkAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    public virtual async Task should_reject_a_request_with_an_empty_body()
+    {
+        var sender = CreateSuccessfulSender();
+        var request = new SendBulkSmsRequest
+        {
+            Destinations = [new SmsRequestDestination(20, "1001234567")],
+            Text = "",
+        };
+
+        var act = async () => await sender.SendBulkAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    public virtual async Task should_return_a_result_for_every_recipient()
+    {
+        var sender = CreateSuccessfulSender();
+        var request = SmsRequests.Bulk("Hello world", (20, "1001234567"), (20, "1009876543"));
+
+        var response = await sender.SendBulkAsync(request);
+
+        response.AllSucceeded.Should().BeTrue();
+        response.Results.Should().HaveCount(2);
+        response.Results.Select(r => r.Destination).Should().BeEquivalentTo(request.Destinations);
+    }
+
+    public virtual async Task should_report_a_transient_failure_on_a_transport_fault()
+    {
+        var sender = CreateFaultingSender();
+        var request = SmsRequests.Bulk("Hello world", (20, "1001234567"), (20, "1009876543"));
+
+        var response = await sender.SendBulkAsync(request);
+
+        response.AllSucceeded.Should().BeFalse();
+        response.Results.Should().HaveCount(2);
+        response.Results.Should().AllSatisfy(r => r.Result.FailureKind.Should().Be(SmsFailureKind.Transient));
+    }
+
+    public virtual async Task should_propagate_cancellation()
+    {
+        var sender = CreateSuccessfulSender();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var request = SmsRequests.Bulk("Hello world", (20, "1001234567"));
+
+        var act = async () => await sender.SendBulkAsync(request, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Headless.Sms.Tests.Harness/SmsRequests.cs
+++ b/tests/Headless.Sms.Tests.Harness/SmsRequests.cs
@@ -2,10 +2,10 @@
 
 namespace Headless.Sms.Testing;
 
-/// <summary>Builders for <see cref="SendSingleSmsRequest"/> values used across SMS provider tests.</summary>
+/// <summary>Builders for SMS request values used across SMS provider tests.</summary>
 public static class SmsRequests
 {
-    /// <summary>A single-destination request.</summary>
+    /// <summary>A single-recipient <see cref="SendSingleSmsRequest"/>.</summary>
     public static SendSingleSmsRequest Single(
         string text = "Hello world",
         int code = 20,
@@ -15,19 +15,16 @@ public static class SmsRequests
     {
         return new SendSingleSmsRequest
         {
-            Destinations = [new SmsRequestDestination(code, number)],
+            Destination = new SmsRequestDestination(code, number),
             Text = text,
             MessageId = messageId,
         };
     }
 
-    /// <summary>A multi-destination (batch) request.</summary>
-    public static SendSingleSmsRequest Batch(
-        string text = "Hello world",
-        params (int Code, string Number)[] destinations
-    )
+    /// <summary>A multi-recipient <see cref="SendBulkSmsRequest"/> for <see cref="IBulkSmsSender"/>.</summary>
+    public static SendBulkSmsRequest Bulk(string text = "Hello world", params (int Code, string Number)[] destinations)
     {
-        return new SendSingleSmsRequest
+        return new SendBulkSmsRequest
         {
             Destinations = destinations.Select(d => new SmsRequestDestination(d.Code, d.Number)).ToList(),
             Text = text,

--- a/tests/Headless.Sms.Tests.Harness/SmsSenderConformanceTests.cs
+++ b/tests/Headless.Sms.Tests.Harness/SmsSenderConformanceTests.cs
@@ -34,24 +34,20 @@ public abstract class SmsSenderConformanceTests
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
-    public virtual async Task should_reject_a_request_without_destinations()
+    public virtual async Task should_reject_a_null_destination()
     {
         var sender = CreateSuccessfulSender();
-        var request = new SendSingleSmsRequest { Destinations = [], Text = "Hello world" };
+        var request = new SendSingleSmsRequest { Destination = null!, Text = "Hello world" };
 
         var act = async () => await sender.SendAsync(request);
 
-        await act.Should().ThrowAsync<ArgumentException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     public virtual async Task should_reject_a_request_with_an_empty_body()
     {
         var sender = CreateSuccessfulSender();
-        var request = new SendSingleSmsRequest
-        {
-            Destinations = [new SmsRequestDestination(20, "1001234567")],
-            Text = "",
-        };
+        var request = new SendSingleSmsRequest { Destination = new SmsRequestDestination(20, "1001234567"), Text = "" };
 
         var act = async () => await sender.SendAsync(request);
 

--- a/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSetupTests.cs
+++ b/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSetupTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.Twilio;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class TwilioSetupTests
+{
+    [Fact]
+    public void should_not_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessSms(setup =>
+            setup.UseTwilio(
+                _Config(
+                    ("Sid", "AC0000000000000000000000000000000"),
+                    ("AuthToken", "token"),
+                    ("PhoneNumber", "+15551234567")
+                )
+            )
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<IBulkSmsSender>().Should().BeNull();
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}

--- a/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsConformanceTests.cs
@@ -55,8 +55,7 @@ public sealed class TwilioSmsConformanceTests : SmsSenderConformanceTests
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_request_without_destinations() =>
-        base.should_reject_a_request_without_destinations();
+    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>

--- a/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsSenderTests.cs
+++ b/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsSenderTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
-using Headless.Sms;
 using Headless.Sms.Testing;
 using Headless.Sms.Twilio;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -38,17 +37,5 @@ public sealed class TwilioSmsSenderTests
 
         result.Success.Should().BeTrue();
         result.ProviderMessageId.Should().Be("SM123");
-    }
-
-    [Fact]
-    public async Task should_reject_multiple_destinations_as_unsupported_without_calling_twilio()
-    {
-        var client = Substitute.For<ITwilioRestClient>();
-
-        var result = await CreateSender(client).SendAsync(SmsRequests.Batch("hi", (20, "1"), (20, "2")));
-
-        result.Success.Should().BeFalse();
-        result.FailureKind.Should().Be(SmsFailureKind.Unsupported);
-        await client.DidNotReceive().RequestAsync(Arg.Any<Request>());
     }
 }

--- a/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkBulkSmsConformanceTests.cs
@@ -58,6 +58,9 @@ public sealed class VictoryLinkBulkSmsConformanceTests
         base.should_reject_a_request_without_destinations();
 
     [Fact]
+    public override Task should_reject_null_destinations() => base.should_reject_null_destinations();
+
+    [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 

--- a/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkBulkSmsConformanceTests.cs
@@ -11,22 +11,20 @@ using WireMock.ResponseBuilders;
 
 namespace Tests;
 
-/// <summary>
-/// Runs the cross-provider <see cref="SmsSenderConformanceTests"/> contract against the VictoryLink sender.
-/// VictoryLink-specific behavior (numeric response codes, RTL language detection, recipient formatting) lives
-/// in <see cref="VictoryLinkSmsSenderTests"/>.
-/// </summary>
-public sealed class VictoryLinkSmsConformanceTests : SmsSenderConformanceTests, IClassFixture<SmsWireMockFixture>
+/// <summary>Runs the <see cref="SmsBulkSenderConformanceTests"/> contract against the VictoryLink bulk sender.</summary>
+public sealed class VictoryLinkBulkSmsConformanceTests
+    : SmsBulkSenderConformanceTests,
+        IClassFixture<SmsWireMockFixture>
 {
     private readonly SmsWireMockFixture _fixture;
 
-    public VictoryLinkSmsConformanceTests(SmsWireMockFixture fixture)
+    public VictoryLinkBulkSmsConformanceTests(SmsWireMockFixture fixture)
     {
         _fixture = fixture;
         _fixture.Reset();
     }
 
-    protected override ISmsSender CreateSuccessfulSender()
+    protected override IBulkSmsSender CreateSuccessfulSender()
     {
         _fixture
             .Server.Given(Request.Create().WithPath("/send").UsingPost())
@@ -35,7 +33,7 @@ public sealed class VictoryLinkSmsConformanceTests : SmsSenderConformanceTests, 
         return _CreateSender($"{_fixture.BaseUrl}/send");
     }
 
-    protected override ISmsSender CreateFaultingSender() => _CreateSender("http://localhost:1/send");
+    protected override IBulkSmsSender CreateFaultingSender() => _CreateSender("http://localhost:1/send");
 
     private VictoryLinkSmsSender _CreateSender(string endpoint)
     {
@@ -56,14 +54,16 @@ public sealed class VictoryLinkSmsConformanceTests : SmsSenderConformanceTests, 
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
+    public override Task should_reject_a_request_without_destinations() =>
+        base.should_reject_a_request_without_destinations();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 
     [Fact]
-    public override Task should_succeed_for_a_single_destination() => base.should_succeed_for_a_single_destination();
+    public override Task should_return_a_result_for_every_recipient() =>
+        base.should_return_a_result_for_every_recipient();
 
     [Fact]
     public override Task should_report_a_transient_failure_on_a_transport_fault() =>

--- a/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkSetupTests.cs
+++ b/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkSetupTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.VictoryLink;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class VictoryLinkSetupTests
+{
+    [Fact]
+    public void should_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHeadlessSms(setup =>
+            setup.UseVictoryLink(
+                _Config(
+                    ("Endpoint", "https://example.test/sms"),
+                    ("Sender", "SENDER"),
+                    ("UserName", "user"),
+                    ("Password", "password")
+                )
+            )
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}

--- a/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneBulkSmsConformanceTests.cs
@@ -62,6 +62,9 @@ public sealed class VodafoneBulkSmsConformanceTests : SmsBulkSenderConformanceTe
         base.should_reject_a_request_without_destinations();
 
     [Fact]
+    public override Task should_reject_null_destinations() => base.should_reject_null_destinations();
+
+    [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 

--- a/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneBulkSmsConformanceTests.cs
@@ -11,22 +11,18 @@ using WireMock.ResponseBuilders;
 
 namespace Tests;
 
-/// <summary>
-/// Runs the cross-provider <see cref="SmsSenderConformanceTests"/> contract against the Vodafone sender.
-/// Vodafone-specific behavior (XML body, HMAC signature, body-based success detection, surfaced failure
-/// body) lives in <see cref="VodafoneSmsSenderTests"/>.
-/// </summary>
-public sealed class VodafoneSmsConformanceTests : SmsSenderConformanceTests, IClassFixture<SmsWireMockFixture>
+/// <summary>Runs the <see cref="SmsBulkSenderConformanceTests"/> contract against the Vodafone bulk sender.</summary>
+public sealed class VodafoneBulkSmsConformanceTests : SmsBulkSenderConformanceTests, IClassFixture<SmsWireMockFixture>
 {
     private readonly SmsWireMockFixture _fixture;
 
-    public VodafoneSmsConformanceTests(SmsWireMockFixture fixture)
+    public VodafoneBulkSmsConformanceTests(SmsWireMockFixture fixture)
     {
         _fixture = fixture;
         _fixture.Reset();
     }
 
-    protected override ISmsSender CreateSuccessfulSender()
+    protected override IBulkSmsSender CreateSuccessfulSender()
     {
         _fixture
             .Server.Given(Request.Create().WithPath("/submit").UsingPost())
@@ -40,7 +36,7 @@ public sealed class VodafoneSmsConformanceTests : SmsSenderConformanceTests, ICl
         return _CreateSender($"{_fixture.BaseUrl}/submit");
     }
 
-    protected override ISmsSender CreateFaultingSender() => _CreateSender("http://localhost:1/submit");
+    protected override IBulkSmsSender CreateFaultingSender() => _CreateSender("http://localhost:1/submit");
 
     private VodafoneSmsSender _CreateSender(string endpoint)
     {
@@ -62,14 +58,16 @@ public sealed class VodafoneSmsConformanceTests : SmsSenderConformanceTests, ICl
     public override Task should_reject_a_null_request() => base.should_reject_a_null_request();
 
     [Fact]
-    public override Task should_reject_a_null_destination() => base.should_reject_a_null_destination();
+    public override Task should_reject_a_request_without_destinations() =>
+        base.should_reject_a_request_without_destinations();
 
     [Fact]
     public override Task should_reject_a_request_with_an_empty_body() =>
         base.should_reject_a_request_with_an_empty_body();
 
     [Fact]
-    public override Task should_succeed_for_a_single_destination() => base.should_succeed_for_a_single_destination();
+    public override Task should_return_a_result_for_every_recipient() =>
+        base.should_return_a_result_for_every_recipient();
 
     [Fact]
     public override Task should_report_a_transient_failure_on_a_transport_fault() =>

--- a/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneSetupTests.cs
+++ b/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneSetupTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Sms;
+using Headless.Sms.Vodafone;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class VodafoneSetupTests
+{
+    [Fact]
+    public void should_register_bulk_sender_through_setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHeadlessSms(setup =>
+            setup.UseVodafone(
+                _Config(
+                    ("SendSmsEndpoint", "https://example.test/sms"),
+                    ("Sender", "SENDER"),
+                    ("AccountId", "account"),
+                    ("Password", "password"),
+                    ("SecureHash", "secure-hash")
+                )
+            )
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IBulkSmsSender>().Should().BeSameAs(provider.GetRequiredService<ISmsSender>());
+    }
+
+    private static IConfiguration _Config(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                values.Select(static item => new KeyValuePair<string, string?>(item.Key, item.Value))
+            )
+            .Build();
+}


### PR DESCRIPTION
**Stacked on #549** (base = `xshaheen/feat-named-sms-clients`) — review/merge #549 first. This reshapes the SMS API per the chosen design: a clean single-recipient core, with multi-recipient sending as an opt-in capability.

## Breaking change

`ISmsSender.SendAsync` now targets **exactly one recipient**. `SendSingleSmsRequest.Destinations` (list) and `IsBatch` are replaced by a single `Destination`. Greenfield, no deployed consumers.

## What changed

- **Single core**: `SendSingleSmsRequest.Destination` (one `SmsRequestDestination`); every send has one unambiguous outcome + one provider id.
- **Bulk capability**: new `IBulkSmsSender.SendBulkAsync(SendBulkSmsRequest) → SendBulkSmsResponse` — per-recipient `SmsRecipientResult` (`Destination` + `SendSingleSmsResponse`), `AllSucceeded`/`AnySucceeded`, optional `ProviderBatchId`. Built via `FromResults` (per-recipient) or `FromAggregate` (one outcome mirrored to all).
- **Who implements it**: Cequens, Connekio, Infobip, VictoryLink, Vodafone, Dev, Noop. **Twilio and AWS SNS do not** (one recipient per API call) — "no bulk" is expressed structurally by not registering `IBulkSmsSender`, so resolving it fails fast.
- **Fidelity**: Infobip maps real per-recipient message ids from its response; the aggregate-only providers (research-confirmed: Connekio/VictoryLink/Vodafone/Cequens return a single batch status) mirror one outcome to every recipient.
- **DI**: bulk providers register `IBulkSmsSender` as a forward to the same singleton (`sp => (IBulkSmsSender)sp.GetRequiredService<ISmsSender>()`).
- **Removed** the now-unused `SmsFailureKind.Unsupported` (added in #549 for batch rejection, which no longer exists).

## Tests

- Conformance split into `SmsSenderConformanceTests` (7 providers) + `SmsBulkSenderConformanceTests` (5 bulk providers): arg validation, success, per-recipient result count, transport-fault → `Transient`, cancellation.
- Added Infobip per-recipient-id test, Dev bulk test, and `SendBulkSmsResponse` unit tests; converted Connekio's batch-routing test to `SendBulkAsync`; removed the obsolete Twilio/AWS multi-destination rejection tests.

## Verification

- **147 SMS tests pass** (Abstractions 32, VictoryLink 30, Connekio/Vodafone 17, Cequens 16, Infobip 15, AWS 9, Twilio 7, Dev 4).
- `--no-incremental` warnings-as-errors + CI-build of all 18 SMS src/test projects: clean.
- CSharpier clean across all 42 changed `.cs` files.

## Research note (for the dropped review #5)

Verified via vendor docs + real-world wrappers (Resala) that Connekio and Vodafone return **no** usable per-message id, and Cequens's current v1 success-body id field can't be confirmed from public docs — so `ProviderMessageId` stays null on success for those (contract-valid). Bonus finding: our Vodafone success check (`<Success>true</Success>`) differs from Resala's (`<ResultStatus>SUCCESS</ResultStatus>`) — worth confirming against the live API, left untouched here.