### PR TITLE
docs: improve onboarding and messaging guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,68 +7,371 @@
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com)
 [![GitHub Stars](https://img.shields.io/github/stars/xshaheen/headless-framework?style=social)](https://github.com/xshaheen/headless-framework)
 
-150+ NuGet packages &bull; Abstraction + Provider pattern &bull; Zero lock-in
+150+ NuGet packages &bull; Abstraction + Provider pattern &bull; Explicit infrastructure
 
-[Quick Start](#quick-start) &bull; [Packages](#packages) &bull; [Architecture](#architecture) &bull; [Using with AI Agents](#using-headless-with-ai-agents) &bull; [Contributing](#contributing)
+[Quick Start](#quick-start) &bull; [Install By Goal](#install-by-goal) &bull; [Messaging](#messaging) &bull; [Packages](#packages) &bull; [Production Guidance](#production-guidance) &bull; [Contributing](#contributing)
 
 </div>
 
 ---
 
-## Why Headless?
+## What Problem It Solves
 
-Most .NET frameworks force opinions on you — folder structures, ORM choices, messaging transports, cloud providers. **Headless doesn't.**
+Headless Framework is a modular .NET framework for services that need production infrastructure without binding application code to one vendor, broker, database, or hosting shape.
 
-Every feature ships as a pair: a thin **abstraction** package (interfaces and contracts) and one or more **provider** packages (concrete implementations). You pick the pieces you need, wire them up, and own the result.
+Most services eventually need the same infrastructure patterns: reliable message publishing, background consumers, retry policies, caching, blob storage, email delivery, API health checks, OpenTelemetry, and provider-specific configuration. Without a framework layer, business code tends to depend directly on Redis, RabbitMQ, Kafka, Azure, AWS, SQL Server, PostgreSQL, and other implementation details.
 
-- **Composable** — 150+ standalone packages. Use one or use fifty.
-- **Swappable** — Switch from Redis to in-memory caching, or AWS to Azure blob storage, by changing one line.
-- **Explicit** — No hidden conventions, no magic. Every behavior is visible in your code.
-- **Testable** — Every abstraction is mockable. Every provider is integration-tested with Testcontainers.
+Headless separates those concerns:
+
+- **Abstractions** give application code stable interfaces such as `IBus`, `IOutboxBus`, `IQueue`, `IOutboxQueue`, cache, blob, email, and distributed-lock contracts.
+- **Providers** supply concrete infrastructure integrations.
+- **Setup extensions** compose only the packages each service needs.
+- **Local and testing providers** let developers run without cloud or broker dependencies.
+
+Use Headless when you want provider-swappable infrastructure with explicit setup and source-visible behavior. Production correctness still depends on choosing the right provider, storage, retry, transaction, and idempotency model for your service.
+
+## Install By Goal
+
+| Goal | Start With | Add Provider Packages |
+|------|------------|-----------------------|
+| API defaults, health checks, OpenTelemetry, common middleware | `Headless.Api.ServiceDefaults` | None unless your app needs other domains |
+| Local messaging without external infrastructure | `Headless.Messaging.Core` | `Headless.Messaging.InMemory`, `Headless.Messaging.InMemoryStorage` |
+| Durable messaging with RabbitMQ | `Headless.Messaging.Core` | `Headless.Messaging.RabbitMq` plus one durable storage provider |
+| Durable messaging with Kafka | `Headless.Messaging.Core` | `Headless.Messaging.Kafka` plus one durable storage provider |
+| Durable messaging with Azure Service Bus | `Headless.Messaging.Core` | `Headless.Messaging.AzureServiceBus` plus one durable storage provider |
+| Durable outbox storage with PostgreSQL | `Headless.Messaging.Core` | `Headless.Messaging.Storage.PostgreSql` |
+| Durable outbox storage with SQL Server | `Headless.Messaging.Core` | `Headless.Messaging.Storage.SqlServer` |
+| EF Core-backed transactional outbox | `Headless.Messaging.Core` | `Headless.Messaging.Storage.PostgreSql` or `Headless.Messaging.Storage.SqlServer`, then call `UseEntityFramework<TContext>()` |
+| Cache abstraction | `Headless.Caching.Core` | `Headless.Caching.InMemory`, `Headless.Caching.Redis`, or `Headless.Caching.Hybrid` |
+| Blob storage abstraction | `Headless.Blobs.Core` | Azure, AWS, Cloudflare R2, filesystem, Redis, or SFTP provider |
+| Email abstraction | `Headless.Emails.Core` | AWS, Azure Communication Services, MailKit SMTP, or dev provider |
+| Test-only infrastructure | Domain core package | In-memory provider or testing package for that domain |
+
+Messaging always needs:
+
+1. `Headless.Messaging.Core`
+2. One transport provider
+3. One storage provider when using durable outbox, retries, or delayed dispatch
+4. Consumer registrations for messages handled by the service
 
 ## Quick Start
 
+### Start an API
+
 ```bash
 dotnet add package Headless.Api.ServiceDefaults
-dotnet add package Headless.Caching.Redis
-dotnet add package Headless.Blobs.Azure
-dotnet add package Headless.Emails.Aws
 ```
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-// Service defaults: OpenTelemetry, OpenAPI, problem details, JSON, health checks, and more.
-// Binds secrets from the "Headless:StringEncryption" and "Headless:StringHash" config sections.
+// OpenTelemetry, OpenAPI, problem details, JSON, health checks, forwarded headers,
+// compression, exception handling, HSTS, status-code pages, and Headless endpoints.
 builder.AddHeadless();
-
-// Caching — pick a provider on the unified setup builder. Swap UseRedis for UseInMemory
-// (or add an L1/L2 tier) without touching call sites.
-var redis = ConnectionMultiplexer.Connect("localhost:6379");
-builder.Services.AddHeadlessCaching(setup =>
-    setup.UseRedis(options => options.ConnectionMultiplexer = redis)
-);
-
-// Blob storage — the Azure provider consumes a BlobServiceClient registered in DI.
-builder.Services.AddSingleton(new BlobServiceClient(builder.Configuration["Azure:Storage:ConnectionString"]));
-builder.Services.AddHeadlessBlobs(blobs =>
-    blobs.UseAzure(options => options.AutoCreateContainer = true)
-);
-
-// Email — AWS SES reads region/credentials from AWSOptions (here, the "AWS:*" config section).
-builder.Services.AddHeadlessEmails(setup =>
-    setup.UseAwsSes(builder.Configuration.GetAWSOptions())
-);
 
 var app = builder.Build();
 
-// Applies the Headless middleware pipeline (forwarded headers, compression, exception handler,
-// HSTS, status-code pages) and maps the health/alive/OpenAPI endpoints.
 app.UseHeadless();
 app.MapHeadlessEndpoints();
 
 app.Run();
 ```
+
+### Add Local Messaging
+
+This example runs messaging in memory. Use it for learning, local development, and tests. It is not durable production messaging.
+
+```bash
+dotnet add package Headless.Messaging.Core
+dotnet add package Headless.Messaging.InMemory
+dotnet add package Headless.Messaging.InMemoryStorage
+```
+
+```csharp
+using Headless.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddHeadlessMessaging(setup =>
+{
+    setup.UseInMemoryStorage();
+    setup.UseInMemory();
+
+    setup.ForMessage<OrderPlaced>(message =>
+        message
+            .MessageName("orders.placed")
+            .OnBus<OrderPlacedConsumer>(consumer => consumer.Group("orders").Concurrency(4))
+    );
+});
+
+using var app = builder.Build();
+
+await app.Services.GetRequiredService<IBootstrapper>()
+    .BootstrapAsync(CancellationToken.None);
+
+await app.Services.GetRequiredService<IOutboxBus>()
+    .PublishAsync(
+        new OrderPlaced("order-123"),
+        new PublishOptions { MessageName = "orders.placed" },
+        CancellationToken.None
+    );
+
+public sealed record OrderPlaced(string OrderId);
+
+public sealed class OrderPlacedConsumer(ILogger<OrderPlacedConsumer> logger) : IConsume<OrderPlaced>
+{
+    public ValueTask ConsumeAsync(ConsumeContext<OrderPlaced> context, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Processing order {OrderId}", context.Message.OrderId);
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+## Messaging
+
+`Headless.Messaging.Core` separates logical publish intent from transport delivery.
+
+- Use `IBus` to publish directly to the configured broadcast transport.
+- Use `IQueue` to enqueue directly to the configured point-to-point transport.
+- Use `IOutboxBus` to persist broadcast intent first, then let the outbox deliver it.
+- Use `IOutboxQueue` to persist queue intent first, then let the outbox deliver it.
+- Implement `IConsume<TMessage>` for processors and consumers.
+
+### Durable RabbitMQ + PostgreSQL
+
+```bash
+dotnet add package Headless.Messaging.Core
+dotnet add package Headless.Messaging.RabbitMq
+dotnet add package Headless.Messaging.Storage.PostgreSql
+```
+
+```csharp
+builder.Services.AddHeadlessMessaging(setup =>
+{
+    setup.UsePostgreSql(options =>
+    {
+        options.ConnectionString = builder.Configuration.GetConnectionString("Messaging");
+    });
+
+    setup.UseRabbitMq(options =>
+    {
+        options.HostName = builder.Configuration["RabbitMq:HostName"]!;
+        options.Port = builder.Configuration.GetValue("RabbitMq:Port", 5672);
+        options.UserName = builder.Configuration["RabbitMq:UserName"]!;
+        options.Password = builder.Configuration["RabbitMq:Password"]!;
+        options.VirtualHost = "/";
+    });
+
+    setup.ForMessage<OrderPlaced>(message =>
+        message
+            .MessageName("orders.placed")
+            .OnBus<OrderPlacedConsumer>(consumer => consumer.Group("orders").Concurrency(8))
+    );
+});
+```
+
+Call `IBootstrapper.BootstrapAsync(...)` during service startup when you use a manual host path, so Headless can initialize topology before messages are published or consumed.
+
+### Outbox
+
+Use the outbox when publish intent must survive process failure or must be coordinated with application state.
+
+```csharp
+public sealed class OrderPublisher(IOutboxBus outboxBus)
+{
+    public Task PublishAsync(string orderId, CancellationToken cancellationToken)
+    {
+        return outboxBus.PublishAsync(
+            new OrderPlaced(orderId),
+            new PublishOptions
+            {
+                MessageName = "orders.placed",
+                Delay = TimeSpan.FromSeconds(30),
+            },
+            cancellationToken
+        );
+    }
+}
+```
+
+The outbox stores intent first and dispatches later through the configured transport. The EF storage path (`setup.UseEntityFramework<TContext>()` from the SQL Server or PostgreSQL storage packages) enables the transactional outbox by default: a publish inside a coordinated transaction writes the outbox row in the same database transaction and discards it on rollback.
+
+The raw ADO storage paths (`UsePostgreSql(...)` / `UseSqlServer(...)` by connection string, no `DbContext`) stay explicit opt-in: register the matching commit-coordination provider and use the coordinated-transaction helpers.
+
+See:
+
+- [`demo/Headless.Messaging.RabbitMq.SqlServer.Demo`](demo/Headless.Messaging.RabbitMq.SqlServer.Demo)
+- [`demo/Headless.Messaging.Kafka.PostgreSql.Demo`](demo/Headless.Messaging.Kafka.PostgreSql.Demo)
+- [`docs/llms/messaging.md`](docs/llms/messaging.md)
+
+### Retry and Backoff
+
+Retry policy is configured through `MessagingOptions.RetryPolicy`.
+
+```csharp
+using Headless.Messaging.Retry;
+
+builder.Services.AddHeadlessMessaging(setup =>
+{
+    setup.Options.RetryPolicy.MaxInlineRetries = 2;
+    setup.Options.RetryPolicy.MaxPersistedRetries = 15;
+    setup.Options.RetryPolicy.InitialDispatchGrace = TimeSpan.FromSeconds(30);
+    setup.Options.RetryPolicy.DispatchTimeout = TimeSpan.FromMinutes(5);
+    setup.Options.RetryPolicy.BackoffStrategy = new ExponentialBackoffStrategy(
+        initialDelay: TimeSpan.FromSeconds(2),
+        maxDelay: TimeSpan.FromMinutes(5),
+        backoffMultiplier: 2.0
+    );
+
+    // Add one storage provider and one transport provider.
+});
+```
+
+Defaults from `RetryPolicyOptions`:
+
+- `MaxInlineRetries`: `2`
+- `MaxPersistedRetries`: `15`
+- `InitialDispatchGrace`: `30 seconds`
+- `DispatchTimeout`: `5 minutes`
+- `BackoffStrategy`: exponential backoff with jitter
+
+Total observable attempts are `(MaxInlineRetries + 1) * (MaxPersistedRetries + 1)`. With defaults, that is 48 attempts. Delivery remains at-least-once, so consumers must be safe to run more than once.
+
+### Processor and Consumer
+
+```csharp
+public sealed class OrderPlacedConsumer(ILogger<OrderPlacedConsumer> logger) : IConsume<OrderPlaced>
+{
+    public ValueTask ConsumeAsync(ConsumeContext<OrderPlaced> context, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Order placed: {OrderId}", context.Message.OrderId);
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+Register a consumer on a broadcast bus or point-to-point queue:
+
+```csharp
+setup.ForMessage<OrderPlaced>(message =>
+{
+    message.OnBus<OrderPlacedConsumer>(consumer =>
+        consumer.Group("order-projections").Concurrency(4)
+    );
+
+    message.OnQueue<OrderPlacedConsumer>(consumer =>
+        consumer.Group("order-workers").Concurrency(2)
+    );
+});
+```
+
+Use consumer groups to separate independent processing groups. Use concurrency to control how many messages a consumer group processes in parallel within the service instance.
+
+## Configuration Examples
+
+Headless setup is programmatic. Bind provider options from configuration when your service needs environment-specific values.
+
+```csharp
+builder.Services.AddHeadlessMessaging(setup =>
+{
+    var rabbit = builder.Configuration.GetSection("RabbitMq");
+
+    setup.UseRabbitMq(options =>
+    {
+        options.HostName = rabbit["HostName"]!;
+        options.Port = rabbit.GetValue("Port", 5672);
+        options.UserName = rabbit["UserName"]!;
+        options.Password = rabbit["Password"]!;
+        options.VirtualHost = rabbit["VirtualHost"] ?? "/";
+    });
+
+    setup.UsePostgreSql(options =>
+    {
+        options.ConnectionString =
+            builder.Configuration.GetConnectionString("Messaging");
+    });
+});
+```
+
+```json
+{
+  "ConnectionStrings": {
+    "Messaging": "Host=localhost;Database=headless_messaging;Username=postgres;Password=postgres"
+  },
+  "RabbitMq": {
+    "HostName": "localhost",
+    "Port": 5672,
+    "UserName": "myapp_user",
+    "Password": "replace-with-a-secret",
+    "VirtualHost": "/"
+  }
+}
+```
+
+## Guarantees and Limits
+
+Messaging guarantees depend on the configured transport, storage provider, and transaction coordination.
+
+Headless Messaging provides:
+
+- Provider-swappable publishing and consuming APIs.
+- Durable outbox intent when using `IOutboxBus` or `IOutboxQueue` with a durable storage provider.
+- Delay support for outbox-backed `PublishOptions.Delay` and `EnqueueOptions.Delay`.
+- Inline and persisted retry policy configuration.
+- Consumer registration with group and concurrency settings.
+- At-least-once delivery semantics.
+
+Headless Messaging does not guarantee:
+
+- Exactly-once delivery.
+- Idempotent business behavior without idempotent consumer code.
+- Durable delivery when using in-memory transport or in-memory storage.
+- Atomic outbox writes unless application state and Headless storage are coordinated in the same transaction.
+- Uniform broker features across RabbitMQ, Kafka, Azure Service Bus, NATS, Pulsar, Redis, AWS, and in-memory transports.
+
+Consumer guidance:
+
+- Make consumers idempotent.
+- Store processed message IDs or business operation IDs when duplicate processing would be harmful.
+- Treat retry callbacks and exhaustion callbacks as at-least-once signals.
+- Keep consumer side effects safe under process crash and broker redelivery.
+
+## Production Guidance
+
+Before using messaging in production:
+
+- Choose a durable transport provider.
+- Choose exactly one durable storage provider for outbox, retries, and delayed dispatch.
+- Bootstrap topology during service startup.
+- Use `IOutboxBus` or `IOutboxQueue` when publishing must survive process failure.
+- Coordinate the outbox transaction with application state changes when atomicity matters.
+- Configure retry and backoff deliberately.
+- Treat `UseStorageLock` as retry-pickup coordination, not an exactly-once guarantee.
+- Add OpenTelemetry and logs around publish, consume, retry, and exhaustion paths.
+- Protect dashboard endpoints with production authentication.
+- Write integration tests with the actual transport and storage provider combination.
+- Document provider-specific limits such as ordering, delay support, partitioning, dead-letter behavior, queue arguments, and topic naming.
+
+## Examples
+
+| Example | Shows |
+|---------|-------|
+| [`demo/Headless.Messaging.Console.Demo`](demo/Headless.Messaging.Console.Demo) | In-memory transport/storage, consumer registration, bootstrap, publish, callbacks |
+| [`demo/Headless.Messaging.RabbitMq.SqlServer.Demo`](demo/Headless.Messaging.RabbitMq.SqlServer.Demo) | RabbitMQ transport, SQL Server storage, EF coordination, raw ADO coordination, rollback, delayed publish |
+| [`demo/Headless.Messaging.Kafka.PostgreSql.Demo`](demo/Headless.Messaging.Kafka.PostgreSql.Demo) | Kafka transport, PostgreSQL storage, raw coordination, EF coordination |
+
+## Versioning and Compatibility
+
+- Most packages target `.NET 10`.
+- Source generator packages target `netstandard2.0`.
+- The repository pins the .NET SDK in [`global.json`](global.json).
+- Package release notes are published from [GitHub releases](https://github.com/xshaheen/headless-framework/releases).
+
+Check release notes before upgrading, especially for configuration APIs, provider setup, storage schema, retry behavior, and source-generated code.
 
 ## Packages
 

--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -439,6 +439,8 @@ Core owns logical metadata and provider-independent correctness. Provider packag
 
 ```bash
 dotnet add package Headless.Messaging.Core
+dotnet add package Headless.Messaging.InMemory
+dotnet add package Headless.Messaging.InMemoryStorage
 ```
 
 ### Quick Start
@@ -446,7 +448,7 @@ dotnet add package Headless.Messaging.Core
 ```csharp
 services.AddHeadlessMessaging(setup =>
 {
-    setup.UseInMemoryTransport();
+    setup.UseInMemory();
     setup.UseInMemoryStorage();
 
     setup.ForMessage<OrderPlaced>(message =>
@@ -1153,7 +1155,7 @@ Provides in-process bus and queue transport for local development and tests.
 
 ### Key Features
 
-- `setup.UseInMemoryTransport()`.
+- `setup.UseInMemory()`.
 - In-process bus and queue delivery.
 - No external broker.
 
@@ -1166,7 +1168,7 @@ dotnet add package Headless.Messaging.InMemory
 ### Quick Start
 
 ```csharp
-setup.UseInMemoryTransport();
+setup.UseInMemory();
 ```
 
 ### Configuration

--- a/src/Headless.Messaging.Core/Configuration/MessagingOptions.cs
+++ b/src/Headless.Messaging.Core/Configuration/MessagingOptions.cs
@@ -174,8 +174,9 @@ public sealed class MessagingOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether to use distributed storage locking when retrying failed messages.
-    /// When enabled, only one instance in a distributed system will perform message retries, preventing duplicate processing.
-    /// This is essential for clustered deployments to ensure exactly-once retry semantics.
+    /// When enabled, retry processors coordinate pickup through a messaging-keyed distributed lock,
+    /// reducing duplicate retry work across replicas. Message delivery remains at-least-once and
+    /// consumers must stay idempotent.
     /// Default is false.
     /// </summary>
     public bool UseStorageLock { get; set; }

--- a/src/Headless.Messaging.Core/README.md
+++ b/src/Headless.Messaging.Core/README.md
@@ -31,74 +31,90 @@ dotnet add package Headless.Messaging.Core
 
 ## Quick Start
 
+For a local, dependency-free first run, install the in-memory transport and storage providers alongside Core:
+
+```bash
+dotnet add package Headless.Messaging.Core
+dotnet add package Headless.Messaging.InMemory
+dotnet add package Headless.Messaging.InMemoryStorage
+```
+
 ```csharp
-// Register messaging with storage and transport
+using Headless.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var builder = Host.CreateApplicationBuilder(args);
+
 builder.Services.AddHeadlessMessaging(setup =>
 {
-    setup.ForMessagesFromAssemblyContaining<Program>(
-        (ctx, consumer) =>
-        {
-            if (ctx.ConsumerType.Name.EndsWith("Worker", StringComparison.Ordinal))
-            {
-                consumer.OnQueue().Group("imports").Concurrency(4);
-            }
+    setup.UseInMemoryStorage();
+    setup.UseInMemory();
 
-            if (ctx.ConsumerType.Namespace?.Contains(".Experimental.", StringComparison.Ordinal) == true)
-            {
-                consumer.Skip();
-            }
-        }
+    setup.ForMessage<OrderPlaced>(message =>
+        message
+            .MessageName("orders.placed")
+            .OnBus<OrderPlacedConsumer>(consumer => consumer.Group("orders").Concurrency(4))
     );
-
-    // Core configuration (value-typed options live under setup.Options)
-    setup.Options.SucceedMessageExpiredAfter = 24 * 3600;
-    setup.Options.RetryPolicy.MaxPersistedRetries = 50;
-    setup.UseConventions(c =>
-    {
-        c.UseKebabCaseMessageNames();
-        c.UseApplicationId("ordering-api");
-        c.UseVersion("v1");
-    });
-
-    // Add exactly one storage provider (required)
-    setup.UsePostgreSql("connection_string");
-
-    // Add transport (required)
-    setup.UseRabbitMq(rmq =>
-    {
-        rmq.HostName = "localhost";
-        rmq.Port = 5672;
-    });
 });
 
-// Publish broadcast messages with the transactional outbox (reliable delivery).
-// NOTE: on the EF storage path (setup.UseEntityFramework<TContext>()) the outbox is on by default and the
-// commit interceptor is attached for you — see "Transactional Outbox (Atomic Publish)" above. The manual
-// EnlistCommitCoordination below is the raw-ADO / advanced seam: it makes the open transaction the ambient
-// commit coordinator so the outbox writer stores rows INSIDE it; the EF transaction interceptor dispatches
-// them post-commit and discards them on rollback. The enlist is synchronous on purpose — it must run in the
-// caller's frame so the ambient scope flows to the publish below.
-public sealed class OrderService(IOutboxBus bus, AppDbContext dbContext, IServiceProvider services)
-{
-    public async Task PlaceOrderAsync(Order order, CancellationToken ct)
-    {
-        await using var tx = await dbContext.Database.BeginTransactionAsync(ct);
-        await using var _ = dbContext.Database.EnlistCommitCoordination(tx, services);
+using var app = builder.Build();
 
-        await bus.PublishAsync(order, new PublishOptions { MessageName = "orders.placed" }, ct);
-        await dbContext.SaveChangesAsync(ct);
-        await tx.CommitAsync(ct);
+await app.Services.GetRequiredService<IBootstrapper>()
+    .BootstrapAsync(CancellationToken.None);
+
+await app.Services.GetRequiredService<IOutboxBus>()
+    .PublishAsync(
+        new OrderPlaced("order-123"),
+        new PublishOptions { MessageName = "orders.placed" },
+        CancellationToken.None
+    );
+
+public sealed record OrderPlaced(string OrderId);
+
+public sealed class OrderPlacedConsumer(ILogger<OrderPlacedConsumer> logger) : IConsume<OrderPlaced>
+{
+    public ValueTask ConsumeAsync(ConsumeContext<OrderPlaced> context, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Processing order {OrderId}", context.Message.OrderId);
+        return ValueTask.CompletedTask;
     }
 }
+```
 
-// Enqueue point-to-point work directly (fire-and-forget)
-public sealed class ImportService(IQueue queue)
+Publish through the outbox when durability matters:
+
+```csharp
+await serviceProvider.GetRequiredService<IOutboxBus>()
+    .PublishAsync(
+        new OrderPlaced("order-123"),
+        new PublishOptions { MessageName = "orders.placed" },
+        cancellationToken
+    );
+```
+
+For durable infrastructure, replace the in-memory providers with exactly one storage provider and one transport provider:
+
+```csharp
+builder.Services.AddHeadlessMessaging(setup =>
 {
-    public async Task StartAsync(ImportRequested request, CancellationToken ct)
+    setup.UsePostgreSql(options =>
     {
-        await queue.EnqueueAsync(request, new EnqueueOptions { MessageName = "imports.requested" }, ct);
-    }
-}
+        options.ConnectionString = builder.Configuration.GetConnectionString("Messaging");
+    });
+
+    setup.UseRabbitMq(options =>
+    {
+        options.HostName = builder.Configuration["RabbitMq:HostName"]!;
+        options.UserName = builder.Configuration["RabbitMq:UserName"]!;
+        options.Password = builder.Configuration["RabbitMq:Password"]!;
+    });
+
+    setup.ForMessage<OrderPlaced>(message =>
+        message.MessageName("orders.placed").OnBus<OrderPlacedConsumer>()
+    );
+});
 ```
 
 ## Transactional Outbox (Atomic Publish)

--- a/src/Headless.Messaging.Kafka/README.md
+++ b/src/Headless.Messaging.Kafka/README.md
@@ -4,7 +4,7 @@ Apache Kafka transport provider for the messaging system.
 
 ## Problem Solved
 
-Enables high-throughput, distributed event streaming using Apache Kafka with consumer groups, partitions, and exactly-once semantics.
+Enables high-throughput, distributed event streaming using Apache Kafka with consumer groups, partitions, and broker-level ordering controls.
 
 ## Key Features
 
@@ -12,7 +12,7 @@ Enables high-throughput, distributed event streaming using Apache Kafka with con
 - **Partitioning**: Parallel processing with ordered delivery per partition
 - **Consumer Groups**: Load balancing across consumers
 - **Retention**: Persistent message storage with configurable retention
-- **Exactly-Once**: Transactional publishing and consuming
+- **Kafka Configuration Access**: Exposes raw Kafka producer and consumer settings through `MainConfig` and consumer-specific options
 
 ## Installation
 
@@ -119,6 +119,7 @@ options.EnableSubscriberParallelExecute = false; // Disable parallel execution
 - `FetchTopicsAsync(...)` creates concrete topics when auto-create is enabled and normalizes wildcard subscriptions.
 - `SubscribeAsync(...)` joins the configured consumer group to those topics.
 - Partition keys control ordering. Parallel handlers or multiple partitions can reorder observed processing.
+- Headless delivery remains at-least-once. Configure Kafka idempotence or read-committed isolation when you need those broker-level features, and keep consumers idempotent.
 - Topic names, header sizes, and record sizes follow Kafka broker limits.
 
 ## Dependencies

--- a/src/Headless.Messaging.RabbitMq/README.md
+++ b/src/Headless.Messaging.RabbitMq/README.md
@@ -1,23 +1,24 @@
-# Headless.Messaging.RabbitMQ
+# Headless.Messaging.RabbitMq
 
 RabbitMQ transport provider for the messaging system.
 
 ## Problem Solved
 
-Enables reliable message delivery using RabbitMQ with exchanges, queues, routing keys, and advanced AMQP features for flexible pub/sub patterns.
+Enables Headless bus and queue delivery over RabbitMQ using a topic exchange, queue bindings, routing keys, publisher confirms, consumer acknowledgements, and configurable queue arguments.
 
 ## Key Features
 
-- **Exchange/Queue Model**: Flexible routing with topic, direct, fanout, and headers exchanges
-- **Reliability**: Publisher confirms, consumer acknowledgments, and dead-letter exchanges
+- **Topic Exchange/Queue Model**: Declares a topic exchange and binds consumer queues with routing keys derived from message registrations
+- **Reliability**: Optional publisher confirms plus consumer acknowledgments and rejects
 - **Auto-Provisioning**: Automatic exchange and queue creation
-- **Clustering**: High availability with RabbitMQ clusters
-- **Priority Queues**: Message priority support
+- **Clustering**: Comma-separated broker host names for RabbitMQ cluster connectivity
+- **Queue Arguments**: Queue TTL, queue mode, and queue type are exposed through `RabbitMqOptions.QueueArguments`
+- **Consumer QoS**: Global and per-consumer prefetch configuration
 
 ## Installation
 
 ```bash
-dotnet add package Headless.Messaging.RabbitMQ
+dotnet add package Headless.Messaging.RabbitMq
 ```
 
 ## Quick Start
@@ -104,7 +105,7 @@ options.EnableSubscriberParallelExecute = false; // No parallel execution
 
 - **Single consumer**: Messages arrive in publication order
 - **Multiple consumers (`ConsumerThreadCount > 1`)**: No ordering guarantee; concurrent processing
-- **Priority queues**: Higher priority messages delivered first, breaking FIFO order
+- **Broker policies and queue arguments**: Broker-side settings can change observable delivery order
 - **Redelivery after failure**: Failed messages may be redelivered out of order
 
 ### Recommendations
@@ -131,5 +132,6 @@ options.EnableSubscriberParallelExecute = false; // No parallel execution
 ## Side Effects
 
 - Creates exchanges and queues if they don't exist
+- Binds routing keys for configured consumers
 - Establishes persistent connections to RabbitMQ
-- Configures dead-letter exchanges for failed messages
+- Rejects messages with `BasicReject(requeue: true)`; dead-letter behavior follows queue arguments and broker policies outside this package


### PR DESCRIPTION
## Summary

New users can now choose Headless packages by goal, start from a minimal API or local messaging path, and see the messaging guarantees before they reach the full package catalog.

The messaging docs now match the current source shape: `UseInMemory()` is the in-memory transport setup API, consumers implement `IConsume<T>` with `ConsumeContext<T>`, retry/backoff examples use `RetryPolicyOptions`, and outbox guidance distinguishes durable intent from exactly-once delivery. RabbitMQ and Kafka package READMEs now avoid provider claims that were broader than the code-backed contract.

## Notes

Package description/tag generation is still a maintainer confirmation item. I did not add metadata across all packages because the repo may derive NuGet metadata through shared SDK/release tooling.

## Validation

- `rg -n "UseInMemoryTransport|MessageContext|exactly-once retry semantics|exactly-once semantics|Exactly-Once|Headless\\.Messaging\\.RabbitMQ|dead-letter exchanges|Priority Queues|direct, fanout|headers exchanges|github.com/arkanco/headless-framework|Headless\\.Messaging\\.PostgreSql" README.md docs/llms/messaging.md src/Headless.Messaging.Core/README.md src/Headless.Messaging.RabbitMq/README.md src/Headless.Messaging.Kafka/README.md src/Headless.Messaging.Core/Configuration/MessagingOptions.cs || true`
- `git diff --check -- README.md docs/llms/messaging.md src/Headless.Messaging.Core/README.md src/Headless.Messaging.RabbitMq/README.md src/Headless.Messaging.Kafka/README.md src/Headless.Messaging.Core/Configuration/MessagingOptions.cs`
- `dotnet build src/Headless.Messaging.Core/Headless.Messaging.Core.csproj --no-incremental -v:minimal -nologo`
- `make restore`
- Pre-push hook: format check plus `dotnet build "headless-framework.slnx" --configuration "Release" --no-restore -v:q -nologo /clp:ErrorsOnly` passed with 0 warnings and 0 errors.
