### PR TITLE
test(messaging): make InMemory transport header test deterministic

### DIFF
--- a/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryQueueTransportTests.cs
+++ b/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryQueueTransportTests.cs
@@ -116,10 +116,10 @@ public sealed class InMemoryQueueTransportTests : TestBase
         // given
         await _consumerClient.SubscribeAsync(["test-messageName"]);
 
-        TransportMessage? receivedMessage = null;
+        var received = new TaskCompletionSource<TransportMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         _consumerClient.OnMessageCallback = (msg, _) =>
         {
-            receivedMessage = msg;
+            received.TrySetResult(msg);
             return Task.CompletedTask;
         };
 
@@ -151,13 +151,12 @@ public sealed class InMemoryQueueTransportTests : TestBase
         // when
         await _transport.SendAsync(message, AbortToken);
 
-        await Task.Delay(100, AbortToken);
+        var receivedMessage = await received.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // then
-        receivedMessage.Should().NotBeNull();
-        receivedMessage!.Value.GetCorrelationId().Should().Be("corr-123");
-        receivedMessage.Value.Headers["custom-header"].Should().Be("custom-value");
+        receivedMessage.GetCorrelationId().Should().Be("corr-123");
+        receivedMessage.Headers["custom-header"].Should().Be("custom-value");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

`Tests.InMemoryQueueTransportTests.should_support_message_headers` failed on main's CI run [28809231854](https://github.com/xshaheen/headless-framework/actions/runs/28809231854) (`a48ec28eb`, #613) — the only red test out of 8,825 — and is currently blocking a green main for the 0.11.0 release.

The test waited a fixed `Task.Delay(100)` after `SendAsync` before asserting the message arrived, which loses the race under CI scheduling pressure. Not a regression: #610 touched only lock files and `InMemoryConsumerClientTests` in this area; the transport source is unchanged.

## What

Applies the same `TaskCompletionSource(RunContinuationsAsynchronously)` + `WaitAsync(5s)` pattern the sibling settlement tests received in #610, and asserts on the awaited message instead of a nullable closure variable.

## Validation

- `make test-project`: 56/56 green
- 12 consecutive local runs of the suite: 0 failures