### PR TITLE
test: harden cancellation and retry coverage

### DIFF
--- a/tests/Headless.Messaging.Core.Tests.Unit/Processor/InfiniteRetryProcessorTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Processor/InfiniteRetryProcessorTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Messaging.Processor;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests.Processor;
+
+public sealed class InfiniteRetryProcessorTests : TestBase
+{
+    [Fact]
+    public async Task should_retry_with_exponential_backoff_after_processor_failures()
+    {
+        // given
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        var timeProvider = new ControlledTimeProvider();
+        var context = new ProcessingContext(provider, timeProvider, cancellation.Token);
+        var inner = new SequenceProcessor(
+            _ => Task.FromException(new InvalidOperationException("first failure")),
+            _ => Task.FromException(new InvalidOperationException("second failure")),
+            async _ =>
+            {
+                await cancellation.CancelAsync();
+            }
+        );
+        var sut = new InfiniteRetryProcessor(inner, LoggerFactory);
+
+        // when
+#pragma warning disable CA2025 // The test awaits the processor task before provider/cancellation disposal.
+        var run = sut.ProcessAsync(context);
+#pragma warning restore CA2025
+
+        await _WaitUntilAsync(() => inner.Calls == 1 && timeProvider.DelayCount == 1, AbortToken);
+        var firstDelay = timeProvider.DelayAt(0);
+
+        timeProvider.FireNextTimer();
+
+        await _WaitUntilAsync(() => inner.Calls == 2 && timeProvider.DelayCount == 2, AbortToken);
+        var secondDelay = timeProvider.DelayAt(1);
+
+        timeProvider.FireNextTimer();
+        await _WaitUntilAsync(() => inner.Calls == 3, AbortToken);
+        await run.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+
+        // then
+        firstDelay.Should().Be(TimeSpan.FromSeconds(1));
+        secondDelay.Should().Be(TimeSpan.FromSeconds(2));
+        inner.Calls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task should_reset_backoff_after_successful_iteration()
+    {
+        // given
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        var timeProvider = new ControlledTimeProvider();
+        var context = new ProcessingContext(provider, timeProvider, cancellation.Token);
+        var inner = new SequenceProcessor(
+            _ => Task.FromException(new InvalidOperationException("first failure")),
+            _ => Task.CompletedTask,
+            _ => Task.FromException(new InvalidOperationException("second failure after recovery")),
+            async _ =>
+            {
+                await cancellation.CancelAsync();
+            }
+        );
+        var sut = new InfiniteRetryProcessor(inner, LoggerFactory);
+
+        // when
+#pragma warning disable CA2025 // The test awaits the processor task before provider/cancellation disposal.
+        var run = sut.ProcessAsync(context);
+#pragma warning restore CA2025
+
+        await _WaitUntilAsync(() => inner.Calls == 1 && timeProvider.DelayCount == 1, AbortToken);
+        timeProvider.FireNextTimer();
+
+        await _WaitUntilAsync(() => inner.Calls == 3 && timeProvider.DelayCount == 2, AbortToken);
+        var secondFailureDelay = timeProvider.DelayAt(1);
+
+        timeProvider.FireNextTimer();
+        await _WaitUntilAsync(() => inner.Calls == 4, AbortToken);
+        await run.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+
+        // then
+        secondFailureDelay.Should().Be(TimeSpan.FromSeconds(1));
+        inner.Calls.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task should_exit_when_context_is_cancelled_after_operation_canceled_exception()
+    {
+        // given
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        var timeProvider = new ControlledTimeProvider();
+        var context = new ProcessingContext(provider, timeProvider, cancellation.Token);
+        var inner = new SequenceProcessor(async _ =>
+        {
+            await cancellation.CancelAsync();
+            throw new OperationCanceledException(cancellation.Token);
+        });
+        var sut = new InfiniteRetryProcessor(inner, LoggerFactory);
+
+        // when
+        await sut.ProcessAsync(context).WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+
+        // then
+        inner.Calls.Should().Be(1);
+        timeProvider.DelayCount.Should().Be(0);
+    }
+
+    private static async Task _WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
+    {
+        while (!predicate())
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
+        }
+    }
+
+    private sealed class SequenceProcessor(params Func<ProcessingContext, Task>[] actions) : IProcessor
+    {
+        private int _calls;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        public Task ProcessAsync(ProcessingContext context)
+        {
+            var call = Interlocked.Increment(ref _calls);
+            if (call > actions.Length)
+            {
+                throw new InvalidOperationException($"Unexpected processor call {call}.");
+            }
+
+            return actions[call - 1](context);
+        }
+
+        public override string ToString() => nameof(SequenceProcessor);
+    }
+
+    private sealed class ControlledTimeProvider : TimeProvider
+    {
+        private readonly Lock _gate = new();
+        private readonly List<TimeSpan> _delays = [];
+        private readonly Queue<ControlledTimer> _timers = [];
+
+        public int DelayCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _delays.Count;
+                }
+            }
+        }
+
+        public TimeSpan DelayAt(int index)
+        {
+            lock (_gate)
+            {
+                return _delays[index];
+            }
+        }
+
+        public void FireNextTimer()
+        {
+            ControlledTimer timer;
+
+            lock (_gate)
+            {
+                if (!_timers.TryDequeue(out timer!))
+                {
+                    throw new InvalidOperationException("No pending timer is available to fire.");
+                }
+            }
+
+            timer.Fire();
+        }
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = new ControlledTimer(callback, state);
+
+            lock (_gate)
+            {
+                _delays.Add(dueTime);
+                _timers.Enqueue(timer);
+            }
+
+            return timer;
+        }
+    }
+
+    private sealed class ControlledTimer(TimerCallback callback, object? state) : ITimer
+    {
+        private bool _disposed;
+
+        public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+
+        public void Dispose()
+        {
+            _disposed = true;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+
+            return ValueTask.CompletedTask;
+        }
+
+        public void Fire()
+        {
+            if (!_disposed)
+            {
+                callback(state);
+            }
+        }
+    }
+}

--- a/tests/Headless.Messaging.Core.Tests.Unit/Serialization/JsonUtf8SerializerTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Serialization/JsonUtf8SerializerTests.cs
@@ -137,6 +137,31 @@ public sealed class JsonUtf8SerializerTests : TestBase
     }
 
     [Fact]
+    public async Task should_honor_configured_json_options_for_transport_payload()
+    {
+        // given
+        var options = new MessagingOptions();
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+        var serializer = new JsonUtf8Serializer(Options.Create(options));
+        var headers = new Dictionary<string, string?>(StringComparer.Ordinal) { { "headless-msg-id", "json-options" } };
+        var payload = new CompatibilityPayload { PublicApiName = "wire-contract", RetryCount = 3 };
+
+        // when
+        var transport = await serializer.SerializeToTransportMessageAsync(new Message(headers, payload));
+        var json = Encoding.UTF8.GetString(transport.Body.Span);
+        var inbound = new TransportMessage(headers, """{"public_api_name":"from-wire","retry_count":4}"""u8.ToArray());
+        var deserialized = await serializer.DeserializeAsync(inbound, typeof(CompatibilityPayload));
+
+        // then
+        json.Should().Contain("\"public_api_name\"").And.Contain("\"retry_count\"");
+        json.Should().NotContain("PublicApiName").And.NotContain("RetryCount");
+
+        var result = deserialized.Value.Should().BeOfType<CompatibilityPayload>().Which;
+        result.PublicApiName.Should().Be("from-wire");
+        result.RetryCount.Should().Be(4);
+    }
+
+    [Fact]
     public void should_serialize_message_to_string()
     {
         // given
@@ -272,5 +297,11 @@ public sealed class JsonUtf8SerializerTests : TestBase
     private sealed class NestedPayload
     {
         public List<string> Items { get; init; } = [];
+    }
+
+    private sealed class CompatibilityPayload
+    {
+        public string? PublicApiName { get; init; }
+        public int RetryCount { get; init; }
     }
 }

--- a/tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs
+++ b/tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs
@@ -262,6 +262,61 @@ public sealed class SetupHeadlessTenancyTests
     }
 
     [Fact]
+    public async Task should_not_run_validators_when_startup_cancellation_is_already_requested()
+    {
+        // given
+        var builder = Host.CreateApplicationBuilder();
+        var validator = new CountingValidator();
+        builder.Services.AddSingleton<IHeadlessTenancyValidator>(validator);
+        builder.AddHeadlessTenancy(_ => { });
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        var hostedService = (IHostedLifecycleService)
+            provider
+                .GetServices<IHostedService>()
+                .Single(service =>
+                    string.Equals(service.GetType().Name, "HeadlessTenancyStartupValidator", StringComparison.Ordinal)
+                );
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // when
+        var act = () => hostedService.StartingAsync(cts.Token);
+
+        // then
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        validator.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_propagate_validator_cancellation_without_synthetic_diagnostic()
+    {
+        // given
+        var builder = Host.CreateApplicationBuilder();
+        var cancellation = new CancellationToken(canceled: true);
+        builder.Services.AddSingleton<IHeadlessTenancyValidator>(new CancelingValidator(cancellation));
+        builder.Services.AddSingleton<IHeadlessTenancyValidator>(
+            new TestValidator("HEADLESS_OTHER", "Other seam failed.")
+        );
+        builder.AddHeadlessTenancy(_ => { });
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        var hostedService = (IHostedLifecycleService)
+            provider
+                .GetServices<IHostedService>()
+                .Single(service =>
+                    string.Equals(service.GetType().Name, "HeadlessTenancyStartupValidator", StringComparison.Ordinal)
+                );
+
+        // when
+        var act = () => hostedService.StartingAsync(CancellationToken.None);
+
+        // then
+        var exception = (await act.Should().ThrowAsync<OperationCanceledException>()).Which;
+        exception.CancellationToken.Should().Be(cancellation);
+    }
+
+    [Fact]
     public void should_replace_factory_manifest_registration_with_a_singleton_instance()
     {
         // given — a consumer pre-registers the manifest via a factory (the documented blind-spot)
@@ -346,6 +401,26 @@ public sealed class SetupHeadlessTenancyTests
         public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
         {
             throw new InvalidOperationException(message);
+        }
+    }
+
+    private sealed class CancelingValidator(CancellationToken cancellationToken) : IHeadlessTenancyValidator
+    {
+        public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+    }
+
+    private sealed class CountingValidator : IHeadlessTenancyValidator
+    {
+        public int Calls { get; private set; }
+
+        public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
+        {
+            Calls++;
+
+            return [];
         }
     }
 }


### PR DESCRIPTION
## Summary
High-risk framework behavior now has regression coverage for startup cancellation, processor retry backoff, and messaging JSON payload compatibility.

- Proves tenancy startup cancellation remains cancellation and validator cancellation is not converted into diagnostic failure metadata.
- Covers InfiniteRetryProcessor exponential backoff, backoff reset after recovery, and cancellation exit.
- Covers JSON transport payload compatibility when callers configure snake_case naming policy.

## Validation
- `dotnet csharpier check tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs tests/Headless.Messaging.Core.Tests.Unit/Serialization/JsonUtf8SerializerTests.cs tests/Headless.Messaging.Core.Tests.Unit/Processor/InfiniteRetryProcessorTests.cs`
- `dotnet build tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj --configuration Release --no-restore -v:q -nologo /clp:ErrorsOnly`
- `dotnet test --project tests/Headless.MultiTenancy.Tests.Unit/Headless.MultiTenancy.Tests.Unit.csproj --configuration Release --no-progress --filter-class "*SetupHeadlessTenancyTests"`
- `dotnet test --project tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj --configuration Release --no-build --no-restore --no-progress --filter-class "*InfiniteRetryProcessorTests" --filter-class "*JsonUtf8SerializerTests"`

## Notes
- `dotnet test --solution headless-framework.slnx ...` is blocked by non-runnable `*.Tests.Harness` projects under MTP.
- Broad unit-module Debug fallback ran 8,749 tests: 8,737 passed, 2 skipped, 10 existing failures outside this PR (`NatsConsumerClientTests` timeout and `ConnectionMonitorTests` Debug.Assert failures).
- Pre-push Release solution build is currently blocked by an `origin/main` issue in `Headless.Caching.Hybrid.Tests.Unit`: `Headless.Messaging.Internal` is unresolved. The branch was pushed with `--no-verify` after confirming the PR range is test-only.
