### PR TITLE
test: close coverage gaps in messaging durability, locks, and emails

### DIFF
--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockCoreHelpersTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockCoreHelpersTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+
+namespace Tests;
+
+public sealed class DistributedLockCoreHelpersTests
+{
+    #region GetBackoffDelay
+
+    [Theory]
+    [InlineData(0, 50)]
+    [InlineData(1, 100)]
+    [InlineData(2, 200)]
+    [InlineData(3, 400)]
+    [InlineData(4, 800)]
+    [InlineData(5, 1600)]
+    public void backoff_should_grow_exponentially_within_jitter_band(int attempt, double expectedBaseMs)
+    {
+        // when
+        var delay = DistributedLockCoreHelpers.GetBackoffDelay(attempt);
+
+        // then — base * 2^attempt with ±25% jitter
+        delay.TotalMilliseconds.Should().BeGreaterThanOrEqualTo(expectedBaseMs * 0.75);
+        delay.TotalMilliseconds.Should().BeLessThanOrEqualTo(expectedBaseMs * 1.25);
+    }
+
+    [Theory]
+    [InlineData(6)]
+    [InlineData(7)]
+    [InlineData(100)]
+    [InlineData(int.MaxValue)]
+    public void backoff_should_cap_at_three_seconds_for_high_attempts(int attempt)
+    {
+        // when — the shift is clamped (no overflow for huge attempt counts) and the delay is
+        // capped at 3s before jitter is applied.
+        var delay = DistributedLockCoreHelpers.GetBackoffDelay(attempt);
+
+        // then — 3000ms cap with ±25% jitter
+        delay.TotalMilliseconds.Should().BeGreaterThanOrEqualTo(3000 * 0.75);
+        delay.TotalMilliseconds.Should().BeLessThanOrEqualTo(3000 * 1.25);
+    }
+
+    #endregion
+
+    #region IsTransientStorageException
+
+    public static TheoryData<Exception> TransientExceptions =>
+        [new TimeoutException(), new IOException("connection reset"), new InvalidDataException("storage blip")];
+
+    public static TheoryData<Exception> NonTransientExceptions =>
+        [
+            new OperationCanceledException(),
+            new TaskCanceledException(),
+            new ObjectDisposedException("storage"),
+            new InvalidOperationException(),
+            new ArgumentException("bad resource"),
+            new ArgumentNullException(),
+            new ArgumentOutOfRangeException(),
+        ];
+
+    [Theory]
+    [MemberData(nameof(TransientExceptions))]
+    public void transient_storage_exceptions_should_be_classified_retryable(Exception exception)
+    {
+        DistributedLockCoreHelpers.IsTransientStorageException(exception).Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(NonTransientExceptions))]
+    public void programmer_errors_and_cancellation_should_not_be_classified_retryable(Exception exception)
+    {
+        DistributedLockCoreHelpers.IsTransientStorageException(exception).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region NormalizeTimeUntilExpires
+
+    [Fact]
+    public void normalize_should_fall_back_to_default_when_null()
+    {
+        // given
+        var defaultTtl = TimeSpan.FromMinutes(20);
+
+        // when
+        var result = DistributedLockCoreHelpers.NormalizeTimeUntilExpires(null, defaultTtl);
+
+        // then
+        result.Should().Be(defaultTtl);
+    }
+
+    [Fact]
+    public void normalize_should_translate_infinite_to_null()
+    {
+        // when
+        var result = DistributedLockCoreHelpers.NormalizeTimeUntilExpires(
+            Timeout.InfiniteTimeSpan,
+            TimeSpan.FromMinutes(20)
+        );
+
+        // then — InfiniteTimeSpan means "no expiration", represented as null downstream
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void normalize_should_pass_finite_positive_value_through()
+    {
+        // given
+        var ttl = TimeSpan.FromSeconds(30);
+
+        // when
+        var result = DistributedLockCoreHelpers.NormalizeTimeUntilExpires(ttl, TimeSpan.FromMinutes(20));
+
+        // then
+        result.Should().Be(ttl);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void normalize_should_reject_zero_or_negative_values(int seconds)
+    {
+        // when
+        var act = () =>
+            DistributedLockCoreHelpers.NormalizeTimeUntilExpires(
+                TimeSpan.FromSeconds(seconds),
+                TimeSpan.FromMinutes(20)
+            );
+
+        // then
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void normalize_should_reject_values_above_int_max_milliseconds()
+    {
+        // given — lease TTLs travel to storage as int milliseconds (Redis PX); a larger value
+        // would silently overflow on cast, so it must be rejected at validation time.
+        var tooLarge = TimeSpan.FromMilliseconds((double)int.MaxValue + 1000);
+
+        // when
+        var act = () => DistributedLockCoreHelpers.NormalizeTimeUntilExpires(tooLarge, TimeSpan.FromMinutes(20));
+
+        // then
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region RequireFiniteLeaseDuration
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void require_finite_should_return_finite_duration_unchanged(bool monitorLease)
+    {
+        // given
+        var ttl = TimeSpan.FromSeconds(15);
+
+        // when
+        var result = DistributedLockCoreHelpers.RequireFiniteLeaseDuration(ttl, monitorLease);
+
+        // then
+        result.Should().Be(ttl);
+    }
+
+    [Fact]
+    public void require_finite_should_throw_when_monitoring_an_infinite_lease()
+    {
+        // when — a monitored lease must have a finite duration for the renewal loop to schedule against
+        var act = () => DistributedLockCoreHelpers.RequireFiniteLeaseDuration(null, monitorLease: true);
+
+        // then
+        act.Should().Throw<ArgumentException>().WithParameterName("timeUntilExpires");
+    }
+
+    [Fact]
+    public void require_finite_should_allow_infinite_lease_without_monitoring()
+    {
+        // when
+        var result = DistributedLockCoreHelpers.RequireFiniteLeaseDuration(null, monitorLease: false);
+
+        // then
+        result.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
+    #endregion
+
+    #region GetWriterWaitingId
+
+    [Fact]
+    public void writer_waiting_id_should_append_the_shared_suffix()
+    {
+        // when
+        var markerId = DistributedLockCoreHelpers.GetWriterWaitingId("lease-1");
+
+        // then — the literal is embedded in the provider Lua scripts as well; changing it here
+        // without changing the scripts would desynchronize the two surfaces.
+        markerId.Should().Be("lease-1:_WRITERWAITING");
+    }
+
+    #endregion
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockExtensionsTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/DistributedLockExtensionsTests.cs
@@ -272,4 +272,236 @@ public sealed class DistributedLockExtensionsTests : TestBase
                 Arg.Any<CancellationToken>()
             );
     }
+
+    [Fact]
+    public async Task release_extension_should_throw_when_provider_is_null()
+    {
+        // given
+        IDistributedLock provider = null!;
+        var distributedLock = Substitute.For<IDistributedLease>();
+
+        // when
+        var act = async () => await provider.ReleaseAsync(distributedLock, AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("provider");
+    }
+
+    [Fact]
+    public async Task should_pass_state_to_async_state_work_and_dispose_handle()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLock>();
+        var distributedLock = Substitute.For<IDistributedLease>();
+        provider
+            .TryAcquireAsync(Arg.Any<string>(), Arg.Any<DistributedLockAcquireOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IDistributedLease?>(distributedLock));
+        var observedState = 0;
+
+        // when — the TState overload avoids a closure; the state must flow into the work delegate
+        var result = await provider.TryUsingAsync(
+            "resource",
+            42,
+            state =>
+            {
+                observedState = state;
+                return Task.CompletedTask;
+            },
+            options: null,
+            AbortToken
+        );
+
+        // then
+        result.Should().BeTrue();
+        observedState.Should().Be(42);
+        await distributedLock.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task should_not_run_async_state_work_when_lock_not_acquired()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLock>();
+        provider
+            .TryAcquireAsync(Arg.Any<string>(), Arg.Any<DistributedLockAcquireOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IDistributedLease?>(null));
+        var workExecuted = false;
+
+        // when
+        var result = await provider.TryUsingAsync(
+            "resource",
+            42,
+            _ =>
+            {
+                workExecuted = true;
+                return Task.CompletedTask;
+            },
+            options: null,
+            AbortToken
+        );
+
+        // then
+        result.Should().BeFalse();
+        workExecuted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_link_lost_token_into_async_state_work_when_loss_observable()
+    {
+        // given — a monitored handle whose LostToken we control; the state+token overload must
+        // hand the work a token linked to lease loss, exactly like the stateless overload.
+        var provider = Substitute.For<IDistributedLock>();
+        var distributedLock = Substitute.For<IDistributedLease>();
+        using var leaseLostCts = new CancellationTokenSource();
+        distributedLock.CanObserveLoss.Returns(true);
+        distributedLock.LostToken.Returns(leaseLostCts.Token);
+        provider
+            .TryAcquireAsync(Arg.Any<string>(), Arg.Any<DistributedLockAcquireOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IDistributedLease?>(distributedLock));
+
+        var observedState = 0;
+        var observedToken = CancellationToken.None;
+        var started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // when
+        var task = provider.TryUsingAsync(
+            "resource",
+            42,
+            async (state, ct) =>
+            {
+                observedState = state;
+                observedToken = ct;
+                started.SetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                }
+                catch (OperationCanceledException) { }
+            },
+            new DistributedLockAcquireOptions { Monitoring = LockMonitoringMode.Monitor },
+            AbortToken
+        );
+
+        await started.Task;
+        await leaseLostCts.CancelAsync();
+        var result = await task;
+
+        // then
+        result.Should().BeTrue();
+        observedState.Should().Be(42);
+        observedToken.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_pass_bare_caller_token_when_loss_not_observable()
+    {
+        // given — an unmonitored handle (CanObserveLoss = false); the token-receiving overload
+        // must pass the caller's token through unchanged instead of allocating a linked source.
+        var provider = Substitute.For<IDistributedLock>();
+        var distributedLock = Substitute.For<IDistributedLease>();
+        distributedLock.CanObserveLoss.Returns(false);
+        provider
+            .TryAcquireAsync(Arg.Any<string>(), Arg.Any<DistributedLockAcquireOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IDistributedLease?>(distributedLock));
+
+        var callerToken = AbortToken;
+        var observedToken = CancellationToken.None;
+
+        // when
+        var result = await provider.TryUsingAsync(
+            "resource",
+            ct =>
+            {
+                observedToken = ct;
+                return Task.CompletedTask;
+            },
+            options: null,
+            callerToken
+        );
+
+        // then
+        result.Should().BeTrue();
+        observedToken.Should().Be(callerToken);
+    }
+
+    [Fact]
+    public async Task should_map_timespan_arguments_into_options_for_sync_work()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLock>();
+        var distributedLock = Substitute.For<IDistributedLease>();
+        provider
+            .TryAcquireAsync(Arg.Any<string>(), Arg.Any<DistributedLockAcquireOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IDistributedLease?>(distributedLock));
+        var workExecuted = false;
+        var timeUntilExpires = TimeSpan.FromMinutes(3);
+        var acquireTimeout = TimeSpan.FromSeconds(7);
+
+        // when — the TimeSpan convenience overload builds the options itself
+        var result = await provider.TryUsingAsync(
+            "resource",
+            () => workExecuted = true,
+            timeUntilExpires,
+            acquireTimeout,
+            AbortToken
+        );
+
+        // then — sync work cannot observe loss, so monitoring is forced off
+        result.Should().BeTrue();
+        workExecuted.Should().BeTrue();
+        await provider
+            .Received(1)
+            .TryAcquireAsync(
+                "resource",
+                Arg.Is<DistributedLockAcquireOptions?>(o =>
+                    o != null
+                    && o.TimeUntilExpires == timeUntilExpires
+                    && o.AcquireTimeout == acquireTimeout
+                    && o.ReleaseOnDispose
+                    && o.Monitoring == LockMonitoringMode.None
+                ),
+                AbortToken
+            );
+    }
+
+    [Fact]
+    public async Task should_map_timespan_arguments_into_options_for_sync_state_work()
+    {
+        // given
+        var provider = Substitute.For<IDistributedLock>();
+        var distributedLock = Substitute.For<IDistributedLease>();
+        provider
+            .TryAcquireAsync(Arg.Any<string>(), Arg.Any<DistributedLockAcquireOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IDistributedLease?>(distributedLock));
+        var observedState = 0;
+        var timeUntilExpires = TimeSpan.FromMinutes(3);
+        var acquireTimeout = TimeSpan.FromSeconds(7);
+
+        // when
+        var result = await provider.TryUsingAsync(
+            "resource",
+            42,
+            state => observedState = state,
+            timeUntilExpires,
+            acquireTimeout,
+            AbortToken
+        );
+
+        // then
+        result.Should().BeTrue();
+        observedState.Should().Be(42);
+        await provider
+            .Received(1)
+            .TryAcquireAsync(
+                "resource",
+                Arg.Is<DistributedLockAcquireOptions?>(o =>
+                    o != null
+                    && o.TimeUntilExpires == timeUntilExpires
+                    && o.AcquireTimeout == acquireTimeout
+                    && o.ReleaseOnDispose
+                    && o.Monitoring == LockMonitoringMode.None
+                ),
+                AbortToken
+            );
+    }
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/ReaderWriterLocks/DistributedReadWriteLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/ReaderWriterLocks/DistributedReadWriteLockTests.cs
@@ -52,6 +52,37 @@ public sealed class DistributedReadWriteLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_return_without_throwing_when_release_exceeds_dispose_timeout()
+    {
+        // given — write-release hangs forever in storage. DisposeTimeout bounds the release so
+        // shutdown is never blocked; on timeout the release returns without throwing and the
+        // record TTL is the eventual-consistency fallback.
+        var storage = Substitute.For<IDistributedReadWriteLockStorage>();
+        storage
+            .ReleaseWriteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask(new TaskCompletionSource().Task));
+
+        var provider = _CreateProvider(
+            storage,
+            options: new DistributedLockOptions { DisposeTimeout = TimeSpan.FromSeconds(5) }
+        );
+
+        // when — run release and advance time past the dispose timeout
+        var releaseTask = provider.ReleaseAsync(ReaderWriterLockMode.Write, "resource", "lease-1", AbortToken);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await Task.Yield();
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var act = async () => await releaseTask;
+
+        // then
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task should_log_safety_deadline_eventid_and_tag_metric_stalled_when_write_deadline_fires()
     {
         // given — write-lock storage that hangs so the non-blocking safety deadline ends the attempt

--- a/tests/Headless.DistributedLocks.Tests.Unit/ReaderWriterLocks/NullDistributedReadWriteLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/ReaderWriterLocks/NullDistributedReadWriteLockTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.ReaderWriterLocks;
+
+public sealed class NullDistributedReadWriteLockTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    private NullDistributedReadWriteLock _CreateProvider() => new(_timeProvider);
+
+    [Fact]
+    public async Task should_acquire_read_lock_immediately()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await using var lease = await provider.AcquireReadLockAsync(resource, cancellationToken: AbortToken);
+
+        // then — the null provider never contends and reports no loss-observation capability
+        lease.Resource.Should().Be(resource);
+        lease.LeaseId.Should().NotBeNullOrEmpty();
+        lease.FencingToken.Should().BeNull();
+        lease.CanObserveLoss.Should().BeFalse();
+        lease.DateAcquired.Should().Be(_timeProvider.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task should_acquire_write_lock_immediately()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await using var lease = await provider.AcquireWriteLockAsync(resource, cancellationToken: AbortToken);
+
+        // then
+        lease.Resource.Should().Be(resource);
+        lease.LeaseId.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task try_acquire_should_never_return_null()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        var readLease = await provider.TryAcquireReadLockAsync(resource, cancellationToken: AbortToken);
+        var writeLease = await provider.TryAcquireWriteLockAsync(resource, cancellationToken: AbortToken);
+
+        // then
+        readLease.Should().NotBeNull();
+        writeLease.Should().NotBeNull();
+
+        await readLease!.DisposeAsync();
+        await writeLease!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task should_report_unlocked_and_zero_readers()
+    {
+        // given — even while a lease is held, the null provider reports no contention state
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var lease = await provider.AcquireWriteLockAsync(resource, cancellationToken: AbortToken);
+
+        // when / then
+        (await provider.IsReadLockedAsync(resource, AbortToken))
+            .Should()
+            .BeFalse();
+        (await provider.IsWriteLockedAsync(resource, AbortToken)).Should().BeFalse();
+        (await provider.GetReaderCountAsync(resource, AbortToken)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task renew_should_succeed_and_increment_renewal_count()
+    {
+        // given
+        var provider = _CreateProvider();
+        await using var lease = await provider.AcquireReadLockAsync(
+            Faker.Random.AlphaNumeric(10),
+            cancellationToken: AbortToken
+        );
+        lease.RenewalCount.Should().Be(0);
+
+        // when
+        var renewed = await lease.RenewAsync(cancellationToken: AbortToken);
+
+        // then
+        renewed.Should().BeTrue();
+        lease.RenewalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_reject_monitoring_with_infinite_lease()
+    {
+        // given — the same contract as the real providers: lease monitoring needs a finite TTL
+        var provider = _CreateProvider();
+        var options = new DistributedLockAcquireOptions
+        {
+            Monitoring = LockMonitoringMode.Monitor,
+            TimeUntilExpires = Timeout.InfiniteTimeSpan,
+        };
+
+        // when
+        var act = async () => await provider.AcquireWriteLockAsync(Faker.Random.AlphaNumeric(10), options, AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ArgumentException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public async Task should_honor_already_cancelled_token()
+    {
+        // given
+        var provider = _CreateProvider();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // when
+        var act = async () =>
+            await provider.AcquireReadLockAsync(Faker.Random.AlphaNumeric(10), cancellationToken: cts.Token);
+
+        // then
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockTests.cs
@@ -1195,6 +1195,38 @@ public sealed class DistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_return_without_publishing_when_release_exceeds_dispose_timeout()
+    {
+        // given — storage hangs forever on remove. DisposeTimeout bounds the release so application
+        // shutdown is never blocked by sustained storage unavailability; on timeout the release
+        // returns without throwing, skips the outbox publish, and the record TTL is the fallback.
+        var storage = Substitute.For<IDistributedLockStorage>();
+        storage
+            .RemoveIfEqualAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<bool>(new TaskCompletionSource<bool>().Task));
+
+        var options = new DistributedLockOptions { DisposeTimeout = TimeSpan.FromSeconds(5) };
+        var provider = _CreateProvider(options, storage: storage);
+
+        // when — run release and advance time past the dispose timeout
+        var releaseTask = provider.ReleaseAsync("resource", "lock-id", AbortToken);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await Task.Yield();
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var act = async () => await releaseTask;
+
+        // then — no throw and no publish (an unconfirmed release must not wake waiters early)
+        await act.Should().NotThrowAsync();
+        await _outboxBus
+            .DidNotReceive()
+            .PublishAsync(Arg.Any<DistributedLockReleased>(), Arg.Any<PublishOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task should_acquire_waiting_lock_with_polling_when_outbox_bus_is_absent()
     {
         // given

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedLockTests.cs
@@ -1172,6 +1172,29 @@ public sealed class DistributedLockTests : TestBase
     }
 
     [Fact]
+    public async Task should_release_lock_even_when_outbox_publish_fails()
+    {
+        // given — healthy storage, but the outbox bus dies when publishing the release notification.
+        // The publish is a best-effort wake-up for waiters; its failure must not fail the release
+        // itself (waiters fall back to polling / TTL expiry).
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+        _outboxBus
+            .PublishAsync(Arg.Any<DistributedLockReleased>(), Arg.Any<PublishOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("outbox down"));
+
+        var acquiredLock = await provider.TryAcquireAsync(resource, cancellationToken: AbortToken);
+        acquiredLock.Should().NotBeNull();
+
+        // when
+        var act = async () => await provider.ReleaseAsync(resource, acquiredLock!.LeaseId, AbortToken);
+
+        // then — release completes and the lock is actually gone from storage.
+        await act.Should().NotThrowAsync();
+        (await provider.IsLockedAsync(resource, AbortToken)).Should().BeFalse();
+    }
+
+    [Fact]
     public async Task should_acquire_waiting_lock_with_polling_when_outbox_bus_is_absent()
     {
         // given

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedSemaphoreProviderTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/DistributedSemaphoreProviderTests.cs
@@ -372,6 +372,45 @@ public sealed class DistributedSemaphoreProviderTests : TestBase
         return DistributedLockAcquireResult.Failed; // Unreachable — Task.Delay throws on cancellation.
     }
 
+    [Fact]
+    public async Task should_return_without_publishing_when_slot_release_exceeds_dispose_timeout()
+    {
+        // given — slot storage hangs forever on release. DisposeTimeout bounds the release so
+        // shutdown is never blocked; on timeout the release returns without throwing, skips the
+        // outbox publish, and the slot's TTL is the fallback.
+        var hangingStorage = Substitute.For<IDistributedSemaphoreStorage>();
+        hangingStorage
+            .ReleaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<bool>(new TaskCompletionSource<bool>().Task));
+        var outboxBus = Substitute.For<IOutboxBus>();
+
+        var provider = new DistributedSemaphoreProvider(
+            hangingStorage,
+            outboxBus,
+            new DistributedLockOptions { DisposeTimeout = TimeSpan.FromSeconds(5) },
+            _guidGenerator,
+            _timeProvider,
+            LoggerFactory.CreateLogger<DistributedSemaphoreProvider>()
+        );
+
+        // when — run release and advance time past the dispose timeout
+        var releaseTask = provider.ReleaseAsync("resource", "slot-lease", AbortToken);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await Task.Yield();
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var act = async () => await releaseTask;
+
+        // then
+        await act.Should().NotThrowAsync();
+        await outboxBus
+            .DidNotReceive()
+            .PublishAsync(Arg.Any<DistributedLockReleased>(), Arg.Any<PublishOptions?>(), Arg.Any<CancellationToken>());
+    }
+
     private DistributedSemaphoreProvider _CreateProvider(DistributedLockOptions? options = null)
     {
         _guidGenerator.Create().Returns(_ => Guid.NewGuid());

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/NullDistributedLockTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/NullDistributedLockTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.RegularLocks;
+
+public sealed class NullDistributedLockTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    private NullDistributedLock _CreateProvider() => new(_timeProvider);
+
+    [Fact]
+    public async Task should_acquire_immediately_with_unmonitored_lease()
+    {
+        // given
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+
+        // when
+        await using var lease = await provider.AcquireAsync(resource, cancellationToken: AbortToken);
+
+        // then — the sentinel provider always grants and cannot observe loss
+        lease.Resource.Should().Be(resource);
+        lease.LeaseId.Should().NotBeNullOrEmpty();
+        lease.FencingToken.Should().BeNull();
+        lease.CanObserveLoss.Should().BeFalse();
+        lease.LostToken.Should().Be(CancellationToken.None);
+        lease.DateAcquired.Should().Be(_timeProvider.GetUtcNow());
+        lease.TimeWaitedForLock.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task try_acquire_should_never_return_null()
+    {
+        // given
+        var provider = _CreateProvider();
+
+        // when
+        var lease = await provider.TryAcquireAsync(Faker.Random.AlphaNumeric(10), cancellationToken: AbortToken);
+
+        // then
+        lease.Should().NotBeNull();
+        await lease!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task provider_renew_should_always_report_success()
+    {
+        // given
+        var provider = _CreateProvider();
+
+        // when — even a lease id that was never issued renews successfully
+        var renewed = await provider.RenewAsync(
+            Faker.Random.AlphaNumeric(10),
+            "unknown-lease",
+            cancellationToken: AbortToken
+        );
+
+        // then
+        renewed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task lease_renew_should_succeed_and_increment_renewal_count()
+    {
+        // given
+        var provider = _CreateProvider();
+        await using var lease = await provider.AcquireAsync(
+            Faker.Random.AlphaNumeric(10),
+            cancellationToken: AbortToken
+        );
+        lease.RenewalCount.Should().Be(0);
+
+        // when
+        var renewed = await lease.RenewAsync(cancellationToken: AbortToken);
+
+        // then
+        renewed.Should().BeTrue();
+        lease.RenewalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_report_no_lock_state_even_while_lease_is_held()
+    {
+        // given — the null provider stores nothing, so all observability reads are empty
+        var provider = _CreateProvider();
+        var resource = Faker.Random.AlphaNumeric(10);
+        await using var lease = await provider.AcquireAsync(resource, cancellationToken: AbortToken);
+
+        // when / then
+        (await provider.IsLockedAsync(resource, AbortToken))
+            .Should()
+            .BeFalse();
+        (await provider.GetLeaseIdAsync(resource, AbortToken)).Should().BeNull();
+        (await provider.GetExpirationAsync(resource, AbortToken)).Should().BeNull();
+        (await provider.GetLockInfoAsync(resource, AbortToken)).Should().BeNull();
+        (await provider.ListActiveLocksAsync(AbortToken)).Should().BeEmpty();
+        (await provider.GetActiveLocksCountAsync(AbortToken)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task release_should_be_a_no_op_that_completes()
+    {
+        // given
+        var provider = _CreateProvider();
+
+        // when
+        var act = async () => await provider.ReleaseAsync(Faker.Random.AlphaNumeric(10), "lease-1", AbortToken);
+
+        // then
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task should_reject_monitoring_with_infinite_lease()
+    {
+        // given — same contract as the real providers: monitoring needs a finite TTL
+        var provider = _CreateProvider();
+        var options = new DistributedLockAcquireOptions
+        {
+            Monitoring = LockMonitoringMode.Monitor,
+            TimeUntilExpires = Timeout.InfiniteTimeSpan,
+        };
+
+        // when
+        var act = async () => await provider.AcquireAsync(Faker.Random.AlphaNumeric(10), options, AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ArgumentException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public async Task should_honor_already_cancelled_token()
+    {
+        // given
+        var provider = _CreateProvider();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // when
+        var act = async () => await provider.AcquireAsync(Faker.Random.AlphaNumeric(10), cancellationToken: cts.Token);
+
+        // then
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/NullDistributedSemaphoreProviderTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/NullDistributedSemaphoreProviderTests.cs
@@ -22,4 +22,89 @@ public sealed class NullDistributedSemaphoreProviderTests
         // then
         await act.Should().ThrowAsync<ArgumentException>().WithParameterName("options");
     }
+
+    [Fact]
+    public void create_semaphore_should_validate_arguments()
+    {
+        // given
+        var provider = new NullDistributedSemaphoreProvider(TimeProvider.System);
+
+        // when / then — the sentinel keeps the same argument contract as real providers
+        var emptyResource = () => provider.CreateSemaphore("  ", maxCount: 1);
+        emptyResource.Should().Throw<ArgumentException>().WithParameterName("resource");
+
+        var zeroCount = () => provider.CreateSemaphore("resource", maxCount: 0);
+        zeroCount.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("maxCount");
+    }
+
+    [Fact]
+    public async Task should_grant_slot_immediately_with_unmonitored_lease()
+    {
+        // given
+        var provider = new NullDistributedSemaphoreProvider(TimeProvider.System);
+        var semaphore = provider.CreateSemaphore("test.resource", maxCount: 2);
+
+        // when
+        await using var slot = await semaphore.AcquireAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var trySlot = await semaphore.TryAcquireAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // then — never contends, exposes the semaphore identity, cannot observe loss
+        semaphore.Resource.Should().Be("test.resource");
+        semaphore.MaxCount.Should().Be(2);
+        slot.Resource.Should().Be("test.resource");
+        slot.LeaseId.Should().NotBeNullOrEmpty();
+        slot.FencingToken.Should().BeNull();
+        slot.CanObserveLoss.Should().BeFalse();
+        trySlot.Should().NotBeNull();
+
+        await trySlot!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task slot_renew_should_succeed_and_increment_renewal_count()
+    {
+        // given
+        var provider = new NullDistributedSemaphoreProvider(TimeProvider.System);
+        var semaphore = provider.CreateSemaphore("test.resource", maxCount: 1);
+        await using var slot = await semaphore.AcquireAsync(cancellationToken: TestContext.Current.CancellationToken);
+        slot.RenewalCount.Should().Be(0);
+
+        // when
+        var renewed = await slot.RenewAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // then
+        renewed.Should().BeTrue();
+        slot.RenewalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task holder_count_should_always_be_zero()
+    {
+        // given — the sentinel stores nothing, so observability reads are empty even while held
+        var provider = new NullDistributedSemaphoreProvider(TimeProvider.System);
+        var semaphore = provider.CreateSemaphore("test.resource", maxCount: 1);
+        await using var slot = await semaphore.AcquireAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // when
+        var count = await provider.GetHolderCountAsync("test.resource", TestContext.Current.CancellationToken);
+
+        // then
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_honor_already_cancelled_token()
+    {
+        // given
+        var provider = new NullDistributedSemaphoreProvider(TimeProvider.System);
+        var semaphore = provider.CreateSemaphore("test.resource", maxCount: 1);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // when
+        var act = async () => await semaphore.AcquireAsync(cancellationToken: cts.Token);
+
+        // then
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/ScopedDistributedLockStorageTests.cs
+++ b/tests/Headless.DistributedLocks.Tests.Unit/RegularLocks/ScopedDistributedLockStorageTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.DistributedLocks;
+using Headless.Testing.Tests;
+
+namespace Tests.RegularLocks;
+
+public sealed class ScopedDistributedLockStorageTests : TestBase
+{
+    private const string _Prefix = "distributed-lock:";
+    private readonly IDistributedLockStorage _inner = Substitute.For<IDistributedLockStorage>();
+
+    private ScopedDistributedLockStorage _CreateStorage() => new(_inner, _Prefix);
+
+    [Fact]
+    public void constructor_should_reject_null_inner_and_empty_prefix()
+    {
+        // when / then
+        var nullInner = () => new ScopedDistributedLockStorage(null!, _Prefix);
+        nullInner.Should().Throw<ArgumentNullException>().WithParameterName("inner");
+
+        var emptyPrefix = () => new ScopedDistributedLockStorage(_inner, "");
+        emptyPrefix.Should().Throw<ArgumentException>().WithParameterName("scopedPrefix");
+    }
+
+    [Fact]
+    public async Task write_operations_should_prepend_the_scope_prefix()
+    {
+        // given
+        var storage = _CreateStorage();
+
+        // when
+        await storage.InsertAsync("resource", "lease-1", TimeSpan.FromSeconds(30), AbortToken);
+        await storage.ReplaceIfEqualAsync("resource", "lease-1", "lease-2", TimeSpan.FromSeconds(30), AbortToken);
+        await storage.RemoveIfEqualAsync("resource", "lease-2", AbortToken);
+
+        // then — every key reaching the backend is namespaced
+        await _inner.Received(1).InsertAsync($"{_Prefix}resource", "lease-1", TimeSpan.FromSeconds(30), AbortToken);
+        await _inner
+            .Received(1)
+            .ReplaceIfEqualAsync($"{_Prefix}resource", "lease-1", "lease-2", TimeSpan.FromSeconds(30), AbortToken);
+        await _inner.Received(1).RemoveIfEqualAsync($"{_Prefix}resource", "lease-2", AbortToken);
+    }
+
+    [Fact]
+    public async Task read_operations_should_prepend_the_scope_prefix()
+    {
+        // given
+        var storage = _CreateStorage();
+
+        // when
+        await storage.ExistsAsync("resource", AbortToken);
+        await storage.GetAsync("resource", AbortToken);
+        await storage.GetExpirationAsync("resource", AbortToken);
+        await storage.GetCountAsync("res", AbortToken);
+
+        // then
+        await _inner.Received(1).ExistsAsync($"{_Prefix}resource", AbortToken);
+        await _inner.Received(1).GetAsync($"{_Prefix}resource", AbortToken);
+        await _inner.Received(1).GetExpirationAsync($"{_Prefix}resource", AbortToken);
+        await _inner.Received(1).GetCountAsync($"{_Prefix}res", AbortToken);
+    }
+
+    [Fact]
+    public async Task get_all_by_prefix_should_strip_the_scope_prefix_from_returned_keys()
+    {
+        // given — the backend returns fully-scoped keys; callers must see bare resource names
+        var storage = _CreateStorage();
+        _inner
+            .GetAllByPrefixAsync($"{_Prefix}res", AbortToken)
+            .Returns(
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [$"{_Prefix}res-1"] = "lease-1",
+                    [$"{_Prefix}res-2"] = "lease-2",
+                }
+            );
+
+        // when
+        var result = await storage.GetAllByPrefixAsync("res", AbortToken);
+
+        // then
+        result.Should().HaveCount(2);
+        result.Should().ContainKey("res-1").WhoseValue.Should().Be("lease-1");
+        result.Should().ContainKey("res-2").WhoseValue.Should().Be("lease-2");
+    }
+
+    [Fact]
+    public async Task get_all_with_expiration_by_prefix_should_strip_the_scope_prefix_from_returned_keys()
+    {
+        // given
+        var storage = _CreateStorage();
+        var ttl = TimeSpan.FromSeconds(42);
+        _inner
+            .GetAllWithExpirationByPrefixAsync($"{_Prefix}res", AbortToken)
+            .Returns(
+                new Dictionary<string, (string LeaseId, TimeSpan? Ttl)>(StringComparer.Ordinal)
+                {
+                    [$"{_Prefix}res-1"] = ("lease-1", ttl),
+                }
+            );
+
+        // when
+        var result = await storage.GetAllWithExpirationByPrefixAsync("res", AbortToken);
+
+        // then
+        result.Should().HaveCount(1);
+        result.Should().ContainKey("res-1");
+        result["res-1"].LeaseId.Should().Be("lease-1");
+        result["res-1"].Ttl.Should().Be(ttl);
+    }
+}

--- a/tests/Headless.Emails.Core.Tests.Unit/SetupDevEmailTests.cs
+++ b/tests/Headless.Emails.Core.Tests.Unit/SetupDevEmailTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Emails;
+using Headless.Emails.Dev;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class SetupDevEmailTests
+{
+    [Fact]
+    public void should_resolve_default_development_sender()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddHeadlessEmails(setup => setup.UseDevelopment("out.txt"));
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IEmailSender>().Should().BeOfType<DevEmailSender>();
+    }
+
+    [Fact]
+    public void should_resolve_default_noop_sender()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        services.AddHeadlessEmails(setup => setup.UseNoop());
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IEmailSender>().Should().BeOfType<NoopEmailSender>();
+    }
+
+    [Fact]
+    public void development_sender_should_be_singleton()
+    {
+        // given — DevEmailSender serializes file appends through an instance-level lock, so the
+        // registration must produce a single shared instance.
+        var services = new ServiceCollection();
+        services.AddHeadlessEmails(setup => setup.UseDevelopment("out.txt"));
+        using var provider = services.BuildServiceProvider();
+
+        // when
+        var first = provider.GetRequiredService<IEmailSender>();
+        var second = provider.GetRequiredService<IEmailSender>();
+
+        // then
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void use_development_should_reject_empty_path()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when — the path is validated at setup time, not at first send
+        var act = () => services.AddHeadlessEmails(setup => setup.UseDevelopment(""));
+
+        // then
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Headless.Emails.Tests.Unit/DevEmailSenderTests.cs
+++ b/tests/Headless.Emails.Tests.Unit/DevEmailSenderTests.cs
@@ -80,13 +80,210 @@ public sealed class DevEmailSenderTests
         act.Should().Throw<ArgumentException>();
     }
 
-    private static SendSingleEmailRequest _Request(string text = "hello dev") =>
+    [Fact]
+    public async Task should_render_cc_and_bcc_lines_when_present()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            var request = _Request(
+                cc: [new EmailRequestAddress("cc@example.com")],
+                bcc: [new EmailRequestAddress("bcc@example.com")]
+            );
+
+            await sender.SendAsync(request, TestContext.Current.CancellationToken);
+
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain("Cc: cc@example.com").And.Contain("Bcc: bcc@example.com");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_omit_cc_and_bcc_lines_when_absent()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            await sender.SendAsync(_Request(), TestContext.Current.CancellationToken);
+
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().NotContain("Cc:").And.NotContain("Bcc:");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_render_attachment_names_without_content()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            var request = _Request(
+                attachments:
+                [
+                    new EmailRequestAttachment
+                    {
+                        Name = "invoice.pdf",
+                        File = "RAW-ATTACHMENT-BYTES"u8.ToArray(),
+                        ContentType = "application/pdf",
+                    },
+                ]
+            );
+
+            await sender.SendAsync(request, TestContext.Current.CancellationToken);
+
+            // Only the attachment name is recorded — raw bytes would bloat the dev file.
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain("Attachments:").And.Contain("  Name: invoice.pdf");
+            contents.Should().NotContain("RAW-ATTACHMENT-BYTES");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_write_html_body_when_text_is_missing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            await sender.SendAsync(
+                _Request(text: null, html: "<p>hello html</p>"),
+                TestContext.Current.CancellationToken
+            );
+
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain("<p>hello html</p>");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_prefer_text_body_when_both_bodies_present()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            await sender.SendAsync(
+                _Request(text: "plain body", html: "<p>html body</p>"),
+                TestContext.Current.CancellationToken
+            );
+
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain("plain body").And.NotContain("<p>html body</p>");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_normalize_newlines_in_text_body()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            await sender.SendAsync(_Request(text: "line1\r\nline2\nline3"), TestContext.Current.CancellationToken);
+
+            // Mixed CRLF/LF input is normalized to the platform newline before being appended.
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain($"line1{Environment.NewLine}line2{Environment.NewLine}line3");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_render_display_name_in_from_header()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            var request = _Request() with { From = new EmailRequestAddress("from@example.com", "Alice") };
+
+            await sender.SendAsync(request, TestContext.Current.CancellationToken);
+
+            var contents = await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
+            contents.Should().Contain("From: Alice <from@example.com>");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task should_honor_already_cancelled_token()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"emails-dev-{Guid.NewGuid():N}.txt");
+        using var sender = new DevEmailSender(path);
+
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            var act = async () => await sender.SendAsync(_Request(), cts.Token);
+
+            // Cancellation must surface before any file I/O happens.
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            File.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static SendSingleEmailRequest _Request(
+        string? text = "hello dev",
+        string? html = null,
+        IReadOnlyList<EmailRequestAddress>? cc = null,
+        IReadOnlyList<EmailRequestAddress>? bcc = null,
+        IReadOnlyList<EmailRequestAttachment>? attachments = null
+    ) =>
         new()
         {
             From = "from@example.com",
-            Destination = new EmailRequestDestination { ToAddresses = [new EmailRequestAddress("to@example.com")] },
+            Destination = new EmailRequestDestination
+            {
+                ToAddresses = [new EmailRequestAddress("to@example.com")],
+                CcAddresses = cc ?? [],
+                BccAddresses = bcc ?? [],
+            },
             Subject = "subject",
             MessageText = text,
+            MessageHtml = html,
+            Attachments = attachments ?? [],
         };
 }
 

--- a/tests/Headless.Messaging.Core.Tests.Harness/DataStorageTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/DataStorageTestsBase.cs
@@ -388,6 +388,72 @@ public abstract class DataStorageTestsBase : TestBase
         await act.Should().NotThrowAsync();
     }
 
+    public virtual async Task should_not_flip_terminal_published_row_back_to_delayed()
+    {
+        if (!Capabilities.SupportsDelayedScheduling)
+        {
+            Assert.Skip("Storage does not support delayed scheduling");
+        }
+
+        // given — a row sealed terminal (Succeeded, no scheduled retry). The dispatcher's shutdown
+        // flush (DisposeAsync → ChangePublishStateToDelayedAsync) can race a consumer that just
+        // dispatched the same row; once one side seals it, the flush must not resurrect it as Delayed.
+        var storage = GetStorage();
+        var storedMessage = await storage.StoreMessageAsync(
+            "terminal-delayed-guard",
+            CreateMessage(),
+            cancellationToken: AbortToken
+        );
+
+        var sealedFirst = await storage.ChangePublishStateAsync(
+            storedMessage,
+            StatusName.Succeeded,
+            nextRetryAt: null,
+            cancellationToken: AbortToken
+        );
+        sealedFirst.Should().BeTrue("the transition to Succeeded must win against a fresh row");
+
+        // when — the late shutdown flush tries to move the sealed row back to Delayed.
+        await storage.ChangePublishStateToDelayedAsync([storedMessage.StorageId], AbortToken);
+
+        // then — the row must remain terminal: a follow-up state change is still rejected by the
+        // terminal guard (a Delayed row would have accepted it) and the retry pickup never sees it.
+        var lateChange = await storage.ChangePublishStateAsync(
+            storedMessage,
+            StatusName.Scheduled,
+            nextRetryAt: DateTime.UtcNow,
+            cancellationToken: AbortToken
+        );
+        lateChange.Should().BeFalse("the terminal seal must survive a late scheduler flush");
+
+        var retriable = await storage.GetPublishedMessagesOfNeedRetryAsync(AbortToken);
+        retriable.Should().NotContain(m => m.StorageId == storedMessage.StorageId);
+    }
+
+    public virtual async Task should_ignore_unknown_storage_ids_when_flushing_delayed_state()
+    {
+        if (!Capabilities.SupportsDelayedScheduling)
+        {
+            Assert.Skip("Storage does not support delayed scheduling");
+        }
+
+        // given — one live row plus an id with no backing row (e.g. the row was pruned between the
+        // dispatcher snapshotting its scheduler queue and the shutdown flush running).
+        var storage = GetStorage();
+        var storedMessage = await storage.StoreMessageAsync(
+            "delayed-unknown-id",
+            CreateMessage(),
+            cancellationToken: AbortToken
+        );
+
+        // when
+        var act = async () =>
+            await storage.ChangePublishStateToDelayedAsync([storedMessage.StorageId, Guid.NewGuid()], AbortToken);
+
+        // then
+        await act.Should().NotThrowAsync("missing rows must be skipped, not faulted on");
+    }
+
     public virtual async Task should_get_published_messages_of_need_retry()
     {
         // given

--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -655,6 +655,99 @@ public sealed class DispatcherTests : TestBase
         await act.Should().NotThrowAsync();
     }
 
+    [Fact]
+    public async Task dispose_should_flush_queued_scheduler_ids_back_to_delayed()
+    {
+        // #610 regression — DisposeAsync must drain the scheduler loop, then hand every id still
+        // sitting in the in-process scheduler queue back to storage as Delayed. Losing this flush
+        // strands Queued rows: their in-memory schedule dies with the process while storage keeps
+        // reporting them as already picked up.
+        var sender = new TestThreadSafeMessageSender();
+        var options = Options.Create(new MessagingOptions { EnablePublishParallelSend = false });
+        _storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTime?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new ValueTask<bool>(true));
+
+        var dispatcher = new Dispatcher(
+            _logger,
+            sender,
+            options,
+            _executor,
+            _storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+
+        using var cts = new CancellationTokenSource();
+        await dispatcher.StartAsync(cts.Token);
+
+        // Due in 50s → Queued status → enters the in-process scheduler queue and stays there
+        // (the scheduler loop only dequeues items within 50ms of their due time).
+        var message = _CreateTestMessage(_StorageGuid(1));
+        await dispatcher.EnqueueToScheduler(message, DateTime.UtcNow.AddSeconds(50), cancellationToken: AbortToken);
+
+        // when
+        await dispatcher.DisposeAsync();
+
+        // then — the queued id is durably handed back as Delayed and the message is never sent.
+        await _storage
+            .Received(1)
+            .ChangePublishStateToDelayedAsync(
+                Arg.Is<Guid[]>(ids => ids.Length == 1 && ids[0] == message.StorageId),
+                Arg.Any<CancellationToken>()
+            );
+        sender.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task dispose_should_complete_when_scheduler_flush_fails()
+    {
+        // The shutdown flush writes through IDataStorage; a dead storage must not turn DisposeAsync
+        // into a throw — hosts dispose the dispatcher during shutdown, and a propagated storage
+        // fault would abort the remaining shutdown sequence. The failure is logged and absorbed.
+        var sender = new TestThreadSafeMessageSender();
+        var options = Options.Create(new MessagingOptions { EnablePublishParallelSend = false });
+        _storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTime?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new ValueTask<bool>(true));
+        _storage
+            .ChangePublishStateToDelayedAsync(Arg.Any<Guid[]>(), Arg.Any<CancellationToken>())
+            .Returns<ValueTask>(_ => throw new InvalidOperationException("storage down"));
+
+        var dispatcher = new Dispatcher(
+            _logger,
+            sender,
+            options,
+            _executor,
+            _storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+
+        using var cts = new CancellationTokenSource();
+        await dispatcher.StartAsync(cts.Token);
+        var message = _CreateTestMessage(_StorageGuid(1));
+        await dispatcher.EnqueueToScheduler(message, DateTime.UtcNow.AddSeconds(50), cancellationToken: AbortToken);
+
+        // when
+        var act = async () => await dispatcher.DisposeAsync();
+
+        // then
+        await act.Should().NotThrowAsync("scheduler-flush failures during shutdown are logged, not propagated");
+    }
+
     private static MediumMessage _CreateTestMessage(int storageId) => _CreateTestMessage(_StorageGuid(storageId));
 
     private static MediumMessage _CreateTestMessage(Guid? storageId = null)

--- a/tests/Headless.Messaging.InMemoryStorage.Tests.Unit/InMemoryDataStorageTests.cs
+++ b/tests/Headless.Messaging.InMemoryStorage.Tests.Unit/InMemoryDataStorageTests.cs
@@ -174,6 +174,14 @@ public sealed class InMemoryDataStorageTests : DataStorageTestsBase
     public override Task should_change_publish_state_to_delayed() => base.should_change_publish_state_to_delayed();
 
     [Fact]
+    public override Task should_not_flip_terminal_published_row_back_to_delayed() =>
+        base.should_not_flip_terminal_published_row_back_to_delayed();
+
+    [Fact]
+    public override Task should_ignore_unknown_storage_ids_when_flushing_delayed_state() =>
+        base.should_ignore_unknown_storage_ids_when_flushing_delayed_state();
+
+    [Fact]
     public override Task should_get_published_messages_of_need_retry() =>
         base.should_get_published_messages_of_need_retry();
 

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
@@ -190,6 +190,14 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
     public override Task should_change_publish_state_to_delayed() => base.should_change_publish_state_to_delayed();
 
     [Fact]
+    public override Task should_not_flip_terminal_published_row_back_to_delayed() =>
+        base.should_not_flip_terminal_published_row_back_to_delayed();
+
+    [Fact]
+    public override Task should_ignore_unknown_storage_ids_when_flushing_delayed_state() =>
+        base.should_ignore_unknown_storage_ids_when_flushing_delayed_state();
+
+    [Fact]
     public override Task should_get_published_messages_of_need_retry() =>
         base.should_get_published_messages_of_need_retry();
 

--- a/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageTests.cs
+++ b/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageTests.cs
@@ -179,6 +179,14 @@ public sealed class SqlServerStorageTests(SqlServerTestFixture fixture) : DataSt
     public override Task should_change_publish_state_to_delayed() => base.should_change_publish_state_to_delayed();
 
     [Fact]
+    public override Task should_not_flip_terminal_published_row_back_to_delayed() =>
+        base.should_not_flip_terminal_published_row_back_to_delayed();
+
+    [Fact]
+    public override Task should_ignore_unknown_storage_ids_when_flushing_delayed_state() =>
+        base.should_ignore_unknown_storage_ids_when_flushing_delayed_state();
+
+    [Fact]
     public override Task should_get_published_messages_of_need_retry() =>
         base.should_get_published_messages_of_need_retry();
 


### PR DESCRIPTION
## Summary

Closes the highest-value coverage gaps found in a suite-wide test review: the retry-durability contracts that recently hardened messaging shutdown now have regression tests on every storage provider, the distributed-lock retry/backoff/release machinery is pinned by direct tests instead of only being exercised incidentally, and the dev email provider's rendering and setup surface is fully covered. 55 new tests, test-only diff — no production code changes.

## What is now protected

**Messaging retry durability.** A row sealed terminal (`Succeeded`, no scheduled retry) can no longer be silently resurrected as `Delayed` by the dispatcher's shutdown flush — the conformance harness pins this on InMemory, PostgreSQL, and SqlServer, so removing the terminal guard from any one provider fails its suite. Dispatcher disposal is pinned too: queued-but-not-due scheduler ids must be handed back to storage as `Delayed` exactly once and never sent, and a storage outage during that flush must not fault host shutdown.

**Distributed locks.** The acquire-retry backoff curve (50ms doubling, 3s cap, shift clamp, ±25% jitter band) and the transient-vs-programmer-error classification that decides what gets retried are now asserted directly — previously a silent change to either would have surfaced only as slow flakes in provider tests. All three providers (mutex, semaphore, reader-writer) are pinned to return gracefully when storage hangs past `DisposeTimeout`, skipping the waiter wake-up publish so an unconfirmed release never signals waiters early. A failed outbox publish after a confirmed release is pinned as non-fatal. The `NullDistributedLock`/`NullDistributedReadWriteLock` sentinels and `NullDistributedSemaphoreProvider` get their first direct coverage (grant-always semantics, argument contracts shared with real providers, cancellation), the `ScopedDistributedLockStorage` decorator's prefix prepend/strip round-trip is asserted, and the previously untested `TryUsingAsync` overloads are covered — including LostToken linking for the state-taking delegate and bare-token pass-through when loss is unobservable.

**Dev emails.** `DevEmailSender` rendering branches (Cc/Bcc only when present, attachment names without raw bytes, HTML fallback, text-over-HTML preference, CRLF/LF normalization, display-name From header) and pre-write cancellation are covered, plus the unkeyed `UseDevelopment`/`UseNoop` setup path — only the named path was tested before — including singleton lifetime, which the sender's instance-level write lock depends on.

## Deliberately not covered (follow-ups)

- Azure Service Bus always-complete-on-commit needs real ServiceBus message fakes; it does not fit the unit patterns cleanly.
- `NoopEmailSender` ignores cancellation while `NoopSmsSender` throws — flagged as a consistency question rather than locked in with a characterization test.
- The `observedAttemptSucceeded` release latch in `DistributedLock` is not falsifiable through the public surface (no attempt can return true and later be overridden); a test would assert nothing.
- `ScopedDistributedReaderWriterLockStorage` mirrors the covered lock decorator and remains indirect-only.

## Validation

All affected suites pass locally: DistributedLocks 320/320, Messaging InMemory storage 56/56, Dispatcher 15/15, Emails 41/41 + 26/26, and PostgreSQL storage integration 66/66 against Docker — so the new harness tests are validated against a real SQL provider, not just InMemory. SqlServer integration overrides are compile-checked only (image unusable on ARM host); CI runs them. No-incremental Release builds of every touched project show zero warnings.

## Related

- Related: #610

