### PR TITLE
perf: reduce messaging and cache hot-path allocations

### DIFF
--- a/benchmarks/Headless.Caching.Benchmarks/Program.cs
+++ b/benchmarks/Headless.Caching.Benchmarks/Program.cs
@@ -11,5 +11,6 @@ BenchmarkSwitcher
         typeof(DistributedOnlyCacheBenchmarks),
         typeof(FactoryCacheBenchmarks),
         typeof(FeatureCacheBenchmarks),
+        typeof(InMemorySetPagingBenchmarks),
     ])
     .Run(args, BenchmarkRunConfig.Create(args));

--- a/benchmarks/Headless.Caching.Benchmarks/README.md
+++ b/benchmarks/Headless.Caching.Benchmarks/README.md
@@ -47,3 +47,4 @@ BenchmarkDotNet writes Markdown and HTML artifacts under `artifacts/benchmark/ca
 - Distributed-only lane: Headless Redis, FusionCache Redis with memory skipped, Foundatio Redis, and Microsoft Redis `IDistributedCache`.
 - Factory lane: atomic `GetOrAdd` providers only.
 - Feature lane: providers with hybrid, fail-safe, or eager-refresh semantics only.
+- In-memory set paging lane: direct `InMemoryCache.GetSetAsync<string>` paging over 100 and 10,000 member sets.

--- a/benchmarks/Headless.Caching.Benchmarks/Scenarios/InMemorySetPagingBenchmarks.cs
+++ b/benchmarks/Headless.Caching.Benchmarks/Scenarios/InMemorySetPagingBenchmarks.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+
+namespace Headless.Caching.Benchmarks.Scenarios;
+
+/// <summary>
+/// Measures the Headless in-memory set paging path directly. The benchmark isolates the page read from provider
+/// comparison overhead so allocation changes in <see cref="InMemoryCache.GetSetAsync{T}"/> are easy to inspect.
+/// </summary>
+[MemoryDiagnoser]
+public sealed class InMemorySetPagingBenchmarks : IDisposable
+{
+    private readonly TimeSpan _expiration = TimeSpan.FromMinutes(5);
+    private InMemoryCache? _cache;
+    private string _key = "";
+
+    [Params(100, 10_000)]
+    public int SetSize { get; set; }
+
+    [Params(1, 50)]
+    public int PageIndex { get; set; }
+
+    [Params(50)]
+    public int PageSize { get; set; }
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        _cache = new InMemoryCache(TimeProvider.System, new InMemoryCacheOptions());
+        _key = string.Create(CultureInfo.InvariantCulture, $"set:{SetSize}:{PageIndex}:{Guid.NewGuid():N}");
+        var values = Enumerable
+            .Range(0, SetSize)
+            .Select(static i => string.Create(CultureInfo.InvariantCulture, $"item-{i}"));
+        await _cache.SetAddAsync(_key, values, _expiration, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup() => Dispose();
+
+    public void Dispose()
+    {
+        _cache?.Dispose();
+        _cache = null;
+        GC.SuppressFinalize(this);
+    }
+
+    [Benchmark]
+    public async ValueTask<CacheValue<ICollection<string>>> GetStringSetPageAsync()
+    {
+        return await Cache.GetSetAsync<string>(_key, PageIndex, PageSize, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private InMemoryCache Cache =>
+        _cache ?? throw new InvalidOperationException("Benchmark cache was not initialized.");
+}

--- a/benchmarks/Headless.Messaging.Benchmarks/Program.cs
+++ b/benchmarks/Headless.Messaging.Benchmarks/Program.cs
@@ -5,5 +5,5 @@ using Headless.Messaging.Benchmarks;
 using Headless.Messaging.Benchmarks.Scenarios;
 
 BenchmarkSwitcher
-    .FromTypes([typeof(ConsumeDispatchBenchmarks), typeof(MessageHeaderBenchmarks)])
+    .FromTypes([typeof(ConsumeDispatchBenchmarks), typeof(PublishDispatchBenchmarks), typeof(MessageHeaderBenchmarks)])
     .Run(args, BenchmarkRunConfig.Create());

--- a/benchmarks/Headless.Messaging.Benchmarks/README.md
+++ b/benchmarks/Headless.Messaging.Benchmarks/README.md
@@ -1,12 +1,11 @@
 # Headless Messaging Benchmarks
 
-Micro-benchmarks for the per-message **consume dispatch** path in `Headless.Messaging.Core`. The suite
+Micro-benchmarks for the per-message **publish/consume dispatch** paths in `Headless.Messaging.Core`. The suite
 isolates the residual per-dispatch allocation costs identified by the hot-path performance audit
 (`.context/docs/perf-audit-22-06-2026.md`) so candidate optimizations can be validated against a baseline.
 
-The benchmarks drive `ConsumeMiddlewarePipeline.ExecuteAsync` directly (synchronous, in-process, no transport
-or background processor), so they measure exactly the dispatch plumbing — not transport or storage I/O. The
-project is granted `InternalsVisibleTo` by `Headless.Messaging.Core` to reach the internal pipeline.
+The benchmarks drive the publish/consume middleware pipelines directly (synchronous, in-process, no transport
+or background processor), so they measure exactly the dispatch plumbing — not transport or storage I/O.
 
 ## Run
 
@@ -27,10 +26,11 @@ always enabled — the **Allocated** column is the headline metric for these all
 ## Lanes
 
 - **`ConsumeDispatchBenchmarks`** — full per-dispatch path via `ExecuteAsync`, parameterized by registered
-  middleware count (0 / 1 / 5). Each call exercises three audit findings together:
-  - **F-2** middleware resolution (`_ResolveMiddleware`): `MakeGenericType` + `GetServices` + LINQ per call.
-  - **F-3** reflection dispatch fallback (`_DispatchAsync`): `MakeGenericMethod(...).Invoke(...)` per call
-    (the descriptor carries no `HandlerId`, so the runtime-invoker fast path is skipped).
+  middleware count (0 / 1 / 5). Each call exercises the residual consume dispatch costs:
+  - **F-2** middleware resolution (`_ResolveMiddleware`): `GetServices` + LINQ/array materialization per call.
   - **F-14** header copy: `new MessageHeader(originHeaders)` clones the header dictionary per call.
+- **`PublishDispatchBenchmarks`** — full per-publish path via `ExecuteAsync`, parameterized by middleware count
+  (0 / 1 / 5) and header count (0 / 8). This isolates publish-context creation, header snapshotting, middleware
+  service resolution, and delegate-chain construction without transport/storage work.
 - **`MessageHeaderBenchmarks`** — isolates **F-14**: `new MessageHeader(headers)` parameterized by header
   count (4 / 8 / 16), so the copy cost can be read independently of the rest of the dispatch path.

--- a/benchmarks/Headless.Messaging.Benchmarks/Scenarios/ConsumeDispatchBenchmarks.cs
+++ b/benchmarks/Headless.Messaging.Benchmarks/Scenarios/ConsumeDispatchBenchmarks.cs
@@ -11,11 +11,9 @@ namespace Headless.Messaging.Benchmarks.Scenarios;
 
 /// <summary>
 /// Measures the per-message consume dispatch path (<see cref="ConsumeMiddlewarePipeline.ExecuteAsync"/>).
-/// Each call exercises the three audit findings on this path:
+/// Each call exercises the residual hot-path costs on this path:
 /// <list type="bullet">
-/// <item>F-2 — middleware resolution (<c>_ResolveMiddleware</c>): MakeGenericType + GetServices + LINQ per call.</item>
-/// <item>F-3 — reflection dispatch fallback (<c>_DispatchAsync</c>): the descriptor carries no HandlerId, so
-/// dispatch goes through <c>MakeGenericMethod(...).Invoke(...)</c> per call.</item>
+/// <item>F-2 — middleware resolution (<c>_ResolveMiddleware</c>): GetServices + LINQ/array materialization per call.</item>
 /// <item>F-14 — header copy: <c>new MessageHeader(originHeaders)</c> clones the header dictionary per call.</item>
 /// </list>
 /// Vary <see cref="MiddlewareCount"/> to characterize the F-2 component.

--- a/benchmarks/Headless.Messaging.Benchmarks/Scenarios/PublishDispatchBenchmarks.cs
+++ b/benchmarks/Headless.Messaging.Benchmarks/Scenarios/PublishDispatchBenchmarks.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using Headless.Messaging.Benchmarks.Support;
+using Headless.Messaging.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Headless.Messaging.Benchmarks.Scenarios;
+
+/// <summary>
+/// Measures the per-message publish dispatch path (<see cref="PublishMiddlewarePipeline.ExecuteAsync{T}"/>).
+/// Each call exercises publish-context creation, header snapshotting, middleware service resolution, and
+/// delegate-chain construction without transport or storage I/O.
+/// </summary>
+[MemoryDiagnoser]
+public class PublishDispatchBenchmarks
+{
+    private ServiceProvider _provider = null!;
+    private PublishMiddlewarePipeline _pipeline = null!;
+    private BenchmarkPayload _payload = null!;
+    private PublishOptions _options = null!;
+
+    [Params(0, 1, 5)]
+    public int MiddlewareCount { get; set; }
+
+    [Params(0, 8)]
+    public int HeaderCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+
+        for (var i = 0; i < MiddlewareCount; i++)
+        {
+            services.AddScoped<IPublishMiddleware<PublishContext>, NoOpPublishMiddleware>();
+        }
+
+        _provider = services.BuildServiceProvider();
+        _pipeline = new PublishMiddlewarePipeline(_provider);
+        _payload = new BenchmarkPayload("payload");
+        _options = _CreateOptions(HeaderCount);
+
+        _pipeline
+            .ExecuteAsync(
+                _payload,
+                IntentType.Bus,
+                _options,
+                delayTime: null,
+                static (_, _, _) => Task.CompletedTask,
+                cancellationToken: CancellationToken.None
+            )
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _provider.Dispose();
+
+    [Benchmark]
+    public Task ExecuteDispatch()
+    {
+        return _pipeline.ExecuteAsync(
+            _payload,
+            IntentType.Bus,
+            _options,
+            delayTime: null,
+            static (_, _, _) => Task.CompletedTask,
+            cancellationToken: CancellationToken.None
+        );
+    }
+
+    private static PublishOptions _CreateOptions(int headerCount)
+    {
+        var headers = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        for (var i = 0; i < headerCount; i++)
+        {
+            headers[string.Create(CultureInfo.InvariantCulture, $"header-{i}")] = string.Create(
+                CultureInfo.InvariantCulture,
+                $"value-{i}"
+            );
+        }
+
+        return new PublishOptions { Headers = headers };
+    }
+}

--- a/benchmarks/Headless.Messaging.Benchmarks/Support/BenchmarkConsumeSupport.cs
+++ b/benchmarks/Headless.Messaging.Benchmarks/Support/BenchmarkConsumeSupport.cs
@@ -10,8 +10,7 @@ public sealed record BenchmarkPayload(string Value);
 
 /// <summary>
 /// A no-op <see cref="IMessageDispatcher"/>. Registered in the benchmark service provider so the consume
-/// pipeline's reflection dispatch fallback (no runtime invoker) resolves a target that does no handler work,
-/// isolating the per-dispatch plumbing cost.
+/// pipeline resolves a target that does no handler work, isolating the per-dispatch plumbing cost.
 /// </summary>
 internal sealed class NoOpMessageDispatcher : IMessageDispatcher
 {
@@ -38,4 +37,10 @@ internal sealed class NoOpMessageDispatcher : IMessageDispatcher
 internal sealed class NoOpConsumeMiddleware : IConsumeMiddleware<ConsumeContext>
 {
     public ValueTask InvokeAsync(ConsumeContext context, Func<ValueTask> next) => next();
+}
+
+/// <summary>A pass-through publish middleware used to vary the registered middleware count per publish.</summary>
+internal sealed class NoOpPublishMiddleware : IPublishMiddleware<PublishContext>
+{
+    public ValueTask InvokeAsync(PublishContext context, Func<ValueTask> next) => next();
 }

--- a/src/Headless.Caching.InMemory/InMemoryCache.cs
+++ b/src/Headless.Caching.InMemory/InMemoryCache.cs
@@ -1171,7 +1171,7 @@ public sealed class InMemoryCache
         // miss for that page (Redis parity; HasValue reflects the requested page's members, not key existence).
         var skip = (pageIndex.Value - 1) * pageSize;
         var skipped = 0;
-        var page = new List<T>();
+        var page = new List<T>(pageSize);
 
         foreach (var kvp in dictionary)
         {

--- a/src/Headless.Messaging.Abstractions/MessageHeader.cs
+++ b/src/Headless.Messaging.Abstractions/MessageHeader.cs
@@ -15,9 +15,16 @@ namespace Headless.Messaging;
 /// <see cref="RewriteCallback"/> for the supported write paths inside a consumer handler.
 /// </remarks>
 [PublicAPI]
-public sealed class MessageHeader(IDictionary<string, string?> dictionary)
-    : ReadOnlyDictionary<string, string?>(new Dictionary<string, string?>(dictionary, StringComparer.Ordinal))
+public sealed class MessageHeader : ReadOnlyDictionary<string, string?>
 {
+    /// <summary>Initializes a new snapshot from the supplied header dictionary.</summary>
+    /// <param name="dictionary">The source headers to copy.</param>
+    public MessageHeader(IDictionary<string, string?> dictionary)
+        : base(new Dictionary<string, string?>(dictionary, StringComparer.Ordinal)) { }
+
+    internal MessageHeader()
+        : base(new Dictionary<string, string?>(StringComparer.Ordinal)) { }
+
     internal IDictionary<string, string?>? ResponseHeader { get; set; }
 
     /// <summary>

--- a/src/Headless.Messaging.Core/Internal/ConsumeMiddlewarePipeline.cs
+++ b/src/Headless.Messaging.Core/Internal/ConsumeMiddlewarePipeline.cs
@@ -3,6 +3,7 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using FastExpressionCompiler;
 using Headless.Messaging.Configuration;
 using Headless.Messaging.Messages;
@@ -40,6 +41,13 @@ internal sealed class ConsumeMiddlewarePipeline(
     // Caches the IConsumeMiddleware<TContext> closed service type per concrete ConsumeContext type, so the
     // resolution path avoids running MakeGenericType on every dispatch.
     private static readonly ConcurrentDictionary<Type, Type> _TypedMiddlewareServiceTypes = new();
+
+    // Cache the tracked-type HashSet per (registry, direction). The registry instance is stable for
+    // the application's lifetime, so we never recompute the set on the hot consume path.
+    private static readonly ConditionalWeakTable<
+        IMiddlewareDescriptorRegistry,
+        ConcurrentDictionary<MiddlewareDirection, HashSet<Type>>
+    > _TrackedTypesByRegistry = [];
 
     private readonly ConcurrentDictionary<
         Type,
@@ -231,10 +239,17 @@ internal sealed class ConsumeMiddlewarePipeline(
         MiddlewareDirection direction
     )
     {
-        var trackedTypes = descriptorRegistry!
-            .Descriptors.Where(descriptor => descriptor.Direction == direction)
-            .Select(descriptor => descriptor.MiddlewareType)
-            .ToHashSet();
+        var perDirection = _TrackedTypesByRegistry.GetValue(descriptorRegistry!, static _ => new());
+        var trackedTypes = perDirection.GetOrAdd(
+            direction,
+            (dir, registry) =>
+                [
+                    .. registry
+                        .Descriptors.Where(descriptor => descriptor.Direction == dir)
+                        .Select(descriptor => descriptor.MiddlewareType),
+                ],
+            descriptorRegistry!
+        );
 
         return middleware.Where(current => !trackedTypes.Contains(current.GetType()));
     }

--- a/src/Headless.Messaging.Core/Internal/PublishMiddlewarePipeline.cs
+++ b/src/Headless.Messaging.Core/Internal/PublishMiddlewarePipeline.cs
@@ -33,6 +33,10 @@ internal sealed class PublishMiddlewarePipeline(
     private static readonly ConcurrentDictionary<MiddlewareDispatchKey, PublishMiddlewareInvoker> _TypedInvokers =
         new();
 
+    // Caches the IPublishMiddleware<TContext> closed service type per concrete PublishContext type, so the
+    // resolution path avoids running MakeGenericType on every publish.
+    private static readonly ConcurrentDictionary<Type, Type> _TypedMiddlewareServiceTypes = new();
+
     // Cache the tracked-type HashSet per (registry, direction). The registry instance is stable for
     // the application's lifetime, so we never recompute the set on the hot publish path.
     private static readonly ConditionalWeakTable<
@@ -136,7 +140,7 @@ internal sealed class PublishMiddlewarePipeline(
 
     private object[] _ResolveMiddleware(IServiceProvider provider, PublishContext context)
     {
-        var directMiddleware = _ResolveDirectMiddleware(provider, context).ToArray();
+        var directMiddleware = _ResolveDirectMiddleware(provider, context);
 
         if (
             descriptorRegistry is not null
@@ -158,7 +162,10 @@ internal sealed class PublishMiddlewarePipeline(
 
     private static object[] _ResolveDirectMiddleware(IServiceProvider provider, PublishContext context)
     {
-        var typedServiceType = typeof(IPublishMiddleware<>).MakeGenericType(context.GetType());
+        var typedServiceType = _TypedMiddlewareServiceTypes.GetOrAdd(
+            context.GetType(),
+            static contextType => typeof(IPublishMiddleware<>).MakeGenericType(contextType)
+        );
         var busMiddleware = provider.GetServices<IPublishMiddleware<PublishContext>>().Cast<object>();
         var typedMiddleware = provider
             .GetServices(typedServiceType)

--- a/src/Headless.Messaging.Core/PublishContext.cs
+++ b/src/Headless.Messaging.Core/PublishContext.cs
@@ -27,11 +27,7 @@ public abstract class PublishContext
         IntentType = intentType;
         OptionsCore = options;
         DelayTimeCore = delayTime;
-        Headers = new MessageHeader(
-            options?.Headers is null
-                ? new Dictionary<string, string?>(StringComparer.Ordinal)
-                : new Dictionary<string, string?>(options.Headers, StringComparer.Ordinal)
-        );
+        Headers = _CreateHeaders(options);
         MessageName = options?.MessageName;
         CancellationToken = cancellationToken;
     }
@@ -110,13 +106,12 @@ public abstract class PublishContext
 
     private protected void RefreshOptionSnapshot(MessageOptions? options)
     {
-        Headers = new MessageHeader(
-            options?.Headers is null
-                ? new Dictionary<string, string?>(StringComparer.Ordinal)
-                : new Dictionary<string, string?>(options.Headers, StringComparer.Ordinal)
-        );
+        Headers = _CreateHeaders(options);
         MessageName = options?.MessageName;
     }
+
+    private static MessageHeader _CreateHeaders(MessageOptions? options) =>
+        options?.Headers is null ? new MessageHeader() : new MessageHeader(options.Headers);
 
     private protected bool IsCompleted { get; private set; }
 

--- a/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs
+++ b/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheTests.cs
@@ -1293,6 +1293,24 @@ public sealed class InMemoryCacheTests : TestBase
         paged.Value.Should().BeNull();
     }
 
+    [Fact]
+    public async Task should_page_object_set_items_after_filtering_expired_items()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.SetAddAsync(key, new[] { 1, 2 }, TimeSpan.FromSeconds(1), AbortToken);
+        _timeProvider.Advance(TimeSpan.FromSeconds(2));
+        await cache.SetAddAsync(key, new[] { 3, 4, 5 }, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.GetSetAsync<object>(key, pageIndex: 2, pageSize: 2, cancellationToken: AbortToken);
+
+        // then
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo([5]);
+    }
+
     #endregion
 
     #region SetRemoveAsync
@@ -1451,6 +1469,24 @@ public sealed class InMemoryCacheTests : TestBase
         // then
         page.HasValue.Should().BeTrue();
         page.Value.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task should_page_string_set_items_after_filtering_expired_items()
+    {
+        // given
+        using var cache = _CreateCache();
+        var key = Faker.Random.AlphaNumeric(10);
+        await cache.SetAddAsync(key, new[] { "expired-a", "expired-b" }, TimeSpan.FromSeconds(1), AbortToken);
+        _timeProvider.Advance(TimeSpan.FromSeconds(2));
+        await cache.SetAddAsync(key, new[] { "live-a", "live-b", "live-c" }, TimeSpan.FromMinutes(5), AbortToken);
+
+        // when
+        var result = await cache.GetSetAsync<string>(key, pageIndex: 2, pageSize: 2, cancellationToken: AbortToken);
+
+        // then
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(["live-c"]);
     }
 
     #endregion

--- a/tests/Headless.Messaging.Core.Tests.Unit/ContextTypes/PublishContextTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ContextTypes/PublishContextTests.cs
@@ -113,5 +113,28 @@ public sealed class PublishContextTests : TestBase
         baseContext.MessageName.Should().Be("orders");
     }
 
+    [Fact]
+    public void should_snapshot_headers_from_publish_options()
+    {
+        // given
+        var headers = new Dictionary<string, string?>(StringComparer.Ordinal) { ["x-feature"] = "enabled" };
+        var options = new PublishOptions { Headers = headers };
+
+        // when
+        var context = new PublishingContext<OrderPlaced>(
+            new OrderPlaced("order-1"),
+            IntentType.Bus,
+            options,
+            delayTime: null
+        );
+        headers["x-feature"] = "disabled";
+        headers["x-new"] = "new";
+
+        // then
+        context.Headers.Should().ContainKey("x-feature");
+        context.Headers["x-feature"].Should().Be("enabled");
+        context.Headers.Should().NotContainKey("x-new");
+    }
+
     private sealed record OrderPlaced(string OrderId);
 }


### PR DESCRIPTION
## Summary

This reduces allocation work on the messaging publish/consume hot paths without changing middleware semantics: publish headers now avoid the extra intermediate dictionary copy, publish/consume middleware type metadata is cached, and consume direct-middleware filtering reuses the same tracked-type cache pattern already used by publish.

In-memory set paging now keeps the current `main` streaming semantics and pre-sizes the requested page buffer, while new regression coverage verifies paging after expired members are filtered.

## Benchmark Coverage

| Area | Benchmark coverage | Notes |
| --- | --- | --- |
| Messaging publish dispatch | `PublishDispatchBenchmarks` | Covers publish context creation, header snapshotting, middleware resolution, and delegate-chain construction with 0/1/5 middleware and 0/8 headers. |
| Messaging consume dispatch | Existing lane docs updated | Removes stale reflection-fallback wording so the lane matches the current runtime path. |
| In-memory set paging | `InMemorySetPagingBenchmarks` | Covers `GetSetAsync<string>` paging over 100 and 10,000 member sets. |

No comparative BenchmarkDotNet run is included in this PR. The new lanes are intended to produce the before/after allocation table for follow-up measurement.

## Validation

- `make format-check`
- `make build-project PROJECT=src/Headless.Caching.InMemory/Headless.Caching.InMemory.csproj`
- `make build-project PROJECT=src/Headless.Messaging.Core/Headless.Messaging.Core.csproj`
- `make build-project PROJECT=benchmarks/Headless.Messaging.Benchmarks/Headless.Messaging.Benchmarks.csproj`
- `dotnet build benchmarks/Headless.Caching.Benchmarks/Headless.Caching.Benchmarks.csproj --configuration Release --no-restore -v:q -nologo /clp:ErrorsOnly -m:1 /nr:false`
- `make quality-analyzers-project PROJECT=src/Headless.Messaging.Core/Headless.Messaging.Core.csproj`
- `make quality-analyzers-project PROJECT=src/Headless.Caching.InMemory/Headless.Caching.InMemory.csproj`
- `make quality-analyzers-project PROJECT=benchmarks/Headless.Messaging.Benchmarks/Headless.Messaging.Benchmarks.csproj`
- `make quality-analyzers-project PROJECT=benchmarks/Headless.Caching.Benchmarks/Headless.Caching.Benchmarks.csproj`
- `tests/Headless.Caching.InMemory.Tests.Unit/bin/Release/net10.0/Headless.Caching.InMemory.Tests.Unit -noLogo` after Release build with SourceLink disabled: 231 total, 0 failed
- `tests/Headless.Messaging.Core.Tests.Unit/bin/Release/net10.0/Headless.Messaging.Core.Tests.Unit -noLogo` after Release build with SourceLink disabled: 897 total, 0 failed
- Pre-push hook after `make restore`: format-check plus `dotnet build headless-framework.slnx --configuration Release --no-restore -v:q -nologo /clp:ErrorsOnly`, 0 warnings/errors

Manual diff review completed. Dedicated multi-agent review was not run because this harness exposes subagents only when explicitly requested.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is library hot-path allocation work plus benchmark/test coverage, with no deployed service, endpoint, schema, or runtime configuration change in this repository.
