### PR TITLE
fix(audit): resolve temp store-generated values and honor Throw strategy

### DIFF
--- a/docs/llms/audit-log.md
+++ b/docs/llms/audit-log.md
@@ -84,7 +84,7 @@ Code against `IAuditLog<TContext>` and `IReadAuditLog<TContext>` — never refer
 - On SQLite, override the default composite primary key `(CreatedAt, Id)` with a single-column key on `Id` — SQLite cannot autoincrement composite keys.
 - When reading `OldValues` / `NewValues` after a provider round-trip, expect `JsonElement` values; use `GetDecimal()`, `GetBoolean()`, etc. for typed access.
 - Raw providers (PostgreSql, SqlServer) attempt to enroll writes in the consumer's ambient EF transaction when the database drivers match. If there is no ambient transaction, audit rows commit on a separate connection before `SaveChanges` — an entity-save failure then leaves orphan audit rows. Use an explicit transaction on the EF side to guarantee atomicity.
-- `CaptureErrorStrategy` defaults to `Continue`: a capture failure logs an error and lets `SaveChanges` proceed without audit entries for that batch. Set to `Throw` to abort the save when capture fails.
+- `CaptureErrorStrategy` defaults to `Continue`: a capture failure logs an error and lets `SaveChanges` proceed — a per-entity failure skips only that entity's audit entry, a whole-capture failure skips the batch. Set to `Throw` to abort the save when capture fails.
 
 ## Core Concepts
 
@@ -169,7 +169,7 @@ Provides a provider-agnostic audit log API for capturing field-level entity chan
 - `IAuditLogStore` — storage abstraction called by the change-tracking pipeline; `Save`/`SaveAsync` take the saving `DbContext` and return `IAuditLogStoreEntry` handles.
 - `IAuditLogStoreEntry` — provider handle; orchestrator calls `DiscardPendingChanges()` on failure and `ReleaseAfterCommit()` after success. Both must be idempotent.
 - `IAuditChangeCapture` — scans ChangeTracker entries and produces `AuditLogEntryData` records.
-- `IAuditEntityIdResolver` — patches deferred entity IDs after `SaveChanges` assigns store-generated keys.
+- `IAuditEntityIdResolver` — patches deferred entity IDs and temporary property values (store-generated keys, FKs to just-added principals) after `SaveChanges` assigns real keys.
 - `IAmbientDbTransactionAccessor` — allows raw ADO.NET stores to enroll in the consumer's active `DbConnection`/`DbTransaction` without taking an EF dependency.
 - `IAuditLogStorageOptionsExtension` — setup-time hook for storage provider packages.
 - `HeadlessAuditLogSetupBuilder` — fluent builder passed to `AddHeadlessAuditLog(setup => ...)`; exposes `ConfigureOptions`, `ConfigureStorage`, and `RegisterExtension`.

--- a/src/Headless.AuditLog.Abstractions/AuditLogOptions.cs
+++ b/src/Headless.AuditLog.Abstractions/AuditLogOptions.cs
@@ -67,8 +67,10 @@ public sealed class AuditLogOptions
         };
 
     /// <summary>
-    /// Strategy applied when audit capture (<c>IAuditChangeCapture.CaptureChanges</c>) throws.
-    /// Default: <see cref="CaptureErrorStrategy.Continue"/> — log an error and continue the entity save without audit entries for that batch.
+    /// Strategy applied when audit capture (<c>IAuditChangeCapture.CaptureChanges</c>) throws,
+    /// for both per-entity capture failures and whole-capture failures.
+    /// Default: <see cref="CaptureErrorStrategy.Continue"/> — log an error and continue the entity save;
+    /// a per-entity failure skips only that entity's audit entry, a whole-capture failure skips the batch.
     /// Set to <see cref="CaptureErrorStrategy.Throw"/> to abort the save when audit capture fails.
     /// </summary>
     public CaptureErrorStrategy CaptureErrorStrategy { get; set; } = CaptureErrorStrategy.Continue;
@@ -77,7 +79,11 @@ public sealed class AuditLogOptions
 /// <summary>Strategy applied when audit capture throws.</summary>
 public enum CaptureErrorStrategy
 {
-    /// <summary>Log the failure as an error and continue the entity save without audit entries for that batch.</summary>
+    /// <summary>
+    /// Log the failure as an error and continue the entity save. A per-entity capture failure
+    /// skips only that entity's audit entry; a whole-capture failure skips all audit entries
+    /// for the batch.
+    /// </summary>
     Continue = 0,
 
     /// <summary>Log the failure and rethrow so the entity save is aborted.</summary>

--- a/src/Headless.AuditLog.Abstractions/IAuditEntityIdResolver.cs
+++ b/src/Headless.AuditLog.Abstractions/IAuditEntityIdResolver.cs
@@ -3,14 +3,21 @@
 namespace Headless.AuditLog;
 
 /// <summary>
-/// Resolves deferred entity IDs on captured audit entries after SaveChanges has assigned
-/// store-generated keys. Implemented by capture services that support two-phase ID resolution.
+/// Resolves deferred store-generated values on captured audit entries after SaveChanges has
+/// assigned real keys. Implemented by capture services that support two-phase resolution.
 /// </summary>
 public interface IAuditEntityIdResolver
 {
     /// <summary>
     /// Patches <see cref="AuditLogEntryData.EntityId"/> on entries whose primary key was
-    /// deferred (e.g., identity/sequence-backed Added entities). Call after SaveChanges.
+    /// deferred (e.g., identity/sequence-backed Added entities), and replaces captured property
+    /// values that held provider temporary values (store-generated keys, foreign keys pointing
+    /// at just-added principals) with the real post-save values. Call after SaveChanges.
     /// </summary>
+    /// <remarks>
+    /// Implementations MUST resolve only the entries passed in — never state shared with other
+    /// in-flight captures — and MUST be safe to call again for the same entries after an
+    /// execution-strategy retry, where store-generated keys may differ between attempts.
+    /// </remarks>
     void ResolveEntityIds(IReadOnlyList<AuditLogEntryData> entries);
 }

--- a/src/Headless.AuditLog.Abstractions/README.md
+++ b/src/Headless.AuditLog.Abstractions/README.md
@@ -23,7 +23,7 @@ Provides a provider-agnostic audit log API for capturing field-level entity chan
 - `IAuditLogStore` — storage abstraction called by the change-tracking pipeline; `Save`/`SaveAsync` take the saving `DbContext` and return `IAuditLogStoreEntry` handles.
 - `IAuditLogStoreEntry` — provider handle; orchestrator calls `DiscardPendingChanges()` on failure and `ReleaseAfterCommit()` after success. Both must be idempotent.
 - `IAuditChangeCapture` — scans ChangeTracker entries and produces `AuditLogEntryData` records.
-- `IAuditEntityIdResolver` — patches deferred entity IDs after `SaveChanges` assigns store-generated keys.
+- `IAuditEntityIdResolver` — patches deferred entity IDs and temporary property values (store-generated keys, FKs to just-added principals) after `SaveChanges` assigns real keys.
 - `IAmbientDbTransactionAccessor` — allows raw ADO.NET stores to enroll in the consumer's active `DbConnection`/`DbTransaction` without taking an EF dependency.
 - `HeadlessAuditLogSetupBuilder` — fluent builder passed to `AddHeadlessAuditLog(setup => ...)`; exposes `ConfigureOptions`, `ConfigureStorage`, and `RegisterExtension`.
 

--- a/src/Headless.Orm.EntityFramework/Contexts/Auditing/EfAuditChangeCapture.cs
+++ b/src/Headless.Orm.EntityFramework/Contexts/Auditing/EfAuditChangeCapture.cs
@@ -42,7 +42,14 @@ internal sealed class EfAuditChangeCapture(
 
     private readonly ConcurrentDictionary<Type, bool> _entityFilterCache = new();
     private readonly ConcurrentDictionary<(Type Type, string PropertyName), bool> _propertyFilterCache = new();
-    private readonly List<(AuditLogEntryData Data, EntityEntry EntityEntry)> _deferredEntityIds = [];
+
+    // Deferred store-generated value resolution, keyed on the produced data object itself so
+    // interleaved captures on the same scoped instance (e.g. a domain-event handler saving a
+    // second DbContext mid-save) cannot clobber each other's state. Entries intentionally stay
+    // registered after resolution so execution-strategy retries can re-resolve; the table
+    // releases them together with their data objects.
+    private readonly ConditionalWeakTable<AuditLogEntryData, DeferredEntryResolution> _deferredResolutions = [];
+
     private bool _hasLoggedDisabledWarning;
 
     /// <inheritdoc />
@@ -62,7 +69,6 @@ internal sealed class EfAuditChangeCapture(
             return [];
         }
 
-        _deferredEntityIds.Clear();
         List<AuditLogEntryData>? result = null;
 
         foreach (var obj in entries)
@@ -90,16 +96,13 @@ internal sealed class EfAuditChangeCapture(
                 {
                     result ??= [];
                     result.Add(data);
-
-                    // Defer EntityId resolution for Added entities with store-generated keys.
-                    if (entry.State == EntityState.Added)
-                    {
-                        _deferredEntityIds.Add((data, entry));
-                    }
                 }
             }
-            catch (Exception e) when (e is not OptionsValidationException)
+            catch (Exception e)
+                when (e is not OptionsValidationException && opts.CaptureErrorStrategy == CaptureErrorStrategy.Continue)
             {
+                // Continue-only: under CaptureErrorStrategy.Throw the failure propagates so the
+                // save aborts instead of committing an entity change without its audit row.
                 _logger.LogAuditCaptureFailed(e, entry.Metadata.ClrType.FullName);
             }
         }
@@ -110,15 +113,27 @@ internal sealed class EfAuditChangeCapture(
     /// <inheritdoc />
     public void ResolveEntityIds(IReadOnlyList<AuditLogEntryData> entries)
     {
-        foreach (var (data, entityEntry) in _deferredEntityIds)
+        foreach (var data in entries)
         {
-            var (_, entityId) = _GetEntityIdentity(entityEntry);
-            data.EntityId = entityId;
-        }
+            if (!_deferredResolutions.TryGetValue(data, out var resolution))
+            {
+                continue;
+            }
 
-        // Not cleared here — cleared at the start of the next CaptureChanges call.
-        // This allows execution strategy retries to re-resolve after failed attempts
-        // where store-generated keys may differ.
+            if (resolution.ResolveEntityId)
+            {
+                var (_, entityId) = _GetEntityIdentity(resolution.Entry);
+                data.EntityId = entityId;
+            }
+
+            if (resolution.TemporaryValuePatches is not null)
+            {
+                foreach (var patch in resolution.TemporaryValuePatches)
+                {
+                    patch.Target[patch.PropertyName] = patch.Property.CurrentValue;
+                }
+            }
+        }
     }
 
     private void _LogDisabledWarningOnce()
@@ -229,6 +244,7 @@ internal sealed class EfAuditChangeCapture(
         var newValues = new Dictionary<string, object?>(StringComparer.Ordinal);
         var changedFields = new List<string>();
         var actionContext = new ActionContext();
+        List<TemporaryValuePatch>? temporaryValuePatches = null;
 
         foreach (var property in entry.Properties)
         {
@@ -290,6 +306,20 @@ internal sealed class EfAuditChangeCapture(
                 property.CurrentValue,
                 property.IsModified
             );
+
+            // Store-generated keys and FKs pointing at just-added principals hold EF temporary
+            // values until SaveChanges runs; remember where the value landed so ResolveEntityIds
+            // can patch in the real value post-save.
+            if (
+                property.IsTemporary
+                && (
+                    changeType is AuditChangeType.Created
+                    || (changeType is AuditChangeType.Updated && property.IsModified)
+                )
+            )
+            {
+                (temporaryValuePatches ??= []).Add(new TemporaryValuePatch(newValues, propertyName, property));
+            }
         }
 
         // Skip updates with no real changed fields
@@ -301,7 +331,7 @@ internal sealed class EfAuditChangeCapture(
         var action = _DetermineAction(changeType.Value, actionContext);
         var (entityType, entityId) = _GetEntityIdentity(entry);
 
-        return new AuditLogEntryData
+        var data = new AuditLogEntryData
         {
             UserId = userId,
             AccountId = accountId,
@@ -316,6 +346,18 @@ internal sealed class EfAuditChangeCapture(
             ChangedFields = changedFields.Count > 0 ? changedFields : null,
             CreatedAt = timestamp,
         };
+
+        // Created entries need EntityId re-resolution once store-generated keys are assigned;
+        // any entry may additionally carry temporary property values that need patching post-save.
+        if (changeType is AuditChangeType.Created || temporaryValuePatches is not null)
+        {
+            _deferredResolutions.Add(
+                data,
+                new DeferredEntryResolution(entry, changeType is AuditChangeType.Created, temporaryValuePatches)
+            );
+        }
+
+        return data;
     }
 
     private static void _CaptureActionFlags(ActionContext context, string propertyName, PropertyEntry property)
@@ -565,6 +607,18 @@ internal sealed class EfAuditChangeCapture(
         SensitiveDataStrategy? SensitiveStrategy
     );
 
+    private sealed record DeferredEntryResolution(
+        EntityEntry Entry,
+        bool ResolveEntityId,
+        List<TemporaryValuePatch>? TemporaryValuePatches
+    );
+
+    private readonly record struct TemporaryValuePatch(
+        Dictionary<string, object?> Target,
+        string PropertyName,
+        PropertyEntry Property
+    );
+
     private sealed class ActionContext
     {
         public bool IsSoftDeleted { get; set; }
@@ -579,10 +633,12 @@ internal sealed class EfAuditChangeCapture(
 
 internal static partial class EfAuditChangeCaptureLog
 {
+    // Error, not Warning: with CaptureErrorStrategy.Continue this entity's change is about to be
+    // persisted without its audit row — operators must see that in logs.
     [LoggerMessage(
         EventId = 1,
         EventName = "AuditCaptureFailed",
-        Level = LogLevel.Warning,
+        Level = LogLevel.Error,
         Message = "Audit capture failed for entity {EntityType}. Audit entry skipped; entity save continues."
     )]
     public static partial void LogAuditCaptureFailed(this ILogger logger, Exception exception, string? entityType);

--- a/tests/Headless.AuditLog.Storage.EntityFramework.Tests.Integration/AuditLogIntegrationTests.cs
+++ b/tests/Headless.AuditLog.Storage.EntityFramework.Tests.Integration/AuditLogIntegrationTests.cs
@@ -152,6 +152,74 @@ public sealed class AuditLogIntegrationTests : TestBase
     }
 
     [Fact]
+    public async Task created_entity_with_store_generated_key_persists_real_key_in_new_values()
+    {
+        // Regression: NewValues used to persist the EF temporary key (e.g. -2147482647) because
+        // values were captured before SaveChanges and only EntityId was patched afterwards.
+
+        // given
+        var (sp, conn) = await AuditIntegrationFixture.CreateAsync();
+        await using var _ = conn;
+        await using var __ = sp;
+        await using var scope = sp.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<AuditTestDbContext>();
+
+        var order = new GeneratedOrder { CustomerName = "Generated" };
+        db.GeneratedOrders.Add(order);
+
+        // when
+        await db.SaveChangesAsync(AbortToken);
+        db.ChangeTracker.Clear();
+
+        // then
+        var entries = await db.Set<AuditLogEntry>().AsNoTracking().ToListAsync(AbortToken);
+        entries.Should().ContainSingle();
+
+        var entry = entries[0];
+        entry.EntityId.Should().Be(order.Id.ToString(CultureInfo.InvariantCulture));
+        entry.NewValues.Should().ContainKey("Id");
+        entry.NewValues!["Id"].Should().BeOfType<JsonElement>().Subject.GetInt32().Should().Be(order.Id);
+    }
+
+    [Fact]
+    public async Task created_child_with_fk_to_new_parent_persists_real_fk_in_new_values()
+    {
+        // A child's FK to a just-added parent also carries an EF temporary value at capture time
+        // and must resolve to the real parent key post-save.
+
+        // given
+        var (sp, conn) = await AuditIntegrationFixture.CreateAsync();
+        await using var _ = conn;
+        await using var __ = sp;
+        await using var scope = sp.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<AuditTestDbContext>();
+
+        var order = new GeneratedOrder { CustomerName = "Parent" };
+        var line = new GeneratedOrderLine { Order = order, Sku = "sku-1" };
+        db.GeneratedOrders.Add(order);
+        db.GeneratedOrderLines.Add(line);
+
+        // when
+        await db.SaveChangesAsync(AbortToken);
+        db.ChangeTracker.Clear();
+
+        // then
+        var entries = await db.Set<AuditLogEntry>().AsNoTracking().ToListAsync(AbortToken);
+        entries.Should().HaveCount(2);
+
+        var lineEntry = entries.Single(e => e.EntityType == typeof(GeneratedOrderLine).FullName);
+        lineEntry.EntityId.Should().Be(line.Id.ToString(CultureInfo.InvariantCulture));
+        lineEntry.NewValues.Should().ContainKey("GeneratedOrderId");
+        lineEntry
+            .NewValues!["GeneratedOrderId"]
+            .Should()
+            .BeOfType<JsonElement>()
+            .Subject.GetInt32()
+            .Should()
+            .Be(order.Id);
+    }
+
+    [Fact]
     public async Task read_audit_log_query_returns_dto_results()
     {
         // given

--- a/tests/Headless.AuditLog.Storage.EntityFramework.Tests.Integration/Fixture/AuditTestDbContext.cs
+++ b/tests/Headless.AuditLog.Storage.EntityFramework.Tests.Integration/Fixture/AuditTestDbContext.cs
@@ -15,6 +15,8 @@ public class AuditTestDbContext(
 
     public DbSet<GeneratedOrder> GeneratedOrders => Set<GeneratedOrder>();
 
+    public DbSet<GeneratedOrderLine> GeneratedOrderLines => Set<GeneratedOrderLine>();
+
     public override string DefaultSchema => "";
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -22,6 +24,11 @@ public class AuditTestDbContext(
         base.OnModelCreating(modelBuilder);
         modelBuilder.Entity<Order>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<GeneratedOrder>().Property(e => e.Id).ValueGeneratedOnAdd();
+        modelBuilder.Entity<GeneratedOrderLine>(b =>
+        {
+            b.Property(e => e.Id).ValueGeneratedOnAdd();
+            b.HasOne(e => e.Order).WithMany().HasForeignKey(e => e.GeneratedOrderId);
+        });
         modelBuilder.AddHeadlessAuditLog(auditLogStorage.Value);
 
         // SQLite doesn't support ValueGeneratedOnAdd on composite-key columns (no sequence support).

--- a/tests/Headless.AuditLog.Storage.EntityFramework.Tests.Integration/Fixture/GeneratedOrderLine.cs
+++ b/tests/Headless.AuditLog.Storage.EntityFramework.Tests.Integration/Fixture/GeneratedOrderLine.cs
@@ -1,0 +1,14 @@
+using Headless.AuditLog;
+
+namespace Tests.Fixture;
+
+public sealed class GeneratedOrderLine : IAuditTracked
+{
+    public int Id { get; set; }
+
+    public int GeneratedOrderId { get; set; }
+
+    public GeneratedOrder? Order { get; set; }
+
+    public string Sku { get; set; } = "";
+}

--- a/tests/Headless.AuditLog.Tests.Unit/EfAuditChangeCaptureTests.cs
+++ b/tests/Headless.AuditLog.Tests.Unit/EfAuditChangeCaptureTests.cs
@@ -75,6 +75,12 @@ public class CompositeKeyOrder : IAuditTracked
     public string Name { get; set; } = "";
 }
 
+public class GeneratedKeyOrder : IAuditTracked
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}
+
 public class Address
 {
     public string Street { get; set; } = "";
@@ -94,6 +100,7 @@ public class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(
     public DbSet<PropertyTransformOrder> PropertyTransformOrders => Set<PropertyTransformOrder>();
     public DbSet<FrameworkManagedOrder> FrameworkManagedOrders => Set<FrameworkManagedOrder>();
     public DbSet<CompositeKeyOrder> CompositeKeyOrders => Set<CompositeKeyOrder>();
+    public DbSet<GeneratedKeyOrder> GeneratedKeyOrders => Set<GeneratedKeyOrder>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -105,6 +112,7 @@ public class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(
         modelBuilder.Entity<PropertyTransformOrder>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<FrameworkManagedOrder>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<CompositeKeyOrder>().HasKey(e => new { e.TenantId, e.OrderId });
+        modelBuilder.Entity<GeneratedKeyOrder>().Property(e => e.Id).ValueGeneratedOnAdd();
     }
 }
 
@@ -1022,6 +1030,128 @@ public sealed class EfAuditChangeCaptureTests : TestBase
             // then - non-EntityEntry objects are silently skipped; valid entry is captured
             result.Should().ContainSingle();
             result[0].Action.Should().Be(AuditActionNames.Created);
+        }
+    }
+
+    [Fact]
+    public async Task resolve_entity_ids_patches_temporary_store_generated_values_after_save()
+    {
+        // given - a store-generated key holds an EF temporary value at capture time
+        var (db, conn) = _CreateDb();
+        await using (conn)
+        await using (db)
+        {
+            var order = new GeneratedKeyOrder { Name = "gen" };
+            db.GeneratedKeyOrders.Add(order);
+
+            var sut = _CreateSut();
+            var result = _Capture(sut, db);
+            result.Should().ContainSingle();
+
+            // when
+            await db.SaveChangesAsync(AbortToken);
+            sut.ResolveEntityIds(result);
+
+            // then - both EntityId and the captured Id value reflect the real post-save key
+            order.Id.Should().BePositive();
+            result[0].EntityId.Should().Be(order.Id.ToString(CultureInfo.InvariantCulture));
+            result[0].NewValues.Should().ContainKey("Id").WhoseValue.Should().Be(order.Id);
+        }
+    }
+
+    [Fact]
+    public async Task resolve_entity_ids_resolves_passed_entries_when_another_capture_interleaves()
+    {
+        // given - one scoped capture instance shared by two contexts (e.g. a domain-event
+        // handler saving a second DbContext mid-save must not clobber the outer capture's state)
+        var (db, conn) = _CreateDb();
+        var (db2, conn2) = _CreateDb();
+        await using (conn)
+        await using (db)
+        await using (conn2)
+        await using (db2)
+        {
+            var order = new GeneratedKeyOrder { Name = "outer" };
+            db.GeneratedKeyOrders.Add(order);
+
+            var sut = _CreateSut();
+            var outerResult = _Capture(sut, db);
+            outerResult.Should().ContainSingle();
+
+            // when - an interleaved capture for a second context runs before the outer resolve
+            db2.GeneratedKeyOrders.Add(new GeneratedKeyOrder { Name = "inner" });
+            _ = _Capture(sut, db2);
+
+            await db.SaveChangesAsync(AbortToken);
+            sut.ResolveEntityIds(outerResult);
+
+            // then - the outer entries still resolve to their real post-save values
+            outerResult[0].EntityId.Should().Be(order.Id.ToString(CultureInfo.InvariantCulture));
+            outerResult[0].NewValues.Should().ContainKey("Id").WhoseValue.Should().Be(order.Id);
+        }
+    }
+
+    [Fact]
+    public async Task capture_error_strategy_continue_skips_failing_entity_and_keeps_others()
+    {
+        // given - the entity filter throws for one entity type only
+        var (db, conn) = _CreateDb();
+        await using (conn)
+        await using (db)
+        {
+            db.Orders.Add(
+                new Order
+                {
+                    Id = Guid.NewGuid(),
+                    CustomerName = "ok",
+                    Email = "a@b.com",
+                    Phone = "555",
+                }
+            );
+            db.Customers.Add(new Customer { Id = Guid.NewGuid(), Name = "boom" });
+
+            var sut = _CreateSut(options =>
+                options.EntityFilter = type =>
+                    type == typeof(Customer) ? throw new InvalidOperationException("boom") : false
+            );
+
+            // when
+            var result = _Capture(sut, db);
+
+            // then - the failing entity's entry is skipped; the healthy entity is still captured
+            result.Should().ContainSingle(e => e.EntityType == typeof(Order).FullName);
+        }
+    }
+
+    [Fact]
+    public async Task capture_error_strategy_throw_propagates_per_entity_capture_failure()
+    {
+        // given
+        var (db, conn) = _CreateDb();
+        await using (conn)
+        await using (db)
+        {
+            db.Orders.Add(
+                new Order
+                {
+                    Id = Guid.NewGuid(),
+                    CustomerName = "ok",
+                    Email = "a@b.com",
+                    Phone = "555",
+                }
+            );
+
+            var sut = _CreateSut(options =>
+            {
+                options.CaptureErrorStrategy = CaptureErrorStrategy.Throw;
+                options.EntityFilter = _ => throw new InvalidOperationException("boom");
+            });
+
+            // when
+            var act = () => _Capture(sut, db);
+
+            // then - the per-entity failure aborts the capture instead of being swallowed
+            act.Should().Throw<InvalidOperationException>().WithMessage("boom");
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes three defects in the EF audit change-capture pipeline, found during a package review of `Headless.AuditLog.*`:

- **Audit rows recorded EF temporary keys instead of real ones.** Property values are captured before `SaveChanges`, so a Created entry for an identity-keyed entity persisted `NewValues.Id = -2147482647` (a child's FK to a just-added parent hit the same path) while only `EntityId` was patched post-save. Capture now remembers every `IsTemporary` property that lands in `NewValues`, and `ResolveEntityIds` patches in the real post-save values.
- **Interleaved captures clobbered each other's deferred state.** The scoped capture service kept its deferred-resolution list as instance state cleared on every `CaptureChanges` call, so a nested save (e.g. a domain-event handler writing a second `DbContext` in the same scope) wiped the outer save's pending resolutions and left temporary `EntityId` values persisted. Deferred work is now keyed on each produced `AuditLogEntryData` via a `ConditionalWeakTable`, and `ResolveEntityIds` resolves only the entries passed to it. Entries stay registered so execution-strategy retries can still re-resolve.
- **`CaptureErrorStrategy.Throw` never fired for per-entity failures.** The per-entity catch swallowed every capture failure with a Warning regardless of strategy, so an audit-tracked change could commit without its audit row even under `Throw`. The catch now applies only under `Continue` (exception filter, so the original stack propagates under `Throw`), and the skip log is elevated to Error since the entity change is about to persist unaudited.

Consumer-visible behavior changes: under `Throw`, a per-entity capture failure now aborts the save (previously it was silently skipped); the `AuditCaptureFailed` event logs at Error instead of Warning. XML docs, `docs/llms/audit-log.md`, and the Abstractions README are updated to match.

## Validation

The first bug was confirmed empirically before the fix: a probe test against the existing SQLite fixture persisted `NewValues[Id]=-2147482647` alongside `EntityId=1`. After the fix:

- `Headless.AuditLog.Tests.Unit`: 34/34 pass — 4 new tests covering temp-value patching, interleaved-capture resolution, `Continue` skipping only the failing entity, and `Throw` propagation.
- `Headless.AuditLog.Storage.EntityFramework.Tests.Integration`: 18/18 pass — 2 new regression tests, including the FK-to-new-parent case via a new `GeneratedOrderLine` fixture entity.
- `make quality-analyzers-project` clean on `Headless.Orm.EntityFramework` and `Headless.AuditLog.Abstractions`; CSharpier applied.
