### PR TITLE
perf(extensions): streamline collection and directory helpers

### DIFF
--- a/src/Headless.Extensions/Collections/CollectionExtensions.cs
+++ b/src/Headless.Extensions/Collections/CollectionExtensions.cs
@@ -87,6 +87,19 @@ public static class CollectionExtensions
 
         var addedItems = items.TryGetNonEnumeratedCount(out var count) ? new List<T>(count) : [];
 
+        if (source is ISet<T> set)
+        {
+            foreach (var item in items)
+            {
+                if (set.Add(item))
+                {
+                    addedItems.Add(item);
+                }
+            }
+
+            return addedItems;
+        }
+
         // List<T>.Contains is O(n), making the naive loop O(n*m). For large lists, snapshot the existing
         // items into a HashSet (same default equality as List<T>.Contains) so membership checks are O(1).
         // Newly added items are tracked in the set too, preserving the de-duplication of repeated items.

--- a/src/Headless.Extensions/IO/DirectoryHelper.cs
+++ b/src/Headless.Extensions/IO/DirectoryHelper.cs
@@ -61,10 +61,7 @@ public static class DirectoryHelper
     /// <exception cref="UnauthorizedAccessException">Thrown when the caller does not have the required permission.</exception>
     public static void CreateIfNotExists(string directory)
     {
-        if (!Directory.Exists(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        Directory.CreateDirectory(directory);
     }
 
     /// <summary>Creates the directory described by <paramref name="directory"/> if it does not already exist.</summary>
@@ -73,10 +70,7 @@ public static class DirectoryHelper
     /// <exception cref="UnauthorizedAccessException">Thrown when the caller does not have the required permission.</exception>
     public static void CreateIfNotExists(DirectoryInfo directory)
     {
-        if (!directory.Exists)
-        {
-            directory.Create();
-        }
+        directory.Create();
     }
 
     #endregion

--- a/tests/Headless.Extensions.Tests.Unit/Collections/CollectionExtensionsTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/Collections/CollectionExtensionsTests.cs
@@ -136,6 +136,19 @@ public sealed class CollectionExtensionsTests
     }
 
     [Fact]
+    public void add_if_not_contains_with_items_uses_set_membership()
+    {
+        // given
+        var set = new HashSet<int> { 1, 2, 3 };
+        var items = new[] { 2, 3, 4, 4, 5 };
+        // when
+        var addedItems = set.AddIfNotContains(items);
+        // then
+        addedItems.Should().Equal(4, 5);
+        set.Should().BeEquivalentTo([1, 2, 3, 4, 5]);
+    }
+
+    [Fact]
     public void remove_all_with_predicate_removes_matching_items()
     {
         // given

--- a/tests/Headless.Extensions.Tests.Unit/IO/DirectoryHelperTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/IO/DirectoryHelperTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.IO;
+
+namespace Tests.IO;
+
+public sealed class DirectoryHelperTests
+{
+    [Fact]
+    public void create_if_not_exists_creates_missing_directory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            DirectoryHelper.CreateIfNotExists(directory);
+
+            Directory.Exists(directory).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory);
+            }
+        }
+    }
+
+    [Fact]
+    public void create_if_not_exists_allows_existing_directory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+
+            DirectoryHelper.CreateIfNotExists(directory);
+            DirectoryHelper.CreateIfNotExists(new DirectoryInfo(directory));
+
+            Directory.Exists(directory).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extension helpers now avoid avoidable filesystem and collection work without changing their contracts. Set-backed bulk additions use the set insertion result as the membership check, and directory creation relies on the idempotent BCL create operation instead of probing first.

## Validation

- `make format`
- `make build-project PROJECT=src/Headless.Extensions/Headless.Extensions.csproj` - 0 warnings, 0 errors
- `make quality-analyzers-project PROJECT=src/Headless.Extensions/Headless.Extensions.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Extensions.Tests.Unit/Headless.Extensions.Tests.Unit.csproj` - 1,441 passed
- `make format-check`
- pre-push Release solution build - 0 warnings, 0 errors

Note: full `make quality-analyzers` still reports an out-of-scope suggestion in `src/Headless.Api.Core/Extensions/Http/HttpRequestExtensions.cs:191` (`RCS1128 Use coalesce expression`).
