### PR TITLE
build: bump Headless MSBuild SDK to 0.0.119

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Headless.NET.Sdk": "0.0.117",
-    "Headless.NET.Sdk.Web": "0.0.117",
-    "Headless.NET.Sdk.Test": "0.0.117",
-    "Headless.NET.Sdk.Razor": "0.0.117",
-    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.117",
-    "Headless.NET.Sdk.WindowsDesktop": "0.0.117"
+    "Headless.NET.Sdk": "0.0.119",
+    "Headless.NET.Sdk.Web": "0.0.119",
+    "Headless.NET.Sdk.Test": "0.0.119",
+    "Headless.NET.Sdk.Razor": "0.0.119",
+    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.119",
+    "Headless.NET.Sdk.WindowsDesktop": "0.0.119"
   }
 }


### PR DESCRIPTION
Bumps the six `Headless.NET.Sdk*` MSBuild SDKs in `global.json` from **0.0.117 → 0.0.119**.

- `.NET SDK` (`sdk.version` 10.0.301) is unchanged — only the `msbuild-sdks` block.
- Verified locally: `dotnet build` resolves and builds clean against 0.0.119 (no quarantine block, no missing-package error).

Standalone and independent of the reuse/consistency stack (#559–#562).