### PR TITLE
ci: strengthen validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make rebuild
 
-      - name: "Test with coverage"
+      - name: "Unit tests with coverage"
         run: make ci-test
 
       - name: "Generate coverage summary"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           lfs: false
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -105,16 +106,84 @@ jobs:
         run: make dashboards
         shell: bash
 
-      - name: "Format, build, and pack"
-        # Dashboards are already built above (before the token is present), so we skip
-        # the in-build npm step (BuildDashboardSpa=false) and no lifecycle scripts run
-        # while the credential is available. GITHUB_PACKAGES_TOKEN is scoped to THIS step
-        # only — the earlier `npm ci` never sees it, and it is never written to disk.
-        # NuGet expands it from nuget.config's %GITHUB_PACKAGES_TOKEN% credential entry.
+      - name: "Format check"
+        run: make format-check
+
+      - name: "Build"
+        # Dashboards are already built above (before the token is present), so the
+        # solution build runs with BuildDashboardSpa=false and no lifecycle scripts
+        # run while the credential is available. GITHUB_PACKAGES_TOKEN is scoped to
+        # this restore/build step only and is expanded from nuget.config's
+        # %GITHUB_PACKAGES_TOKEN% credential entry.
         env:
           BuildDashboardSpa: "false"
           GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make ci-build
+        run: make rebuild
+
+      - name: "Test with coverage"
+        run: make ci-test
+
+      - name: "Generate coverage summary"
+        if: always()
+        run: |
+          set -euo pipefail
+
+          if [ -d "${TEST_RESULTS_DIR}" ] && find "${TEST_RESULTS_DIR}" -name '*.cobertura.xml' -print -quit | grep -q .; then
+            dotnet reportgenerator \
+              -reports:"${TEST_RESULTS_DIR}/**/*.cobertura.xml" \
+              -targetdir:"./artifacts/coverage/report" \
+              -reporttypes:"Html;JsonSummary"
+          else
+            echo "::warning::No Cobertura coverage files were found under ${TEST_RESULTS_DIR}."
+          fi
+        shell: bash
+
+      - name: "Pack"
+        run: make pack-built
+
+      - name: "Verify package artifacts"
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          packages=("${PACKAGES_DIR}"/*.nupkg)
+          symbols=("${PACKAGES_DIR}"/*.snupkg)
+
+          if [ "${#packages[@]}" -eq 0 ]; then
+            echo "No .nupkg files were created in ${PACKAGES_DIR}."
+            exit 1
+          fi
+
+          if [ "${#symbols[@]}" -eq 0 ]; then
+            echo "No .snupkg files were created in ${PACKAGES_DIR}."
+            exit 1
+          fi
+
+          echo "Created ${#packages[@]} package(s) and ${#symbols[@]} symbol package(s)."
+        shell: bash
+
+      - name: "Upload test results"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results
+          path: |
+            artifacts/test-results/**/*.trx
+            artifacts/test-results/**/*.dmp
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: "Upload coverage results"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-results
+          path: |
+            artifacts/test-results/**/*.cobertura.xml
+            artifacts/test-results/**/*.coverage
+            artifacts/coverage/report/**
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: "Publish Artifacts"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           lfs: false
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -61,13 +62,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - name: "Authenticate GitHub Packages"
-        env:
-          GH_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: dotnet nuget update source github.com --username xshaheen --password "$GH_PACKAGES_TOKEN" --store-password-in-clear-text --configfile nuget.config
-        shell: bash
-
       - name: "Restore"
+        env:
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make restore
 
       - name: Initialize CodeQL

--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           lfs: false
+          persist-credentials: false
 
       - name: "Setup Node"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/r2-conformance.yml
+++ b/.github/workflows/r2-conformance.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -62,14 +63,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - name: "Authenticate GitHub Packages"
-        run: dotnet nuget update source github.com --username xshaheen --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --configfile nuget.config
-        shell: bash
+      - name: "Restore"
+        env:
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make restore-project PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
+
+      - name: "Build"
+        run: make build-project-no-restore PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
 
       - name: "Run R2 conformance suite"
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        run: make test-project TEST_PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
+        run: make test-project-fast TEST_PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ hook-build: ## Git hook: incremental solution build over warm outputs (no restor
 	$(DOTNET) build "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-restore -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
 
 .PHONY: ci-build
-ci-build: format-check rebuild pack-built ## CI: check formatting, clean-build, then pack already-built projects.
+ci-build: format-check rebuild ci-test pack-built ## CI: check formatting, clean-build, test with coverage, then pack already-built projects.
 
 .PHONY: build
 build: restore ## Build the solution.
@@ -116,6 +116,11 @@ rebuild-no-restore: ## Build without restore or incremental compilation; use aft
 .PHONY: build-project
 build-project: restore-project ## Build one project; preferred when working on a specified project.
 	@test -n "$(PROJECT)" || (echo "PROJECT is required. Example: make build-project PROJECT=src/Headless.Api/Headless.Api.csproj" && exit 2)
+	$(DOTNET) build "$(PROJECT)" --configuration "$(CONFIGURATION)" --no-restore -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
+
+.PHONY: build-project-no-restore
+build-project-no-restore: ## Build one project without restore; use after restore-project.
+	@test -n "$(PROJECT)" || (echo "PROJECT is required. Example: make build-project-no-restore PROJECT=src/Headless.Api/Headless.Api.csproj" && exit 2)
 	$(DOTNET) build "$(PROJECT)" --configuration "$(CONFIGURATION)" --no-restore -v:q -nologo /clp:ErrorsOnly $(MSBUILD_ARGS)
 
 .PHONY: quality-analyzers
@@ -164,6 +169,11 @@ test: build ## Build, then run all tests. Use TEST_FILTER='--filter-class X' for
 test-fast: ## Run all tests without restore/build. Requires existing $(CONFIGURATION) build outputs.
 	@mkdir -p "$(TEST_RESULTS_DIR)"
 	$(DOTNET) test --solution "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-build --no-restore --results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) $(TEST_ARGS) $(TEST_FILTER)
+
+.PHONY: ci-test
+ci-test: ## Run prebuilt tests with CI coverage output. Requires existing $(CONFIGURATION) build outputs.
+	@mkdir -p "$(TEST_RESULTS_DIR)"
+	$(DOTNET) test --solution "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-build --no-restore --results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) $(TEST_ARGS) $(TEST_FILTER) $(COVERAGE_ARGS)
 
 .PHONY: test-modules
 test-modules: build ## Run prebuilt test DLLs via MTP --test-modules. Override TEST_MODULES if needed.

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ TEST_MAX_PARALLEL ?= 3
 TEST_TIMEOUT ?= 15m
 
 COVERAGE_ARGS ?= -p:EnableCodeCoverage=true --coverage-output-format cobertura
+CI_TEST_ARGS ?= --report-trx --coverage --coverage-output-format cobertura
 
 .PHONY: help
 help: ## Show available commands.
@@ -171,9 +172,9 @@ test-fast: ## Run all tests without restore/build. Requires existing $(CONFIGURA
 	$(DOTNET) test --solution "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-build --no-restore --results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) $(TEST_ARGS) $(TEST_FILTER)
 
 .PHONY: ci-test
-ci-test: ## Run prebuilt tests with CI coverage output. Requires existing $(CONFIGURATION) build outputs.
+ci-test: ## Run prebuilt unit tests with CI coverage output. Requires existing $(CONFIGURATION) build outputs.
 	@mkdir -p "$(TEST_RESULTS_DIR)"
-	$(DOTNET) test --solution "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-build --no-restore --results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) $(TEST_ARGS) $(TEST_FILTER) $(COVERAGE_ARGS)
+	$(DOTNET) test --test-modules "$(UNIT_TEST_MODULES)" --root-directory "$(CURDIR)" --results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) $(TEST_ARGS) $(TEST_FILTER) $(CI_TEST_ARGS)
 
 .PHONY: test-modules
 test-modules: build ## Run prebuilt test DLLs via MTP --test-modules. Override TEST_MODULES if needed.


### PR DESCRIPTION
## Summary

CI now validates package-producing changes with a clearer required path: format check, clean Release build, unit test execution with coverage, package creation, and explicit package artifact sanity checks all run before any publish job can start. Test, coverage, and diagnostic artifacts are uploaded from the build job so failures leave reviewable evidence instead of only log output.

The publish behavior is unchanged: GitHub Packages still publish only from `main` or release events, and nuget.org still publishes only from release events. Restore credentials are now scoped to restore/build steps and checkouts no longer persist credentials into workspaces that build or test PR code.

Main CI intentionally runs unit tests only. Provider integration and conformance suites remain outside the required CI test target because they need Docker, external services, or protected credentials; R2 continues to run through its dedicated conformance workflow.

Analyzer verification remains covered by the Release build through the Headless SDK/MSBuild analyzer setup. I did not add `dotnet format analyzers` as a required CI step because the solution-wide formatter-analyzer scan was materially too slow for the fast-feedback goal.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/codeql-analysis.yml .github/workflows/dashboards.yml .github/workflows/r2-conformance.yml`
- `git diff --check`
- `make -n ci-build`
- `make -n build-project-no-restore PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj`
- `make -n test-project-fast TEST_PROJECT=tests/Headless.Blobs.CloudflareR2.Tests.Integration/Headless.Blobs.CloudflareR2.Tests.Integration.csproj`
- `make restore-project PROJECT=tests/Headless.Checks.Tests.Unit/Headless.Checks.Tests.Unit.csproj`
- `make build-project-no-restore PROJECT=tests/Headless.Checks.Tests.Unit/Headless.Checks.Tests.Unit.csproj`
- `make test-project-fast TEST_PROJECT=tests/Headless.Checks.Tests.Unit/Headless.Checks.Tests.Unit.csproj` passed 392 tests
- `make ci-test UNIT_TEST_MODULES=tests/Headless.Checks.Tests.Unit/bin/Release/net10.0/Headless.Checks.Tests.Unit.dll TEST_RESULTS_DIR=artifacts/test-results-unit-smoke3` passed 392 tests and produced TRX plus Cobertura output
- `dotnet reportgenerator -reports:"artifacts/test-results-unit-smoke3/**/*.cobertura.xml" -targetdir:"artifacts/coverage-unit-smoke3/report" -reporttypes:"Html;JsonSummary"` produced `Summary.json`
- Pre-push hook: incremental Release solution build passed with 0 warnings and 0 errors
