### PR TITLE
docs: improve new user onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 150+ NuGet packages &bull; Abstraction + Provider pattern &bull; Explicit infrastructure
 
-[Quick Start](#quick-start) &bull; [Install By Goal](#install-by-goal) &bull; [Messaging](#messaging) &bull; [Packages](#packages) &bull; [Production Guidance](#production-guidance) &bull; [Contributing](#contributing)
+[Quick Start](#quick-start) &bull; [Pick Packages By Job](#pick-packages-by-job) &bull; [Messaging](#messaging) &bull; [Packages](#packages) &bull; [Production Guidance](#production-guidance) &bull; [Contributing](#contributing)
 
 </div>
 
@@ -30,19 +30,18 @@ Headless separates those concerns:
 
 Use Headless when you want provider-swappable infrastructure with explicit setup and source-visible behavior. Production correctness still depends on choosing the right provider, storage, retry, transaction, and idempotency model for your service.
 
-## Install By Goal
+## Pick Packages By Job
 
-| Goal | Start With | Add Provider Packages |
-|------|------------|-----------------------|
-| API defaults, health checks, OpenTelemetry, common middleware | `Headless.Api.ServiceDefaults` | None unless your app needs other domains |
-| Local messaging without external infrastructure | `Headless.Messaging.Core` | `Headless.Messaging.InMemory`, `Headless.Messaging.InMemoryStorage` |
-| Durable messaging with RabbitMQ | `Headless.Messaging.Core` | `Headless.Messaging.RabbitMq` plus one durable storage provider |
-| Durable messaging with Kafka | `Headless.Messaging.Core` | `Headless.Messaging.Kafka` plus one durable storage provider |
-| Durable messaging with Azure Service Bus | `Headless.Messaging.Core` | `Headless.Messaging.AzureServiceBus` plus one durable storage provider |
-| Durable outbox storage with PostgreSQL | `Headless.Messaging.Core` | `Headless.Messaging.Storage.PostgreSql` |
-| Durable outbox storage with SQL Server | `Headless.Messaging.Core` | `Headless.Messaging.Storage.SqlServer` |
-| EF Core-backed transactional outbox | `Headless.Messaging.Core` | `Headless.Messaging.Storage.PostgreSql` or `Headless.Messaging.Storage.SqlServer`, then call `UseEntityFramework<TContext>()` |
-| Cache abstraction | `Headless.Caching.Core` | `Headless.Caching.InMemory`, `Headless.Caching.Redis`, or `Headless.Caching.Hybrid` |
+| Job | Start With | Add When You Need |
+|-----|------------|-------------------|
+| API defaults, health checks, OpenTelemetry, common middleware | `Headless.Api.ServiceDefaults` | Other domain packages only when the API uses them |
+| Local or test messaging | `Headless.Messaging.Core` | `Headless.Messaging.InMemory`, `Headless.Messaging.InMemoryStorage`, or `Headless.Messaging.Testing` |
+| Production messaging transport | `Headless.Messaging.Core` | One transport: AWS, Azure Service Bus, Kafka, NATS, Pulsar, RabbitMQ, or Redis |
+| Durable outbox, delayed dispatch, and persisted retry | `Headless.Messaging.Core` | One storage provider: PostgreSQL or SQL Server |
+| EF Core-backed transactional outbox | Messaging core plus PostgreSQL or SQL Server storage | Call `UseEntityFramework<TContext>()` |
+| Raw ADO outbox coordination | Messaging core plus PostgreSQL or SQL Server storage | Register the matching commit-coordination provider and use coordinated-transaction helpers |
+| Messaging dashboard | `Headless.Messaging.Dashboard` | `Headless.Messaging.Dashboard.K8s` for Kubernetes node discovery |
+| Cache abstraction | `Headless.Caching.Core` | In-memory, Redis, hybrid, BCL adapter, output cache, or distributed-lock-backed cache |
 | Blob storage abstraction | `Headless.Blobs.Core` | Azure, AWS, Cloudflare R2, filesystem, Redis, or SFTP provider |
 | Email abstraction | `Headless.Emails.Core` | AWS, Azure Communication Services, MailKit SMTP, or dev provider |
 | Test-only infrastructure | Domain core package | In-memory provider or testing package for that domain |
@@ -221,6 +220,7 @@ builder.Services.AddHeadlessMessaging(setup =>
     setup.Options.RetryPolicy.MaxPersistedRetries = 15;
     setup.Options.RetryPolicy.InitialDispatchGrace = TimeSpan.FromSeconds(30);
     setup.Options.RetryPolicy.DispatchTimeout = TimeSpan.FromMinutes(5);
+    setup.Options.RetryPolicy.OnExhaustedTimeout = TimeSpan.FromSeconds(30);
     setup.Options.RetryPolicy.BackoffStrategy = new ExponentialBackoffStrategy(
         initialDelay: TimeSpan.FromSeconds(2),
         maxDelay: TimeSpan.FromMinutes(5),
@@ -237,9 +237,12 @@ Defaults from `RetryPolicyOptions`:
 - `MaxPersistedRetries`: `15`
 - `InitialDispatchGrace`: `30 seconds`
 - `DispatchTimeout`: `5 minutes`
+- `OnExhaustedTimeout`: `30 seconds`
 - `BackoffStrategy`: exponential backoff with jitter
 
 Total observable attempts are `(MaxInlineRetries + 1) * (MaxPersistedRetries + 1)`. With defaults, that is 48 attempts. Delivery remains at-least-once, so consumers must be safe to run more than once.
+
+`RetryPolicy.OnExhausted` is invoked after the retry budget is consumed or a backoff strategy returns `RetryDecision.Exhausted`. Permanent failures and cancellations short-circuit the retry budget and do not invoke that callback. The callback is bounded by `OnExhaustedTimeout`, is caught and logged on failure, and must be idempotent because broker redelivery and crash recovery can still produce repeated terminal observations.
 
 ### Processor and Consumer
 
@@ -358,11 +361,19 @@ Before using messaging in production:
 
 ## Examples
 
+Messaging demos are intentionally small and local-first. Several use fixed local connection strings, unauthenticated dashboards, or demo-only credentials; treat them as runnable examples of wiring, not production templates.
+
 | Example | Shows |
 |---------|-------|
 | [`demo/Headless.Messaging.Console.Demo`](demo/Headless.Messaging.Console.Demo) | In-memory transport/storage, consumer registration, bootstrap, publish, callbacks |
-| [`demo/Headless.Messaging.RabbitMq.SqlServer.Demo`](demo/Headless.Messaging.RabbitMq.SqlServer.Demo) | RabbitMQ transport, SQL Server storage, EF coordination, raw ADO coordination, rollback, delayed publish |
+| [`demo/Headless.Messaging.Aws.InMemory.Demo`](demo/Headless.Messaging.Aws.InMemory.Demo) | AWS transport setup with in-memory storage and dashboard wiring |
+| [`demo/Headless.Messaging.AzureServiceBus.InMemory.Demo`](demo/Headless.Messaging.AzureServiceBus.InMemory.Demo) | Azure Service Bus setup, headers, SQL filters, custom producers, in-memory storage |
+| [`demo/Headless.Messaging.Dashboard.Auth.Demo`](demo/Headless.Messaging.Dashboard.Auth.Demo) | Dashboard host authentication with OpenID Connect, custom auth scheme, and anonymous variants |
+| [`demo/Headless.Messaging.Dashboard.Jwt.Demo`](demo/Headless.Messaging.Dashboard.Jwt.Demo) | Dashboard host authentication with JWT bearer auth and in-memory messaging |
 | [`demo/Headless.Messaging.Kafka.PostgreSql.Demo`](demo/Headless.Messaging.Kafka.PostgreSql.Demo) | Kafka transport, PostgreSQL storage, raw coordination, EF coordination |
+| [`demo/Headless.Messaging.Pulsar.InMemory.Demo`](demo/Headless.Messaging.Pulsar.InMemory.Demo) | Pulsar transport with in-memory storage and dashboard wiring |
+| [`demo/Headless.Messaging.RabbitMq.SqlServer.Demo`](demo/Headless.Messaging.RabbitMq.SqlServer.Demo) | RabbitMQ transport, SQL Server storage, EF coordination, raw ADO coordination, rollback, delayed publish |
+| [`demo/Headless.Messaging.Redis.SqlServer.Demo`](demo/Headless.Messaging.Redis.SqlServer.Demo) | Redis transport, SQL Server storage, dashboard wiring, Swagger in development |
 
 ## Versioning and Compatibility
 
@@ -414,6 +425,7 @@ Property-level audit logging for tracking entity mutations and explicit business
 | Package | Description |
 |---------|-------------|
 | [Headless.AuditLog.Abstractions](src/Headless.AuditLog.Abstractions/README.md) | Audit log contracts and interfaces |
+| [Headless.AuditLog.Core](src/Headless.AuditLog.Core/README.md) | Audit log DI setup, options validation, and provider setup pipeline |
 | [Headless.AuditLog.Storage.EntityFramework](src/Headless.AuditLog.Storage.EntityFramework/README.md) | EF Core audit log persistence |
 | [Headless.AuditLog.Storage.PostgreSql](src/Headless.AuditLog.Storage.PostgreSql/README.md) | PostgreSQL raw audit log storage |
 | [Headless.AuditLog.Storage.SqlServer](src/Headless.AuditLog.Storage.SqlServer/README.md) | SQL Server raw audit log storage |
@@ -455,6 +467,7 @@ Verify CAPTCHA tokens behind one pass/fail abstraction. Compose Google reCAPTCHA
 | Package | Description |
 |---------|-------------|
 | [Headless.Captcha.Abstractions](src/Headless.Captcha.Abstractions/README.md) | CAPTCHA verification interfaces and builder |
+| [Headless.Captcha.Core](src/Headless.Captcha.Core/README.md) | CAPTCHA setup and validation pipeline |
 | [Headless.Captcha.ReCaptcha](src/Headless.Captcha.ReCaptcha/README.md) | Google reCAPTCHA v2/v3 provider |
 | [Headless.Captcha.Turnstile](src/Headless.Captcha.Turnstile/README.md) | Cloudflare Turnstile provider |
 
@@ -690,6 +703,7 @@ Send SMS messages through a unified interface with providers for major regional 
 | Package | Description |
 |---------|-------------|
 | [Headless.Sms.Abstractions](src/Headless.Sms.Abstractions/README.md) | SMS sending interfaces |
+| [Headless.Sms.Core](src/Headless.Sms.Core/README.md) | SMS setup builder and provider selection |
 | [Headless.Sms.Aws](src/Headless.Sms.Aws/README.md) | AWS SNS SMS provider |
 | [Headless.Sms.Cequens](src/Headless.Sms.Cequens/README.md) | Cequens SMS provider |
 | [Headless.Sms.Connekio](src/Headless.Sms.Connekio/README.md) | Connekio SMS provider |
@@ -706,6 +720,7 @@ Lightweight connection factories for raw SQL access when you need to drop below 
 | Package | Description |
 |---------|-------------|
 | [Headless.Sql.Abstractions](src/Headless.Sql.Abstractions/README.md) | SQL connection interfaces |
+| [Headless.Sql.Core](src/Headless.Sql.Core/README.md) | Default scoped ambient current-connection implementation |
 | [Headless.Sql.PostgreSql](src/Headless.Sql.PostgreSql/README.md) | PostgreSQL connection factory |
 | [Headless.Sql.SqlServer](src/Headless.Sql.SqlServer/README.md) | SQL Server connection factory |
 | [Headless.Sql.Sqlite](src/Headless.Sql.Sqlite/README.md) | SQLite connection factory |

--- a/demo/Headless.Messaging.Aws.InMemory.Demo/README.md
+++ b/demo/Headless.Messaging.Aws.InMemory.Demo/README.md
@@ -1,0 +1,23 @@
+# Headless.Messaging.Aws.InMemory.Demo
+
+ASP.NET Core demo for wiring the AWS messaging transport with in-memory storage.
+
+## Shows
+
+- Assembly scanning with `ForMessagesFromAssembly(...)`.
+- AWS transport setup through `UseAws(...)`.
+- In-memory storage through `UseInMemoryStorage()`.
+- Messaging dashboard registration with `WithNoAuth()`.
+- Controller-based publishing.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Aws.InMemory.Demo
+```
+
+The demo configures `RegionEndpoint.CNNorthWest1`; AWS credentials and reachable AWS messaging resources must come from your normal AWS SDK environment.
+
+## Production Note
+
+The dashboard is unauthenticated and storage is in memory. Use durable storage and production authentication before using this shape outside local demos.

--- a/demo/Headless.Messaging.AzureServiceBus.InMemory.Demo/README.md
+++ b/demo/Headless.Messaging.AzureServiceBus.InMemory.Demo/README.md
@@ -1,0 +1,24 @@
+# Headless.Messaging.AzureServiceBus.InMemory.Demo
+
+ASP.NET Core demo for Azure Service Bus publishing with in-memory Headless storage.
+
+## Shows
+
+- `UseAzureServiceBus(...)` with a configured connection string.
+- Custom headers through `CustomHeadersBuilder`.
+- SQL filters through `SqlFilters`.
+- Custom topic/subscription producer configuration.
+- Dashboard registration with `WithNoAuth()`.
+- Minimal endpoints that publish integration and domain messages.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.AzureServiceBus.InMemory.Demo
+```
+
+Set the `AzureServiceBus` connection string in configuration before running.
+
+## Production Note
+
+The dashboard is unauthenticated and storage is in memory. Use durable storage, protected dashboard access, and non-demo credentials for production.

--- a/demo/Headless.Messaging.Console.Demo/README.md
+++ b/demo/Headless.Messaging.Console.Demo/README.md
@@ -1,0 +1,24 @@
+# Headless.Messaging.Console.Demo
+
+Console demo for the smallest in-process messaging setup.
+
+## Shows
+
+- `AddHeadlessMessaging(...)` without ASP.NET Core.
+- In-memory transport through `UseInMemory()`.
+- In-memory storage through `UseInMemoryStorage()`.
+- Bus consumer registration with `OnBus<TConsumer>()`.
+- `IOutboxBus.PublishAsync(...)` with callback metadata.
+- A custom bus consume middleware.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Console.Demo
+```
+
+The process publishes a `ShowTimeEvent` every two seconds until the console exits.
+
+## Production Note
+
+This demo is local-only. In-memory transport and storage do not provide durable production messaging.

--- a/demo/Headless.Messaging.Dashboard.Auth.Demo/README.md
+++ b/demo/Headless.Messaging.Dashboard.Auth.Demo/README.md
@@ -1,0 +1,23 @@
+# Headless.Messaging.Dashboard.Auth.Demo
+
+ASP.NET Core demo for Messaging Dashboard host authentication.
+
+## Shows
+
+- `UseDashboard(d => d.WithHostAuthentication(policy))`.
+- OpenID Connect plus cookie authentication for dashboard access.
+- A custom authentication scheme variant.
+- Anonymous dashboard registration as a commented alternative.
+- In-memory messaging transport and storage.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Dashboard.Auth.Demo
+```
+
+The active startup path combines OpenID Connect and the custom authentication scheme. Other variants are kept as methods in `Startup` and can be selected by changing the call in `ConfigureServices`.
+
+## Production Note
+
+This demo uses public demo identity-provider values and in-memory messaging. Replace auth settings, require HTTPS, and use durable providers for production.

--- a/demo/Headless.Messaging.Dashboard.Jwt.Demo/README.md
+++ b/demo/Headless.Messaging.Dashboard.Jwt.Demo/README.md
@@ -1,0 +1,23 @@
+# Headless.Messaging.Dashboard.Jwt.Demo
+
+ASP.NET Core demo for protecting the Messaging Dashboard with JWT bearer authentication.
+
+## Shows
+
+- JWT bearer authentication and an authorization policy.
+- `UseDashboard(d => d.WithHostAuthentication(policy))`.
+- In-memory messaging transport and storage.
+- A hosted service that publishes demo messages.
+- `/security/createToken` endpoint for demo token creation.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Dashboard.Jwt.Demo
+```
+
+Create a token by posting user `bob` with password `bob` to `/security/createToken`, then use it when opening dashboard endpoints.
+
+## Production Note
+
+The JWT setup disables issuer and audience validation and allows query-string tokens for the demo. Validate issuer, audience, HTTPS, signing keys, and token transport before using this pattern in production.

--- a/demo/Headless.Messaging.Kafka.PostgreSql.Demo/README.md
+++ b/demo/Headless.Messaging.Kafka.PostgreSql.Demo/README.md
@@ -1,0 +1,24 @@
+# Headless.Messaging.Kafka.PostgreSql.Demo
+
+ASP.NET Core demo for Kafka transport with PostgreSQL messaging storage.
+
+## Shows
+
+- Queue consumer registration with `OnQueue<TConsumer>()`.
+- Raw PostgreSQL storage through `UsePostgreSql(connectionString)`.
+- Kafka transport through `UseKafka(...)`.
+- Dashboard registration with `WithNoAuth()`.
+- Explicit PostgreSQL and EF commit-coordination registration for raw storage examples.
+- Controller endpoints for coordinated publishing patterns.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Kafka.PostgreSql.Demo
+```
+
+Run local PostgreSQL and Kafka first. The connection string and Kafka broker address are hard-coded in the demo source.
+
+## Production Note
+
+The raw PostgreSQL storage path needs explicit commit coordination. The dashboard is unauthenticated, and local container values are demo placeholders.

--- a/demo/Headless.Messaging.Pulsar.InMemory.Demo/README.md
+++ b/demo/Headless.Messaging.Pulsar.InMemory.Demo/README.md
@@ -1,0 +1,23 @@
+# Headless.Messaging.Pulsar.InMemory.Demo
+
+ASP.NET Core demo for Pulsar transport with in-memory Headless storage.
+
+## Shows
+
+- Assembly scanning with `ForMessagesFromAssembly(...)`.
+- Pulsar transport through `UsePulsar(...)`.
+- In-memory storage through `UseInMemoryStorage()`.
+- Messaging dashboard registration with `WithNoAuth()`.
+- Controller-based publishing.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Pulsar.InMemory.Demo
+```
+
+The Pulsar URI defaults to `pulsar://localhost:6650` and can be overridden with `AppSettings:PulsarUri`.
+
+## Production Note
+
+The dashboard is unauthenticated and storage is in memory. Use durable storage and protected dashboard access for production.

--- a/demo/Headless.Messaging.RabbitMq.SqlServer.Demo/README.md
+++ b/demo/Headless.Messaging.RabbitMq.SqlServer.Demo/README.md
@@ -1,0 +1,24 @@
+# Headless.Messaging.RabbitMq.SqlServer.Demo
+
+ASP.NET Core demo for RabbitMQ transport with SQL Server messaging storage.
+
+## Shows
+
+- EF Core messaging storage through `UseEntityFramework<AppDbContext>()`.
+- RabbitMQ transport through `UseRabbitMq(...)`.
+- Dashboard registration with `WithNoAuth()`.
+- EF-backed transactional outbox behavior.
+- Raw ADO coordination for the `/coordinated/adonet` path.
+- Delayed publish and rollback examples in controllers.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.RabbitMq.SqlServer.Demo
+```
+
+Run local SQL Server and RabbitMQ first. The demo source includes a SQL Server container command and uses fixed local connection values.
+
+## Production Note
+
+The EF storage path enables transactional outbox wiring by default. The dashboard is unauthenticated, and local connection strings are demo placeholders.

--- a/demo/Headless.Messaging.Redis.SqlServer.Demo/README.md
+++ b/demo/Headless.Messaging.Redis.SqlServer.Demo/README.md
@@ -1,0 +1,23 @@
+# Headless.Messaging.Redis.SqlServer.Demo
+
+ASP.NET Core demo for Redis transport with SQL Server messaging storage.
+
+## Shows
+
+- Redis transport setup through `UseRedis(...)`.
+- SQL Server messaging storage through `UseSqlServer(...)`.
+- Queue consumer registration with `OnQueue<TConsumer>()`.
+- Dashboard registration with `WithNoAuth()`.
+- Swagger UI in Development.
+
+## Run
+
+```bash
+dotnet run --project demo/Headless.Messaging.Redis.SqlServer.Demo
+```
+
+Run reachable Redis and SQL Server instances first. The demo uses fixed local/container connection values in source.
+
+## Production Note
+
+The dashboard is unauthenticated, the Redis consume error handler rethrows, and connection values are demo placeholders.

--- a/src/Headless.Api.ServiceDefaults/README.md
+++ b/src/Headless.Api.ServiceDefaults/README.md
@@ -4,6 +4,18 @@ The one-line bootstrap for Headless APIs. Combines the [`Headless.Api.Core`](../
 
 If you want the happy-path API bootstrap, install this package. It transitively pulls in `Headless.Api.Core`.
 
+## Problem Solved
+
+Most API hosts need the same baseline wiring before application code starts: problem details, response compression, OpenTelemetry, OpenAPI, health checks, forwarded headers, HttpClient resilience, static web assets, and startup validation. This package composes those defaults behind `builder.AddHeadless()`, `app.UseHeadless()`, and `app.MapHeadlessEndpoints()`.
+
+## Key Features
+
+- `AddHeadless()` registers core API primitives plus host defaults.
+- `UseHeadless()` applies the framework middleware order.
+- `MapHeadlessEndpoints()` maps health, liveness, OpenAPI, and static-asset endpoints.
+- Startup validation catches missing Headless middleware or endpoint mapping before the host starts.
+- OpenTelemetry, OpenAPI, service discovery, HttpClient resilience, and static assets are option-driven.
+
 ## Installation
 
 ```bash
@@ -194,3 +206,9 @@ Both sections are required.
 - `OpenTelemetry.Instrumentation.AspNetCore`
 - `OpenTelemetry.Instrumentation.Http`
 - `OpenTelemetry.Instrumentation.Runtime`
+
+## Side Effects
+
+- Registers MVC, Minimal API, validation, OpenTelemetry, OpenAPI, health-check, HttpClient, service-discovery, response-compression, exception-handler, and startup-validation services according to options.
+- `UseHeadless()` adds middleware for forwarded headers, compression, status-code pages, exception handling, HTTPS redirection, HSTS outside Development, and no-cache headers when the response did not set `Cache-Control`.
+- `MapHeadlessEndpoints()` maps `/health`, `/alive`, the configured OpenAPI JSON route, and static web assets when enabled.

--- a/src/Headless.AuditLog.Core/Headless.AuditLog.Core.csproj
+++ b/src/Headless.AuditLog.Core/Headless.AuditLog.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Description>Audit log DI setup package with options validation, setup builders, and exactly-one-storage-provider registration.</Description>
     <RootNamespace>Headless.AuditLog</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Headless.AuditLog.Core/README.md
+++ b/src/Headless.AuditLog.Core/README.md
@@ -22,10 +22,9 @@ dotnet add package Headless.AuditLog.Core
 
 Add exactly one storage provider package too:
 
-```bash
-dotnet add package Headless.AuditLog.Storage.EntityFramework
-# or Headless.AuditLog.Storage.PostgreSql / Headless.AuditLog.Storage.SqlServer
-```
+- `dotnet add package Headless.AuditLog.Storage.EntityFramework`
+- `dotnet add package Headless.AuditLog.Storage.PostgreSql`
+- `dotnet add package Headless.AuditLog.Storage.SqlServer`
 
 ## Quick Start
 
@@ -46,6 +45,10 @@ services.AddHeadlessAuditLog(setup =>
     setup.UseEntityFramework<AppDbContext>();
 });
 ```
+
+## Configuration
+
+Configure audit behavior through `setup.ConfigureOptions(...)` and storage shape through `setup.ConfigureStorage(...)`. Then select exactly one storage provider by calling the provider extension, such as `UseEntityFramework<TContext>()`, from the installed storage package.
 
 ## Dependencies
 

--- a/src/Headless.Dashboard.Authentication/README.md
+++ b/src/Headless.Dashboard.Authentication/README.md
@@ -13,6 +13,47 @@ Provides a unified authentication system with 5 modes so both Jobs and Messaging
 - **Auth Middleware**: Protects API endpoints while allowing static file access
 - **Frontend Config**: Provides auth info to frontend for adaptive login UI
 
+## Installation
+
+```bash
+dotnet add package Headless.Dashboard.Authentication
+```
+
+Dashboard packages normally reference this package for you. Add it directly only when you are building dashboard infrastructure that consumes the shared auth primitives.
+
+## Quick Start
+
+Use the auth modes through the dashboard package builders:
+
+```csharp
+builder.Services.AddHeadlessMessaging(setup =>
+{
+    setup.UseDashboard(dashboard =>
+    {
+        dashboard.WithBasicAuth("admin", "secret");
+        dashboard.WithSessionTimeout(30);
+    });
+});
+```
+
+For host-owned authentication:
+
+```csharp
+builder.Services.AddAuthorizationBuilder().AddPolicy(
+    "DashboardPolicy",
+    policy => policy.RequireAuthenticatedUser()
+);
+
+builder.Services.AddHeadlessMessaging(setup =>
+{
+    setup.UseDashboard(dashboard => dashboard.WithHostAuthentication("DashboardPolicy"));
+});
+```
+
+## Configuration
+
+`AuthConfig` exposes `Mode`, `BasicCredentials`, `ApiKey`, `CustomValidator`, `SessionTimeoutMinutes`, and `HostAuthorizationPolicy`. The dashboard builders set those values through methods such as `WithNoAuth()`, `WithBasicAuth(...)`, `WithApiKey(...)`, `WithHostAuthentication(...)`, `WithCustomAuth(...)`, and `WithSessionTimeout(...)`.
+
 ## Auth Modes
 
 | Mode | Description |
@@ -40,3 +81,7 @@ Provides a unified authentication system with 5 modes so both Jobs and Messaging
 
 - `Headless.Jobs.Dashboard`
 - `Headless.Messaging.Dashboard`
+
+## Side Effects
+
+None when referenced by itself. Dashboard packages register `AuthConfig`, `IAuthService`, and dashboard middleware when their dashboard setup extensions are used.

--- a/src/Headless.Messaging.Core/Headless.Messaging.Core.csproj
+++ b/src/Headless.Messaging.Core/Headless.Messaging.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>Core services, options, and setup primitives for Headless messaging packages.</Description>
+    <Description>Composition package for Headless messaging: outbox runtime, retries, delayed dispatch, consumer orchestration, and provider setup hooks.</Description>
     <PackageTags>headless;messaging;dotnet</PackageTags>
     <RootNamespace>Headless.Messaging</RootNamespace>
   </PropertyGroup>

--- a/src/Headless.Messaging.Dashboard.K8s/README.md
+++ b/src/Headless.Messaging.Dashboard.K8s/README.md
@@ -59,6 +59,20 @@ builder.Services.AddMessagingDashboardStandalone(
 );
 ```
 
+## Configuration
+
+`UseK8sDiscovery(...)` registers a singleton `K8sDiscoveryOptions` instance.
+
+```csharp
+setup.UseK8sDiscovery(k8s =>
+{
+    k8s.K8sClientConfig = KubernetesClientConfiguration.BuildDefaultConfig();
+    k8s.ShowOnlyExplicitVisibleNodes = true;
+});
+```
+
+`ShowOnlyExplicitVisibleNodes` defaults to `true`. With that default, only Kubernetes Services labeled `headless.messaging.visibility:show` appear in the dashboard node list. Set it to `false` to list all services returned from the configured namespace.
+
 ## Dependencies
 
 - `Headless.Messaging.Dashboard`

--- a/src/Headless.Messaging.InMemory/Headless.Messaging.InMemory.csproj
+++ b/src/Headless.Messaging.InMemory/Headless.Messaging.InMemory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>in-memory integration for Headless messaging.</Description>
+    <Description>In-memory bus and queue transport provider for local development and tests without an external broker.</Description>
     <PackageTags>headless;messaging;in-memory;dotnet</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Headless.Messaging.InMemoryStorage/Headless.Messaging.InMemoryStorage.csproj
+++ b/src/Headless.Messaging.InMemoryStorage/Headless.Messaging.InMemoryStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>in-memory storage integration for Headless messaging.</Description>
+    <Description>In-memory messaging storage for local development and tests that do not require durable outbox persistence.</Description>
     <PackageTags>headless;messaging;in-memory-storage;dotnet</PackageTags>
   </PropertyGroup>
 

--- a/src/Headless.Messaging.Nats/README.md
+++ b/src/Headless.Messaging.Nats/README.md
@@ -2,6 +2,10 @@
 
 NATS JetStream transport provider for the Headless messaging system.
 
+## Problem Solved
+
+Adds a NATS-backed transport to Headless messaging so the core bus and queue abstractions can publish to JetStream subjects while keeping storage, retry, and consumer registration in the shared messaging pipeline.
+
 ## Key Features
 
 - **Lightweight**: Minimal resource footprint, cloud-native

--- a/src/Headless.Messaging.Storage.PostgreSql/Headless.Messaging.Storage.PostgreSql.csproj
+++ b/src/Headless.Messaging.Storage.PostgreSql/Headless.Messaging.Storage.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>PostgreSQL storage provider for Headless messaging.</Description>
+    <Description>PostgreSQL storage provider for Headless messaging outbox rows, delayed dispatch, persisted retries, and monitoring data.</Description>
     <PackageTags>headless;messaging;storage;postgresql;dotnet</PackageTags>
   </PropertyGroup>
 

--- a/src/Headless.Messaging.Storage.SqlServer/Headless.Messaging.Storage.SqlServer.csproj
+++ b/src/Headless.Messaging.Storage.SqlServer/Headless.Messaging.Storage.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>SQL Server storage provider for Headless messaging.</Description>
+    <Description>SQL Server storage provider for Headless messaging outbox rows, delayed dispatch, persisted retries, and monitoring data.</Description>
     <PackageTags>headless;messaging;storage;sql-server;dotnet</PackageTags>
   </PropertyGroup>
 

--- a/src/Headless.Messaging.Testing/Headless.Messaging.Testing.csproj
+++ b/src/Headless.Messaging.Testing/Headless.Messaging.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>Testing utilities and fakes for Headless messaging packages.</Description>
+    <Description>In-process Headless messaging test harness with awaitable published, consumed, faulted, and exhausted message assertions.</Description>
     <PackageTags>headless;messaging;testing;dotnet</PackageTags>
     <IsTestProject>false</IsTestProject>
     <IsTestableProject>false</IsTestableProject>

--- a/src/Headless.Messaging.Testing/README.md
+++ b/src/Headless.Messaging.Testing/README.md
@@ -287,3 +287,9 @@ None. `MessagingTestHarness` has no configuration class or options object. The o
 - `Headless.Messaging.Core`
 - `Headless.Messaging.InMemory`
 - `Headless.Messaging.InMemoryStorage`
+
+## Side Effects
+
+- `MessagingTestHarness.CreateAsync(...)` builds and owns an in-process `ServiceProvider` until the harness is disposed.
+- `AddMessagingTestHarness()` decorates an existing host's messaging registrations and must run after `AddHeadlessMessaging(...)`.
+- Transport parallelism is disabled inside the harness to keep observations deterministic.

--- a/src/Headless.Sql.Core/Headless.Sql.Core.csproj
+++ b/src/Headless.Sql.Core/Headless.Sql.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Headless.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Description>Default scoped ambient current-connection implementation for provider-agnostic SQL unit-of-work patterns.</Description>
     <RootNamespace>Headless.Sql</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Headless.Sql.Core/README.md
+++ b/src/Headless.Sql.Core/README.md
@@ -24,6 +24,10 @@ dotnet add package Headless.Sql.Core
 builder.Services.AddScoped<ISqlCurrentConnection, DefaultSqlCurrentConnection>();
 ```
 
+## Configuration
+
+There is no options object. Choose the scoped lifetime explicitly when registering `DefaultSqlCurrentConnection`; it is intended to represent one ambient SQL connection per request or unit-of-work scope.
+
 ## Dependencies
 
 - `Headless.Sql.Abstractions`


### PR DESCRIPTION
## Summary

New users now get a clearer path from problem statement to package choice, quick start, messaging examples, and production caveats. The docs also close the package README/catalog gaps found in the audit without adding behavior that is not already present in code.

## What Changed

- Reworked the root package picker, examples list, retry/backoff notes, and missing package catalog entries.
- Brought drifted package READMEs back into the required package-doc structure.
- Added short README guides for the messaging demo projects so users can tell what each demo proves before opening code.
- Sharpened NuGet descriptions for messaging storage/testing, audit-log core, and SQL core packages.

## Validation

- Package README required-section scan: `checked=162 failures=0`
- Root README package-catalog coverage scan: `missing=0`
- `git diff --check`
- `dotnet msbuild <changed csproj> -getProperty:Description -nologo`
- Pre-push hook: `dotnet build headless-framework.slnx --configuration Release --no-restore -v:q -nologo /clp:ErrorsOnly`