### PR TITLE
build(tests): silence CA1707/IDE1006 naming warnings in base-SDK harness libraries

### DIFF
--- a/tests/Headless.CommitCoordination.Tests.Harness/Headless.CommitCoordination.Tests.Harness.csproj
+++ b/tests/Headless.CommitCoordination.Tests.Harness/Headless.CommitCoordination.Tests.Harness.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Tests</RootNamespace>
     <IsTestProject>false</IsTestProject>
+    <!-- Stays a library harness (not a test-runner); suppress the snake_case test-naming warnings the
+         Test SDK silences for test projects via IsTestableProject, without becoming a test project. -->
+    <NoWarn>$(NoWarn);CA1707;IDE1006</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Headless.CommitCoordination.Core\Headless.CommitCoordination.Core.csproj" />

--- a/tests/Headless.Coordination.Tests.Harness/Headless.Coordination.Tests.Harness.csproj
+++ b/tests/Headless.Coordination.Tests.Harness/Headless.Coordination.Tests.Harness.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Tests</RootNamespace>
     <IsTestProject>false</IsTestProject>
+    <!-- Stays a library harness (not a test-runner); suppress the snake_case test-naming warnings the
+         Test SDK silences for test projects via IsTestableProject, without becoming a test project. -->
+    <NoWarn>$(NoWarn);CA1707;IDE1006</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Headless.Coordination.Core\Headless.Coordination.Core.csproj" />

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/Headless.Jobs.EntityFramework.Tests.Harness.csproj
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/Headless.Jobs.EntityFramework.Tests.Harness.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Tests</RootNamespace>
     <IsTestProject>false</IsTestProject>
+    <!-- Stays a library harness (not a test-runner); suppress the snake_case test-naming warnings the
+         Test SDK silences for test projects via IsTestableProject, without becoming a test project. -->
+    <NoWarn>$(NoWarn);CA1707;IDE1006</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />


### PR DESCRIPTION
The 3 `*.Tests.Harness` projects on the base `Headless.NET.Sdk` with `<IsTestProject>false</IsTestProject>` (CommitCoordination, Coordination, Jobs.EntityFramework) are deliberate **library** harnesses, so they don't receive the test-noise naming suppressions that `Headless.NET.Sdk.Test` applies (via `IsTestableProject=true` → `NoWarn CA1707;IDE1006` + `Tests.editorconfig`).

This adds `<NoWarn>$(NoWarn);CA1707;IDE1006</NoWarn>` to those 3 — silencing the snake_case test-member-naming warnings **the same way test projects do**, while keeping them libraries.

Deliberately **not** switching them to `Headless.NET.Sdk.Test` / `IsTestableProject=true`: that import (`SupportTestProjects.targets`) unconditionally forces `IsTestProject=true` + `GenerateProgramFile=true`, converting these libraries into test-runner projects. Verified `IsTestProject` stays `false` with this approach; all 3 build clean (0 warnings).