### PR TITLE
fix(core): honor user and password policy contracts

### DIFF
--- a/docs/llms/core.md
+++ b/docs/llms/core.md
@@ -103,7 +103,7 @@ Provides standardized interfaces for common cross-cutting concerns (clock, user,
 
 - **Abstractions**:
     - `IClock` - Testable time abstraction (wraps `TimeProvider`)
-    - `ICurrentUser` - Current authenticated user context with roles and claims
+    - `ICurrentUser` - Current authenticated user context; `UserId` and `Roles` are exposed only for authenticated principals
     - `ICurrentTenant` - Multi-tenancy support with scoped tenant switching
     - `ITenantWriteGuardBypass` - Explicit bypass scope for audited host/admin tenant writes
     - `CrossTenantWriteException` / `MissingTenantContextException` - tenant write-guard exceptions (non-transient; exclude from retry)
@@ -111,7 +111,7 @@ Provides standardized interfaces for common cross-cutting concerns (clock, user,
     - `ICurrentLocale` - Localization context (language, locale, culture)
     - `ICurrentTimeZone` - Timezone handling
     - `ICurrentPrincipalAccessor` - Scoped `ClaimsPrincipal` access with temporary switching
-    - `IPasswordGenerator` - Configurable secure password generation
+    - `IPasswordGenerator` - Configurable secure password generation; remaining character pools are required only when filler or extra unique characters are needed
     - `ICancellationTokenProvider` - Cancellation token access with fallback logic
     - `ITimezoneProvider` - Windows/IANA timezone conversion and listing
     - `IApplicationInformationAccessor` / `IBuildInformationAccessor` - Application metadata and build info

--- a/src/Headless.Core/Abstractions/ICurrentUser.cs
+++ b/src/Headless.Core/Abstractions/ICurrentUser.cs
@@ -114,7 +114,7 @@ public sealed class PrincipalCurrentUser(ClaimsPrincipal? principal) : ICurrentU
     public bool IsAuthenticated => principal?.Identity?.IsAuthenticated == true;
 
     /// <inheritdoc/>
-    public UserId? UserId => principal.GetUserId();
+    public UserId? UserId => IsAuthenticated ? principal.GetUserId() : null;
 
     /// <inheritdoc/>
     public string? AccountType => principal.GetAccountType();
@@ -123,5 +123,5 @@ public sealed class PrincipalCurrentUser(ClaimsPrincipal? principal) : ICurrentU
     public AccountId? AccountId => principal.GetAccountId();
 
     /// <inheritdoc/>
-    public IReadOnlySet<string> Roles => principal.GetRoles();
+    public IReadOnlySet<string> Roles => IsAuthenticated ? principal.GetRoles() : ImmutableHashSet<string>.Empty;
 }

--- a/src/Headless.Core/Abstractions/IPasswordGenerator.cs
+++ b/src/Headless.Core/Abstractions/IPasswordGenerator.cs
@@ -87,7 +87,8 @@ public sealed class PasswordGenerator : IPasswordGenerator
     /// </exception>
     /// <exception cref="InvalidOperationException">
     /// The options are internally inconsistent: <see cref="GeneratePasswordOptions.Length"/> is less than the
-    /// number of enabled required-character sets; no character set is enabled for the remaining fill pool; or
+    /// number of enabled required-character sets; no character set is enabled when remaining characters or
+    /// additional unique characters must be drawn from the remaining fill pool; or
     /// <see cref="GeneratePasswordOptions.RequiredUniqueChars"/> exceeds the total number of distinct characters
     /// across all available sets.
     /// </exception>
@@ -115,20 +116,25 @@ public sealed class PasswordGenerator : IPasswordGenerator
         );
 
         Ensure.True(
-            options.UseDigitsInRemaining
-                || options.UseLowercaseInRemaining
-                || options.UseUppercaseInRemaining
-                || options.UseNonAlphanumericInRemaining,
-            "Invalid password configuration provided. At least one character set must be used in remaining characters."
-        );
-
-        Ensure.True(
             requiredUniqueChars
                 <= _NonAlphanumericChars.Length + _DigitsChars.Length + _LowercaseChars.Length + _UppercaseChars.Length,
             "Invalid password configuration provided. Required unique characters count is greater than the total available characters."
         );
 
         requiredUniqueChars = Math.Min(requiredUniqueChars, length);
+
+        var hasRemainingCharacterSet =
+            options.UseDigitsInRemaining
+            || options.UseLowercaseInRemaining
+            || options.UseUppercaseInRemaining
+            || options.UseNonAlphanumericInRemaining;
+
+        var needsRemainingCharacterSet = length > requiredCharsCount || requiredUniqueChars > requiredCharsCount;
+
+        Ensure.True(
+            !needsRemainingCharacterSet || hasRemainingCharacterSet,
+            "Invalid password configuration provided. At least one character set must be used in remaining characters."
+        );
 
         /* Generate password */
 

--- a/src/Headless.Core/README.md
+++ b/src/Headless.Core/README.md
@@ -10,14 +10,14 @@ Provides standardized interfaces for common cross-cutting concerns (clock, user,
 
 - **Abstractions**:
   - `IClock` - Testable time abstraction (wraps `TimeProvider`)
-  - `ICurrentUser` - Current authenticated user context with roles and claims
+  - `ICurrentUser` - Current authenticated user context; `UserId` and `Roles` are exposed only for authenticated principals
   - `ICurrentTenant` - Multi-tenancy support with scoped tenant switching
   - `ITenantWriteGuardBypass` - Explicit bypass scope for audited host/admin tenant writes
   - `CrossTenantWriteException` - Non-transient exception for blocked tenant-owned writes
   - `ICurrentLocale` - Localization context (language, locale, culture)
   - `ICurrentTimeZone` - Timezone handling
   - `ICurrentPrincipalAccessor` - Scoped `ClaimsPrincipal` access with temporary switching
-  - `IPasswordGenerator` - Configurable secure password generation
+  - `IPasswordGenerator` - Configurable secure password generation; remaining character pools are required only when filler or extra unique characters are needed
   - `ICancellationTokenProvider` - Cancellation token access with fallback logic
   - `ITimezoneProvider` - Windows/IANA timezone conversion and listing
   - `IApplicationInformationAccessor` / `IBuildInformationAccessor` - Application metadata and build info

--- a/tests/Headless.Core.Tests.Unit/Abstractions/PrincipalCurrentUserTests.cs
+++ b/tests/Headless.Core.Tests.Unit/Abstractions/PrincipalCurrentUserTests.cs
@@ -2,6 +2,8 @@
 
 using System.Security.Claims;
 using Headless.Abstractions;
+using Headless.Constants;
+using UserId = Headless.Primitives.UserId;
 
 namespace Tests.Abstractions;
 
@@ -37,6 +39,24 @@ public sealed class PrincipalCurrentUserTests
 
         // then
         sut.IsAuthenticated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void unauthenticated_principal_should_not_expose_user_id_or_roles()
+    {
+        // given
+        UserId userId = "user-123";
+
+        var principal = new ClaimsPrincipal(
+            new ClaimsIdentity([new Claim(UserClaimTypes.UserId, userId), new Claim(UserClaimTypes.Roles, "admin")])
+        );
+
+        var sut = new PrincipalCurrentUser(principal);
+
+        // then
+        sut.IsAuthenticated.Should().BeFalse();
+        sut.UserId.Should().BeNull();
+        sut.Roles.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Headless.Core.Tests.Unit/Core/PasswordGeneratorTests.cs
+++ b/tests/Headless.Core.Tests.Unit/Core/PasswordGeneratorTests.cs
@@ -61,6 +61,48 @@ public sealed class PasswordGeneratorTests
     }
 
     [Fact]
+    public void generate_password_should_allow_no_remaining_pool_when_required_sets_fill_length()
+    {
+        // when
+        var password = _passwordGenerator.GeneratePassword(
+            new GeneratePasswordOptions(4)
+            {
+                UseDigitsInRemaining = false,
+                UseLowercaseInRemaining = false,
+                UseUppercaseInRemaining = false,
+                UseNonAlphanumericInRemaining = false,
+            }
+        );
+
+        // then
+        password.Should().HaveLength(4);
+        password.Any(char.IsDigit).Should().BeTrue();
+        password.Any(char.IsLower).Should().BeTrue();
+        password.Any(char.IsUpper).Should().BeTrue();
+        password.AsEnumerable().Should().Contain(c => !char.IsLetterOrDigit(c));
+    }
+
+    [Fact]
+    public void generate_password_should_bound_required_unique_chars_by_length_before_requiring_remaining_pool()
+    {
+        // when
+        var password = _passwordGenerator.GeneratePassword(
+            new GeneratePasswordOptions(4)
+            {
+                RequiredUniqueChars = 5,
+                UseDigitsInRemaining = false,
+                UseLowercaseInRemaining = false,
+                UseUppercaseInRemaining = false,
+                UseNonAlphanumericInRemaining = false,
+            }
+        );
+
+        // then
+        password.Should().HaveLength(4);
+        password.Distinct().Should().HaveCount(4);
+    }
+
+    [Fact]
     public void validate_required_unique_chars_should_throw_invalid_operation_exception()
     {
         // when


### PR DESCRIPTION
## Summary

`ICurrentUser` now honors its authentication contract: unauthenticated principals no longer expose `UserId` or `Roles` even if claim values are present.

`PasswordGenerator` now accepts policies where required character sets fully satisfy the requested length, so callers do not need to enable a filler pool when no filler or extra unique characters are needed.

## Affected Packages

- `Headless.Core`
- `docs/llms/core.md`

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Test only

## Validation

- [ ] `make build`
- [ ] `make format-check`
- [ ] `make test-unit`
- [x] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [x] Added or updated tests for behavior changes
- [x] Updated XML docs for public API changes
- [x] Updated package `README.md` files for public behavior/setup changes
- [x] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
make build-project PROJECT=src/Headless.Core/Headless.Core.csproj
make test-project TEST_PROJECT=tests/Headless.Core.Tests.Unit/Headless.Core.Tests.Unit.csproj
dotnet csharpier check src/Headless.Core/Abstractions/ICurrentUser.cs src/Headless.Core/Abstractions/IPasswordGenerator.cs tests/Headless.Core.Tests.Unit/Abstractions/PrincipalCurrentUserTests.cs tests/Headless.Core.Tests.Unit/Core/PasswordGeneratorTests.cs
make restore
git push -u origin HEAD  # pre-push hook ran changed-file CSharpier check and Release solution build successfully

Regression proof before implementation: the new Core unit tests failed for unauthenticated user claims and no-remaining-pool password policies, then passed after the fix.
```

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
N/A
```

## Release Notes

- Fix `PrincipalCurrentUser` so unauthenticated principals do not expose `UserId` or `Roles`.
- Fix `PasswordGenerator` validation so a remaining character pool is required only when filler or extra unique characters must be generated.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a library contract bug fix covered by unit tests; validation should come from CI and downstream package test suites rather than runtime logs or dashboards.
