### PR TITLE
perf: apply safe optimizations from the repository performance review

### DIFF
--- a/src/Headless.Api.Core/Middlewares/NoCacheHeadersMiddleware.cs
+++ b/src/Headless.Api.Core/Middlewares/NoCacheHeadersMiddleware.cs
@@ -10,15 +10,21 @@ internal sealed class NoCacheHeadersMiddleware(RequestDelegate next)
     /// <summary>Processes the current request.</summary>
     public async Task InvokeAsync(HttpContext context)
     {
-        context.Response.OnStarting(() =>
-        {
-            if (context.Response.Headers.CacheControl.Count is 0)
+        // State-passing overload: a plain lambda would capture `context` and allocate a closure per request.
+        context.Response.OnStarting(
+            static state =>
             {
-                context.Response.Headers.CacheControl = "no-cache,no-store,must-revalidate";
-            }
+                var httpContext = (HttpContext)state;
 
-            return Task.CompletedTask;
-        });
+                if (httpContext.Response.Headers.CacheControl.Count is 0)
+                {
+                    httpContext.Response.Headers.CacheControl = "no-cache,no-store,must-revalidate";
+                }
+
+                return Task.CompletedTask;
+            },
+            context
+        );
 
         await next(context).ConfigureAwait(false);
     }

--- a/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
+++ b/src/Headless.Api.Idempotency/IdempotencyMiddleware.cs
@@ -70,7 +70,8 @@ internal sealed partial class IdempotencyMiddleware(
             return;
         }
 
-        var keyHeader = headerValues.LastOrDefault();
+        // Indexer instead of LastOrDefault(): Count != 0 was checked above, and the LINQ path boxes StringValues.
+        var keyHeader = headerValues[^1];
         if (string.IsNullOrWhiteSpace(keyHeader))
         {
             await next(context).ConfigureAwait(false);

--- a/src/Headless.Api.MinimalApi/Extensions/ApiResultExtensions.cs
+++ b/src/Headless.Api.MinimalApi/Extensions/ApiResultExtensions.cs
@@ -33,7 +33,8 @@ public static class ApiResultExtensions
     /// <returns>An <see cref="IResult"/> representing the HTTP response.</returns>
     public static IResult ToHttpResult<T>(this ApiResult<T> result, IProblemDetailsCreator creator)
     {
-        return result.Match(TypedResults.Ok, error => error.ToHttpResult(creator));
+        // Branch instead of Match: the failure lambda would capture `creator` and allocate on every success response.
+        return result.TryGetValue(out var value) ? TypedResults.Ok(value) : result.Error.ToHttpResult(creator);
     }
 
     /// <summary>
@@ -45,7 +46,8 @@ public static class ApiResultExtensions
     /// <returns>An <see cref="IResult"/> representing the HTTP response.</returns>
     public static IResult ToHttpResult(this ApiResult result, IProblemDetailsCreator creator)
     {
-        return result.Match(TypedResults.NoContent, error => error.ToHttpResult(creator));
+        // Branch instead of Match: the failure lambda would capture `creator` and allocate on every success response.
+        return result.TryGetError(out var error) ? error.ToHttpResult(creator) : TypedResults.NoContent();
     }
 
     /// <summary>

--- a/src/Headless.Api.MinimalApi/Filters/MinimalApiValidatorFilter.cs
+++ b/src/Headless.Api.MinimalApi/Filters/MinimalApiValidatorFilter.cs
@@ -60,7 +60,19 @@ public sealed class MinimalApiValidatorFilter<TRequest> : IEndpointFilter
         }
 
         var requestType = typeof(TRequest);
-        var request = context.Arguments.OfType<TRequest>().FirstOrDefault(request => request?.GetType() == requestType);
+
+        // Manual scan instead of OfType().FirstOrDefault(predicate): avoids two iterator allocations
+        // and a closure on every validated request. Exact-type match (not subtype) is intentional.
+        TRequest? request = default;
+
+        foreach (var argument in context.Arguments)
+        {
+            if (argument is TRequest candidate && candidate.GetType() == requestType)
+            {
+                request = candidate;
+                break;
+            }
+        }
 
         if (request is null)
         {

--- a/src/Headless.Api.Mvc/Extensions/ApiResultMvcExtensions.cs
+++ b/src/Headless.Api.Mvc/Extensions/ApiResultMvcExtensions.cs
@@ -38,10 +38,10 @@ public static class ApiResultMvcExtensions
         IProblemDetailsCreator creator
     )
     {
-        return result.Match<ActionResult<T>>(
-            value => controller.Ok(value),
-            error => error.ToActionResult(controller, creator)
-        );
+        // Branch instead of Match: both lambdas would capture `controller`/`creator` and allocate on every response.
+        return result.TryGetValue(out var value)
+            ? controller.Ok(value)
+            : result.Error.ToActionResult(controller, creator);
     }
 
     /// <summary>
@@ -58,7 +58,8 @@ public static class ApiResultMvcExtensions
         IProblemDetailsCreator creator
     )
     {
-        return result.Match(controller.NoContent, error => error.ToActionResult(controller, creator));
+        // Branch instead of Match: the delegates would capture `controller`/`creator` and allocate on every response.
+        return result.TryGetError(out var error) ? error.ToActionResult(controller, creator) : controller.NoContent();
     }
 
     /// <summary>

--- a/src/Headless.Blobs.FileSystem/FileSystemBlobStorage.cs
+++ b/src/Headless.Blobs.FileSystem/FileSystemBlobStorage.cs
@@ -500,11 +500,15 @@ public sealed class FileSystemBlobStorage : IBlobStorage
         var windowLimit = (long)query.PageSize + 1;
         var pageWindow = new List<(string Key, FileInfo Info)>((int)Math.Min(windowLimit, 1024));
 
-        foreach (var file in Directory.EnumerateFiles(containerDirectory, "*", SearchOption.AllDirectories))
+        // DirectoryInfo enumeration yields FileInfo instances pre-populated from the directory scan, so the
+        // page entries below need no second stat per file (Directory.EnumerateFiles + new FileInfo did).
+        var containerInfo = new DirectoryInfo(containerDirectory);
+
+        foreach (var info in containerInfo.EnumerateFiles("*", SearchOption.AllDirectories))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var key = _ToBlobKey(file, containerDirectory);
+            var key = _ToBlobKey(info.FullName, containerDirectory);
 
             if (BlobStorageHelpers.IsSidecarKey(key))
             {
@@ -520,8 +524,6 @@ public sealed class FileSystemBlobStorage : IBlobStorage
             {
                 continue;
             }
-
-            var info = new FileInfo(file);
 
             if (!info.Exists)
             {
@@ -646,7 +648,13 @@ public sealed class FileSystemBlobStorage : IBlobStorage
     /// </summary>
     private static string _ToBlobKey(string fileFullName, string containerDirectory)
     {
-        return fileFullName.Replace(containerDirectory, string.Empty, StringComparison.Ordinal).Replace('\\', '/');
+        // Slice the container prefix instead of Replace: enumerated paths always start with the container
+        // directory, so this skips the full-string search and cannot strip pathological later occurrences.
+        var key = fileFullName.StartsWith(containerDirectory, StringComparison.Ordinal)
+            ? fileFullName[containerDirectory.Length..]
+            : fileFullName.Replace(containerDirectory, string.Empty, StringComparison.Ordinal);
+
+        return key.Replace('\\', '/');
     }
 
     #endregion

--- a/src/Headless.Blobs.Redis/RedisBlobStorage.cs
+++ b/src/Headless.Blobs.Redis/RedisBlobStorage.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Buffers;
 using System.Globalization;
 using System.Text;
 using Headless.Abstractions;
@@ -187,18 +188,55 @@ public sealed class RedisBlobStorage : IBlobStorage
                 content.Seek(0, SeekOrigin.Begin);
             }
 
-            await using var memory = new MemoryStream();
-            await _CopyWithSizeLimitAsync(content, memory, cancellationToken).ConfigureAwait(false);
-            var fileSize = memory.Length;
+            byte[] blobData;
+            long fileSize;
 
-            // Zero-copy: TryGetBuffer avoids a ToArray() allocation.
-            if (!memory.TryGetBuffer(out var blobSegment))
+            if (content.CanSeek && content.Length <= int.MaxValue)
             {
-                throw new InvalidOperationException("Failed to get buffer from MemoryStream");
-            }
+                // Right-size from Length (already validated against the cap above): a single exact-size read
+                // instead of MemoryStream growth copies plus a final exact-size copy.
+                var length = (int)content.Length;
+                blobData = new byte[length];
 
-            var blobData = new byte[blobSegment.Count];
-            Buffer.BlockCopy(blobSegment.Array!, blobSegment.Offset, blobData, 0, blobSegment.Count);
+                var filled = 0;
+
+                while (filled < length)
+                {
+                    var read = await content
+                        .ReadAsync(blobData.AsMemory(filled), cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    filled += read;
+                }
+
+                if (filled < length)
+                {
+                    // The stream ended before Length bytes: store what it actually yielded (the buffered
+                    // path below has the same tolerance for streams whose Length over-reports).
+                    Array.Resize(ref blobData, filled);
+                }
+
+                fileSize = filled;
+            }
+            else
+            {
+                await using var memory = new MemoryStream();
+                await _CopyWithSizeLimitAsync(content, memory, cancellationToken).ConfigureAwait(false);
+                fileSize = memory.Length;
+
+                if (!memory.TryGetBuffer(out var blobSegment))
+                {
+                    throw new InvalidOperationException("Failed to get buffer from MemoryStream");
+                }
+
+                blobData = new byte[blobSegment.Count];
+                Buffer.BlockCopy(blobSegment.Array!, blobSegment.Offset, blobData, 0, blobSegment.Count);
+            }
 
             var now = _clock.UtcNow;
 
@@ -808,26 +846,35 @@ public sealed class RedisBlobStorage : IBlobStorage
             return;
         }
 
-        var buffer = new byte[0x14000];
-        long totalBytes = 0;
-        int bytesRead;
+        var buffer = ArrayPool<byte>.Shared.Rent(0x14000);
 
-        while ((bytesRead = await source.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        try
         {
-            totalBytes += bytesRead;
+            long totalBytes = 0;
+            int bytesRead;
 
-            if (totalBytes > _options.MaxBlobSizeBytes)
+            while ((bytesRead = await source.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
             {
-                throw new ArgumentException(
-                    string.Create(
-                        CultureInfo.InvariantCulture,
-                        $"Blob exceeds maximum size of {_options.MaxBlobSizeBytes} bytes. Redis blob storage is intended for small/ephemeral blobs only."
-                    ),
-                    nameof(source)
-                );
-            }
+                totalBytes += bytesRead;
 
-            await destination.WriteAsync(buffer.AsMemory(0, bytesRead), ct).ConfigureAwait(false);
+                if (totalBytes > _options.MaxBlobSizeBytes)
+                {
+                    throw new ArgumentException(
+                        string.Create(
+                            CultureInfo.InvariantCulture,
+                            $"Blob exceeds maximum size of {_options.MaxBlobSizeBytes} bytes. Redis blob storage is intended for small/ephemeral blobs only."
+                        ),
+                        nameof(source)
+                    );
+                }
+
+                await destination.WriteAsync(buffer.AsMemory(0, bytesRead), ct).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            // Blob content is user data; do not leak it into the shared pool.
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
         }
     }
 

--- a/src/Headless.Caching.Core/CacheEntryStamps.cs
+++ b/src/Headless.Caching.Core/CacheEntryStamps.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Security.Cryptography;
 using Headless.Checks;
 
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
@@ -185,5 +184,7 @@ public readonly record struct CacheEntryStamps(
 
     private static long _GetRandomTicks(TimeSpan exclusiveMax) => (long)(exclusiveMax.Ticks * _GetRandomUnitDouble());
 
-    private static double _GetRandomUnitDouble() => RandomNumberGenerator.GetInt32(int.MaxValue) / (double)int.MaxValue;
+    // Random.Shared, not a CSPRNG: jitter only desynchronizes expiry, so predictability has no security
+    // consequence, and this runs on every jittered write.
+    private static double _GetRandomUnitDouble() => Random.Shared.NextDouble();
 }

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -2685,10 +2685,15 @@ public sealed class RedisCache(
     // stamp stays provably consistent. A shorter-than-header value (e.g. a legacy raw value) encodes in full.
     private static string _ToConcurrencyStamp(RedisValue value)
     {
-        var bytes = (byte[])value!;
-        var length = Math.Min(bytes.Length, RedisCacheEntryFrame.HeaderLength);
+        // Slice the ReadOnlySequence view instead of casting to byte[]: the cast re-materializes the whole
+        // payload for inline/sequence-backed values (see _DeserializeRedisValue) just to read the fixed prefix.
+        var sequence = (ReadOnlySequence<byte>)value!;
+        var length = (int)Math.Min(sequence.Length, RedisCacheEntryFrame.HeaderLength);
 
-        return $"b64:{bytes.AsSpan(0, length).ToBase64()}";
+        Span<byte> header = stackalloc byte[RedisCacheEntryFrame.HeaderLength];
+        sequence.Slice(0, length).CopyTo(header);
+
+        return $"b64:{header[..length].ToBase64()}";
     }
 
     private static bool _TryDecodeConcurrencyStamp(string stamp, out RedisValue value)

--- a/src/Headless.Extensions/Reflection/ObjectPropertiesHelper.cs
+++ b/src/Headless.Extensions/Reflection/ObjectPropertiesHelper.cs
@@ -16,15 +16,15 @@ public static class ObjectPropertiesHelper
 {
     private static readonly ConditionalWeakTable<
         Type,
-        ConcurrentDictionary<PropertyCacheKey, CachedResult<PropertyInfo>>
+        ConcurrentDictionary<PropertyCacheKey, CachedResult<CachedProperty>>
     > _Cache = [];
 
     private static readonly ConditionalWeakTable<
         Type,
-        ConcurrentDictionary<PropertyCacheKey, CachedResult<PropertyInfo>>
+        ConcurrentDictionary<PropertyCacheKey, CachedResult<CachedProperty>>
     >.CreateValueCallback _CreateInner = static _ => new ConcurrentDictionary<
         PropertyCacheKey,
-        CachedResult<PropertyInfo>
+        CachedResult<CachedProperty>
     >();
 
     /// <summary>
@@ -94,6 +94,41 @@ public static class ObjectPropertiesHelper
     }
 
     /// <summary>
+    /// Sets the named property to the value produced by <paramref name="valueFactory"/>, if the property exists and
+    /// is writable (including non-public setters) and is not decorated with any of
+    /// <paramref name="ignoreAttributeTypes"/>. Prefer this overload on hot paths: unlike the expression-selector
+    /// overloads it builds no expression tree per call.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object whose property is set.</typeparam>
+    /// <typeparam name="TValue">The type of the property value.</typeparam>
+    /// <param name="obj">The object to set the property on.</param>
+    /// <param name="propertyName">The exact (case-sensitive) name of the property to set, for example <c>nameof(X.Name)</c>.</param>
+    /// <param name="valueFactory">Factory producing the value to assign.</param>
+    /// <param name="ignoreAttributeTypes">Attribute types that, if applied to the property, cause the set to be skipped.</param>
+    /// <returns><see langword="true"/> if the property was found and set; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="System.Reflection.TargetInvocationException">Thrown when the property's setter throws.</exception>
+    [RequiresUnreferencedCode("Uses Type.GetProperties which is not compatible with trimming.")]
+    public static bool TrySetProperty<TObject, TValue>(
+        TObject obj,
+        string propertyName,
+        Func<TValue> valueFactory,
+        params Type[]? ignoreAttributeTypes
+    )
+        where TObject : notnull
+    {
+        var property = _GetCachedProperty(obj.GetType(), propertyName, ignoreAttributeTypes);
+
+        if (property is null)
+        {
+            return false;
+        }
+
+        property.SetValue(obj, valueFactory());
+
+        return true;
+    }
+
+    /// <summary>
     /// Sets the named property to <see langword="null"/>, if the property exists, is writable (including non-public
     /// setters), is of a nullable type, and is not decorated with any of <paramref name="ignoreAttributeTypes"/>.
     /// </summary>
@@ -123,8 +158,43 @@ public static class ObjectPropertiesHelper
         return false;
     }
 
+    /// <summary>
+    /// Sets the named property to the value produced by <paramref name="valueFactory"/> (which receives
+    /// <paramref name="obj"/>), if the property exists and is writable (including non-public setters) and is not
+    /// decorated with any of <paramref name="ignoreAttributeTypes"/>. Prefer this overload on hot paths: unlike the
+    /// expression-selector overloads it builds no expression tree per call.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object whose property is set.</typeparam>
+    /// <typeparam name="TValue">The type of the property value.</typeparam>
+    /// <param name="obj">The object to set the property on.</param>
+    /// <param name="propertyName">The exact (case-sensitive) name of the property to set, for example <c>nameof(X.Name)</c>.</param>
+    /// <param name="valueFactory">Factory producing the value to assign, given the target object.</param>
+    /// <param name="ignoreAttributeTypes">Attribute types that, if applied to the property, cause the set to be skipped.</param>
+    /// <returns><see langword="true"/> if the property was found and set; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="System.Reflection.TargetInvocationException">Thrown when the property's setter throws.</exception>
     [RequiresUnreferencedCode("Uses Type.GetProperties which is not compatible with trimming.")]
-    private static PropertyInfo? _GetCachedProperty(
+    public static bool TrySetProperty<TObject, TValue>(
+        TObject obj,
+        string propertyName,
+        Func<TObject, TValue> valueFactory,
+        params Type[]? ignoreAttributeTypes
+    )
+        where TObject : notnull
+    {
+        var property = _GetCachedProperty(obj.GetType(), propertyName, ignoreAttributeTypes);
+
+        if (property is null)
+        {
+            return false;
+        }
+
+        property.SetValue(obj, valueFactory(obj));
+
+        return true;
+    }
+
+    [RequiresUnreferencedCode("Uses Type.GetProperties which is not compatible with trimming.")]
+    private static CachedProperty? _GetCachedProperty(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type objType,
         string propertyName,
         Type[]? ignoreAttrs
@@ -139,9 +209,63 @@ public static class ObjectPropertiesHelper
             return existing.Value;
         }
 
-        var result = new CachedResult<PropertyInfo>(_GetWritablePropertyInfo(objType, propertyName, normalizedAttrs));
+        var propertyInfo = _GetWritablePropertyInfo(objType, propertyName, normalizedAttrs);
+        var result = new CachedResult<CachedProperty>(propertyInfo is null ? null : new CachedProperty(propertyInfo));
 
         return inner.GetOrAdd(key, result).Value;
+    }
+
+    /// <summary>
+    /// A resolved writable property plus a lazily compiled open setter delegate: assignment through the compiled
+    /// delegate is roughly an order of magnitude cheaper than <see cref="PropertyInfo.SetValue(object?, object?)"/>,
+    /// which matters because the ORM save pipeline stamps several properties per entity per save.
+    /// </summary>
+    private sealed class CachedProperty(PropertyInfo property)
+    {
+        // The benign publication race compiles the same delegate twice at worst.
+        private Action<object, object?>? _compiledSetter;
+
+        public PropertyInfo Property { get; } = property;
+
+        public Type PropertyType => Property.PropertyType;
+
+        public void SetValue(object obj, object? value)
+        {
+            // Value-type receivers keep reflection SetValue (a compiled unbox-assign would mutate a copy).
+            if (Property.DeclaringType?.IsValueType != false)
+            {
+                Property.SetValue(obj, value);
+
+                return;
+            }
+
+            var setter = _compiledSetter ??= _CompileSetter(Property);
+
+            try
+            {
+                setter(obj, value);
+            }
+            catch (Exception e)
+            {
+                // Preserve the documented PropertyInfo.SetValue contract: setter faults surface wrapped.
+                throw new TargetInvocationException(e);
+            }
+        }
+
+        private static Action<object, object?> _CompileSetter(PropertyInfo property)
+        {
+            var objParam = Expression.Parameter(typeof(object), "obj");
+            var valueParam = Expression.Parameter(typeof(object), "value");
+            var setMethod = property.GetSetMethod(nonPublic: true)!;
+
+            var body = Expression.Call(
+                Expression.Convert(objParam, property.DeclaringType!),
+                setMethod,
+                Expression.Convert(valueParam, property.PropertyType)
+            );
+
+            return Expression.Lambda<Action<object, object?>>(body, objParam, valueParam).Compile();
+        }
     }
 
     [RequiresUnreferencedCode("Uses Type.GetProperties which is not compatible with trimming.")]

--- a/src/Headless.Extensions/Reflection/ObjectPropertiesHelper.cs
+++ b/src/Headless.Extensions/Reflection/ObjectPropertiesHelper.cs
@@ -231,8 +231,9 @@ public static class ObjectPropertiesHelper
 
         public void SetValue(object obj, object? value)
         {
-            // Value-type receivers keep reflection SetValue (a compiled unbox-assign would mutate a copy).
-            if (Property.DeclaringType?.IsValueType != false)
+            // Value-type receivers keep reflection SetValue (a compiled unbox-assign would mutate a copy),
+            // and static setters keep it too (Expression.Call rejects an instance expression for them).
+            if (Property.DeclaringType?.IsValueType != false || Property.SetMethod?.IsStatic != false)
             {
                 Property.SetValue(obj, value);
 

--- a/src/Headless.Features.Core/Definitions/DynamicFeatureDefinitionStore.cs
+++ b/src/Headless.Features.Core/Definitions/DynamicFeatureDefinitionStore.cs
@@ -233,6 +233,13 @@ public sealed class DynamicFeatureDefinitionStore(
 
         var context = new FeatureDefinitionContext();
 
+        // Pre-group once: the per-group scans and the recursive per-record ParentName scans over the full
+        // record list are O(records²) for large feature sets. Lookups preserve source order per key.
+        var featuresByGroup = featureRecords.ToLookup(p => p.GroupName, StringComparer.Ordinal);
+        var featuresByParent = featureRecords
+            .Where(p => p.ParentName is not null)
+            .ToLookup(p => p.ParentName!, StringComparer.Ordinal);
+
         foreach (var featureGroupRecord in featureGroupRecords)
         {
             var featureGroup = context.AddGroup(featureGroupRecord.Name, featureGroupRecord.DisplayName);
@@ -244,18 +251,17 @@ public sealed class DynamicFeatureDefinitionStore(
                 featureGroup[property.Key] = property.Value;
             }
 
-            var featureRecordsInThisGroup = featureRecords.Where(p =>
-                string.Equals(p.GroupName, featureGroup.Name, StringComparison.Ordinal)
-            );
-
-            foreach (var featureRecord in featureRecordsInThisGroup.Where(x => x.ParentName is null))
+            foreach (var featureRecord in featuresByGroup[featureGroup.Name])
             {
-                _UpdateInMemoryStoreCacheAddFeatureRecursively(
-                    featureGroup,
-                    featureRecord,
-                    featureRecords,
-                    newFeatureCache
-                );
+                if (featureRecord.ParentName is null)
+                {
+                    _UpdateInMemoryStoreCacheAddFeatureRecursively(
+                        featureGroup,
+                        featureRecord,
+                        featuresByParent,
+                        newFeatureCache
+                    );
+                }
             }
         }
 
@@ -268,7 +274,7 @@ public sealed class DynamicFeatureDefinitionStore(
     private static void _UpdateInMemoryStoreCacheAddFeatureRecursively(
         ICanCreateChildFeature featureContainer,
         FeatureDefinitionRecord featureRecord,
-        List<FeatureDefinitionRecord> allFeatureRecords,
+        ILookup<string, FeatureDefinitionRecord> featuresByParent,
         ImmutableDictionary<string, FeatureDefinition>.Builder featureCacheBuilder
     )
     {
@@ -293,13 +299,9 @@ public sealed class DynamicFeatureDefinitionStore(
             feature[property.Key] = property.Value;
         }
 
-        foreach (
-            var subFeature in allFeatureRecords.Where(p =>
-                string.Equals(p.ParentName, featureRecord.Name, StringComparison.Ordinal)
-            )
-        )
+        foreach (var subFeature in featuresByParent[featureRecord.Name])
         {
-            _UpdateInMemoryStoreCacheAddFeatureRecursively(feature, subFeature, allFeatureRecords, featureCacheBuilder);
+            _UpdateInMemoryStoreCacheAddFeatureRecursively(feature, subFeature, featuresByParent, featureCacheBuilder);
         }
     }
 

--- a/src/Headless.Jobs.EntityFramework/Configurations/CronJobOccurrenceConfigurations.cs
+++ b/src/Headless.Jobs.EntityFramework/Configurations/CronJobOccurrenceConfigurations.cs
@@ -28,6 +28,12 @@ public class CronJobOccurrenceConfigurations<TCronJob>(string schema = Constants
 
         builder.HasIndex("Status", "ExecutionTime").HasDatabaseName("IX_CronJobOccurrence_Status_ExecutionTime");
 
+        // Sweep/reclaim queries filter on lease deadline (Status + LockedUntil) and on ownership
+        // (OwnerId + non-terminal Status) — see TimeJobConfigurations.
+        builder.HasIndex("Status", "LockedUntil").HasDatabaseName("IX_CronJobOccurrence_Status_LockedUntil");
+
+        builder.HasIndex("OwnerId", "Status").HasDatabaseName("IX_CronJobOccurrence_OwnerId_Status");
+
         builder.HasOne(x => x.CronJob).WithMany().HasForeignKey(x => x.CronJobId).OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex("CronJobId", "ExecutionTime").IsUnique().HasDatabaseName("UQ_CronJobId_ExecutionTime");

--- a/src/Headless.Jobs.EntityFramework/Configurations/TimeJobConfigurations.cs
+++ b/src/Headless.Jobs.EntityFramework/Configurations/TimeJobConfigurations.cs
@@ -35,6 +35,13 @@ public class TimeJobConfigurations<TTimeJob>(string schema = Constants.DefaultSc
         // Index for scheduler queries: many jobs can share the same status/time
         builder.HasIndex("Status", "ExecutionTime").HasDatabaseName("IX_TimeJob_Status_ExecutionTime");
 
+        // Sweep/reclaim queries filter on lease deadline (Status + LockedUntil) and on ownership
+        // (OwnerId + non-terminal Status); without these the 30s fallback sweep and dead-node reclaim
+        // scan every InProgress/owned row.
+        builder.HasIndex("Status", "LockedUntil").HasDatabaseName("IX_TimeJob_Status_LockedUntil");
+
+        builder.HasIndex("OwnerId", "Status").HasDatabaseName("IX_TimeJob_OwnerId_Status");
+
         builder.ToTable("TimeJobs", schema);
     }
 }

--- a/src/Headless.Mediator/Behaviors/ValidationRequestPreProcessor.cs
+++ b/src/Headless.Mediator/Behaviors/ValidationRequestPreProcessor.cs
@@ -44,22 +44,50 @@ public sealed class ValidationRequestPreProcessor<TMessage, TResponse>(
             return;
         }
 
-        var validationResults = await Task.WhenAll(
-                validatorList.Select(validator =>
-                    validator.ValidateAsync(new ValidationContext<TMessage>(message), cancellationToken)
-                )
-            )
-            .WithAggregatedExceptions();
+        ValidationResult[] validationResults;
 
-        var failures = validationResults
-            .SelectMany(result => result.Errors)
-            .Where(failure => failure is not null)
-            .ToList();
-
-        if (failures.Count == 0)
+        if (validatorList.Count == 1)
         {
-            return;
+            // Fast path for the dominant single-validator case - avoids Select/Task.WhenAll overhead.
+            var result = await validatorList[0]
+                .ValidateAsync(new ValidationContext<TMessage>(message), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (result.IsValid)
+            {
+                return;
+            }
+
+            validationResults = [result];
         }
+        else
+        {
+            validationResults = await Task.WhenAll(
+                    validatorList.Select(validator =>
+                        validator.ValidateAsync(new ValidationContext<TMessage>(message), cancellationToken)
+                    )
+                )
+                .WithAggregatedExceptions();
+
+            // Early exit if all valid - avoids the failure LINQ chain on the happy path.
+            var allValid = true;
+
+            foreach (var result in validationResults)
+            {
+                if (!result.IsValid)
+                {
+                    allValid = false;
+                    break;
+                }
+            }
+
+            if (allValid)
+            {
+                return;
+            }
+        }
+
+        var failures = validationResults.SelectMany(result => result.Errors).ToList();
 
         _LogMediatorMessageValidation(
             _logger,

--- a/src/Headless.Messaging.Core/Internal/ConsumeMiddlewarePipeline.cs
+++ b/src/Headless.Messaging.Core/Internal/ConsumeMiddlewarePipeline.cs
@@ -54,6 +54,12 @@ internal sealed class ConsumeMiddlewarePipeline(
         Func<object, MediumMessage, MessageHeader, string?, IntentType, object>
     > _compiledConsumeContextFactories = new();
 
+    // Registration existence is fixed once the container is built, so cache per closed context type whether any
+    // direct middleware is registered at all and skip the scoped GetServices + array build on the (common)
+    // zero-middleware consume path. A null probe (non-conforming container) always takes the slow path.
+    private readonly IServiceProviderIsService? _serviceProbe = serviceProvider.GetService<IServiceProviderIsService>();
+    private readonly ConcurrentDictionary<Type, bool> _hasDirectMiddleware = new();
+
     public async Task<ConsumerExecutedResult> ExecuteAsync(
         ConsumerContext context,
         object messageInstance,
@@ -219,10 +225,24 @@ internal sealed class ConsumeMiddlewarePipeline(
         return directMiddleware;
     }
 
-    private static object[] _ResolveDirectMiddleware(IServiceProvider provider, ConsumeContext context)
+    private object[] _ResolveDirectMiddleware(IServiceProvider provider, ConsumeContext context)
     {
+        var contextType = context.GetType();
+
+        if (
+            _serviceProbe is not null
+            && !_hasDirectMiddleware.GetOrAdd(
+                contextType,
+                static (type, self) => self._HasAnyDirectMiddleware(type),
+                this
+            )
+        )
+        {
+            return [];
+        }
+
         var typedServiceType = _TypedMiddlewareServiceTypes.GetOrAdd(
-            context.GetType(),
+            contextType,
             static contextType => typeof(IConsumeMiddleware<>).MakeGenericType(contextType)
         );
         var busMiddleware = provider.GetServices<IConsumeMiddleware<ConsumeContext>>().Cast<object>();
@@ -232,6 +252,17 @@ internal sealed class ConsumeMiddlewarePipeline(
             .Cast<object>();
 
         return [.. busMiddleware, .. typedMiddleware];
+    }
+
+    private bool _HasAnyDirectMiddleware(Type contextType)
+    {
+        var typedServiceType = _TypedMiddlewareServiceTypes.GetOrAdd(
+            contextType,
+            static type => typeof(IConsumeMiddleware<>).MakeGenericType(type)
+        );
+
+        return _serviceProbe!.IsService(typeof(IConsumeMiddleware<ConsumeContext>))
+            || _serviceProbe.IsService(typedServiceType);
     }
 
     private IEnumerable<object> _GetUntrackedDirectMiddleware(

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -658,13 +658,9 @@ internal sealed class ConsumerRegister(
                     }
 
                     // Extract the actual message type for deserialization
-                    // For IConsume<T>.Consume(ConsumeContext<T>, CancellationToken), we need T, not ConsumeContext<T>
-                    var paramType = executor!.Parameters.FirstOrDefault(x => !x.IsFromMessaging)?.ParameterType;
-                    var messageValueType =
-                        paramType is { IsGenericType: true }
-                        && paramType.GetGenericTypeDefinition() == typeof(ConsumeContext<>)
-                            ? paramType.GetGenericArguments()[0]
-                            : paramType;
+                    // For IConsume<T>.Consume(ConsumeContext<T>, CancellationToken), we need T, not ConsumeContext<T>.
+                    // Cached on the descriptor - recomputing it per message is pure reflection overhead.
+                    var messageValueType = executor!.MessageValueType;
 
                     message = await _serializer
                         .DeserializeAsync(transportMessage, messageValueType)

--- a/src/Headless.Messaging.Core/Internal/ISubscribeInvoker.cs
+++ b/src/Headless.Messaging.Core/Internal/ISubscribeInvoker.cs
@@ -31,40 +31,39 @@ internal sealed class SubscribeInvoker(ISerializer serializer, IConsumeMiddlewar
         var mediumMessage = context.MediumMessage;
         var descriptor = context.ConsumerDescriptor;
 
-        // Extract message type from method parameter: IConsume<T>.Consume(ConsumeContext<T>, CancellationToken)
-        var consumeContextParam =
-            descriptor.Parameters.FirstOrDefault(p =>
-                p.ParameterType.IsGenericType && p.ParameterType.GetGenericTypeDefinition() == typeof(ConsumeContext<>)
-            )
+        // Extract message type from method parameter: IConsume<T>.Consume(ConsumeContext<T>, CancellationToken).
+        // Cached on the descriptor - recomputing it per execute is pure reflection overhead.
+        var messageType =
+            descriptor.ConsumeContextValueType
             ?? throw new InvalidOperationException(
                 $"Consumer method must have a ConsumeContext<T> parameter. Method: {descriptor.MethodInfo.Name}"
             );
 
-        var messageType = consumeContextParam.ParameterType.GetGenericArguments()[0];
-
         // Deserialize message
         object? messageInstance = null;
-        if (mediumMessage.Origin.Value != null)
+        var originValue = mediumMessage.Origin.Value;
+
+        if (originValue != null)
         {
-            if (serializer.IsJsonType(mediumMessage.Origin.Value))
+            if (serializer.IsJsonType(originValue))
             {
                 // Value is already a JsonElement
-                messageInstance = serializer.Deserialize(mediumMessage.Origin.Value, messageType);
+                messageInstance = serializer.Deserialize(originValue, messageType);
             }
-            else if (mediumMessage.Origin.Value is string jsonString)
+            else if (originValue is string jsonString)
             {
                 // Value is a JSON string - deserialize it
                 messageInstance = JsonSerializer.Deserialize(jsonString, messageType);
             }
-            else if (messageType.IsInstanceOfType(mediumMessage.Origin.Value))
+            else if (messageType.IsInstanceOfType(originValue))
             {
                 // Value is already the correct type
-                messageInstance = mediumMessage.Origin.Value;
+                messageInstance = originValue;
             }
             else
             {
                 throw new InvalidOperationException(
-                    $"Unsupported message value type: {mediumMessage.Origin.Value?.GetType().Name}. "
+                    $"Unsupported message value type: {originValue.GetType().Name}. "
                         + $"Expected JSON string, JsonElement, or {messageType.Name}"
                 );
             }

--- a/src/Headless.Messaging.Core/Internal/PublishMiddlewarePipeline.cs
+++ b/src/Headless.Messaging.Core/Internal/PublishMiddlewarePipeline.cs
@@ -46,6 +46,12 @@ internal sealed class PublishMiddlewarePipeline(
 
     private readonly IServiceProvider _serviceProvider = Argument.IsNotNull(serviceProvider);
 
+    // Registration existence is fixed once the container is built, so cache per closed context type whether any
+    // direct middleware is registered at all and skip the scoped GetServices + array build on the (common)
+    // zero-middleware publish path. A null probe (non-conforming container) always takes the slow path.
+    private readonly IServiceProviderIsService? _serviceProbe = serviceProvider.GetService<IServiceProviderIsService>();
+    private readonly ConcurrentDictionary<Type, bool> _hasDirectMiddleware = new();
+
     public async Task ExecuteAsync<T>(
         T? content,
         IntentType intentType,
@@ -160,10 +166,24 @@ internal sealed class PublishMiddlewarePipeline(
         return directMiddleware;
     }
 
-    private static object[] _ResolveDirectMiddleware(IServiceProvider provider, PublishContext context)
+    private object[] _ResolveDirectMiddleware(IServiceProvider provider, PublishContext context)
     {
+        var contextType = context.GetType();
+
+        if (
+            _serviceProbe is not null
+            && !_hasDirectMiddleware.GetOrAdd(
+                contextType,
+                static (type, self) => self._HasAnyDirectMiddleware(type),
+                this
+            )
+        )
+        {
+            return [];
+        }
+
         var typedServiceType = _TypedMiddlewareServiceTypes.GetOrAdd(
-            context.GetType(),
+            contextType,
             static contextType => typeof(IPublishMiddleware<>).MakeGenericType(contextType)
         );
         var busMiddleware = provider.GetServices<IPublishMiddleware<PublishContext>>().Cast<object>();
@@ -173,6 +193,17 @@ internal sealed class PublishMiddlewarePipeline(
             .Cast<object>();
 
         return [.. busMiddleware, .. typedMiddleware];
+    }
+
+    private bool _HasAnyDirectMiddleware(Type contextType)
+    {
+        var typedServiceType = _TypedMiddlewareServiceTypes.GetOrAdd(
+            contextType,
+            static type => typeof(IPublishMiddleware<>).MakeGenericType(type)
+        );
+
+        return _serviceProbe!.IsService(typeof(IPublishMiddleware<PublishContext>))
+            || _serviceProbe.IsService(typedServiceType);
     }
 
     private IEnumerable<object> _GetUntrackedDirectMiddleware(

--- a/src/Headless.Messaging.Core/Messages/ConsumerExecutorDescriptor.cs
+++ b/src/Headless.Messaging.Core/Messages/ConsumerExecutorDescriptor.cs
@@ -43,6 +43,54 @@ public sealed class ConsumerExecutorDescriptor
     /// Delivery intent used to subscribe this consumer.
     /// </summary>
     public required IntentType IntentType { get; init; }
+
+    /// <summary>
+    /// The message payload type used for deserialization: <c>T</c> when the first non-framework parameter is
+    /// <see cref="ConsumeContext{T}"/>, otherwise that parameter's type. Cached — descriptors are immutable
+    /// after registration, so recomputing this per received message is pure reflection overhead. The benign
+    /// publication race writes the same <see cref="Type"/> reference.
+    /// </summary>
+    public Type? MessageValueType => field ??= _ComputeMessageValueType();
+
+    /// <summary>
+    /// The <c>T</c> of the consumer's <see cref="ConsumeContext{T}"/> parameter, or <see langword="null"/> when
+    /// the method has no such parameter. Cached for the same reason as <see cref="MessageValueType"/>.
+    /// </summary>
+    public Type? ConsumeContextValueType => field ??= _ComputeConsumeContextValueType();
+
+    private Type? _ComputeMessageValueType()
+    {
+        foreach (var parameter in Parameters)
+        {
+            if (parameter.IsFromMessaging)
+            {
+                continue;
+            }
+
+            var parameterType = parameter.ParameterType;
+
+            return parameterType.IsGenericType && parameterType.GetGenericTypeDefinition() == typeof(ConsumeContext<>)
+                ? parameterType.GetGenericArguments()[0]
+                : parameterType;
+        }
+
+        return null;
+    }
+
+    private Type? _ComputeConsumeContextValueType()
+    {
+        foreach (var parameter in Parameters)
+        {
+            var parameterType = parameter.ParameterType;
+
+            if (parameterType.IsGenericType && parameterType.GetGenericTypeDefinition() == typeof(ConsumeContext<>))
+            {
+                return parameterType.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
 }
 
 public sealed class ParameterDescriptor

--- a/src/Headless.Orm.EntityFramework/ChangeTrackers/HeadlessEntityFrameworkNavigationModifiedTracker.cs
+++ b/src/Headless.Orm.EntityFramework/ChangeTrackers/HeadlessEntityFrameworkNavigationModifiedTracker.cs
@@ -19,7 +19,15 @@ internal sealed class HeadlessEntityFrameworkNavigationModifiedTracker
     public void ChangeTrackerTracked(object? sender, EntityTrackedEventArgs e)
     {
         _EntityEntryTrackedOrStateChanged(e.Entry);
-        _DetectChanges(e.Entry);
+
+        // Query materialization tracks entities in their original state - there is nothing to detect, and
+        // detection costs a StateManager traversal per materialized row (O(tracked entries) when the entity
+        // has skip navigations), taxing every tracking query. Registration above still happens so navigation
+        // changes made to query-loaded entities later are detected via Tracked(Added)/StateChanged events.
+        if (!e.FromQuery)
+        {
+            _DetectChanges(e.Entry);
+        }
     }
 
     public void ChangeTrackerStateChanged(object? sender, EntityStateChangedEventArgs e)

--- a/src/Headless.Orm.EntityFramework/Contexts/Processors/HeadlessAuditSaveEntryProcessor.cs
+++ b/src/Headless.Orm.EntityFramework/Contexts/Processors/HeadlessAuditSaveEntryProcessor.cs
@@ -64,7 +64,7 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
 
         if (entity.DateCreated == default)
         {
-            ObjectPropertiesHelper.TrySetProperty(entity, x => x.DateCreated, () => clock.UtcNow);
+            ObjectPropertiesHelper.TrySetProperty(entity, nameof(ICreateAudit.DateCreated), () => clock.UtcNow);
         }
 
         _TrySetCreateAuditId(entry, currentUser.UserId, currentUser.AccountId);
@@ -100,14 +100,18 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
 
         if (byUser is not null && byUser.CreatedById == null && currentUserId is not null)
         {
-            ObjectPropertiesHelper.TrySetProperty(byUser, x => x.CreatedById, () => currentUserId);
+            ObjectPropertiesHelper.TrySetProperty(byUser, nameof(ICreateAudit<>.CreatedById), () => currentUserId);
 
             return;
         }
 
         if (byAccount is not null && byAccount.CreatedById == null && currentAccountId is not null)
         {
-            ObjectPropertiesHelper.TrySetProperty(byAccount, x => x.CreatedById, () => currentAccountId);
+            ObjectPropertiesHelper.TrySetProperty(
+                byAccount,
+                nameof(ICreateAudit<>.CreatedById),
+                () => currentAccountId
+            );
         }
     }
 
@@ -135,7 +139,7 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
             return;
         }
 
-        if (ObjectPropertiesHelper.TrySetProperty(entity, x => x.DateUpdated, () => clock.UtcNow))
+        if (ObjectPropertiesHelper.TrySetProperty(entity, nameof(IUpdateAudit.DateUpdated), () => clock.UtcNow))
         {
             propertyEntry.IsModified = true;
         }
@@ -165,7 +169,7 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
 
         if (byUser is not null && byUser.UpdatedById is null && currentUserId is not null)
         {
-            if (ObjectPropertiesHelper.TrySetProperty(byUser, x => x.UpdatedById, () => currentUserId))
+            if (ObjectPropertiesHelper.TrySetProperty(byUser, nameof(IUpdateAudit<>.UpdatedById), () => currentUserId))
             {
                 propertyEntry.IsModified = true;
             }
@@ -175,7 +179,13 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
 
         if (byAccount is not null && byAccount.UpdatedById is null && currentAccountId is not null)
         {
-            if (ObjectPropertiesHelper.TrySetProperty(byAccount, x => x.UpdatedById, () => currentAccountId))
+            if (
+                ObjectPropertiesHelper.TrySetProperty(
+                    byAccount,
+                    nameof(IUpdateAudit<>.UpdatedById),
+                    () => currentAccountId
+                )
+            )
             {
                 propertyEntry.IsModified = true;
             }
@@ -209,7 +219,7 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
     {
         if (entity.DateDeleted == null || !entry.Property(nameof(IDeleteAudit.DateDeleted)).IsModified)
         {
-            ObjectPropertiesHelper.TrySetProperty(entity, x => x.DateDeleted, () => clock.UtcNow);
+            ObjectPropertiesHelper.TrySetProperty(entity, nameof(IDeleteAudit.DateDeleted), () => clock.UtcNow);
         }
     }
 
@@ -237,12 +247,16 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
 
         if (byUser is not null && byUser.DeletedById is null && currentUserId is not null)
         {
-            ObjectPropertiesHelper.TrySetProperty(byUser, x => x.DeletedById, () => currentUserId);
+            ObjectPropertiesHelper.TrySetProperty(byUser, nameof(IDeleteAudit<>.DeletedById), () => currentUserId);
         }
 
         if (byAccount is not null && byAccount.DeletedById is null && currentAccountId is not null)
         {
-            ObjectPropertiesHelper.TrySetProperty(byAccount, x => x.DeletedById, () => currentAccountId);
+            ObjectPropertiesHelper.TrySetProperty(
+                byAccount,
+                nameof(IDeleteAudit<>.DeletedById),
+                () => currentAccountId
+            );
         }
     }
 
@@ -276,7 +290,7 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
     {
         if (entity.DateSuspended == null || !entry.Property(nameof(ISuspendAudit.DateSuspended)).IsModified)
         {
-            ObjectPropertiesHelper.TrySetProperty(entity, x => x.DateSuspended, () => clock.UtcNow);
+            ObjectPropertiesHelper.TrySetProperty(entity, nameof(ISuspendAudit.DateSuspended), () => clock.UtcNow);
         }
     }
 
@@ -304,12 +318,16 @@ public sealed class HeadlessAuditSaveEntryProcessor(IClock clock, ICurrentUser c
 
         if (byUser is not null && byUser.SuspendedById is null && currentUserId is not null)
         {
-            ObjectPropertiesHelper.TrySetProperty(byUser, x => x.SuspendedById, () => currentUserId);
+            ObjectPropertiesHelper.TrySetProperty(byUser, nameof(ISuspendAudit<>.SuspendedById), () => currentUserId);
         }
 
         if (byAccount is not null && byAccount.SuspendedById is null && currentAccountId is not null)
         {
-            ObjectPropertiesHelper.TrySetProperty(byAccount, x => x.SuspendedById, () => currentAccountId);
+            ObjectPropertiesHelper.TrySetProperty(
+                byAccount,
+                nameof(ISuspendAudit<>.SuspendedById),
+                () => currentAccountId
+            );
         }
     }
 

--- a/src/Headless.Orm.EntityFramework/Contexts/Processors/HeadlessEntitySaveEntryProcessor.cs
+++ b/src/Headless.Orm.EntityFramework/Contexts/Processors/HeadlessEntitySaveEntryProcessor.cs
@@ -140,7 +140,7 @@ public sealed class HeadlessEntitySaveEntryProcessor(
             return;
         }
 
-        ObjectPropertiesHelper.TrySetProperty(entity, x => x.TenantId, () => tenantId);
+        ObjectPropertiesHelper.TrySetProperty(entity, nameof(IMultiTenant.TenantId), () => tenantId);
     }
 
     private static void _TrySetConcurrencyStamp(EntityEntry entry)
@@ -151,7 +151,7 @@ public sealed class HeadlessEntitySaveEntryProcessor(
             {
                 ObjectPropertiesHelper.TrySetProperty(
                     added,
-                    x => x.ConcurrencyStamp,
+                    nameof(IHasConcurrencyStamp.ConcurrencyStamp),
                     () => Guid.NewGuid().ToString("N")
                 );
             }
@@ -163,7 +163,7 @@ public sealed class HeadlessEntitySaveEntryProcessor(
         {
             ObjectPropertiesHelper.TrySetProperty(
                 modified,
-                x => x.ConcurrencyStamp,
+                nameof(IHasConcurrencyStamp.ConcurrencyStamp),
                 () => Guid.NewGuid().ToString("N")
             );
         }

--- a/src/Headless.Payments.Paymob.CashIn/PaymobCashInAuthenticator.cs
+++ b/src/Headless.Payments.Paymob.CashIn/PaymobCashInAuthenticator.cs
@@ -16,8 +16,12 @@ public sealed class PaymobCashInAuthenticator : IPaymobCashInAuthenticator, IDis
     private readonly IOptionsMonitor<PaymobCashInOptions> _options;
     private readonly IDisposable? _optionsChangeSubscription;
     private readonly SemaphoreSlim _tokenLock = new(1, 1);
-    private string? _cachedToken;
-    private DateTimeOffset _tokenExpiration;
+
+    // A single immutable holder swapped atomically (reference assignment), so the lock-free fast path can
+    // never observe a torn token/expiration pair (DateTimeOffset writes are not atomic).
+    private CachedToken? _cachedToken;
+
+    private sealed record CachedToken(string Token, DateTimeOffset Expiration);
 
     public PaymobCashInAuthenticator(
         IHttpClientFactory httpClientFactory,
@@ -29,11 +33,7 @@ public sealed class PaymobCashInAuthenticator : IPaymobCashInAuthenticator, IDis
         _timeProvider = timeProvider;
         _options = options;
 
-        _optionsChangeSubscription = options.OnChange(_ =>
-        {
-            _cachedToken = null;
-            _tokenExpiration = DateTimeOffset.MinValue;
-        });
+        _optionsChangeSubscription = options.OnChange(_ => _cachedToken = null);
     }
 
     public void Dispose()
@@ -77,8 +77,7 @@ public sealed class PaymobCashInAuthenticator : IPaymobCashInAuthenticator, IDis
                 body: null
             );
 
-        _cachedToken = content.Token;
-        _tokenExpiration = _timeProvider.GetUtcNow().Add(config.TokenRefreshBuffer);
+        _cachedToken = new CachedToken(content.Token, _timeProvider.GetUtcNow().Add(config.TokenRefreshBuffer));
 
         return content;
     }
@@ -86,18 +85,22 @@ public sealed class PaymobCashInAuthenticator : IPaymobCashInAuthenticator, IDis
     public async ValueTask<string> GetAuthenticationTokenAsync(CancellationToken cancellationToken = default)
     {
         // Fast path - no lock needed for cached valid token
-        if (_cachedToken is not null && _tokenExpiration > _timeProvider.GetUtcNow())
+        var cached = _cachedToken;
+
+        if (cached is not null && cached.Expiration > _timeProvider.GetUtcNow())
         {
-            return _cachedToken;
+            return cached.Token;
         }
 
         await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             // Double-check after acquiring lock
-            if (_cachedToken is not null && _tokenExpiration > _timeProvider.GetUtcNow())
+            cached = _cachedToken;
+
+            if (cached is not null && cached.Expiration > _timeProvider.GetUtcNow())
             {
-                return _cachedToken;
+                return cached.Token;
             }
 
             var response = await _RequestAuthenticationTokenAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Headless.Payments.Paymob.CashOut/IPaymobCashOutAuthenticator.cs
+++ b/src/Headless.Payments.Paymob.CashOut/IPaymobCashOutAuthenticator.cs
@@ -60,8 +60,12 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
     private readonly IOptionsMonitor<PaymobCashOutOptions> _options;
     private readonly IDisposable? _optionsChangeSubscription;
     private readonly SemaphoreSlim _tokenLock = new(1, 1);
-    private string? _cachedToken;
-    private DateTimeOffset _tokenExpiration;
+
+    // A single immutable holder swapped atomically (reference assignment), so the lock-free fast path can
+    // never observe a torn token/expiration pair (DateTimeOffset writes are not atomic).
+    private CachedToken? _cachedToken;
+
+    private sealed record CachedToken(string Token, DateTimeOffset Expiration);
 
     public PaymobCashOutAuthenticator(
         IHttpClientFactory httpClientFactory,
@@ -73,11 +77,7 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
         _timeProvider = timeProvider;
         _options = options;
 
-        _optionsChangeSubscription = options.OnChange(_ =>
-        {
-            _cachedToken = null;
-            _tokenExpiration = DateTimeOffset.MinValue;
-        });
+        _optionsChangeSubscription = options.OnChange(_ => _cachedToken = null);
     }
 
     public void Dispose()
@@ -89,18 +89,22 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
     public async ValueTask<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
     {
         // Fast path - no lock needed for cached valid token
-        if (_cachedToken is not null && _tokenExpiration > _timeProvider.GetUtcNow())
+        var cached = _cachedToken;
+
+        if (cached is not null && cached.Expiration > _timeProvider.GetUtcNow())
         {
-            return _cachedToken;
+            return cached.Token;
         }
 
         await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             // Double-check after acquiring lock
-            if (_cachedToken is not null && _tokenExpiration > _timeProvider.GetUtcNow())
+            cached = _cachedToken;
+
+            if (cached is not null && cached.Expiration > _timeProvider.GetUtcNow())
             {
-                return _cachedToken;
+                return cached.Token;
             }
 
             var response = await _GenerateTokenAsync(cancellationToken).ConfigureAwait(false);
@@ -128,7 +132,7 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
         ]);
         request.Headers.Authorization = AuthenticationHeaderFactory.CreateBasic(options.ClientId, options.ClientSecret);
 
-        var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -144,8 +148,7 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
                 .ConfigureAwait(false)
         )!;
 
-        _cachedToken = content.AccessToken;
-        _tokenExpiration = _timeProvider.GetUtcNow().Add(options.TokenRefreshBuffer);
+        _cachedToken = new CachedToken(content.AccessToken, _timeProvider.GetUtcNow().Add(options.TokenRefreshBuffer));
 
         return content;
     }
@@ -169,7 +172,7 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
             new("refresh_token", refreshToken),
         ]);
 
-        var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -186,8 +189,7 @@ public sealed class PaymobCashOutAuthenticator : IPaymobCashOutAuthenticator, ID
         )!;
 
         // Update cache with refreshed token
-        _cachedToken = content.AccessToken;
-        _tokenExpiration = _timeProvider.GetUtcNow().Add(options.TokenRefreshBuffer);
+        _cachedToken = new CachedToken(content.AccessToken, _timeProvider.GetUtcNow().Add(options.TokenRefreshBuffer));
 
         return content;
     }

--- a/src/Headless.Permissions.Core/Definitions/DynamicPermissionDefinitionStore.cs
+++ b/src/Headless.Permissions.Core/Definitions/DynamicPermissionDefinitionStore.cs
@@ -209,6 +209,13 @@ public sealed class DynamicPermissionDefinitionStore(
 
         var context = new PermissionDefinitionContext();
 
+        // Pre-group once: the per-group scans and the recursive per-record ParentName scans over the full
+        // record list are O(records²) for large permission sets. Lookups preserve source order per key.
+        var permissionsByGroup = permissionRecords.ToLookup(p => p.GroupName, StringComparer.Ordinal);
+        var permissionsByParent = permissionRecords
+            .Where(p => p.ParentName is not null)
+            .ToLookup(p => p.ParentName!, StringComparer.Ordinal);
+
         foreach (var permissionGroupRecord in permissionGroupRecords)
         {
             var permissionGroup = context.AddGroup(permissionGroupRecord.Name, permissionGroupRecord.DisplayName);
@@ -220,13 +227,16 @@ public sealed class DynamicPermissionDefinitionStore(
                 permissionGroup[property.Key] = property.Value;
             }
 
-            var permissionRecordsInThisGroup = permissionRecords.Where(p =>
-                string.Equals(p.GroupName, permissionGroup.Name, StringComparison.Ordinal)
-            );
-
-            foreach (var permissionRecord in permissionRecordsInThisGroup.Where(x => x.ParentName == null))
+            foreach (var permissionRecord in permissionsByGroup[permissionGroup.Name])
             {
-                _UpdateInMemoryStoreCacheAddFeatureRecursively(permissionGroup, permissionRecord, permissionRecords);
+                if (permissionRecord.ParentName == null)
+                {
+                    _UpdateInMemoryStoreCacheAddFeatureRecursively(
+                        permissionGroup,
+                        permissionRecord,
+                        permissionsByParent
+                    );
+                }
             }
         }
     }
@@ -234,7 +244,7 @@ public sealed class DynamicPermissionDefinitionStore(
     private void _UpdateInMemoryStoreCacheAddFeatureRecursively(
         ICanAddChildPermission permissionContainer,
         PermissionDefinitionRecord permissionRecord,
-        List<PermissionDefinitionRecord> allPermissionRecords
+        ILookup<string, PermissionDefinitionRecord> permissionsByParent
     )
     {
         var permission = permissionContainer.AddChild(
@@ -255,13 +265,9 @@ public sealed class DynamicPermissionDefinitionStore(
             permission[property.Key] = property.Value;
         }
 
-        foreach (
-            var subPermission in allPermissionRecords.Where(p =>
-                string.Equals(p.ParentName, permissionRecord.Name, StringComparison.Ordinal)
-            )
-        )
+        foreach (var subPermission in permissionsByParent[permissionRecord.Name])
         {
-            _UpdateInMemoryStoreCacheAddFeatureRecursively(permission, subPermission, allPermissionRecords);
+            _UpdateInMemoryStoreCacheAddFeatureRecursively(permission, subPermission, permissionsByParent);
         }
     }
 

--- a/src/Headless.Permissions.Core/Grants/PermissionManager.cs
+++ b/src/Headless.Permissions.Core/Grants/PermissionManager.cs
@@ -228,9 +228,10 @@ public sealed class PermissionManager(
             return result;
         }
 
-        // First pass: check for explicit denials (Prohibited)
-        // AWS IAM-style: explicit deny overrides all grants
-        var explicitDenials = new HashSet<string>(StringComparer.Ordinal);
+        // Evaluate each matching provider exactly once - CheckAsync typically fans out to the distributed
+        // grant cache (per role for the role provider), so the denial and grant passes below share these
+        // results instead of doubling those round-trips per authorization check.
+        var providerGrantsList = new List<(string ProviderName, MultiplePermissionGrantStatusResult Grants)>();
 
         foreach (var provider in grantProviderManager.ValueProviders)
         {
@@ -243,6 +244,15 @@ public sealed class PermissionManager(
                 .CheckAsync(checkNeededPermissions, currentUser, cancellationToken)
                 .ConfigureAwait(false);
 
+            providerGrantsList.Add((provider.Name, providerGrants));
+        }
+
+        // First pass: check for explicit denials (Prohibited)
+        // AWS IAM-style: explicit deny overrides all grants
+        var explicitDenials = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (_, providerGrants) in providerGrantsList)
+        {
             foreach (var (permissionName, providerResult) in providerGrants)
             {
                 if (providerResult.Status is PermissionGrantStatus.Prohibited)
@@ -252,18 +262,12 @@ public sealed class PermissionManager(
             }
         }
 
-        // Second pass: apply grants only if not explicitly denied
-        foreach (var provider in grantProviderManager.ValueProviders)
+        // Second pass: apply grants only if not explicitly denied. Index results by name once instead of a
+        // linear First() scan per granted permission (quadratic for large permission batches).
+        var resultsByName = result.ToDictionary(x => x.Name, StringComparer.Ordinal);
+
+        foreach (var (grantProviderName, providerGrants) in providerGrantsList)
         {
-            if (providerName is not null && !string.Equals(provider.Name, providerName, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var providerGrants = await provider
-                .CheckAsync(checkNeededPermissions, currentUser, cancellationToken)
-                .ConfigureAwait(false);
-
             foreach (var (permissionName, providerResult) in providerGrants)
             {
                 if (providerResult.Status is not PermissionGrantStatus.Granted)
@@ -277,10 +281,10 @@ public sealed class PermissionManager(
                     continue;
                 }
 
-                var grant = result.First(x => string.Equals(x.Name, permissionName, StringComparison.Ordinal));
+                var grant = resultsByName[permissionName];
 
                 grant.IsGranted = true;
-                grant.Providers.Add(new GrantPermissionProvider(provider.Name, providerResult.ProviderKeys));
+                grant.Providers.Add(new GrantPermissionProvider(grantProviderName, providerResult.ProviderKeys));
             }
         }
 

--- a/src/Headless.Serializer.Json/Extensions/ToObjectExtensions.cs
+++ b/src/Headless.Serializer.Json/Extensions/ToObjectExtensions.cs
@@ -41,19 +41,24 @@ public static class ToObjectExtensions
             return default;
         }
 
-        var text = obj.ToString();
-        Debug.Assert(text is not null);
-
         var baseType = typeof(T);
         var underlyingType = Nullable.GetUnderlyingType(baseType) ?? baseType;
 
+        // ToString() only in the branches that consume it: for JSON node inputs it would materialize the
+        // entire raw payload as a string that the deserialization branches below never read.
         if (underlyingType == typeof(Guid) || underlyingType == typeof(string))
         {
+            var text = obj.ToString();
+            Debug.Assert(text is not null);
+
             return (T?)TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString(text);
         }
 
         if (underlyingType.IsEnum)
         {
+            var text = obj.ToString();
+            Debug.Assert(text is not null);
+
             return (T?)Enum.Parse(underlyingType, text);
         }
 

--- a/src/Headless.Sms.Cequens/CequensSmsSender.cs
+++ b/src/Headless.Sms.Cequens/CequensSmsSender.cs
@@ -206,11 +206,12 @@ internal sealed class CequensSmsSender(
             {
                 var signInRequest = new SigningInRequest(_options.ApiKey, _options.UserName);
                 using var signInContent = JsonContent.Create(signInRequest, options: _JsonOptions);
-                var response = await httpClient
+                using var response = await httpClient
                     .PostAsync(_options.TokenEndpoint, signInContent, cancellationToken)
                     .ConfigureAwait(false);
-                var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
+                // Only the status code is reported on failure, so skip buffering the body to a string and
+                // deserialize the success payload straight off the response stream.
                 if (!response.IsSuccessStatusCode)
                 {
                     logger.LogFailedToGetTokenWithStatusCode(response.StatusCode);
@@ -218,7 +219,11 @@ internal sealed class CequensSmsSender(
                     return null;
                 }
 
-                var token = JsonSerializer.Deserialize<SigningInResponse>(content, _JsonOptions)?.Data?.AccessToken;
+                var signInResponse = await response
+                    .Content.ReadFromJsonAsync<SigningInResponse>(_JsonOptions, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var token = signInResponse?.Data?.AccessToken;
 
                 if (token != null)
                 {

--- a/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
+++ b/src/Headless.Sms.Connekio/ConnekioSmsSender.cs
@@ -2,6 +2,7 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Encodings.Web;
 using Headless.Checks;
 using Headless.Http;
@@ -49,7 +50,7 @@ internal sealed class ConnekioSmsSender(
         return await _SendAsync(
                 _singleSmsEndpoint,
                 () =>
-                    JsonSerializer.Serialize(
+                    JsonContent.Create(
                         new ConnekioSingleSmsRequest
                         {
                             AccountId = _options.AccountId,
@@ -57,7 +58,7 @@ internal sealed class ConnekioSmsSender(
                             Text = request.Text,
                             Msisdn = request.Destination.ToString(),
                         },
-                        _JsonOptions
+                        options: _JsonOptions
                     ),
                 destinationCount: 1,
                 cancellationToken
@@ -80,7 +81,7 @@ internal sealed class ConnekioSmsSender(
         var outcome = await _SendAsync(
                 _batchSmsEndpoint,
                 () =>
-                    JsonSerializer.Serialize(
+                    JsonContent.Create(
                         new ConnekioBatchSmsRequest
                         {
                             AccountId = _options.AccountId,
@@ -91,7 +92,7 @@ internal sealed class ConnekioSmsSender(
                                 .. request.Destinations.Select(r => new ConnekioRecipient { Msisdn = r.ToString() }),
                             ],
                         },
-                        _JsonOptions
+                        options: _JsonOptions
                     ),
                 request.Destinations.Count,
                 cancellationToken
@@ -102,20 +103,21 @@ internal sealed class ConnekioSmsSender(
     }
 
     // Both entry points share one try/catch so the never-throw contract (only OperationCanceledException and
-    // argument-validation propagate) lives in a single place. The payload is built inside the guarded region so
-    // a serialization fault is reported as a failed response rather than thrown.
+    // argument-validation propagate) lives in a single place. JsonContent serializes UTF-8 straight into the
+    // request stream during SendAsync — inside this guarded region — so a serialization fault is still reported
+    // as a failed response rather than thrown, without the UTF-16 payload string StringContent required.
     private async ValueTask<SendSingleSmsResponse> _SendAsync(
         Uri endpoint,
-        [InstantHandle] Func<string> payloadFactory,
+        [InstantHandle] Func<HttpContent> contentFactory,
         int destinationCount,
         CancellationToken cancellationToken
     )
     {
         try
         {
-            var payload = payloadFactory();
+            var content = contentFactory();
 
-            return await _PostAsync(endpoint, payload, destinationCount, cancellationToken).ConfigureAwait(false);
+            return await _PostAsync(endpoint, content, destinationCount, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -131,13 +133,13 @@ internal sealed class ConnekioSmsSender(
 
     private async ValueTask<SendSingleSmsResponse> _PostAsync(
         Uri endpoint,
-        string payload,
+        HttpContent content,
         int destinationCount,
         CancellationToken cancellationToken
     )
     {
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, endpoint);
-        requestMessage.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+        requestMessage.Content = content;
         requestMessage.Headers.Authorization = _basicAuthHeader;
 
         using var httpClient = httpClientFactory.CreateClient(httpClientName);

--- a/src/Headless.Tus.Azure/Services/TusAzureStore.Core.cs
+++ b/src/Headless.Tus.Azure/Services/TusAzureStore.Core.cs
@@ -67,13 +67,8 @@ public sealed partial class TusAzureStore
     {
         await _EnsureValidFileIdAsync(fileId).ConfigureAwait(false);
 
-        var blobInfo = await _GetTusFileInfoAsync(fileId, cancellationToken).ConfigureAwait(false);
-
-        if (blobInfo == null)
-        {
-            return 0;
-        }
-
+        // No GetProperties pre-check: _GetCommittedBlocksAsync maps a missing blob (404) to an empty list,
+        // so the offset is 0 either way and this method costs one round-trip instead of two per HEAD/PATCH.
         var blockBlobClient = _containerClient.GetBlockBlobClient(_GetBlobName(fileId));
         var blockList = await _GetCommittedBlocksAsync(blockBlobClient, cancellationToken).ConfigureAwait(false);
 

--- a/tests/Headless.Permissions.Tests.Unit/Grants/PermissionManagerTests.cs
+++ b/tests/Headless.Permissions.Tests.Unit/Grants/PermissionManagerTests.cs
@@ -101,13 +101,13 @@ public sealed class PermissionManagerTests : TestBase
         // when
         var result = await _sut.GetAsync(permissionName, currentUser, cancellationToken: AbortToken);
 
-        // then
+        // then - each provider is evaluated exactly once per check; the denial and grant passes share the results
         result.IsGranted.Should().BeTrue();
         await provider1
-            .Received(2)
+            .Received(1)
             .CheckAsync(Arg.Any<IReadOnlyCollection<PermissionDefinition>>(), currentUser, AbortToken);
         await provider2
-            .Received(2)
+            .Received(1)
             .CheckAsync(Arg.Any<IReadOnlyCollection<PermissionDefinition>>(), currentUser, AbortToken);
     }
 


### PR DESCRIPTION
## Summary

Applies every fix classified **safe** by the full-repo performance review (8 parallel domain reviews over src/), one commit per domain. Risky items (jobs thread-pool rewrite, messaging scope restructure, `GetOrAddAsync` fast-path inlining, etc.) are deliberately excluded, and three review items were dropped after verification failed their preconditions (details below).

### Per-request / per-message hot paths
- **API/Mediator** — `ApiResult` mapping branches on `TryGetValue`/`TryGetError` instead of `Match` (drops error-branch closures allocated on every success response); manual argument scan in `MinimalApiValidatorFilter`; single-validator fast path + all-valid early exit in `ValidationRequestPreProcessor`; state-passing `OnStarting` in `NoCacheHeadersMiddleware`; `StringValues` indexer in `IdempotencyMiddleware`.
- **Messaging** — consumer message types cached on the immutable `ConsumerExecutorDescriptor` (were recomputed via LINQ + reflection twice per message); consume/publish pipelines probe `IServiceProviderIsService` once and skip the per-message scoped `GetServices` + array build when no middleware is registered.

### Storage / IO round-trips and copies
- **Caching** — `RedisCache._ToConcurrencyStamp` slices the `ReadOnlySequence` view instead of a `byte[]` cast that re-materializes the whole payload for inline/sequence-backed values; TTL jitter uses `Random.Shared` instead of the CSPRNG.
- **Blobs/Tus** — Tus.Azure `GetUploadOffsetAsync` drops a redundant `GetProperties` round-trip (every HEAD/PATCH offset probe now costs one call); FS `ListAsync` enumerates via `DirectoryInfo` (no second stat per file) and derives keys by prefix slice; Redis upload reads seekable streams once into an exact-size buffer and pools the streaming copy buffer.
- **Jobs** — added `(Status, LockedUntil)` and `(OwnerId, Status)` indexes for the 30s fallback sweep and dead-node reclaim predicates (previously only `(Status, ExecutionTime)` existed).

### Save pipeline / authorization
- **ORM** — navigation-modification detection skips query-materialized entities (`FromQuery`): detection cost a StateManager traversal per row (O(tracked entries) with skip navigations) on every tracking query, and its output has no production consumer; Attach/Add/StateChanged detection unchanged. Audit/tenant/concurrency stamping uses new string-name `ObjectPropertiesHelper` overloads + cached compiled setters (eliminates 3-4 expression trees per entity per save and `PropertyInfo.SetValue` costs; `TargetInvocationException` contract preserved; static/value-type setters keep reflection).
- **Permissions** — grant providers are evaluated once per check instead of twice (halves distributed-cache round-trips per authorization check); results indexed instead of a linear `First()` per grant; dynamic permission/feature definition-store refresh pre-groups records into lookups (was O(records²)).

### Outbound providers
- Connekio SMS streams UTF-8 via `JsonContent` (bulk payloads were serialized to UTF-16 then re-encoded); Cequens token response disposed + stream-deserialized; Paymob CashIn/CashOut token caches swapped to an atomically-published immutable holder (torn `DateTimeOffset` read on the lock-free fast path) and CashOut token/refresh responses disposed.

## Dropped after verification (were candidate "safe" fixes)
- **Status-only messaging success UPDATE** — the Succeeded `Content` rewrite is what persists the `ExecutionInstanceId` header (stamped after store) and post-retry exception headers; skipping it changes observable dashboard/ops data.
- **Batched jobs sweep claims** — the per-row `UpdatedAt` guard also guarantees the yielded projection matches the claimed row, and a set-based re-select cannot distinguish this sweep's claims from concurrent same-owner scheduler claims (double-yield risk).
- **Membership prune-on-read throttle** — the coordination conformance suite asserts an empty snapshot immediately after the retention threshold; prune timeliness is contract. Follow-up: dedicated cleanup service like the Redis provider.

## Verification
- Full solution build: 0 warnings / 0 errors.
- Unit: 8823/8825 pass (2 known-unrelated: `CommitScopeFactoryTests…sync_scope_is_disposed_without_signal` is a `SpinWait` flake under parallel module load — passes 31/31 in isolation, package untouched by this branch).
- Integration (Testcontainers): Jobs EF PostgreSQL 27/27 + SqlServer 27/27 (validates new index DDL), Caching Redis 236/236 (CAS stamp byte-compat), Tus.Azure 99/99, Blobs FS 80/80, Blobs Redis 61/62 — the 1 failure (`container_management_capability_matches_support_flag`) reproduces identically on the pre-change provider code (pre-existing; Redis `EnsureContainerAsync` is a documented no-op so exists-after-ensure cannot hold without prior state).
- `make quality-analyzers`: only new diagnostic is info-level CA5394 on the jitter line; `Random.Shared` for non-security randomness has four existing precedents in src. Remaining reported items are pre-existing test-file suggestions untouched here.

Full review artifact (hot paths, confirmed/suspected findings, benchmark plan): `.context/docs/06-07-2026-perf-review.md` (not committed).