### PR TITLE
fix(api): align auth and idempotency contracts

### DIFF
--- a/docs/llms/api.md
+++ b/docs/llms/api.md
@@ -120,6 +120,8 @@ Additional packages:
 - Use `UseHeadless()` for the default middleware order (`UseStatusCodePages()` before `UseExceptionHandler()`), then add auth/tenant middleware, then map endpoints. `UseHeadless` and `MapHeadlessEndpoints` are idempotent.
 - For tenant-aware HTTP apps, configure `builder.AddHeadlessTenancy(tenancy => tenancy.Http(http => http.ResolveFromClaims()))` and place `app.UseHeadlessTenancy()` after app-owned `UseAuthentication()` and before app-owned `UseAuthorization()`.
 - For idempotent-replay middleware, register `services.AddIdempotency(o => { ... })` and place `app.UseIdempotency()` AFTER `UseAuthorization()` and AFTER `UseHeadlessTenancy()`. Idempotency reads `ICurrentTenant.Id` for cache-key composition; tenant and auth must be resolved first so unauthenticated/unauthorized requests do not allocate cache slots. `InFlightStrategy = WaitAndReplay` requires `IDistributedLock`; the DI startup validator fails fast if it is missing.
+- Basic and API-key handlers authenticate only credentials supplied for their own scheme. Do not rely on an existing cookie/bearer principal to satisfy an endpoint that explicitly requires `Basic` or `ApiKey`.
+- API-key query-string authentication is opt-in (`AllowApiKeyInQueryString = true`); the dynamic scheme provider ignores `?api_key=` unless the API-key handler would accept it.
 - Use `MapHeadlessEndpoints()` to expose `/health`, `/alive`, OpenAPI JSON, and static web assets. `AddHeadless()` registers a `self` health check tagged `live`.
 - Keep `TrustForwardedHeadersFromAnyProxy` disabled unless the service is reachable only through trusted proxy infrastructure.
 - `Headless.Api.ServiceDefaults` validates by default that `UseHeadless()`, `UseStatusCodesRewriter()`, and `MapHeadlessEndpoints()` were applied at startup. For custom/manual pipelines, disable via `options.Validation.RequireUseHeadless = false`, `options.Validation.RequireStatusCodesRewriter = false`, and `options.Validation.RequireMapHeadlessEndpoints = false`.
@@ -263,6 +265,7 @@ Exposes each API primitive individually so teams that need à-la-carte compositi
 - `AddHeadlessTimeService()` — `TimeProvider.System`, `IClock`, `ITimezoneProvider` (all `TryAddSingleton`)
 - `AddServerTimingMiddleware()` + `UseServerTiming()` — appends `Server-Timing` trailer when response supports trailers
 - `UseNoCacheWhenMissingCacheHeaders()` — injects `Cache-Control: no-cache,no-store,must-revalidate` when response omits the header
+- Basic/API-key authentication helpers — `AddBasicSchema()` and `AddApiKey()` register the canonical `Basic` and `ApiKey` schemes; handlers only authenticate credentials supplied for their own scheme
 - HTTP tenant resolution: `ResolveFromClaims()`, `UseHeadlessTenancy()`, `[SkipTenantResolution]`, `.SkipTenantResolution()`
 - HTTP tenant authorization: `TenantRequirement`, `[AllowMissingTenant]`, `.AllowMissingTenant()`, `[RequireTenant]`, `.RequireTenant()`
 - Diagnostic listeners: `AddHeadlessApiDiagnosticListeners()`, `BadRequestDiagnosticAdapter`, `MiddlewareAnalysisDiagnosticAdapter`
@@ -338,6 +341,8 @@ Exception mapping from `AddHeadlessProblemDetails()`:
 All other exceptions return `false`; the host default or a downstream handler renders them.
 
 `StatusCodesRewriterMiddleware` is required for the `g:tenant_required` discriminator on 403 authorization rejections. It is wired by ServiceDefaults; apps that skip ServiceDefaults must call `UseStatusCodesRewriter()` themselves. `TenantRequirement` must live in `DefaultPolicy` or `FallbackPolicy` — the startup validator does not inspect named policies. `UseHeadlessTenancy()` / `UseTenantResolution()` must run after `UseRouting()` so endpoint metadata is available when `[SkipTenantResolution]` is evaluated.
+
+`AddBasicSchema()` defaults to the canonical `Basic` authentication scheme and `AddApiKey()` defaults to `ApiKey`. `DynamicAuthenticationSchemeProvider` selects those same canonical names. API keys are read from the configured header by default; query-string keys are routed and accepted only when `ApiKeyAuthenticationSchemeOptions.AllowApiKeyInQueryString` is `true`.
 
 ### Dependencies
 
@@ -753,7 +758,7 @@ app.MapPost("/webhooks", HandleWebhook)
 | `WinnerLockLease` | 5 minutes | Lease duration for the winner's distributed lock under `WaitAndReplay`. Must be >= `InFlightLockTimeout`. Capped at 1 hour. |
 | `MaxBodySizeForHashing` | 1 MiB | Maximum body size eligible for fingerprinting. Capped at 64 MiB. |
 | `OversizeBehavior` | `Reject` | `Reject` returns 413 (`g:idempotency_body_too_large`). `PassThrough` runs the handler without idempotency guarantees. |
-| `OnCacheError` | `FailOpen` | `FailOpen` logs a warning and bypasses idempotency for the failing request. `Throw` propagates the exception as 5xx. |
+| `OnCacheError` | `FailOpen` | `FailOpen` logs a warning and bypasses idempotency for pre-handler cache failures; post-handler finalize failures remove the marker and preserve the handler response. `Throw` propagates the exception as 5xx. |
 | `RequireUserIdentity` | `true` | When `true`, the default cache key requires an authenticated user; tenant-only anonymous requests pass through. Set `false` for webhook receivers / OAuth callbacks. |
 | `MismatchStatusCode` | 422 | Status code for fingerprint mismatch. Must be 409 or 422. |
 | `ReplayHeaderAllowlist` | Content-Type, Content-Language, Content-Encoding, Content-Disposition, Location, Link, ETag, Last-Modified, Cache-Control, Vary | Response headers copied into the cached record. `Set-Cookie` and `traceparent` are excluded by design. |
@@ -775,10 +780,10 @@ app.MapPost("/webhooks", HandleWebhook)
 
 ### Side Effects
 
-- Reads `ICurrentTenant.Id` and `ICurrentUser.UserId` for cache-key composition; when both are absent and no `KeyDeriver` is configured, the middleware passes through without applying idempotency.
+- Reads `ICurrentTenant.Id` and authenticated `ICurrentUser.UserId` for cache-key composition; when both are absent and no `KeyDeriver` is configured, the middleware passes through without applying idempotency.
 - Buffers the request body up to `MaxBodySizeForHashing + 1` bytes via `HttpRequest.EnableBuffering`.
 - On replay, writes `Idempotent-Replayed: true` to the response. Pre-existing allowlisted response headers set by upstream middleware are removed before captured headers are written for byte-equivalent replay.
-- On cache miss, inserts an `InFlight` sentinel marker before invoking the handler, then upserts the `Complete` record afterward using compare-and-swap (`TryReplaceIfEqualAsync`). The marker uses the same TTL as `IdempotencyKeyExpiration`.
+- On cache miss, inserts an `InFlight` sentinel marker before invoking the handler, then promotes it to the `Complete` record afterward using compare-and-swap (`TryReplaceIfEqualAsync`). The marker uses the same TTL as `IdempotencyKeyExpiration`.
 - When the **response** body exceeds `MaxBodySizeForHashing` (`captureStream.TruncatedCapture`), the completed record is not stored and replay does not apply. `OversizeBehavior` controls **request**-body handling only.
 
 ---

--- a/src/Headless.Api.Core/Abstractions/HttpCurrentUser.cs
+++ b/src/Headless.Api.Core/Abstractions/HttpCurrentUser.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Immutable;
 using System.Security.Claims;
 using Headless.Abstractions;
 using AccountId = Headless.Primitives.AccountId;
@@ -13,11 +14,11 @@ internal sealed class HttpCurrentUser(ICurrentPrincipalAccessor accessor) : ICur
 
     public ClaimsPrincipal? Principal => accessor.Principal;
 
-    public UserId? UserId => Principal.GetUserId();
+    public UserId? UserId => IsAuthenticated ? Principal.GetUserId() : null;
 
     public string? AccountType => Principal.GetAccountType();
 
     public AccountId? AccountId => Principal.GetAccountId();
 
-    public IReadOnlySet<string> Roles => Principal.GetRoles();
+    public IReadOnlySet<string> Roles => IsAuthenticated ? Principal.GetRoles() : ImmutableHashSet<string>.Empty;
 }

--- a/src/Headless.Api.Core/Abstractions/HttpCurrentUser.cs
+++ b/src/Headless.Api.Core/Abstractions/HttpCurrentUser.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Collections.Immutable;
 using System.Security.Claims;
 using Headless.Abstractions;
-using AccountId = Headless.Primitives.AccountId;
-using UserId = Headless.Primitives.UserId;
+using Headless.Primitives;
 
 namespace Headless.Api.Abstractions;
 
@@ -16,9 +14,9 @@ internal sealed class HttpCurrentUser(ICurrentPrincipalAccessor accessor) : ICur
 
     public UserId? UserId => IsAuthenticated ? Principal.GetUserId() : null;
 
-    public string? AccountType => Principal.GetAccountType();
+    public string? AccountType => IsAuthenticated ? Principal.GetAccountType() : null;
 
-    public AccountId? AccountId => Principal.GetAccountId();
+    public AccountId? AccountId => IsAuthenticated ? Principal.GetAccountId() : null;
 
-    public IReadOnlySet<string> Roles => IsAuthenticated ? Principal.GetRoles() : ImmutableHashSet<string>.Empty;
+    public IReadOnlySet<string> Roles => IsAuthenticated ? Principal.GetRoles() : [];
 }

--- a/src/Headless.Api.Core/Identity/Authentication/ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/Headless.Api.Core/Identity/Authentication/ApiKey/ApiKeyAuthenticationHandler.cs
@@ -17,7 +17,6 @@ namespace Headless.Api.Identity.Authentication.ApiKey;
 /// <remarks>
 /// Authentication flow:
 /// <list type="number">
-///   <item><description>If the request already carries an authenticated identity, the existing ticket is reused.</description></item>
 ///   <item><description>If no API key is present in the header (or query string when <see cref="ApiKeyAuthenticationSchemeOptions.AllowApiKeyInQueryString"/> is <see langword="true"/>), <c>NoResult</c> is returned so other handlers can run.</description></item>
 ///   <item><description>If the key is blank or not found in the store, <c>NoResult</c> is returned.</description></item>
 ///   <item><description>If the user cannot sign in (email not confirmed, locked out, etc.) <c>Fail</c> is returned.</description></item>
@@ -48,13 +47,6 @@ public sealed class ApiKeyAuthenticationHandler<TUser, TUserId>(
     /// </returns>
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        // This line is important to correct working the multiple authentication schemes
-        // when only cookies sent in request
-        if (Context.User.Identity?.IsAuthenticated ?? false)
-        {
-            return AuthenticateResult.Success(new AuthenticationTicket(Context.User, "context.User"));
-        }
-
         var foundInHeader = Request.Headers.TryGetValue(Options.ApiKeyHeaderName, out var apiKeyValues);
 
         if (!foundInHeader && Options.AllowApiKeyInQueryString)

--- a/src/Headless.Api.Core/Identity/Authentication/ApiKey/ApiKeyAuthenticationSchemeOptions.cs
+++ b/src/Headless.Api.Core/Identity/Authentication/ApiKey/ApiKeyAuthenticationSchemeOptions.cs
@@ -10,7 +10,7 @@ namespace Headless.Api.Identity.Authentication.ApiKey;
 public sealed class ApiKeyAuthenticationSchemeOptions : AuthenticationSchemeOptions
 {
     /// <summary>Default scheme name used when none is specified during registration.</summary>
-    public const string DefaultScheme = "API Key Authentication";
+    public const string DefaultScheme = AuthenticationConstants.Schemas.ApiKey;
 
     /// <summary>Default query-string parameter name (<c>"api_key"</c>).</summary>
     public const string ParamName = "api_key";

--- a/src/Headless.Api.Core/Identity/Authentication/Basic/BasicAuthenticationHandler.cs
+++ b/src/Headless.Api.Core/Identity/Authentication/Basic/BasicAuthenticationHandler.cs
@@ -18,7 +18,6 @@ namespace Headless.Api.Identity.Authentication.Basic;
 /// <remarks>
 /// Authentication flow:
 /// <list type="number">
-///   <item><description>If the request already carries an authenticated identity, the existing ticket is reused.</description></item>
 ///   <item><description>If no <c>Authorization: Basic</c> header is present, <c>NoResult</c> is returned so other handlers can run.</description></item>
 ///   <item><description>If the header value cannot be Base64-decoded or parsed as <c>username:password</c>, <c>Fail</c> is returned.</description></item>
 ///   <item><description>If the user is not found, cannot sign in, is locked out, or the password is wrong, <c>Fail</c> is returned.</description></item>
@@ -48,13 +47,6 @@ public sealed class BasicAuthenticationHandler<TUser, TUserId>(
     /// </returns>
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        // This block is important when working with multiple authentication schemes
-        // when only cookies are being sent in request.
-        if (Context.User.Identity?.IsAuthenticated ?? false)
-        {
-            return AuthenticateResult.Success(new AuthenticationTicket(Context.User, "context.User"));
-        }
-
         if (!_TryGetEncodedCredentials(out var encodedCredentials))
         {
             return AuthenticateResult.NoResult();

--- a/src/Headless.Api.Core/Identity/Authentication/Basic/BasicAuthenticationOptions.cs
+++ b/src/Headless.Api.Core/Identity/Authentication/Basic/BasicAuthenticationOptions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Constants;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Headless.Api.Identity.Authentication.Basic;
@@ -9,7 +10,7 @@ namespace Headless.Api.Identity.Authentication.Basic;
 public sealed class BasicAuthenticationOptions : AuthenticationSchemeOptions
 {
     /// <summary>Default scheme name used when none is specified during registration.</summary>
-    public const string DefaultScheme = "Basic Authentication";
+    public const string DefaultScheme = AuthenticationConstants.Schemas.Basic;
 
     /// <summary>
     /// Scheme name included in the <see cref="Microsoft.AspNetCore.Authentication.AuthenticationTicket"/>.

--- a/src/Headless.Api.Core/Identity/Schemes/DynamicAuthenticationSchemeProvider.cs
+++ b/src/Headless.Api.Core/Identity/Schemes/DynamicAuthenticationSchemeProvider.cs
@@ -17,7 +17,7 @@ namespace Headless.Api.Identity.Schemes;
 /// Scheme selection logic (evaluated on every request):
 /// <list type="bullet">
 ///   <item><description>
-///     API key header / query-string parameter present → <c>ApiKey</c> scheme.
+///     API key header present, or query-string parameter present when query keys are enabled → <c>ApiKey</c> scheme.
 ///   </description></item>
 ///   <item><description>
 ///     <c>Authorization: Basic …</c> header present → <c>Basic</c> scheme.
@@ -33,11 +33,9 @@ namespace Headless.Api.Identity.Schemes;
 public sealed class DynamicAuthenticationSchemeProvider(
     IHttpContextAccessor httpContextAccessor,
     IOptions<AuthenticationOptions> options,
-    IOptions<ApiKeyAuthenticationSchemeOptions> apiKeySchemeOptions
+    IOptionsMonitor<ApiKeyAuthenticationSchemeOptions> apiKeySchemeOptions
 ) : AuthenticationSchemeProvider(options)
 {
-    private readonly ApiKeyAuthenticationSchemeOptions _apiKeyAuthenticationOptions = apiKeySchemeOptions.Value;
-
     /// <inheritdoc/>
     /// <remarks>Selects the scheme based on request credentials before falling back to the configured default.</remarks>
     public override async Task<AuthenticationScheme?> GetDefaultAuthenticateSchemeAsync()
@@ -87,9 +85,10 @@ public sealed class DynamicAuthenticationSchemeProvider(
 
         var request = httpContextAccessor.HttpContext.Request;
 
+        var apiKeyOptions = apiKeySchemeOptions.Get(AuthenticationConstants.Schemas.ApiKey);
         var isApiKey =
-            request.Headers.ContainsKey(_apiKeyAuthenticationOptions.ApiKeyHeaderName)
-            || request.Query.ContainsKey(_apiKeyAuthenticationOptions.ApiKeyParamName);
+            request.Headers.ContainsKey(apiKeyOptions.ApiKeyHeaderName)
+            || (apiKeyOptions.AllowApiKeyInQueryString && request.Query.ContainsKey(apiKeyOptions.ApiKeyParamName));
 
         if (isApiKey)
         {

--- a/src/Headless.Api.Core/README.md
+++ b/src/Headless.Api.Core/README.md
@@ -19,6 +19,7 @@ Exposes each API primitive individually so teams that need à-la-carte compositi
 - `AddHeadlessTimeService()` — `TimeProvider.System`, `IClock`, `ITimezoneProvider` (all `TryAddSingleton`)
 - `AddServerTimingMiddleware()` + `UseServerTiming()` — appends `Server-Timing` trailer when response supports trailers
 - `UseNoCacheWhenMissingCacheHeaders()` — injects `Cache-Control: no-cache,no-store,must-revalidate` when response omits the header
+- Basic/API-key authentication helpers — `AddBasicSchema()` and `AddApiKey()` register the canonical `Basic` and `ApiKey` schemes; handlers only authenticate credentials supplied for their own scheme
 - HTTP tenant resolution: `ResolveFromClaims()`, `UseHeadlessTenancy()`, `[SkipTenantResolution]`, `.SkipTenantResolution()`
 - HTTP tenant authorization: `TenantRequirement`, `[AllowMissingTenant]`, `.AllowMissingTenant()`, `[RequireTenant]`, `.RequireTenant()`
 - Diagnostic listeners: `AddHeadlessApiDiagnosticListeners()`, `BadRequestDiagnosticAdapter`, `MiddlewareAnalysisDiagnosticAdapter`
@@ -93,6 +94,8 @@ Exception mapping registered by `AddHeadlessProblemDetails()`:
 All other exceptions return `false`; the host default or a downstream handler renders them.
 
 `StatusCodesRewriterMiddleware` is required for the `g:tenant_required` discriminator on 403 authorization rejections. `Headless.Api.ServiceDefaults` wires it automatically; apps that skip ServiceDefaults must call `UseStatusCodesRewriter()` themselves. `TenantRequirement` must live in `DefaultPolicy` or `FallbackPolicy` — the startup validator does not inspect named policies. `UseHeadlessTenancy()` / `UseTenantResolution()` must run after `UseRouting()` so endpoint metadata is available when `[SkipTenantResolution]` is evaluated.
+
+`AddBasicSchema()` defaults to the canonical `Basic` authentication scheme and `AddApiKey()` defaults to `ApiKey`. `DynamicAuthenticationSchemeProvider` selects those same canonical names. API keys are read from the configured header by default; query-string keys are routed and accepted only when `ApiKeyAuthenticationSchemeOptions.AllowApiKeyInQueryString` is `true`.
 
 ## Dependencies
 

--- a/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
@@ -631,7 +631,13 @@ internal sealed partial class IdempotencyMiddleware(
                     {
                         LogMarkerCleanupFailed(cacheKey, cleanupEx);
                     }
-                    throw;
+
+                    if (options.OnCacheError == OnCacheErrorBehavior.Throw)
+                    {
+                        throw;
+                    }
+
+                    return;
                 }
 
                 if (!replaced)
@@ -901,7 +907,7 @@ internal sealed partial class IdempotencyMiddleware(
     // ReSharper disable once InconsistentNaming
     private partial void LogSkippedNoIdentity();
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Idempotency finalize (UpsertAsync) failed for key {CacheKey}")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Idempotency finalize (CAS) failed for key {CacheKey}")]
     // ReSharper disable once InconsistentNaming
 
     private partial void LogFinalizeFailed(string cacheKey, Exception exception);

--- a/src/Headless.Api.Idempotency/README.md
+++ b/src/Headless.Api.Idempotency/README.md
@@ -87,7 +87,7 @@ app.MapPost("/webhooks", HandleWebhook)
 | `WinnerLockLease` | 5 minutes | Lease duration for the winner's distributed lock under `WaitAndReplay`. Must be >= `InFlightLockTimeout`. Capped at 1 hour. |
 | `MaxBodySizeForHashing` | 1 MiB | Maximum body size eligible for fingerprinting. Capped at 64 MiB. |
 | `OversizeBehavior` | `Reject` | `Reject` returns 413 (`g:idempotency_body_too_large`). `PassThrough` runs the handler without idempotency guarantees. |
-| `OnCacheError` | `FailOpen` | `FailOpen` logs a warning and bypasses idempotency for the failing request. `Throw` propagates the exception as 5xx. |
+| `OnCacheError` | `FailOpen` | `FailOpen` logs a warning and bypasses idempotency for pre-handler cache failures; post-handler finalize failures remove the marker and preserve the handler response. `Throw` propagates the exception as 5xx. |
 | `RequireUserIdentity` | `true` | When `true`, the default cache key requires an authenticated user; tenant-only anonymous requests pass through. Set `false` for webhook receivers / OAuth callbacks. |
 | `MismatchStatusCode` | 422 | Status code for fingerprint mismatch. Must be 409 or 422. |
 | `ReplayHeaderAllowlist` | Content-Type, Content-Language, Content-Encoding, Content-Disposition, Location, Link, ETag, Last-Modified, Cache-Control, Vary | Response headers copied into the cached record. `Set-Cookie` and `traceparent` are excluded by design. |
@@ -109,8 +109,8 @@ app.MapPost("/webhooks", HandleWebhook)
 
 ## Side Effects
 
-- Reads `ICurrentTenant.Id` and `ICurrentUser.UserId` for cache-key composition; when both are absent and no `KeyDeriver` is configured, the middleware passes through without applying idempotency.
+- Reads `ICurrentTenant.Id` and authenticated `ICurrentUser.UserId` for cache-key composition; when both are absent and no `KeyDeriver` is configured, the middleware passes through without applying idempotency.
 - Buffers the request body up to `MaxBodySizeForHashing + 1` bytes via `HttpRequest.EnableBuffering`.
 - On replay, writes `Idempotent-Replayed: true` to the response. Pre-existing allowlisted response headers set by upstream middleware are removed before captured headers are written for byte-equivalent replay.
-- On cache miss, inserts an `InFlight` sentinel marker before invoking the handler, then upserts the `Complete` record afterward using compare-and-swap (`TryReplaceIfEqualAsync`). The marker uses the same TTL as `IdempotencyKeyExpiration`.
+- On cache miss, inserts an `InFlight` sentinel marker before invoking the handler, then promotes it to the `Complete` record afterward using compare-and-swap (`TryReplaceIfEqualAsync`). The marker uses the same TTL as `IdempotencyKeyExpiration`.
 - When the **response** body exceeds `MaxBodySizeForHashing` (`captureStream.TruncatedCapture`), the completed record is not stored and replay does not apply. `OversizeBehavior` controls **request**-body handling only.

--- a/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
+++ b/tests/Headless.Api.Idempotency.Tests.Unit/IdempotencyMiddlewareTests.cs
@@ -1308,10 +1308,10 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
     // ── new behaviors introduced by middleware rewrite ───────────────────────
 
     [Fact]
-    public async Task should_remove_marker_when_finalize_cas_throws()
+    public async Task should_remove_marker_and_preserve_response_when_finalize_cas_throws_in_fail_open_mode()
     {
         // given — TryReplaceIfEqualAsync fails after successful next; middleware must remove the
-        // marker and rethrow so the orphan does not block subsequent retries for the TTL window.
+        // marker and preserve the successful handler response in the default FailOpen mode.
         byte[] body = [1, 2, 3];
 
         var cache = Substitute.For<ICache>();
@@ -1337,6 +1337,53 @@ public sealed class IdempotencyMiddlewareTests : IdempotencyMiddlewareTestBase
             .Returns<ValueTask<bool>>(_ => throw new InvalidOperationException("cache down"));
 
         var middleware = CreateMiddleware(cache: cache);
+        var context = CreateContext(idempotencyKey: "k1", body: body);
+
+        await middleware.InvokeAsync(
+            context,
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            }
+        );
+
+        context.Response.StatusCode.Should().Be(200);
+        await cache.Received(1).RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_remove_marker_and_throw_when_finalize_cas_throws_in_throw_mode()
+    {
+        // given
+        byte[] body = [1, 2, 3];
+
+        var options = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        options.CurrentValue.Returns(new IdempotencyOptions { OnCacheError = OnCacheErrorBehavior.Throw });
+
+        var cache = Substitute.For<ICache>();
+        cache
+            .GetAsync<IdempotencyRecord>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(CacheValue<IdempotencyRecord>.NoValue);
+        cache
+            .TryInsertAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+        cache
+            .TryReplaceIfEqualAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<IdempotencyRecord?>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns<ValueTask<bool>>(_ => throw new InvalidOperationException("cache down"));
+
+        var middleware = CreateMiddleware(options: options, cache: cache);
         var context = CreateContext(idempotencyKey: "k1", body: body);
 
         var act = () =>

--- a/tests/Headless.Api.Tests.Unit/Abstractions/HttpCurrentUserTests.cs
+++ b/tests/Headless.Api.Tests.Unit/Abstractions/HttpCurrentUserTests.cs
@@ -131,6 +131,23 @@ public sealed class HttpCurrentUserTests : TestBase
     }
 
     [Fact]
+    public void should_return_null_user_id_when_identity_not_authenticated()
+    {
+        // given
+        var identity = new ClaimsIdentity([new Claim(UserClaimTypes.UserId, "user-456")]);
+        var principal = new ClaimsPrincipal(identity);
+        var accessor = Substitute.For<ICurrentPrincipalAccessor>();
+        accessor.Principal.Returns(principal);
+        var sut = new HttpCurrentUser(accessor);
+
+        // when
+        var result = sut.UserId;
+
+        // then
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public void should_return_account_type_from_claims()
     {
         // given
@@ -195,6 +212,26 @@ public sealed class HttpCurrentUserTests : TestBase
     {
         // given
         var identity = new ClaimsIdentity([], "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var accessor = Substitute.For<ICurrentPrincipalAccessor>();
+        accessor.Principal.Returns(principal);
+        var sut = new HttpCurrentUser(accessor);
+
+        // when
+        var result = sut.Roles;
+
+        // then
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void should_return_empty_roles_when_identity_not_authenticated()
+    {
+        // given
+        var identity = new ClaimsIdentity([
+            new Claim(UserClaimTypes.Roles, "admin"),
+            new Claim(UserClaimTypes.Roles, "editor"),
+        ]);
         var principal = new ClaimsPrincipal(identity);
         var accessor = Substitute.For<ICurrentPrincipalAccessor>();
         accessor.Principal.Returns(principal);

--- a/tests/Headless.Api.Tests.Unit/Identity/Authentication/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Headless.Api.Tests.Unit/Identity/Authentication/ApiKeyAuthenticationHandlerTests.cs
@@ -50,7 +50,7 @@ public sealed class ApiKeyAuthenticationHandlerTests : TestBase
     }
 
     [Fact]
-    public async Task should_return_success_when_user_already_authenticated()
+    public async Task should_return_no_result_when_user_already_authenticated_without_api_key()
     {
         // given
         var handler = _CreateHandler();
@@ -67,9 +67,8 @@ public sealed class ApiKeyAuthenticationHandlerTests : TestBase
         var result = await handler.AuthenticateAsync();
 
         // then
-        result.Succeeded.Should().BeTrue();
-        result.Ticket.Should().NotBeNull();
-        result.Ticket!.AuthenticationScheme.Should().Be("context.User");
+        result.None.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Headless.Api.Tests.Unit/Identity/Authentication/BasicAuthenticationHandlerTests.cs
+++ b/tests/Headless.Api.Tests.Unit/Identity/Authentication/BasicAuthenticationHandlerTests.cs
@@ -43,7 +43,7 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
             null
         );
 
-        var options = new BasicAuthenticationOptions { Scheme = "Basic Authentication" };
+        var options = new BasicAuthenticationOptions();
         _optionsMonitor = Substitute.For<IOptionsMonitor<BasicAuthenticationOptions>>();
         _optionsMonitor.Get(Arg.Any<string>()).Returns(options);
         _optionsMonitor.CurrentValue.Returns(options);
@@ -58,7 +58,7 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
     }
 
     [Fact]
-    public async Task should_return_success_when_user_already_authenticated()
+    public async Task should_return_no_result_when_user_already_authenticated_without_basic_credentials()
     {
         // given
         var handler = _CreateHandler();
@@ -75,9 +75,8 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
         var result = await handler.AuthenticateAsync();
 
         // then
-        result.Succeeded.Should().BeTrue();
-        result.Ticket.Should().NotBeNull();
-        result.Ticket!.AuthenticationScheme.Should().Be("context.User");
+        result.None.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
     }
 
     [Fact]
@@ -300,7 +299,7 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
         // then
         result.Succeeded.Should().BeTrue();
         result.Ticket.Should().NotBeNull();
-        result.Ticket!.AuthenticationScheme.Should().Be("Basic Authentication");
+        result.Ticket!.AuthenticationScheme.Should().Be("Basic");
         result.Ticket.Principal.Should().BeSameAs(principal);
     }
 

--- a/tests/Headless.Api.Tests.Unit/Identity/Schemes/DynamicAuthenticationSchemeProviderTests.cs
+++ b/tests/Headless.Api.Tests.Unit/Identity/Schemes/DynamicAuthenticationSchemeProviderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Api.Identity.Authentication.ApiKey;
+using Headless.Api.Identity.Authentication.Basic;
 using Headless.Api.Identity.Schemes;
 using Headless.Constants;
 using Headless.Testing.Tests;
@@ -14,7 +15,7 @@ public sealed class DynamicAuthenticationSchemeProviderTests : TestBase
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IOptions<AuthenticationOptions> _authOptions;
-    private readonly IOptions<ApiKeyAuthenticationSchemeOptions> _apiKeyOptions;
+    private readonly IOptionsMonitor<ApiKeyAuthenticationSchemeOptions> _apiKeyOptions;
 
     public DynamicAuthenticationSchemeProviderTests()
     {
@@ -31,7 +32,14 @@ public sealed class DynamicAuthenticationSchemeProviderTests : TestBase
         authOptions.DefaultSignOutScheme = AuthenticationConstants.Schemas.Bearer;
 
         _authOptions = Options.Create(authOptions);
-        _apiKeyOptions = Options.Create(new ApiKeyAuthenticationSchemeOptions());
+        _apiKeyOptions = _CreateApiKeyOptionsMonitor(new ApiKeyAuthenticationSchemeOptions());
+    }
+
+    [Fact]
+    public void should_use_canonical_basic_and_api_key_scheme_names_by_default()
+    {
+        BasicAuthenticationOptions.DefaultScheme.Should().Be(AuthenticationConstants.Schemas.Basic);
+        ApiKeyAuthenticationSchemeOptions.DefaultScheme.Should().Be(AuthenticationConstants.Schemas.ApiKey);
     }
 
     [Fact]
@@ -67,13 +75,30 @@ public sealed class DynamicAuthenticationSchemeProviderTests : TestBase
     }
 
     [Fact]
-    public async Task should_return_api_key_scheme_when_api_key_query_present()
+    public async Task should_fallback_to_base_when_api_key_query_present_but_query_not_opted_in()
     {
         // given
         var context = _CreateContext();
         context.Request.QueryString = new QueryString("?api_key=test-api-key");
         _httpContextAccessor.HttpContext.Returns(context);
         var provider = _CreateProvider();
+
+        // when
+        var result = await provider.GetDefaultAuthenticateSchemeAsync();
+
+        // then
+        result.Should().NotBeNull();
+        result!.Name.Should().Be(AuthenticationConstants.Schemas.Bearer);
+    }
+
+    [Fact]
+    public async Task should_return_api_key_scheme_when_api_key_query_present_and_query_opted_in()
+    {
+        // given
+        var context = _CreateContext();
+        context.Request.QueryString = new QueryString("?api_key=test-api-key");
+        _httpContextAccessor.HttpContext.Returns(context);
+        var provider = _CreateProvider(new ApiKeyAuthenticationSchemeOptions { AllowApiKeyInQueryString = true });
 
         // when
         var result = await provider.GetDefaultAuthenticateSchemeAsync();
@@ -208,6 +233,26 @@ public sealed class DynamicAuthenticationSchemeProviderTests : TestBase
     private DynamicAuthenticationSchemeProvider _CreateProvider()
     {
         return new DynamicAuthenticationSchemeProvider(_httpContextAccessor, _authOptions, _apiKeyOptions);
+    }
+
+    private DynamicAuthenticationSchemeProvider _CreateProvider(ApiKeyAuthenticationSchemeOptions apiKeyOptions)
+    {
+        return new DynamicAuthenticationSchemeProvider(
+            _httpContextAccessor,
+            _authOptions,
+            _CreateApiKeyOptionsMonitor(apiKeyOptions)
+        );
+    }
+
+    private static IOptionsMonitor<ApiKeyAuthenticationSchemeOptions> _CreateApiKeyOptionsMonitor(
+        ApiKeyAuthenticationSchemeOptions options
+    )
+    {
+        var monitor = Substitute.For<IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>>();
+        monitor.CurrentValue.Returns(options);
+        monitor.Get(Arg.Any<string>()).Returns(options);
+
+        return monitor;
     }
 
     private static DefaultHttpContext _CreateContext()


### PR DESCRIPTION
## Summary

Scheme-specific authentication now requires credentials for that scheme. A request authenticated by a different scheme no longer satisfies endpoints that explicitly require `Basic` or `ApiKey`, and dynamic scheme routing now matches the canonical scheme names registered by the helpers.

Idempotency fail-open behavior is now consistent after a successful handler run: finalize cache failures clean up the in-flight marker and preserve the handler response unless `OnCacheError = Throw` is explicitly configured. HTTP current-user context now mirrors the Core contract by hiding `UserId` and roles for unauthenticated principals.

## Affected Packages

- `Headless.Api.Core`
- `Headless.Api.Idempotency`
- `Headless.Api.Logging.Serilog` behavior via `IRequestContext.User`
- `docs/llms/api.md`

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Test only

## Validation

- [ ] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [x] Added or updated tests for behavior changes
- [x] Updated XML docs for public API changes
- [x] Updated package `README.md` files for public behavior/setup changes
- [x] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
make format-check
make build-project PROJECT=src/Headless.Api.Core/Headless.Api.Core.csproj
make build-project PROJECT=src/Headless.Api.Idempotency/Headless.Api.Idempotency.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Tests.Unit/Headless.Api.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Idempotency.Tests.Unit/Headless.Api.Idempotency.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Tests.Integration/Headless.Api.Tests.Integration.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Idempotency.Tests.Integration/Headless.Api.Idempotency.Tests.Integration.csproj

git push pre-push hook also ran:
- CSharpier check on changed files
- dotnet build headless-framework.slnx --configuration Release --no-restore -v:q -nologo /clp:ErrorsOnly
```

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
BasicAuthenticationOptions.DefaultScheme changed from "Basic Authentication" to "Basic".
ApiKeyAuthenticationSchemeOptions.DefaultScheme changed from "API Key Authentication" to "ApiKey".

Consumers that referenced the old default scheme strings in authorization policies or configuration should switch to AuthenticationConstants.Schemas.Basic / AuthenticationConstants.Schemas.ApiKey, or pass an explicit scheme name to AddBasicSchema()/AddApiKey() if they need the old names temporarily.
```

## Release Notes

- Basic/API-key authentication no longer reuses an unrelated authenticated `HttpContext.User` for scheme-specific endpoints.
- API-key query-string routing now honors `AllowApiKeyInQueryString`.
- Idempotency finalize cache failures now honor `OnCacheError` after the handler succeeds.
- `HttpCurrentUser` no longer exposes unauthenticated `UserId` or role claims.

## Post-Deploy Monitoring & Validation

Watch API auth/idempotency behavior in downstream services that adopt this version for one release window.

Healthy signals:
- No unexpected increase in 401/403 responses on endpoints requiring `Basic` or `ApiKey`.
- Idempotency logs containing `Idempotency finalize (CAS) failed` remain rare and do not correlate with 5xx responses unless `OnCacheError = Throw` is configured.
- Serilog `UserId`/role-derived context is absent for unauthenticated requests.

Failure signals and mitigation:
- If clients using old default scheme names fail authorization, configure explicit scheme names temporarily or migrate policies to `Basic` / `ApiKey`.
- If idempotency guarantees degrade because a backing cache is failing, inspect cache health and the marker cleanup logs before rolling back.
