### PR TITLE
perf(api): streamline accept negotiation

### DIFF
--- a/src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs
+++ b/src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs
@@ -83,24 +83,9 @@ public static class HttpRequestExtensions
             return true;
         }
 
-        var candidates = new List<MediaTypeHeaderValue>(contentTypes.Length);
-
         foreach (var contentType in contentTypes)
         {
-            if (MediaTypeHeaderValue.TryParse(contentType, out var candidate))
-            {
-                candidates.Add(candidate);
-            }
-        }
-
-        if (candidates.Count == 0)
-        {
-            return false;
-        }
-
-        foreach (var candidate in candidates)
-        {
-            if (_CanAccept(parsed, candidate))
+            if (MediaTypeHeaderValue.TryParse(contentType, out var candidate) && _CanAccept(parsed, candidate))
             {
                 return true;
             }


### PR DESCRIPTION
## Summary

Accept negotiation now avoids building a temporary parsed-candidate list when checking multiple response content types. The behavior stays the same: invalid candidate types are ignored, and the first acceptable parsed candidate still wins.

## Validation

- `make format`
- `make build-project PROJECT=src/Headless.Api.Core/Headless.Api.Core.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Api.Tests.Unit/Headless.Api.Tests.Unit.csproj` - 302 passed
- pre-push Release solution build - 0 warnings, 0 errors
