### PR TITLE
fix(messaging): harden consumer review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,3 +193,4 @@ After creating the project, attach it to [headless-framework.slnx](headless-fram
 ## Learnings
 
 - `Range<T>` uses `null` bounds as infinities; range-to-range operations must compare lower and upper bounds with side-specific semantics instead of reusing value containment. (2026-07-04)
+- Kafka concurrent consumers must commit offsets by per-partition contiguous completed watermark; committing a high completed offset directly can acknowledge lower in-flight messages and lose them after a crash. (2026-07-06)

--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -464,7 +464,7 @@ services.AddHeadlessMessaging(setup =>
 ### Configuration
 
 - `MessagingOptions.DefaultGroupName`, `GroupNamePrefix`, `MessageNamePrefix`, and `Version` control naming and isolation. `Version` is validated non-empty and at most 20 characters — the SQL storage providers persist it as a literal into a `VARCHAR(20)`/`nvarchar(20)` column, so an over-long value is rejected at startup instead of failing every outbox insert.
-- Retry configuration lives under `RetryPolicy`, publish/receive retry processors, and storage cleanup options. `RetryBatchSize` (default 200) caps the retry-pickup batch and `SchedulerBatchSize` (default 1,000) caps the delayed/queued scheduler batch.
+- Retry configuration lives under `RetryPolicy`, publish/receive retry processors, and storage cleanup options. `RetryBatchSize` (default 200, `> 0`) caps the retry-pickup batch and `SchedulerBatchSize` (default 1,000, `> 0`) caps the delayed/queued scheduler batch.
 - `UseStorageLock` coordinates retry processors through a messaging-keyed distributed lock provider.
 - `DeadNodeReconcileInterval` (default 1 minute, `> 0`) sets the always-on dead-owner recovery reconcile cadence (see [Dead-owner recovery](#dead-owner-recovery)). Independent of `UseStorageLock`.
 - Register middleware through `MessagingBuilder.AddBusPublishMiddleware<T>()`, `AddBusConsumeMiddleware<T>()`, `AddPublishMiddlewareFor<TMiddleware,TMessage>()`, and `AddConsumeMiddlewareFor<TMiddleware,TMessage>(groupName)`.
@@ -765,7 +765,7 @@ Message ordering guarantees depend on the transport provider and configuration:
 
 ### Transport-Specific Ordering
 
-- **Kafka**: Messages with same partition key are strictly ordered within partitions
+- **Kafka**: Messages with same partition key are strictly ordered within partitions. With concurrent consumers, Headless commits offsets only through the contiguous completed watermark for each partition, so a fast high offset does not acknowledge lower in-flight messages.
 - **Azure Service Bus**: FIFO ordering when sessions are enabled (`EnableSessions = true`)
 - **RabbitMQ**: No ordering guarantees by default; consumers may process messages concurrently
 - **AWS SQS**: FIFO queues provide strict ordering; standard queues do not
@@ -1240,7 +1240,7 @@ Provides Kafka queue-intent transport for partitioned, consumer-group processing
 
 ### Design Notes
 
-Kafka is queue-intent only in this package. `PartitionBy(...)` maps to the Kafka key. The framework does not impose a Kafka key length cap; broker/client configuration owns practical limits. Delivery remains at-least-once; consumers must dedupe by business key or message id.
+Kafka is queue-intent only in this package. `PartitionBy(...)` maps to the Kafka key. The framework does not impose a Kafka key length cap; broker/client configuration owns practical limits. Delivery remains at-least-once; consumers must dedupe by business key or message id. When consumer concurrency is greater than one, successful handlers can finish out of order, but Kafka commits advance only through the contiguous completed offset watermark per partition; a completed high offset does not commit past lower in-flight offsets.
 
 ### Installation
 

--- a/src/Headless.Messaging.Core/Configuration/MessagingOptions.cs
+++ b/src/Headless.Messaging.Core/Configuration/MessagingOptions.cs
@@ -494,6 +494,7 @@ internal sealed class MessagingOptionsValidator : AbstractValidator<MessagingOpt
             .WithMessage("Version must not be empty.")
             .MaximumLength(20)
             .WithMessage("Version must not exceed 20 characters (it is stored in a VARCHAR(20) column).");
+        RuleFor(x => x.SchedulerBatchSize).GreaterThan(0).WithMessage("SchedulerBatchSize must be greater than zero.");
         RuleFor(x => x.RetryBatchSize).GreaterThan(0).WithMessage("RetryBatchSize must be greater than zero.");
         RuleFor(x => x).Custom((_, _) => _ValidateMiddlewareDescriptors(middlewareDescriptorRegistry));
     }

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -382,6 +382,7 @@ internal sealed class ConsumerRegister(
                             catch (Exception e)
                             {
                                 startupReady.TrySetException(e);
+                                _isHealthy = false;
                                 _logger.ConsumerProcessingLoopFailed(e);
                             }
                         },

--- a/src/Headless.Messaging.Core/Processor/Dispatcher.cs
+++ b/src/Headless.Messaging.Core/Processor/Dispatcher.cs
@@ -350,7 +350,7 @@ internal sealed class Dispatcher : IDispatcher
             {
                 AllowSynchronousContinuations = true,
                 SingleReader = isSingleReader,
-                SingleWriter = true,
+                SingleWriter = false,
                 FullMode = BoundedChannelFullMode.Wait,
             }
         );

--- a/src/Headless.Messaging.Core/README.md
+++ b/src/Headless.Messaging.Core/README.md
@@ -244,7 +244,7 @@ builder.Services.AddHeadlessMessaging(setup =>
 ```
 
 - `Version` is validated non-empty and at most 20 characters: the SQL storage providers persist it as a literal into a `VARCHAR(20)`/`nvarchar(20)` column, so an over-long value is rejected at startup instead of failing every outbox insert.
-- `RetryBatchSize` (default 200) caps the retry-pickup batch; `SchedulerBatchSize` (default 1,000) caps the delayed/queued scheduler batch.
+- `RetryBatchSize` (default 200, `> 0`) caps the retry-pickup batch; `SchedulerBatchSize` (default 1,000, `> 0`) caps the delayed/queued scheduler batch.
 
 ## Middleware
 
@@ -318,7 +318,7 @@ Message ordering guarantees depend on the transport provider and configuration:
 
 ### Transport-Specific Ordering
 
-- **Kafka**: Messages with same partition key are strictly ordered within partitions
+- **Kafka**: Messages with same partition key are strictly ordered within partitions. With concurrent consumers, Headless commits offsets only through the contiguous completed watermark for each partition, so a fast high offset does not acknowledge lower in-flight messages.
 - **Azure Service Bus**: FIFO ordering when sessions are enabled (`EnableSessions = true`)
 - **RabbitMQ**: No ordering guarantees by default; consumers may process messages concurrently
 - **AWS SQS**: FIFO queues provide strict ordering; standard queues do not

--- a/src/Headless.Messaging.Core/Transactions/MessageOutboxBuffer.cs
+++ b/src/Headless.Messaging.Core/Transactions/MessageOutboxBuffer.cs
@@ -52,7 +52,11 @@ internal sealed partial class MessageOutboxBuffer : InMemoryWorkBuffer<MediumMes
                         await _dispatcher
                             .EnqueueToScheduler(
                                 message,
-                                DateTime.Parse(message.Origin.Headers[Headers.SentTime]!, CultureInfo.InvariantCulture),
+                                DateTime.Parse(
+                                    message.Origin.Headers[Headers.SentTime]!,
+                                    CultureInfo.InvariantCulture,
+                                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal
+                                ),
                                 transaction: null,
                                 timeoutCts.Token
                             )

--- a/src/Headless.Messaging.Kafka/KafkaConsumerClient.cs
+++ b/src/Headless.Messaging.Kafka/KafkaConsumerClient.cs
@@ -21,6 +21,7 @@ internal sealed class KafkaConsumerClient : IConsumerClient
     private readonly KafkaConsumerConfig? _consumerConfig;
     private readonly Func<ConsumerConfig, IConsumer<string, byte[]>> _consumerFactory;
     private readonly Func<AdminClientConfig, IAdminClient> _adminClientFactory;
+    private readonly KafkaOffsetCommitTracker? _offsetCommitTracker;
 
     // volatile is required: Connect performs double-checked locking on this field, and
     // CommitAsync/RejectAsync read it without taking _lock. Without volatile a reader could
@@ -40,7 +41,12 @@ internal sealed class KafkaConsumerClient : IConsumerClient
     {
         _groupId = groupId;
         _kafkaOptions = Argument.IsNotNull(options.Value);
-        _semaphore = groupConcurrent > 1 ? new SemaphoreSlim(groupConcurrent, groupConcurrent) : null;
+        if (groupConcurrent > 1)
+        {
+            _semaphore = new SemaphoreSlim(groupConcurrent, groupConcurrent);
+            _offsetCommitTracker = new KafkaOffsetCommitTracker();
+        }
+
         _serviceProvider = serviceProvider;
         _consumerConfig = consumerConfig;
         _consumerFactory = consumerFactory ?? _BuildConsumer;
@@ -165,6 +171,34 @@ internal sealed class KafkaConsumerClient : IConsumerClient
                 {
                     continue;
                 }
+
+                var delivery = _TrackDelivery(consumerResult);
+
+                if (_semaphore is not null)
+                {
+                    await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                    _ObserveBackgroundHandler(
+                        Task.Run(
+                            async () =>
+                            {
+                                try
+                                {
+                                    await _ConsumeAsync(delivery).ConfigureAwait(false);
+                                }
+                                finally
+                                {
+                                    _ReleaseSemaphore();
+                                }
+                            },
+                            CancellationToken.None
+                        )
+                    );
+
+                    continue;
+                }
+
+                await _ConsumeAsync(delivery).ConfigureAwait(false);
             }
             catch (ConsumeException e) when (_kafkaOptions.RetriableErrorCodes.Contains(e.Error.Code))
             {
@@ -176,33 +210,6 @@ internal sealed class KafkaConsumerClient : IConsumerClient
                 OnLogCallback!(logArgs);
 
                 continue;
-            }
-
-            if (_semaphore is not null)
-            {
-                var currentResult = consumerResult;
-                await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-                _ObserveBackgroundHandler(
-                    Task.Run(
-                        async () =>
-                        {
-                            try
-                            {
-                                await _ConsumeAsync(currentResult).ConfigureAwait(false);
-                            }
-                            finally
-                            {
-                                _ReleaseSemaphore();
-                            }
-                        },
-                        CancellationToken.None
-                    )
-                );
-            }
-            else
-            {
-                await _ConsumeAsync(consumerResult).ConfigureAwait(false);
             }
         }
         // ReSharper disable once FunctionNeverReturns
@@ -216,14 +223,36 @@ internal sealed class KafkaConsumerClient : IConsumerClient
     public ValueTask CommitAsync(object? sender)
     {
         // ReSharper disable once InconsistentlySynchronizedField -- volatile read; null-check fast path.
-        if (sender is not ConsumeResult<string, byte[]> consumerResult || _consumerClient is null)
+        if (!_TryGetDelivery(sender, out var delivery))
         {
             return ValueTask.CompletedTask;
         }
 
         lock (_lock)
         {
-            _consumerClient.Commit(consumerResult);
+            var consumerClient = _consumerClient;
+
+            if (consumerClient is null)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            if (_offsetCommitTracker is null)
+            {
+                consumerClient.Commit(delivery.ConsumerResult);
+
+                return ValueTask.CompletedTask;
+            }
+
+            if (delivery.IsTracked)
+            {
+                var committableOffsets = _offsetCommitTracker.MarkCommitted(delivery);
+
+                if (committableOffsets.Count > 0)
+                {
+                    consumerClient.Commit(committableOffsets);
+                }
+            }
         }
 
         return ValueTask.CompletedTask;
@@ -232,14 +261,26 @@ internal sealed class KafkaConsumerClient : IConsumerClient
     public ValueTask RejectAsync(object? sender)
     {
         // ReSharper disable once InconsistentlySynchronizedField -- volatile read; null-check fast path.
-        if (sender is not ConsumeResult<string, byte[]> consumerResult || _consumerClient is null)
+        if (!_TryGetDelivery(sender, out var delivery))
         {
             return ValueTask.CompletedTask;
         }
 
         lock (_lock)
         {
-            _consumerClient.Seek(consumerResult.TopicPartitionOffset);
+            var consumerClient = _consumerClient;
+
+            if (consumerClient is null)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            if (_offsetCommitTracker is not null && delivery.IsTracked)
+            {
+                _offsetCommitTracker.MarkRejected(delivery);
+            }
+
+            consumerClient.Seek(delivery.ConsumerResult.TopicPartitionOffset);
         }
 
         return ValueTask.CompletedTask;
@@ -348,8 +389,22 @@ internal sealed class KafkaConsumerClient : IConsumerClient
         }
     }
 
-    private async Task _ConsumeAsync(ConsumeResult<string, byte[]> consumerResult)
+    private KafkaDelivery _TrackDelivery(ConsumeResult<string, byte[]> consumerResult)
     {
+        if (_offsetCommitTracker is null)
+        {
+            return new KafkaDelivery(consumerResult, KafkaDelivery.UntrackedGeneration);
+        }
+
+        lock (_lock)
+        {
+            return _offsetCommitTracker.Track(consumerResult);
+        }
+    }
+
+    private async Task _ConsumeAsync(KafkaDelivery delivery)
+    {
+        var consumerResult = delivery.ConsumerResult;
         TransportMessage message;
         try
         {
@@ -383,11 +438,11 @@ internal sealed class KafkaConsumerClient : IConsumerClient
                 }
             );
 
-            await RejectAsync(consumerResult).ConfigureAwait(false);
+            await RejectAsync(delivery).ConfigureAwait(false);
             return;
         }
 
-        await OnMessageCallback!(message, consumerResult).ConfigureAwait(false);
+        await OnMessageCallback!(message, delivery).ConfigureAwait(false);
     }
 
     private IConsumer<string, byte[]> _BuildConsumer(ConsumerConfig config)
@@ -448,5 +503,133 @@ internal sealed class KafkaConsumerClient : IConsumerClient
             Reason = $"An error occurred during connect kafka --> {e.Reason}",
         };
         OnLogCallback!(logArgs);
+    }
+
+    private static bool _TryGetDelivery(object? sender, out KafkaDelivery delivery)
+    {
+        switch (sender)
+        {
+            case KafkaDelivery tracked:
+                delivery = tracked;
+
+                return true;
+
+            case ConsumeResult<string, byte[]> consumerResult:
+                delivery = new KafkaDelivery(consumerResult, KafkaDelivery.UntrackedGeneration);
+
+                return true;
+
+            default:
+                delivery = null!;
+
+                return false;
+        }
+    }
+
+    private sealed class KafkaDelivery(ConsumeResult<string, byte[]> consumerResult, long generation)
+    {
+        public const long UntrackedGeneration = -1;
+
+        public ConsumeResult<string, byte[]> ConsumerResult { get; } = consumerResult;
+
+        public long Generation { get; } = generation;
+
+        public bool IsTracked => Generation != UntrackedGeneration;
+    }
+
+    private sealed class KafkaOffsetCommitTracker
+    {
+        private readonly Dictionary<TopicPartition, PartitionCommitState> _partitions = [];
+
+        public KafkaDelivery Track(ConsumeResult<string, byte[]> consumerResult)
+        {
+            var offset = consumerResult.TopicPartitionOffset.Offset.Value;
+
+            if (offset < 0)
+            {
+                return new KafkaDelivery(consumerResult, KafkaDelivery.UntrackedGeneration);
+            }
+
+            var topicPartition = consumerResult.TopicPartition;
+
+            if (!_partitions.TryGetValue(topicPartition, out var state))
+            {
+                state = new PartitionCommitState();
+                _partitions.Add(topicPartition, state);
+            }
+
+            if (state.NextCommitOffset is null || offset < state.NextCommitOffset.Value)
+            {
+                state.NextCommitOffset = offset;
+            }
+
+            return new KafkaDelivery(consumerResult, state.Generation);
+        }
+
+        public List<TopicPartitionOffset> MarkCommitted(KafkaDelivery delivery)
+        {
+            var consumerResult = delivery.ConsumerResult;
+            var offset = consumerResult.TopicPartitionOffset.Offset.Value;
+
+            if (
+                offset < 0
+                || !_partitions.TryGetValue(consumerResult.TopicPartition, out var state)
+                || state.Generation != delivery.Generation
+                || state.NextCommitOffset is not { } nextCommitOffset
+            )
+            {
+                return [];
+            }
+
+            if (offset < nextCommitOffset)
+            {
+                return [];
+            }
+
+            state.CompletedOffsets.Add(offset);
+            var advanced = false;
+
+            while (state.CompletedOffsets.Remove(nextCommitOffset))
+            {
+                nextCommitOffset++;
+                advanced = true;
+            }
+
+            if (!advanced)
+            {
+                return [];
+            }
+
+            state.NextCommitOffset = nextCommitOffset;
+
+            return [new TopicPartitionOffset(consumerResult.TopicPartition, new Offset(nextCommitOffset))];
+        }
+
+        public void MarkRejected(KafkaDelivery delivery)
+        {
+            var consumerResult = delivery.ConsumerResult;
+
+            if (
+                !_partitions.TryGetValue(consumerResult.TopicPartition, out var state)
+                || state.Generation != delivery.Generation
+            )
+            {
+                return;
+            }
+
+            var offset = consumerResult.TopicPartitionOffset.Offset.Value;
+            state.Generation++;
+            state.NextCommitOffset = offset >= 0 ? offset : null;
+            state.CompletedOffsets.Clear();
+        }
+
+        private sealed class PartitionCommitState
+        {
+            public long Generation { get; set; }
+
+            public long? NextCommitOffset { get; set; }
+
+            public SortedSet<long> CompletedOffsets { get; } = [];
+        }
     }
 }

--- a/src/Headless.Messaging.Kafka/README.md
+++ b/src/Headless.Messaging.Kafka/README.md
@@ -15,6 +15,10 @@ Enables high-throughput, distributed event streaming using Apache Kafka with con
 - **At-Least-Once Delivery**: Broker delivery plus Headless retry/outbox recovery; consumers must remain idempotent
 - **Kafka Configuration Access**: Exposes raw Kafka producer and consumer settings through `MainConfig` and consumer-specific options
 
+## Design Notes
+
+Kafka is queue-intent only in this package. `PartitionBy(...)` maps to the Kafka key. The framework does not impose a Kafka key length cap; broker/client configuration owns practical limits. Delivery remains at-least-once; consumers must dedupe by business key or message id. When consumer concurrency is greater than one, successful handlers can finish out of order, but Kafka commits advance only through the contiguous completed offset watermark per partition; a completed high offset does not commit past lower in-flight offsets.
+
 ## Installation
 
 ```bash
@@ -116,7 +120,7 @@ options.EnableSubscriberParallelExecute = false; // Disable parallel execution
 - Publish writes the serialized body as record bytes and forwards framework headers.
 - Delivery remains at-least-once. A broker accept followed by a failed success-mark write can redeliver; configure Kafka idempotence or read-committed isolation for broker-level features, and keep consumers idempotent.
 - Delay stays in the core pipeline. This provider does not add broker-native scheduling.
-- Commit commits the consumed partition offset.
+- Commit commits the consumed partition offset. Under concurrent consumption, commits advance only through the contiguous completed offset watermark per partition.
 - Reject seeks back to the failed offset so Kafka can redeliver on the next poll.
 - `FetchTopicsAsync(...)` creates concrete topics when auto-create is enabled and normalizes wildcard subscriptions.
 - `SubscribeAsync(...)` joins the configured consumer group to those topics.

--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlDataStorage.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlDataStorage.cs
@@ -181,7 +181,7 @@ internal sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@Id", message.StorageId),
             new NpgsqlParameter("@Content", serializer.Serialize(message.Origin)),
             new NpgsqlParameter("@Retries", message.Retries),
-            new NpgsqlParameter("@ExpiresAt", message.ExpiresAt.HasValue ? message.ExpiresAt.Value : DBNull.Value),
+            new NpgsqlParameter("@ExpiresAt", message.ExpiresAt.ToUtcParameterValue()),
             new NpgsqlParameter("@NextRetryAt", nextRetryAt.ToUtcParameterValue()),
             new NpgsqlParameter("@LockedUntil", lockedUntil.ToUtcParameterValue()),
             new NpgsqlParameter("@Owner", NpgsqlDbType.Varchar)
@@ -263,7 +263,7 @@ internal sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@IntentType", (short)stored.IntentType),
             new NpgsqlParameter("@Retries", stored.Retries),
             new NpgsqlParameter("@Added", stored.Added),
-            new NpgsqlParameter("@ExpiresAt", stored.ExpiresAt.HasValue ? stored.ExpiresAt.Value : DBNull.Value),
+            new NpgsqlParameter("@ExpiresAt", stored.ExpiresAt.ToUtcParameterValue()),
             new NpgsqlParameter("@NextRetryAt", stored.NextRetryAt.ToUtcParameterValue()),
             new NpgsqlParameter("@LockedUntil", stored.LockedUntil.ToUtcParameterValue()),
             new NpgsqlParameter("@Owner", NpgsqlDbType.Varchar) { Value = DBNull.Value },
@@ -456,10 +456,7 @@ internal sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@IntentType", (short)mediumMessage.IntentType),
             new NpgsqlParameter("@Retries", mediumMessage.Retries),
             new NpgsqlParameter("@Added", mediumMessage.Added),
-            new NpgsqlParameter(
-                "@ExpiresAt",
-                mediumMessage.ExpiresAt.HasValue ? mediumMessage.ExpiresAt.Value : DBNull.Value
-            ),
+            new NpgsqlParameter("@ExpiresAt", mediumMessage.ExpiresAt.ToUtcParameterValue()),
             new NpgsqlParameter("@NextRetryAt", mediumMessage.NextRetryAt.ToUtcParameterValue()),
             new NpgsqlParameter("@LockedUntil", mediumMessage.LockedUntil.ToUtcParameterValue()),
             new NpgsqlParameter("@Owner", NpgsqlDbType.Varchar) { Value = DBNull.Value },
@@ -796,7 +793,7 @@ internal sealed class PostgreSqlDataStorage(
             new NpgsqlParameter("@Id", message.StorageId),
             new NpgsqlParameter("@Content", serializer.Serialize(message.Origin)),
             new NpgsqlParameter("@Retries", message.Retries),
-            new NpgsqlParameter("@ExpiresAt", message.ExpiresAt.HasValue ? message.ExpiresAt.Value : DBNull.Value),
+            new NpgsqlParameter("@ExpiresAt", message.ExpiresAt.ToUtcParameterValue()),
             new NpgsqlParameter("@NextRetryAt", nextRetryAt.ToUtcParameterValue()),
             new NpgsqlParameter("@LockedUntil", lockedUntil.ToUtcParameterValue()),
             new NpgsqlParameter("@Owner", NpgsqlDbType.Varchar)

--- a/tests/Headless.Messaging.Core.Tests.Unit/Configuration/MessagingOptionsValidationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Configuration/MessagingOptionsValidationTests.cs
@@ -300,6 +300,15 @@ public sealed class MessagingOptionsValidationTests : TestBase
     }
 
     [Fact]
+    public void should_reject_messaging_options_with_non_positive_scheduler_batch_size()
+    {
+        var result = new MessagingOptionsValidator().Validate(new MessagingOptions { SchedulerBatchSize = 0 });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(MessagingOptions.SchedulerBatchSize));
+    }
+
+    [Fact]
     public void should_reject_retry_policy_with_non_positive_on_exhausted_timeout()
     {
         // given

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
@@ -299,6 +299,41 @@ public sealed class ConsumerRegisterTests : TestBase
     }
 
     [Fact]
+    public async Task should_mark_register_unhealthy_when_consumer_loop_fails_after_startup()
+    {
+        var failingClient = new PostStartupFailingConsumerClient();
+        var factory = new SequencedConsumerClientFactory(new MetadataConsumerClient(), failingClient);
+
+        await using var provider = _CreateProvider(
+            configureMessaging: setup =>
+            {
+                setup.ForMessage<BootstrapReadyMessage>(message =>
+                    message
+                        .MessageName("ready-messageName")
+                        .OnBus<BootstrapReadyConsumer>(consumer => consumer.Group("ready-group").Concurrency(1))
+                );
+            },
+            configureServices: services =>
+            {
+                services.AddSingleton<IConsumerClientFactory>(factory);
+                services.AddSingleton<BootstrapReadyConsumer>();
+            }
+        );
+
+        var register = (ConsumerRegister)provider.GetRequiredService<IConsumerRegister>();
+        using var hostCts = new CancellationTokenSource();
+
+        await register.StartAsync(hostCts.Token);
+        register.IsHealthy().Should().BeTrue();
+
+        failingClient.Fail(new InvalidOperationException("listener failed"));
+
+        await _WaitUntilAsync(() => !register.IsHealthy(), AbortToken);
+
+        await register.DisposeAsync();
+    }
+
+    [Fact]
     public async Task start_fails_when_queue_consumer_uses_legacy_consumer_factory()
     {
         await using var provider = _CreateProvider(
@@ -525,5 +560,61 @@ public sealed class ConsumerRegisterTests : TestBase
         public ValueTask ResumeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class PostStartupFailingConsumerClient : IConsumerClient
+    {
+        private readonly TaskCompletionSource _failure = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BrokerAddress BrokerAddress => new("test", "failing");
+
+        public Func<TransportMessage, object?, Task>? OnMessageCallback { get; set; }
+
+        public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
+
+        public ValueTask<ICollection<string>> FetchMessageNamesAsync(IEnumerable<string> messageNames)
+        {
+            return ValueTask.FromResult<ICollection<string>>(messageNames.ToArray());
+        }
+
+        public ValueTask SubscribeAsync(IEnumerable<string> messageNames) => ValueTask.CompletedTask;
+
+        public ValueTask WaitUntilReadyAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public async ValueTask ListeningAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            await _failure.Task.WaitAsync(cancellationToken);
+        }
+
+        public void Fail(Exception exception)
+        {
+            _failure.TrySetException(exception);
+        }
+
+        public ValueTask CommitAsync(object? sender) => ValueTask.CompletedTask;
+
+        public ValueTask RejectAsync(object? sender) => ValueTask.CompletedTask;
+
+        public ValueTask PauseAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask ResumeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            _failure.TrySetCanceled();
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static async Task _WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(2));
+
+        while (!predicate())
+        {
+            await Task.Delay(10, timeoutCts.Token).ConfigureAwait(false);
+        }
     }
 }

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/CommitCoordinatorOutboxTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/CommitCoordinatorOutboxTests.cs
@@ -285,6 +285,44 @@ public sealed class CommitCoordinatorOutboxTests : TestBase
         dispatched.Should().Contain(ok.StorageId);
     }
 
+    [Fact]
+    public async Task flush_should_parse_offsetless_delayed_sent_time_as_utc()
+    {
+        var coordinator = new CommitCoordinator();
+        var expectedPublishTime = new DateTime(2026, 7, 6, 9, 30, 0, DateTimeKind.Utc);
+        var capturedPublishTimes = new List<DateTime>();
+
+        var dispatcher = Substitute.For<IDispatcher>();
+        dispatcher
+            .EnqueueToScheduler(
+                Arg.Any<MediumMessage>(),
+                Arg.Do<DateTime>(publishTime => capturedPublishTimes.Add(publishTime)),
+                Arg.Any<object?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.CompletedTask);
+
+        var buffer = new MessageOutboxBuffer(
+            coordinator,
+            dispatcher,
+            TimeSpan.FromSeconds(30),
+            new FakeTimeProvider(),
+            NullLogger<MessageOutboxBuffer>.Instance
+        );
+        var delayed = _BuildMessage();
+        delayed.Origin.Headers[Headers.SentTime] = expectedPublishTime.ToString(CultureInfo.InvariantCulture);
+        delayed.Origin.Headers[Headers.DelayTime] = TimeSpan
+            .FromMinutes(30)
+            .ToString("c", CultureInfo.InvariantCulture);
+        buffer.Add(delayed);
+
+        await coordinator.SignalAsync(CommitOutcome.Committed, new EmptyServiceProvider());
+
+        capturedPublishTimes.Should().ContainSingle();
+        capturedPublishTimes[0].Should().Be(expectedPublishTime);
+        capturedPublishTimes[0].Kind.Should().Be(DateTimeKind.Utc);
+    }
+
     private static MediumMessage _BuildMessage() =>
         new()
         {

--- a/tests/Headless.Messaging.Kafka.Tests.Unit/KafkaConsumerClientTests.cs
+++ b/tests/Headless.Messaging.Kafka.Tests.Unit/KafkaConsumerClientTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Concurrent;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Headless.Messaging.Kafka;
@@ -383,6 +384,112 @@ public sealed class KafkaConsumerClientTests : TestBase
         }
     }
 
+    [Fact]
+    public async Task CommitAsync_should_not_commit_past_inflight_lower_offsets_when_processing_concurrently()
+    {
+        // given
+        var consumer = Substitute.For<IConsumer<string, byte[]>>();
+        var consumeCallCount = 0;
+        consumer
+            .Consume(Arg.Any<TimeSpan>())
+            .Returns(_ =>
+            {
+                var callIndex = Interlocked.Increment(ref consumeCallCount);
+
+                return callIndex switch
+                {
+                    1 => _CreateConsumeResult(100),
+                    2 => _CreateConsumeResult(101),
+                    3 => _CreateConsumeResult(102),
+                    _ => waitAndReturnNull(),
+                };
+
+                static ConsumeResult<string, byte[]> waitAndReturnNull()
+                {
+                    Thread.Sleep(10);
+
+                    return null!;
+                }
+            });
+
+        var committedOffsets = new ConcurrentQueue<long>();
+        consumer
+            .When(c => c.Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>()))
+            .Do(call =>
+            {
+                foreach (var offset in call.Arg<IEnumerable<TopicPartitionOffset>>())
+                {
+                    committedOffsets.Enqueue(offset.Offset.Value);
+                }
+            });
+
+        await using var client = new KafkaConsumerClient(
+            "test-group",
+            3,
+            _options,
+            _serviceProvider,
+            consumerFactory: _ => consumer
+        );
+
+        var releaseOffset100 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOffset101 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var highOffsetCommitted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        client.OnMessageCallback = async (message, sender) =>
+        {
+            var offset = BitConverter.ToInt64(message.Body.Span);
+
+            switch (offset)
+            {
+                case 100:
+                    await releaseOffset100.Task.WaitAsync(AbortToken).ConfigureAwait(false);
+                    await client.CommitAsync(sender).ConfigureAwait(false);
+
+                    break;
+
+                case 101:
+                    await releaseOffset101.Task.WaitAsync(AbortToken).ConfigureAwait(false);
+                    await client.CommitAsync(sender).ConfigureAwait(false);
+
+                    break;
+
+                case 102:
+                    await client.CommitAsync(sender).ConfigureAwait(false);
+                    highOffsetCommitted.TrySetResult();
+
+                    break;
+            }
+        };
+        client.OnLogCallback = _ => { };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var listeningTask = client.ListeningAsync(TimeSpan.FromMilliseconds(10), cts.Token).AsTask();
+
+        try
+        {
+            await highOffsetCommitted.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+
+            committedOffsets.Should().BeEmpty("offset 102 cannot commit while 100 and 101 are still in flight");
+
+            releaseOffset100.TrySetResult();
+            await _WaitUntilAsync(() => committedOffsets.Contains(101), AbortToken);
+            committedOffsets.Should().Equal([101]);
+
+            releaseOffset101.TrySetResult();
+            await _WaitUntilAsync(() => committedOffsets.Contains(103), AbortToken);
+            committedOffsets.Should().Equal([101, 103]);
+
+            consumer.DidNotReceive().Commit(Arg.Any<ConsumeResult<string, byte[]>>());
+        }
+        finally
+        {
+            releaseOffset100.TrySetResult();
+            releaseOffset101.TrySetResult();
+            await cts.CancelAsync();
+            await listeningTask.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+        }
+    }
+
     // -------------------------------------------------------------------------
     // PauseAsync / ResumeAsync
     // -------------------------------------------------------------------------
@@ -563,6 +670,26 @@ public sealed class KafkaConsumerClientTests : TestBase
                 // Best-effort cleanup only.
             }
 #pragma warning restore ERP022 // Unobserved exception in generic exception handler
+        }
+    }
+
+    private static ConsumeResult<string, byte[]> _CreateConsumeResult(long offset)
+    {
+        return new ConsumeResult<string, byte[]>
+        {
+            TopicPartitionOffset = new TopicPartitionOffset("orders.created", new Partition(0), new Offset(offset)),
+            Message = new Message<string, byte[]> { Value = BitConverter.GetBytes(offset), Headers = [] },
+        };
+    }
+
+    private static async Task _WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(2));
+
+        while (!predicate())
+        {
+            await Task.Delay(10, timeoutCts.Token).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
## Summary
Kafka consumers no longer risk acknowledging lower in-flight records when a higher offset finishes first under concurrent processing. The consumer runtime also surfaces post-startup listener failures as unhealthy so transport health can restart dead loops, and the received-message channel now advertises the correct multi-writer mode under parallel execution.

This also tightens delayed outbox scheduling and PostgreSQL timestamp writes so offsetless publish times and `ExpiresAt` parameters stay UTC-safe, and validates `SchedulerBatchSize` the same way retry batch sizing is validated.

## Validation
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Kafka.Tests.Unit/Headless.Messaging.Kafka.Tests.Unit.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj`
- `make build-project PROJECT=src/Headless.Messaging.Storage.PostgreSql/Headless.Messaging.Storage.PostgreSql.csproj`
- `make format-check`
- `make quality-analyzers-project PROJECT=src/Headless.Messaging.Kafka/Headless.Messaging.Kafka.csproj`
- `make quality-analyzers-project PROJECT=src/Headless.Messaging.Core/Headless.Messaging.Core.csproj`
- `make quality-analyzers-project PROJECT=src/Headless.Messaging.Storage.PostgreSql/Headless.Messaging.Storage.PostgreSql.csproj`
- `git diff --check`
- `make restore`
- `make hook-build`
- `git push -u origin xshaheen/fix-messaging-review-hardening` (pre-push format-check + incremental solution build)
