### PR TITLE
fix(api): harden API correctness paths

### DIFF
--- a/docs/llms/api.md
+++ b/docs/llms/api.md
@@ -26,6 +26,7 @@ packages: Api.Abstractions, Api.Core, Api.ServiceDefaults, Api.DataProtection, A
 - [Headless.Api.Core](#headlessapicore)
     - [Problem Solved](#problem-solved-1)
     - [Key Features](#key-features-1)
+    - [Design Notes](#design-notes)
     - [Installation](#installation-1)
     - [Quick Start](#quick-start-1)
     - [Configuration](#configuration-1)
@@ -59,7 +60,7 @@ packages: Api.Abstractions, Api.Core, Api.ServiceDefaults, Api.DataProtection, A
 - [Headless.Api.Idempotency](#headlessapiidempotency)
     - [Problem Solved](#problem-solved-5)
     - [Key Features](#key-features-5)
-    - [Design Notes](#design-notes)
+    - [Design Notes](#design-notes-1)
     - [Installation](#installation-5)
     - [Quick Start](#quick-start-5)
     - [Configuration](#configuration-5)
@@ -269,6 +270,13 @@ Exposes each API primitive individually so teams that need à-la-carte compositi
 - HTTP tenant resolution: `ResolveFromClaims()`, `UseHeadlessTenancy()`, `[SkipTenantResolution]`, `.SkipTenantResolution()`
 - HTTP tenant authorization: `TenantRequirement`, `[AllowMissingTenant]`, `.AllowMissingTenant()`, `[RequireTenant]`, `.RequireTenant()`
 - Diagnostic listeners: `AddHeadlessApiDiagnosticListeners()`, `BadRequestDiagnosticAdapter`, `MiddlewareAnalysisDiagnosticAdapter`
+
+### Design Notes
+
+- `IProblemDetailsCreator` factory methods normalize Headless fields (`traceId`, build metadata, `instance`, timestamp) but leave consumer `ProblemDetailsOptions.CustomizeProblemDetails` callbacks to ASP.NET Core's `IProblemDetailsService` writer. Exception-handler and status-code-rewriter responses therefore run consumer customization once, at write time.
+- `HeadlessApiExceptionHandler` honors `Accept` quality values when deciding whether to write JSON ProblemDetails. A request that rejects JSON with `q=0` is left for downstream/default handlers instead of receiving a JSON body.
+- Basic authentication delegates password validation to `SignInManager.CheckPasswordSignInAsync(..., lockoutOnFailure: true)`, so configured ASP.NET Core Identity lockout policies apply to failed Basic credentials.
+- Batch `IFormFile.SaveAsync(...)` preserves result ordering while bounding concurrent file stream copies to `Environment.ProcessorCount` to avoid unbounded file-handle and disk pressure on large multipart requests.
 
 ### Installation
 

--- a/docs/llms/api.md
+++ b/docs/llms/api.md
@@ -273,8 +273,8 @@ Exposes each API primitive individually so teams that need à-la-carte compositi
 
 ### Design Notes
 
-- `IProblemDetailsCreator` factory methods normalize Headless fields (`traceId`, build metadata, `instance`, timestamp) but leave consumer `ProblemDetailsOptions.CustomizeProblemDetails` callbacks to ASP.NET Core's `IProblemDetailsService` writer. Exception-handler and status-code-rewriter responses therefore run consumer customization once, at write time.
-- `HeadlessApiExceptionHandler` honors `Accept` quality values when deciding whether to write JSON ProblemDetails. A request that rejects JSON with `q=0` is left for downstream/default handlers instead of receiving a JSON body.
+- `IProblemDetailsCreator` factory methods normalize Headless fields (`traceId`, build metadata, `instance`, timestamp) but leave consumer `ProblemDetailsOptions.CustomizeProblemDetails` callbacks to the final response writer. Exception-handler and status-code-rewriter responses run consumer customization once through ASP.NET Core's `IProblemDetailsService`; MVC direct `ObjectResult` responses built from Headless-normalized ProblemDetails are customized once by `Headless.Api.Mvc`.
+- `HeadlessApiExceptionHandler` honors `Accept` quality values when deciding whether to write JSON ProblemDetails. A request that rejects JSON, or explicitly rejects `application/problem+json`, with `q=0` is left for downstream/default handlers instead of receiving a JSON body.
 - Basic authentication delegates password validation to `SignInManager.CheckPasswordSignInAsync(..., lockoutOnFailure: true)`, so configured ASP.NET Core Identity lockout policies apply to failed Basic credentials.
 - Batch `IFormFile.SaveAsync(...)` preserves result ordering while bounding concurrent file stream copies to `Environment.ProcessorCount` to avoid unbounded file-handle and disk pressure on large multipart requests.
 
@@ -916,6 +916,7 @@ Provides consistent MVC configuration, base controllers, and URL canonicalizatio
 - Environment-based action filters (`BlockInEnvironmentAttribute`, `RequireEnvironmentAttribute`)
 - URL canonicalization middleware (`RedirectToCanonicalUrlRule`)
 - Pre-configured JSON and MVC options
+- Direct MVC `ObjectResult` responses carrying Headless-normalized `ProblemDetails` run `ProblemDetailsOptions.CustomizeProblemDetails` once before serialization
 - API versioning integration with API Explorer
 
 ### Installation
@@ -968,3 +969,4 @@ No additional configuration required.
 ### Side Effects
 
 - Configures `MvcOptions` and `JsonOptions` for controllers
+- Adds a result filter that applies ProblemDetails customization to Headless-generated MVC object results

--- a/src/Headless.Api.Core/Abstractions/ProblemDetailsCreator.cs
+++ b/src/Headless.Api.Core/Abstractions/ProblemDetailsCreator.cs
@@ -15,8 +15,7 @@ internal sealed class ProblemDetailsCreator(
     TimeProvider timeProvider,
     IBuildInformationAccessor buildInformationAccessor,
     IHttpContextAccessor httpContextAccessor,
-    IOptions<ApiBehaviorOptions> apiOptionsAccessor,
-    IOptions<ProblemDetailsOptions>? problemOptionsAccessor = null
+    IOptions<ApiBehaviorOptions> apiOptionsAccessor
 ) : IProblemDetailsCreator
 {
     public ProblemDetails EndpointNotFound(ErrorDescriptor? error = null)
@@ -259,17 +258,6 @@ internal sealed class ProblemDetailsCreator(
     private void _Normalize(ProblemDetails problemDetails)
     {
         Normalize(problemDetails);
-
-        if (httpContextAccessor.HttpContext is not null)
-        {
-            problemOptionsAccessor?.Value.CustomizeProblemDetails?.Invoke(
-                new ProblemDetailsContext
-                {
-                    HttpContext = httpContextAccessor.HttpContext,
-                    ProblemDetails = problemDetails,
-                }
-            );
-        }
     }
 
     private static void _SetError(ProblemDetails problemDetails, ErrorDescriptor? error)

--- a/src/Headless.Api.Core/Extensions/Http/FormFileExtensions.cs
+++ b/src/Headless.Api.Core/Extensions/Http/FormFileExtensions.cs
@@ -44,23 +44,31 @@ public static class FormFileExtensions
         CancellationToken token = default
     )
     {
-        var tasks = files.Select(async formFile =>
-        {
-            try
-            {
-                await formFile.SaveAsync(directoryPath, token).ConfigureAwait(false);
+        Argument.IsNotNull(files);
 
-                return Result<Exception>.Ok();
-            }
-            catch (Exception ex)
-            {
-                return Result<Exception>.Fail(ex);
-            }
-        });
+        var indexedFiles = files.Select((formFile, index) => (formFile, index)).ToArray();
+        var results = new Result<Exception>[indexedFiles.Length];
 
-        var result = await Task.WhenAll(tasks).WithAggregatedExceptions().ConfigureAwait(false);
+        await Parallel
+            .ForEachAsync(
+                indexedFiles,
+                new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+                async (item, _) =>
+                {
+                    try
+                    {
+                        await item.formFile.SaveAsync(directoryPath, token).ConfigureAwait(false);
+                        results[item.index] = Result<Exception>.Ok();
+                    }
+                    catch (Exception ex)
+                    {
+                        results[item.index] = Result<Exception>.Fail(ex);
+                    }
+                }
+            )
+            .ConfigureAwait(false);
 
-        return result;
+        return results;
     }
 
     /// <summary>Computes the MD5 hash of the uploaded file's content stream.</summary>
@@ -89,7 +97,7 @@ public static class FormFileExtensions
 
     /// <summary>Reads all bytes from the uploaded file's content stream asynchronously.</summary>
     /// <param name="file">The uploaded file.</param>
-    /// <returns>A task that resolves to a byte array containing the full file content.</returns>
+    /// <returns>A byte array containing the full file content.</returns>
     public static async Task<byte[]> GetAllBytesAsync(this IFormFile file)
     {
         await using var stream = file.OpenReadStream();

--- a/src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs
+++ b/src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs
@@ -151,7 +151,46 @@ public static class HttpRequestExtensions
         return _CanAccept(parsed, candidate);
     }
 
+    internal static bool HasAcceptRejection(this HttpRequest request, string contentType)
+    {
+        Argument.IsNotNull(request);
+        Argument.IsNotNull(contentType);
+
+        var acceptHeader = request.Headers[HeaderNames.Accept];
+
+        if (acceptHeader.Count == 0)
+        {
+            return false;
+        }
+
+        if (!MediaTypeHeaderValue.TryParse(contentType, out var candidate))
+        {
+            return false;
+        }
+
+        var parsed = MediaTypeHeaderValue.ParseList(acceptHeader);
+
+        if (parsed is null or { Count: 0 })
+        {
+            return false;
+        }
+
+        var match = _GetBestAcceptMatch(parsed, candidate);
+
+        return match.Found && match.Quality <= 0;
+    }
+
     private static bool _CanAccept(IList<MediaTypeHeaderValue> acceptHeader, MediaTypeHeaderValue candidate)
+    {
+        var match = _GetBestAcceptMatch(acceptHeader, candidate);
+
+        return match.Found && match.Quality > 0;
+    }
+
+    private static (bool Found, double Quality) _GetBestAcceptMatch(
+        IList<MediaTypeHeaderValue> acceptHeader,
+        MediaTypeHeaderValue candidate
+    )
     {
         double bestQuality = 0;
         var bestSpecificity = -1;
@@ -163,7 +202,7 @@ public static class HttpRequestExtensions
                 continue;
             }
 
-            var specificity = _GetSpecificity(mediaType);
+            var specificity = _GetSpecificity(mediaType, candidate);
             var quality = mediaType.Quality.GetValueOrDefault(1);
 
             if (specificity > bestSpecificity || (specificity == bestSpecificity && quality > bestQuality))
@@ -173,10 +212,10 @@ public static class HttpRequestExtensions
             }
         }
 
-        return bestSpecificity >= 0 && bestQuality > 0;
+        return (bestSpecificity >= 0, bestQuality);
     }
 
-    private static int _GetSpecificity(MediaTypeHeaderValue mediaType)
+    private static int _GetSpecificity(MediaTypeHeaderValue mediaType, MediaTypeHeaderValue candidate)
     {
         if (mediaType.MatchesAllTypes)
         {
@@ -188,6 +227,8 @@ public static class HttpRequestExtensions
             return 1;
         }
 
-        return 2;
+        return string.Equals(mediaType.MediaType.Value, candidate.MediaType.Value, StringComparison.OrdinalIgnoreCase)
+            ? 3
+            : 2;
     }
 }

--- a/src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs
+++ b/src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs
@@ -57,8 +57,8 @@ public static class HttpRequestExtensions
     /// <param name="request">The HTTP request to inspect.</param>
     /// <param name="contentTypes">One or more MIME types to check acceptance of.</param>
     /// <returns>
-    /// <see langword="true"/> if the <c>Accept</c> header is absent, a wildcard (<c>*/*</c>), or
-    /// explicitly includes at least one of <paramref name="contentTypes"/>; otherwise
+    /// <see langword="true"/> if the <c>Accept</c> header is absent, or the best matching media range
+    /// for at least one supplied content type has a positive quality value; otherwise
     /// <see langword="false"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
@@ -83,20 +83,26 @@ public static class HttpRequestExtensions
             return true;
         }
 
-        foreach (var mediaType in parsed)
+        var candidates = new List<MediaTypeHeaderValue>(contentTypes.Length);
+
+        foreach (var contentType in contentTypes)
         {
-            // Wildcard */* matches anything.
-            if (mediaType.MatchesAllTypes)
+            if (MediaTypeHeaderValue.TryParse(contentType, out var candidate))
+            {
+                candidates.Add(candidate);
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (_CanAccept(parsed, candidate))
             {
                 return true;
-            }
-
-            foreach (var contentType in contentTypes)
-            {
-                if (MediaTypeHeaderValue.TryParse(contentType, out var candidate) && mediaType.IsSubsetOf(candidate))
-                {
-                    return true;
-                }
             }
         }
 
@@ -112,8 +118,8 @@ public static class HttpRequestExtensions
     /// <param name="request">The HTTP request to inspect.</param>
     /// <param name="contentType">The MIME type to check acceptance of.</param>
     /// <returns>
-    /// <see langword="true"/> if the <c>Accept</c> header is absent, a wildcard (<c>*/*</c>), or
-    /// explicitly includes <paramref name="contentType"/>; otherwise <see langword="false"/>.
+    /// <see langword="true"/> if the <c>Accept</c> header is absent, or the best matching media range
+    /// for <paramref name="contentType"/> has a positive quality value; otherwise <see langword="false"/>.
     /// Returns <see langword="false"/> when <paramref name="contentType"/> cannot be parsed as a
     /// valid media type.
     /// </returns>
@@ -137,14 +143,51 @@ public static class HttpRequestExtensions
 
         var parsed = MediaTypeHeaderValue.ParseList(acceptHeader);
 
-        foreach (var mediaType in parsed)
+        if (parsed is null or { Count: 0 })
         {
-            if (mediaType.MatchesAllTypes || mediaType.IsSubsetOf(candidate))
+            return true;
+        }
+
+        return _CanAccept(parsed, candidate);
+    }
+
+    private static bool _CanAccept(IList<MediaTypeHeaderValue> acceptHeader, MediaTypeHeaderValue candidate)
+    {
+        double bestQuality = 0;
+        var bestSpecificity = -1;
+
+        foreach (var mediaType in acceptHeader)
+        {
+            if (!candidate.IsSubsetOf(mediaType))
             {
-                return true;
+                continue;
+            }
+
+            var specificity = _GetSpecificity(mediaType);
+            var quality = mediaType.Quality.GetValueOrDefault(1);
+
+            if (specificity > bestSpecificity || (specificity == bestSpecificity && quality > bestQuality))
+            {
+                bestSpecificity = specificity;
+                bestQuality = quality;
             }
         }
 
-        return false;
+        return bestSpecificity >= 0 && bestQuality > 0;
+    }
+
+    private static int _GetSpecificity(MediaTypeHeaderValue mediaType)
+    {
+        if (mediaType.MatchesAllTypes)
+        {
+            return 0;
+        }
+
+        if (mediaType.MatchesAllSubTypes || mediaType.MatchesAllSubTypesWithoutSuffix)
+        {
+            return 1;
+        }
+
+        return 2;
     }
 }

--- a/src/Headless.Api.Core/Identity/Authentication/Basic/BasicAuthenticationHandler.cs
+++ b/src/Headless.Api.Core/Identity/Authentication/Basic/BasicAuthenticationHandler.cs
@@ -59,12 +59,16 @@ public sealed class BasicAuthenticationHandler<TUser, TUserId>(
 
         var user = await userManager.FindByNameAsync(userName).ConfigureAwait(false);
 
-        if (
-            user is null
-            || !await signInManager.CanSignInAsync(user).ConfigureAwait(false)
-            || (userManager.SupportsUserLockout && await userManager.IsLockedOutAsync(user).ConfigureAwait(false))
-            || !await userManager.CheckPasswordAsync(user, password).ConfigureAwait(false)
-        )
+        if (user is null)
+        {
+            return AuthenticateResult.Fail("Invalid user name or password.");
+        }
+
+        var signInResult = await signInManager
+            .CheckPasswordSignInAsync(user, password, lockoutOnFailure: true)
+            .ConfigureAwait(false);
+
+        if (!signInResult.Succeeded)
         {
             return AuthenticateResult.Fail("Invalid user name or password.");
         }

--- a/src/Headless.Api.Core/Middlewares/HeadlessApiExceptionHandler.cs
+++ b/src/Headless.Api.Core/Middlewares/HeadlessApiExceptionHandler.cs
@@ -318,7 +318,8 @@ internal sealed partial class HeadlessApiExceptionHandler(
 
     private static bool _AcceptsJsonProblemDetails(HttpRequest request)
     {
-        return request.CanAccept(ContentTypes.Applications.Json, ContentTypes.Applications.ProblemJson);
+        return !request.HasAcceptRejection(ContentTypes.Applications.ProblemJson)
+            && request.CanAccept(ContentTypes.Applications.Json, ContentTypes.Applications.ProblemJson);
     }
 
     [LoggerMessage(

--- a/src/Headless.Api.Core/README.md
+++ b/src/Headless.Api.Core/README.md
@@ -24,6 +24,13 @@ Exposes each API primitive individually so teams that need à-la-carte compositi
 - HTTP tenant authorization: `TenantRequirement`, `[AllowMissingTenant]`, `.AllowMissingTenant()`, `[RequireTenant]`, `.RequireTenant()`
 - Diagnostic listeners: `AddHeadlessApiDiagnosticListeners()`, `BadRequestDiagnosticAdapter`, `MiddlewareAnalysisDiagnosticAdapter`
 
+## Design Notes
+
+- `IProblemDetailsCreator` factory methods normalize Headless fields (`traceId`, build metadata, `instance`, timestamp) but leave consumer `ProblemDetailsOptions.CustomizeProblemDetails` callbacks to ASP.NET Core's `IProblemDetailsService` writer. Exception-handler and status-code-rewriter responses therefore run consumer customization once, at write time.
+- `HeadlessApiExceptionHandler` honors `Accept` quality values when deciding whether to write JSON ProblemDetails. A request that rejects JSON with `q=0` is left for downstream/default handlers instead of receiving a JSON body.
+- Basic authentication delegates password validation to `SignInManager.CheckPasswordSignInAsync(..., lockoutOnFailure: true)`, so configured ASP.NET Core Identity lockout policies apply to failed Basic credentials.
+- Batch `IFormFile.SaveAsync(...)` preserves result ordering while bounding concurrent file stream copies to `Environment.ProcessorCount` to avoid unbounded file-handle and disk pressure on large multipart requests.
+
 ## Installation
 
 ```bash

--- a/src/Headless.Api.Core/README.md
+++ b/src/Headless.Api.Core/README.md
@@ -26,8 +26,8 @@ Exposes each API primitive individually so teams that need à-la-carte compositi
 
 ## Design Notes
 
-- `IProblemDetailsCreator` factory methods normalize Headless fields (`traceId`, build metadata, `instance`, timestamp) but leave consumer `ProblemDetailsOptions.CustomizeProblemDetails` callbacks to ASP.NET Core's `IProblemDetailsService` writer. Exception-handler and status-code-rewriter responses therefore run consumer customization once, at write time.
-- `HeadlessApiExceptionHandler` honors `Accept` quality values when deciding whether to write JSON ProblemDetails. A request that rejects JSON with `q=0` is left for downstream/default handlers instead of receiving a JSON body.
+- `IProblemDetailsCreator` factory methods normalize Headless fields (`traceId`, build metadata, `instance`, timestamp) but leave consumer `ProblemDetailsOptions.CustomizeProblemDetails` callbacks to the final response writer. Exception-handler and status-code-rewriter responses run consumer customization once through ASP.NET Core's `IProblemDetailsService`; MVC direct `ObjectResult` responses built from Headless-normalized ProblemDetails are customized once by `Headless.Api.Mvc`.
+- `HeadlessApiExceptionHandler` honors `Accept` quality values when deciding whether to write JSON ProblemDetails. A request that rejects JSON, or explicitly rejects `application/problem+json`, with `q=0` is left for downstream/default handlers instead of receiving a JSON body.
 - Basic authentication delegates password validation to `SignInManager.CheckPasswordSignInAsync(..., lockoutOnFailure: true)`, so configured ASP.NET Core Identity lockout policies apply to failed Basic credentials.
 - Batch `IFormFile.SaveAsync(...)` preserves result ordering while bounding concurrent file stream copies to `Environment.ProcessorCount` to avoid unbounded file-handle and disk pressure on large multipart requests.
 

--- a/src/Headless.Api.Core/SetupApiServices.cs
+++ b/src/Headless.Api.Core/SetupApiServices.cs
@@ -92,10 +92,8 @@ public static class SetupApiServices
             services.TryAddSingleton<IProblemDetailsCreator, ProblemDetailsCreator>();
             services.AddProblemDetails();
 
-            // Resolve IProblemDetailsCreator lazily on each request rather than at options-build
-            // time. ProblemDetailsCreator depends on IOptions<ProblemDetailsOptions>; capturing
-            // the singleton via Configure<TDep>() at build time would create a circular DI
-            // dependency that deadlocks during host startup.
+            // Resolve IProblemDetailsCreator from request services so consumer replacements are
+            // honored at write time instead of capturing the default singleton at options-build time.
             services.Configure<Microsoft.AspNetCore.Http.ProblemDetailsOptions>(options =>
             {
                 options.CustomizeProblemDetails += context =>

--- a/src/Headless.Api.Mvc/Filters/HeadlessProblemDetailsResultFilter.cs
+++ b/src/Headless.Api.Mvc/Filters/HeadlessProblemDetailsResultFilter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Options;
+
+namespace Headless.Api.Filters;
+
+internal sealed class HeadlessProblemDetailsResultFilter(IOptions<ProblemDetailsOptions> options)
+    : IAlwaysRunResultFilter
+{
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        if (
+            context.Result is not ObjectResult { Value: ProblemDetails problemDetails }
+            || !_IsHeadlessProblemDetails(problemDetails)
+        )
+        {
+            return;
+        }
+
+        options.Value.CustomizeProblemDetails?.Invoke(
+            new ProblemDetailsContext { HttpContext = context.HttpContext, ProblemDetails = problemDetails }
+        );
+    }
+
+    public void OnResultExecuted(ResultExecutedContext context) { }
+
+    private static bool _IsHeadlessProblemDetails(ProblemDetails problemDetails)
+    {
+        return problemDetails.Extensions.ContainsKey("buildNumber")
+            && problemDetails.Extensions.ContainsKey("commitNumber")
+            && problemDetails.Extensions.ContainsKey("timestamp");
+    }
+}

--- a/src/Headless.Api.Mvc/Options/ConfigureMvcApiOptions.cs
+++ b/src/Headless.Api.Mvc/Options/ConfigureMvcApiOptions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Api.Filters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
@@ -17,6 +18,7 @@ namespace Headless.Api.Options;
 ///   <item>Disables <c>HttpNoContentOutputFormatter.TreatNullValueAsNoContent</c> so that <c>Ok(null)</c> serializes normally instead of emitting 204.</item>
 ///   <item>Enables 406 Not Acceptable when the client's <c>Accept</c> header cannot be satisfied.</item>
 ///   <item>Clears the default model-validator providers and substitutes <c>SystemTextJsonValidationMetadataProvider</c>.</item>
+///   <item>Applies <c>ProblemDetailsOptions.CustomizeProblemDetails</c> once to Headless-normalized MVC problem-details object results.</item>
 /// </list>
 /// Behavior applied to <see cref="ApiBehaviorOptions"/>:
 /// <list type="bullet">
@@ -41,6 +43,15 @@ public sealed class ConfigureMvcApiOptions : IConfigureOptions<MvcOptions>, ICon
         // Clear the default model validator providers and add the System.Text.Json validation metadata provider.
         options.ModelValidatorProviders.Clear();
         options.ModelMetadataDetailsProviders.Add(new SystemTextJsonValidationMetadataProvider());
+
+        if (
+            !options
+                .Filters.OfType<TypeFilterAttribute>()
+                .Any(filter => filter.ImplementationType == typeof(HeadlessProblemDetailsResultFilter))
+        )
+        {
+            options.Filters.Add<HeadlessProblemDetailsResultFilter>();
+        }
 
         // Exception mapping is handled globally by HeadlessApiExceptionHandler (registered in
         // AddHeadlessProblemDetails). No MVC IExceptionFilter needed.

--- a/src/Headless.Api.Mvc/README.md
+++ b/src/Headless.Api.Mvc/README.md
@@ -12,6 +12,7 @@ Provides consistent MVC configuration, base controllers, and URL canonicalizatio
 - Environment-based action filters (`BlockInEnvironmentAttribute`, `RequireEnvironmentAttribute`)
 - URL canonicalization middleware (`RedirectToCanonicalUrlRule`)
 - Pre-configured JSON and MVC options
+- Direct MVC `ObjectResult` responses carrying Headless-normalized `ProblemDetails` run `ProblemDetailsOptions.CustomizeProblemDetails` once before serialization
 - API versioning integration with API Explorer
 
 ## Installation
@@ -64,3 +65,4 @@ No additional configuration required.
 ## Side Effects
 
 - Configures `MvcOptions` and `JsonOptions` for controllers
+- Adds a result filter that applies ProblemDetails customization to Headless-generated MVC object results

--- a/tests/Headless.Api.DataProtection.Tests.Unit/BlobStorageDataProtectionXmlRepositoryTests.cs
+++ b/tests/Headless.Api.DataProtection.Tests.Unit/BlobStorageDataProtectionXmlRepositoryTests.cs
@@ -608,7 +608,7 @@ public sealed class BlobStorageDataProtectionXmlRepositoryTests
         var result = sut.GetAllElements();
 
         result.Should().ContainSingle();
-        result.First().Attribute("id")?.Value.Should().Be("1");
+        result.First().Attribute("id")!.Value.Should().Be("1");
         await storage
             .DidNotReceive()
             .OpenReadStreamAsync(

--- a/tests/Headless.Api.Tests.Integration/ProblemDetailsTests.cs
+++ b/tests/Headless.Api.Tests.Integration/ProblemDetailsTests.cs
@@ -108,6 +108,37 @@ public sealed class ProblemDetailsTests : TestBase
         await _VerifyMalformedSyntax(response);
     }
 
+    [Theory]
+    [InlineData("/mvc/malformed-syntax")]
+    [InlineData("/minimal/malformed-syntax")]
+    public async Task direct_problem_details_should_apply_customize_problem_details_once(string path)
+    {
+        var customizeCount = 0;
+        await using var factory = new CustomWebApplicationFactory(
+            LoggerProvider,
+            configureServices: (_, services) =>
+                services.Configure<ProblemDetailsOptions>(options =>
+                    options.CustomizeProblemDetails = context =>
+                    {
+                        customizeCount++;
+                        context.ProblemDetails.Extensions["x-custom"] = "problem-marker";
+                        context.ProblemDetails.Extensions["x-customize-count"] = customizeCount;
+                    }
+                ),
+            environment: EnvironmentNames.Production
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(path, AbortToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var json = await response.Content.ReadAsStringAsync(AbortToken);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("x-custom").GetString().Should().Be("problem-marker");
+        doc.RootElement.GetProperty("x-customize-count").GetInt32().Should().Be(1);
+        customizeCount.Should().Be(1);
+    }
+
     private static async Task _VerifyMalformedSyntax(HttpResponseMessage response)
     {
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs
+++ b/tests/Headless.Api.Tests.Integration/TenantRequirementTests.cs
@@ -217,6 +217,36 @@ public sealed class TenantRequirementTests : TestBase
             .Be(HeadlessProblemDetailsConstants.Errors.TenantContextRequired.Code);
     }
 
+    [Theory]
+    [InlineData("/tenant-required", "auth-marker", null)]
+    [InlineData("/throw-missing-tenant", "exception-marker", "tenant-a")]
+    public async Task should_apply_customize_problem_details_once_per_response(
+        string path,
+        string marker,
+        string? tenantId
+    )
+    {
+        var customizeCount = 0;
+        await using var app = await _CreateAppAsync(configureProblemDetails: options =>
+            options.CustomizeProblemDetails = context =>
+            {
+                customizeCount++;
+                context.ProblemDetails.Extensions["x-custom"] = marker;
+                context.ProblemDetails.Extensions["x-customize-count"] = customizeCount;
+            }
+        );
+        using var client = HttpTenancyTestHarness.CreateClient(app);
+
+        using var response = await _SendAsync(client, path, user: "alice", tenantId: tenantId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var json = await response.Content.ReadAsStringAsync(AbortToken);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("x-custom").GetString().Should().Be(marker);
+        doc.RootElement.GetProperty("x-customize-count").GetInt32().Should().Be(1);
+        customizeCount.Should().Be(1);
+    }
+
     private async Task<WebApplication> _CreateAppAsync(
         Action<ProblemDetailsOptions>? configureProblemDetails = null,
         bool registerCustomAuthResultHandler = false

--- a/tests/Headless.Api.Tests.Unit/Extensions/FormFileExtensionsTests.cs
+++ b/tests/Headless.Api.Tests.Unit/Extensions/FormFileExtensionsTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Http;
+
+namespace Tests.Extensions;
+
+public sealed class FormFileExtensionsTests : TestBase
+{
+    [Fact]
+    public async Task save_many_should_bound_parallel_file_streams()
+    {
+        // given
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tracker = new StreamConcurrencyTracker();
+        var files = Enumerable
+            .Range(0, Environment.ProcessorCount + 4)
+            .Select(index => new TrackingFormFile($"file-{index}.txt", tracker))
+            .ToArray<IFormFile>();
+
+        try
+        {
+            // when
+            var results = await files.SaveAsync(directory, AbortToken);
+
+            // then
+            results.Should().OnlyContain(result => result.IsSuccess);
+            tracker.MaxActive.Should().BeLessThanOrEqualTo(Environment.ProcessorCount);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TrackingFormFile(string fileName, StreamConcurrencyTracker tracker) : IFormFile
+    {
+        public string ContentType => "text/plain";
+
+        public string ContentDisposition => "";
+
+        public IHeaderDictionary Headers { get; } = new HeaderDictionary();
+
+        public long Length => 1;
+
+        public string Name => fileName;
+
+        public string FileName => fileName;
+
+        public Stream OpenReadStream() => new TrackingReadStream(tracker);
+
+        public void CopyTo(Stream target) => throw new NotSupportedException();
+
+        public async Task CopyToAsync(Stream target, CancellationToken cancellationToken = default)
+        {
+            await using var stream = OpenReadStream();
+            await stream.CopyToAsync(target, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TrackingReadStream : Stream
+    {
+        private readonly StreamConcurrencyTracker _tracker;
+        private bool _read;
+
+        public TrackingReadStream(StreamConcurrencyTracker tracker)
+        {
+            _tracker = tracker;
+            _tracker.Open();
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => 1;
+
+        public override long Position
+        {
+            get => _read ? 1 : 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_read)
+            {
+                return 0;
+            }
+
+            Thread.Sleep(50);
+            buffer[offset] = (byte)'x';
+            _read = true;
+
+            return 1;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (_read)
+            {
+                return 0;
+            }
+
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            buffer.Span[0] = (byte)'x';
+            _read = true;
+
+            return 1;
+        }
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken
+        )
+        {
+            if (_read)
+            {
+                return 0;
+            }
+
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            buffer[offset] = (byte)'x';
+            _read = true;
+
+            return 1;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _tracker.Close();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class StreamConcurrencyTracker
+    {
+        private int _active;
+        private int _maxActive;
+
+        public int MaxActive => _maxActive;
+
+        public void Open()
+        {
+            var active = Interlocked.Increment(ref _active);
+
+            while (true)
+            {
+                var observed = _maxActive;
+                if (active <= observed || Interlocked.CompareExchange(ref _maxActive, active, observed) == observed)
+                {
+                    return;
+                }
+            }
+        }
+
+        public void Close() => Interlocked.Decrement(ref _active);
+    }
+}

--- a/tests/Headless.Api.Tests.Unit/HeadlessApiExceptionHandlerTests.cs
+++ b/tests/Headless.Api.Tests.Unit/HeadlessApiExceptionHandlerTests.cs
@@ -494,6 +494,31 @@ public sealed class HeadlessApiExceptionHandlerTests : TestBase
         await problemDetailsService.DidNotReceive().TryWriteAsync(Arg.Any<ProblemDetailsContext>());
     }
 
+    [Theory]
+    [InlineData("application/json;q=0")]
+    [InlineData("application/problem+json;q=0")]
+    [InlineData("application/json;q=0, application/problem+json;q=0, */*;q=1")]
+    [InlineData("*/*;q=0")]
+    public async Task should_return_false_when_accept_header_rejects_json_with_zero_quality(string acceptHeader)
+    {
+        // given
+        var problemDetailsService = Substitute.For<IProblemDetailsService>();
+        var handler = _CreateHandler(problemDetailsService, _CreateRealCreator());
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Accept = acceptHeader;
+
+        // when
+        var result = await handler.TryHandleAsync(
+            httpContext,
+            new MissingTenantContextException(),
+            TestContext.Current.CancellationToken
+        );
+
+        // then
+        result.Should().BeFalse();
+        await problemDetailsService.DidNotReceive().TryWriteAsync(Arg.Any<ProblemDetailsContext>());
+    }
+
     [Fact]
     public async Task should_log_5007_when_fallback_write_fails()
     {

--- a/tests/Headless.Api.Tests.Unit/HeadlessApiExceptionHandlerTests.cs
+++ b/tests/Headless.Api.Tests.Unit/HeadlessApiExceptionHandlerTests.cs
@@ -497,6 +497,8 @@ public sealed class HeadlessApiExceptionHandlerTests : TestBase
     [Theory]
     [InlineData("application/json;q=0")]
     [InlineData("application/problem+json;q=0")]
+    [InlineData("application/problem+json;q=0, */*;q=1")]
+    [InlineData("application/json;q=1, application/problem+json;q=0")]
     [InlineData("application/json;q=0, application/problem+json;q=0, */*;q=1")]
     [InlineData("*/*;q=0")]
     public async Task should_return_false_when_accept_header_rejects_json_with_zero_quality(string acceptHeader)

--- a/tests/Headless.Api.Tests.Unit/Identity/Authentication/BasicAuthenticationHandlerTests.cs
+++ b/tests/Headless.Api.Tests.Unit/Identity/Authentication/BasicAuthenticationHandlerTests.cs
@@ -199,7 +199,9 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
         var credentials = "testuser:password123".ToBase64();
         context.Request.Headers.Authorization = $"Basic {credentials}";
         _userManager.FindByNameAsync("testuser").Returns(Task.FromResult<TestUser?>(user));
-        _signInManager.CanSignInAsync(user).Returns(Task.FromResult(false));
+        _signInManager
+            .CheckPasswordSignInAsync(user, "password123", lockoutOnFailure: true)
+            .Returns(Task.FromResult(SignInResult.NotAllowed));
 
         await handler.InitializeAsync(
             new AuthenticationScheme("Basic", null, typeof(BasicAuthenticationHandler<TestUser, string>)),
@@ -225,9 +227,9 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
         var credentials = "testuser:password123".ToBase64();
         context.Request.Headers.Authorization = $"Basic {credentials}";
         _userManager.FindByNameAsync("testuser").Returns(Task.FromResult<TestUser?>(user));
-        _signInManager.CanSignInAsync(user).Returns(Task.FromResult(true));
-        _userManager.SupportsUserLockout.Returns(true);
-        _userManager.IsLockedOutAsync(user).Returns(Task.FromResult(true));
+        _signInManager
+            .CheckPasswordSignInAsync(user, "password123", lockoutOnFailure: true)
+            .Returns(Task.FromResult(SignInResult.LockedOut));
 
         await handler.InitializeAsync(
             new AuthenticationScheme("Basic", null, typeof(BasicAuthenticationHandler<TestUser, string>)),
@@ -253,9 +255,9 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
         var credentials = "testuser:wrongpassword".ToBase64();
         context.Request.Headers.Authorization = $"Basic {credentials}";
         _userManager.FindByNameAsync("testuser").Returns(Task.FromResult<TestUser?>(user));
-        _signInManager.CanSignInAsync(user).Returns(Task.FromResult(true));
-        _userManager.SupportsUserLockout.Returns(false);
-        _userManager.CheckPasswordAsync(user, "wrongpassword").Returns(Task.FromResult(false));
+        _signInManager
+            .CheckPasswordSignInAsync(user, "wrongpassword", lockoutOnFailure: true)
+            .Returns(Task.FromResult(SignInResult.Failed));
 
         await handler.InitializeAsync(
             new AuthenticationScheme("Basic", null, typeof(BasicAuthenticationHandler<TestUser, string>)),
@@ -269,6 +271,7 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
         result.Succeeded.Should().BeFalse();
         result.Failure.Should().NotBeNull();
         result.Failure!.Message.Should().Be("Invalid user name or password.");
+        await _signInManager.Received(1).CheckPasswordSignInAsync(user, "wrongpassword", lockoutOnFailure: true);
     }
 
     [Fact]
@@ -283,9 +286,9 @@ public sealed class BasicAuthenticationHandlerTests : TestBase
 
         context.Request.Headers.Authorization = $"Basic {credentials}";
         _userManager.FindByNameAsync("testuser").Returns(Task.FromResult<TestUser?>(user));
-        _signInManager.CanSignInAsync(user).Returns(Task.FromResult(true));
-        _userManager.SupportsUserLockout.Returns(false);
-        _userManager.CheckPasswordAsync(user, "correctpassword").Returns(Task.FromResult(true));
+        _signInManager
+            .CheckPasswordSignInAsync(user, "correctpassword", lockoutOnFailure: true)
+            .Returns(Task.FromResult(SignInResult.Success));
         _signInManager.CreateUserPrincipalAsync(user).Returns(Task.FromResult(principal));
 
         await handler.InitializeAsync(


### PR DESCRIPTION
## Summary

API error and auth paths now preserve consumer intent under edge conditions: Basic-auth failures participate in ASP.NET Core Identity lockout, JSON ProblemDetails are skipped when the request explicitly rejects them, ProblemDetails customization runs once per response, and batch upload saves no longer open every file stream at once.

## Affected Packages

- `Headless.Api.Core`

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Test only

## Validation

- [ ] `make build`
- [ ] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [x] Added or updated tests for behavior changes
- [ ] Updated XML docs for public API changes
- [x] Updated package `README.md` files for public behavior/setup changes
- [x] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
make format
make build-project PROJECT=src/Headless.Api.Core/Headless.Api.Core.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Tests.Unit/Headless.Api.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Tests.Integration/Headless.Api.Tests.Integration.csproj
make test-project TEST_PROJECT=tests/Headless.Api.Mvc.Tests.Unit/Headless.Api.Mvc.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Api.MinimalApi.Tests.Unit/Headless.Api.MinimalApi.Tests.Unit.csproj

git push pre-push hook: changed-file format-check + dotnet build headless-framework.slnx --configuration Release --no-restore -v:q -nologo /clp:ErrorsOnly
```

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
N/A
```

## Release Notes

- Basic authentication now honors configured ASP.NET Core Identity lockout policy for failed password attempts.
- ProblemDetails JSON responses now respect `Accept` quality rejection (`q=0`) and apply consumer customization once per writer invocation.
- Batch form-file saves now use bounded parallelism to reduce file-handle and disk pressure.

## Post-Deploy Monitoring & Validation

No additional production deployment monitoring is required for the framework repository itself. For consuming APIs after upgrading, watch authentication failure/lockout logs for Basic-auth endpoints, error-response content negotiation for clients with custom `Accept` headers, and upload error/latency metrics on endpoints using batch `IFormFile.SaveAsync(...)`.
