### PR TITLE
build(dashboards): migrate jobs dashboard to vuetify 4

### DIFF
--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -19,7 +19,7 @@
         "vue": "^3.5.39",
         "vue-echarts": "^8.0.1",
         "vue-router": "^4.5.0",
-        "vuetify": "^3.7.6",
+        "vuetify": "^4.1.3",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -6857,9 +6857,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.3.tgz",
-      "integrity": "sha512-7QzgftMu8OYKRz/jr2yntPEJ7WFmAzMn8jyeUcW7gz539MjQbDF3UrqZXW3aWi458UVJW9WWvzQn9x5B75Aijw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.3.tgz",
+      "integrity": "sha512-tI6GHgICixvnoncWkSBNMKfwzjbt6H8FxEtGvUxYirOIBu00u5TUANgUbu1ly6wr9sVjvwqakCjUiAYJFsqpMw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -27,7 +27,7 @@
     "vue": "^3.5.39",
     "vue-echarts": "^8.0.1",
     "vue-router": "^4.5.0",
-    "vuetify": "^3.7.6",
+    "vuetify": "^4.1.3",
     "yup": "^1.6.1"
   },
   "devDependencies": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CRUDCronJobDialog.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/cronJobComponents/CRUDCronJobDialog.vue
@@ -390,7 +390,7 @@ defineExpose({
                         ></v-chip>
                       </template>
                       <template v-slot:item="{ props, item }">
-                        <v-list-item v-if="item.raw.header && comboBoxSearch">
+                        <v-list-item v-if="item.header && comboBoxSearch">
                           <span v-if="comboBoxModel.length < values.retries">
                             <v-chip size="small" variant="flat" label>
                               {{ formatTime(parseInt(comboBoxSearch!)) }}
@@ -408,14 +408,14 @@ defineExpose({
                           </span>
                         </v-list-item>
                         <v-list-subheader
-                          v-else-if="item.raw.header"
+                          v-else-if="item.header"
                           :title="item.title"
                         ></v-list-subheader>
                         <v-list-item
-                          v-if="!item.raw.header && comboBoxModel.length < values.retries"
+                          v-if="!item.header && comboBoxModel.length < values.retries"
                           @click="props.onClick as (() => void) | undefined"
                         >
-                          <v-chip :text="item.raw.title" variant="flat" label></v-chip>
+                          <v-chip :text="item.title" variant="flat" label></v-chip>
                         </v-list-item>
                       </template>
                     </v-combobox>

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/components/timeJobComponents/CRUDTimeJobDialogComponent.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/components/timeJobComponents/CRUDTimeJobDialogComponent.vue
@@ -500,7 +500,7 @@ defineExpose({
                         ></v-chip>
                       </template>
                       <template v-slot:item="{ props, item }">
-                        <v-list-item v-if="item.raw.header && comboBoxSearch">
+                        <v-list-item v-if="item.header && comboBoxSearch">
                           <span v-if="comboBoxModel.length < values.retries">
                             <v-chip size="small" variant="flat" label>
                               {{ formatTime(parseInt(comboBoxSearch!)) }}
@@ -518,14 +518,14 @@ defineExpose({
                           </span>
                         </v-list-item>
                         <v-list-subheader
-                          v-else-if="item.raw.header"
+                          v-else-if="item.header"
                           :title="item.title"
                         ></v-list-subheader>
                         <v-list-item
-                          v-if="!item.raw.header && comboBoxModel.length < values.retries"
+                          v-if="!item.header && comboBoxModel.length < values.retries"
                           @click="props.onClick as (() => void) | undefined"
                         >
-                          <v-chip :text="item.raw.title" variant="flat" label></v-chip>
+                          <v-chip :text="item.title" variant="flat" label></v-chip>
                         </v-list-item>
                       </template>
                     </v-combobox>


### PR DESCRIPTION
## Summary
The Jobs dashboard can now build against Vuetify 4 like the Messaging dashboard, including the retry interval comboboxes that previously failed under Vuetify 4's item slot payload.

- Bumps the Jobs dashboard Vuetify dependency to 4.1.3 while keeping the lockfile change scoped to that package.
- Updates the Cron and Time job retry interval combobox slots for the Vuetify 4 item shape.
- Leaves the custom filters on Vuetify's internal raw filter item shape, which is still what the filter callback receives.

## Related
Related: #573

## Validation
- `npx -y npm@10.9.8 ci --ignore-scripts --no-audit --no-fund --min-release-age=0`
- `npx -y npm@10.9.8 run build`
- `npx -y npm@10.9.8 run lint:check`
- `npm_config_min_release_age=0 make dashboards`
- pre-push hook: `dotnet build "headless-framework.slnx" --configuration "Release" --no-restore -v:q -nologo /clp:ErrorsOnly`

## Screenshots
Captured locally from `demo/Headless.Jobs.Dashboard.Jwt.Demo`:

- `.context/arkan/x-demo-reel/jobs-dashboard-vuetify4-migration/jobs-demo-login.png`
- `.context/arkan/x-demo-reel/jobs-dashboard-vuetify4-migration/jobs-demo-dashboard.png`
- `.context/arkan/x-demo-reel/jobs-dashboard-vuetify4-migration/jobs-cron-add-dialog-intervals.png`
- `.context/arkan/x-demo-reel/jobs-dashboard-vuetify4-migration/jobs-time-add-dialog-intervals.png`
