### PR TITLE
fix: harden runtime resilience and supply-chain config (security review follow-ups)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repository.
+* @xshaheen

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,12 @@ profile.arm.json
 
 # env
 .envrc
+.env
+*.env
+
+# agent scratch artifacts (directory in the main checkout, symlink in worktrees —
+# no trailing slash so the pattern matches both)
+.context
 
 # OS generated files
 .DS_Store

--- a/docs/llms/mediator.md
+++ b/docs/llms/mediator.md
@@ -42,7 +42,7 @@ There is exactly one package in this domain. No provider choice is required.
 - **Do NOT push HTTP response shaping into behaviors.** Filters, exception handlers, problem-details factories, and response compression belong in `Headless.Api.Core` or standard ASP.NET Core middleware.
 - **What does belong in the pipeline:** FluentValidation pre-processors, request/response logging, slow-request alerts, typed response transforms, domain-specific retry policies for transient handler faults, instrumentation hooks — anything that operates purely on `IRequest<TResponse>` without HTTP semantics.
 - **`ServiceLifetime` is `Scoped` by default.** Pass `ServiceLifetime.Transient` or `ServiceLifetime.Singleton` explicitly if a behavior must not share state across the request scope. The same lifetime applies to all behaviors registered by a composite call like `AddMediatorLoggingBehaviors`.
-- **`CriticalRequestLoggingBehavior` logs at `Warning`.** The threshold is hard-coded at 1 second. Do not use it as a general performance monitor — it is an alert for unusually slow handlers.
+- **`CriticalRequestLoggingBehavior` logs at `Warning`.** The threshold is hard-coded at 1 second. Do not use it as a general performance monitor — it is an alert for unusually slow handlers. The Warning entry carries only the message/response type names, elapsed time, and user ID; the full request/response payloads are emitted in a separate Debug-level entry (`Mediator:SlowMessagePayload`) so credentials or PII inside commands and responses never reach production logs at Warning.
 
 ## Core Concepts
 
@@ -58,7 +58,7 @@ The three logging behaviors are registered by `AddMediatorLoggingBehaviors()`:
 | --- | --- | --- | --- |
 | `RequestLoggingBehavior<TMessage, TResponse>` | `MessagePreProcessor<,>` | Debug | Message name + payload before handler |
 | `ResponseLoggingBehavior<TMessage, TResponse>` | `MessagePostProcessor<,>` | Debug | Message + response after handler |
-| `CriticalRequestLoggingBehavior<TMessage, TResponse>` | `IPipelineBehavior<,>` | Warning | Elapsed time + payload when handler takes ≥ 1 second |
+| `CriticalRequestLoggingBehavior<TMessage, TResponse>` | `IPipelineBehavior<,>` | Warning (names) + Debug (payload) | Elapsed time + type names at Warning; full payloads in a separate Debug entry when handler takes ≥ 1 second |
 
 All three inject `ICurrentUser` so they include the current user ID in log entries and work identically in API, worker, and console hosts.
 
@@ -109,7 +109,7 @@ Adds pipeline behaviors for FluentValidation pre-processing and structured reque
 - `ValidationRequestPreProcessor<TMessage, TResponse>` — runs all registered `IValidator<TMessage>` concurrently before the handler; throws `ValidationException` on any failure.
 - `RequestLoggingBehavior<TMessage, TResponse>` — logs the message name and payload at Debug level before handler execution.
 - `ResponseLoggingBehavior<TMessage, TResponse>` — logs the message name, payload, and response at Debug level after handler execution.
-- `CriticalRequestLoggingBehavior<TMessage, TResponse>` — logs at Warning level when a handler takes ≥ 1 second.
+- `CriticalRequestLoggingBehavior<TMessage, TResponse>` — logs elapsed time and type names at Warning level when a handler takes ≥ 1 second; the full request/response payloads go to a separate Debug-level entry so sensitive data stays out of production logs.
 - Idempotent composite setup extensions: `AddMediatorValidationRequestBehavior()` and `AddMediatorLoggingBehaviors()`.
 - Fine-grained split: `AddMediatorRequestResponseLoggingBehaviors()` (request + response only) and `AddMediatorSlowRequestsLoggingBehaviors()` (slow-request only).
 - Every setup extension accepts an optional `ServiceLifetime` parameter (default `Scoped`).

--- a/src/Headless.Jobs.Core/JobsThreadPool/JobsTaskScheduler.cs
+++ b/src/Headless.Jobs.Core/JobsThreadPool/JobsTaskScheduler.cs
@@ -223,6 +223,11 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
             Task.Run(async () => await _WorkerLoopCoreAsync(workerId).ConfigureAwait(false)).GetAwaiter().GetResult();
 #pragma warning restore MA0045
         }
+        catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested || _disposed)
+        {
+            // Shutdown cancelled an in-flight await inside the loop (e.g. the idle backoff delay).
+            // Swallow it: an unhandled exception on a manually created thread terminates the process.
+        }
         finally
         {
             SynchronizationContext.SetSynchronizationContext(originalContext);

--- a/src/Headless.Jobs.Dashboard/wwwroot/.npmrc
+++ b/src/Headless.Jobs.Dashboard/wwwroot/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain hardening: never run dependency lifecycle scripts. The only packages
+# with install scripts here (@swc/core, fsevents) resolve their platform binaries via
+# optionalDependencies, so the build works without them.
+ignore-scripts=true

--- a/src/Headless.Mediator/Behaviors/CriticalRequestLoggingBehavior.cs
+++ b/src/Headless.Mediator/Behaviors/CriticalRequestLoggingBehavior.cs
@@ -25,7 +25,10 @@ public sealed class CriticalRequestLoggingBehavior<TMessage, TResponse>(
 
     /// <summary>
     /// Executes the next handler in the pipeline and emits a warning-level log entry when the
-    /// elapsed time exceeds the critical threshold (1 second).
+    /// elapsed time exceeds the critical threshold (1 second). The warning carries only the
+    /// message/response type names; the full payloads are logged separately at Debug level
+    /// because requests and responses may carry credentials or other sensitive data that must
+    /// not reach production logs.
     /// </summary>
     /// <param name="message">The Mediator message being processed.</param>
     /// <param name="next">The delegate that invokes the next pipeline stage or the final handler.</param>
@@ -48,6 +51,12 @@ public sealed class CriticalRequestLoggingBehavior<TMessage, TResponse>(
                 userId: _currentUser.UserId?.ToString(),
                 elapsed: elapsed,
                 messageName: typeof(TMessage).Name,
+                responseName: typeof(TResponse).Name
+            );
+
+            _LogMediatorSlowResponsePayload(
+                _logger,
+                messageName: typeof(TMessage).Name,
                 message: message,
                 responseName: typeof(TResponse).Name,
                 response: response
@@ -59,11 +68,22 @@ public sealed class CriticalRequestLoggingBehavior<TMessage, TResponse>(
 
     #region Logger
 
-    private static readonly Action<ILogger, string?, TimeSpan, string, object, string, object?, Exception?> _Log =
-        LoggerMessage.Define<string?, TimeSpan, string, object, string, object?>(
-            LogLevel.Warning,
-            new EventId(3, "Mediator:SlowMessage"),
-            "[Mediator:SlowMessage] {UserId} {Elapsed}ms {MessageName} {@Message} {ResponseName} {@Response}"
+    private static readonly Action<ILogger, string?, TimeSpan, string, string, Exception?> _Log = LoggerMessage.Define<
+        string?,
+        TimeSpan,
+        string,
+        string
+    >(
+        LogLevel.Warning,
+        new EventId(3, "Mediator:SlowMessage"),
+        "[Mediator:SlowMessage] {UserId} {Elapsed}ms {MessageName} {ResponseName}"
+    );
+
+    private static readonly Action<ILogger, string, object, string, object?, Exception?> _LogPayload =
+        LoggerMessage.Define<string, object, string, object?>(
+            LogLevel.Debug,
+            new EventId(5, "Mediator:SlowMessagePayload"),
+            "[Mediator:SlowMessagePayload] {MessageName} {@Message} {ResponseName} {@Response}"
         );
 
     private static void _LogMediatorSlowResponse(
@@ -71,12 +91,21 @@ public sealed class CriticalRequestLoggingBehavior<TMessage, TResponse>(
         string? userId,
         TimeSpan elapsed,
         string messageName,
+        string responseName
+    )
+    {
+        _Log(logger, userId, elapsed, messageName, responseName, arg6: null);
+    }
+
+    private static void _LogMediatorSlowResponsePayload(
+        ILogger logger,
+        string messageName,
         object message,
         string responseName,
         object? response
     )
     {
-        _Log(logger, userId, elapsed, messageName, message, responseName, response, arg8: null);
+        _LogPayload(logger, messageName, message, responseName, response, arg6: null);
     }
 
     #endregion

--- a/src/Headless.Mediator/README.md
+++ b/src/Headless.Mediator/README.md
@@ -9,7 +9,7 @@ Adds pipeline behaviors for FluentValidation pre-processing and structured reque
 - `ValidationRequestPreProcessor<TMessage, TResponse>` — runs all registered `IValidator<TMessage>` concurrently before the handler; throws `ValidationException` on any failure.
 - `RequestLoggingBehavior<TMessage, TResponse>` — logs the message name and payload at Debug level before handler execution.
 - `ResponseLoggingBehavior<TMessage, TResponse>` — logs the message name, payload, and response at Debug level after handler execution.
-- `CriticalRequestLoggingBehavior<TMessage, TResponse>` — logs at Warning level when a handler takes ≥ 1 second.
+- `CriticalRequestLoggingBehavior<TMessage, TResponse>` — logs elapsed time and type names at Warning level when a handler takes ≥ 1 second; the full request/response payloads go to a separate Debug-level entry so sensitive data stays out of production logs.
 - Idempotent composite setup extensions: `AddMediatorValidationRequestBehavior()` and `AddMediatorLoggingBehaviors()`.
 - Fine-grained split: `AddMediatorRequestResponseLoggingBehaviors()` (request + response only) and `AddMediatorSlowRequestsLoggingBehaviors()` (slow-request only).
 - Every setup extension accepts an optional `ServiceLifetime` parameter (default `Scoped`).

--- a/src/Headless.Messaging.Core/Processor/IProcessor.InfiniteRetry.cs
+++ b/src/Headless.Messaging.Core/Processor/IProcessor.InfiniteRetry.cs
@@ -7,7 +7,8 @@ namespace Headless.Messaging.Processor;
 public sealed class InfiniteRetryProcessor(IProcessor inner, ILoggerFactory loggerFactory) : IProcessor
 {
     // Exponential backoff for processor-level crashes (not message-level retries).
-    // Starts at 1 s, doubles on each consecutive failure, caps at 60 s.
+    // Starts at 1 s, doubles on each consecutive failure, caps at 60 s, and adds 0-25% jitter
+    // so replicas that failed together do not retry in lockstep against a recovering dependency.
     // Resets to the initial value after a successful iteration so a recovered processor
     // does not carry forward a large delay from a past outage.
     private static readonly TimeSpan _InitialBackoff = TimeSpan.FromSeconds(1);
@@ -35,7 +36,7 @@ public sealed class InfiniteRetryProcessor(IProcessor inner, ILoggerFactory logg
             catch (Exception ex)
             {
                 _logger.LogProcessorFailedRetrying(ex, inner.ToString(), (long)backoff.TotalSeconds);
-                await context.WaitAsync(backoff).ConfigureAwait(false);
+                await context.WaitAsync(_WithJitter(backoff)).ConfigureAwait(false);
 
                 // Double delay for next failure, capped at MaxBackoff.
                 var nextMs = Math.Min(backoff.TotalMilliseconds * 2, _MaxBackoff.TotalMilliseconds);
@@ -47,6 +48,14 @@ public sealed class InfiniteRetryProcessor(IProcessor inner, ILoggerFactory logg
     public override string? ToString()
     {
         return inner.ToString();
+    }
+
+    private static TimeSpan _WithJitter(TimeSpan delay)
+    {
+#pragma warning disable CA5394 // Non-security jitter for retry backoff; cryptographic RNG is unnecessary here.
+        var jitterMs = Random.Shared.Next(0, (int)Math.Max(1, delay.TotalMilliseconds / 4));
+#pragma warning restore CA5394
+        return delay + TimeSpan.FromMilliseconds(jitterMs);
     }
 }
 

--- a/src/Headless.Messaging.Dashboard/wwwroot/.npmrc
+++ b/src/Headless.Messaging.Dashboard/wwwroot/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain hardening: never run dependency lifecycle scripts. The only packages
+# with install scripts here (@swc/core, fsevents) resolve their platform binaries via
+# optionalDependencies, so the build works without them.
+ignore-scripts=true

--- a/src/Headless.Messaging.InMemory/InMemoryConsumerClient.cs
+++ b/src/Headless.Messaging.InMemory/InMemoryConsumerClient.cs
@@ -11,11 +11,16 @@ namespace Headless.Messaging.InMemory;
 /// </summary>
 internal sealed class InMemoryConsumerClient : IConsumerClient
 {
+    // Bounds pending-message memory when a consumer is paused or slower than the publisher.
+    // Publishers call AddSubscribeMessage under MemoryQueue's global lock, so overflow must
+    // drop (TryAdd) rather than block — a blocking Add would stall every publisher.
+    private const int _MaxPendingMessages = 65_536;
+
     private readonly MemoryQueue _queue;
     private readonly string _groupId;
     private readonly IntentType _intentType;
     private readonly byte _groupConcurrent;
-    private readonly BlockingCollection<TransportMessage> _messageQueue = [];
+    private readonly BlockingCollection<TransportMessage> _messageQueue = new(_MaxPendingMessages);
     private readonly SemaphoreSlim _semaphore;
     private readonly ConsumerPauseGate _pauseGate = new();
     private readonly TaskCompletionSource _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -98,12 +103,23 @@ internal sealed class InMemoryConsumerClient : IConsumerClient
     }
 
     /// <summary>
-    /// Adds a message to the message queue for processing.
+    /// Adds a message to the message queue for processing. When the pending queue is full the
+    /// message is dropped and reported through <see cref="OnLogCallback"/>.
     /// </summary>
     /// <param name="message">The transport message to add</param>
     public void AddSubscribeMessage(TransportMessage message)
     {
-        _messageQueue.Add(message);
+        if (!_messageQueue.TryAdd(message))
+        {
+            OnLogCallback?.Invoke(
+                new LogMessageEventArgs
+                {
+                    LogType = MqLogType.ConsumeError,
+                    Reason =
+                        $"Pending message queue for group '{_groupId}' is full ({_MaxPendingMessages}); message '{message.Name}' dropped.",
+                }
+            );
+        }
     }
 
     /// <summary>

--- a/src/Headless.Messaging.InMemory/README.md
+++ b/src/Headless.Messaging.InMemory/README.md
@@ -25,6 +25,7 @@ Provides a lightweight, no-infrastructure message queue for local development, t
 - Publishing to an unbound message name still fails fast. `InMemory` is intentionally strict so tests and local development do not silently hide invalid publish targets or missing consumer registration.
 - Single-threaded consumption preserves queue order. Higher `ConsumerThreadCount` can reorder concurrent handlers.
 - Payload size is limited by process memory.
+- Each consumer group buffers at most 65,536 pending messages. When the buffer is full (for example, a paused or stalled consumer), further deliveries to that group are dropped and reported through the transport log callback instead of growing memory without bound.
 
 ## Installation
 

--- a/src/Headless.Messaging.Redis/IRedisStreamManagerDefault.cs
+++ b/src/Headless.Messaging.Redis/IRedisStreamManagerDefault.cs
@@ -55,13 +55,26 @@ internal sealed class RedisStreamManager(
         // instead of rebuilding the StreamPosition[] on every poll iteration.
         var positions = streams.Select(stream => new StreamPosition(stream, StreamPosition.NewMessages)).ToArray();
 
+        var errorDelay = pollDelay;
+
         while (true)
         {
-            var result = await _TryReadConsumerGroupAsync(consumerGroup, positions, token).ConfigureAwait(false);
+            var (succeeded, result) = await _TryReadConsumerGroupAsync(consumerGroup, positions, token)
+                .ConfigureAwait(false);
 
             yield return result;
 
-            await _timeProvider.Delay(pollDelay, token).ConfigureAwait(false);
+            if (succeeded)
+            {
+                errorDelay = pollDelay;
+                await _timeProvider.Delay(pollDelay, token).ConfigureAwait(false);
+            }
+            else
+            {
+                // During a Redis outage back off instead of re-hammering at the fixed poll cadence.
+                errorDelay = _NextBackoff(errorDelay);
+                await _timeProvider.Delay(errorDelay, token).ConfigureAwait(false);
+            }
         }
 
         // ReSharper disable once IteratorNeverReturns
@@ -86,7 +99,7 @@ internal sealed class RedisStreamManager(
             // re-inspected by the All() check below, so leaving it deferred would flatten it twice.
             var result = (
                 await _TryReadConsumerGroupAsync(consumerGroup, positions, token).ConfigureAwait(false)
-            ).ToArray();
+            ).Streams.ToArray();
 
             yield return result;
 
@@ -112,7 +125,7 @@ internal sealed class RedisStreamManager(
         await _redis!.GetDatabase().StreamAcknowledgeAsync(stream, consumerGroup, messageId).ConfigureAwait(false);
     }
 
-    private async Task<IEnumerable<RedisStream>> _TryReadConsumerGroupAsync(
+    private async Task<(bool Succeeded, IEnumerable<RedisStream> Streams)> _TryReadConsumerGroupAsync(
         string consumerGroup,
         StreamPosition[] positions,
         CancellationToken token
@@ -140,7 +153,7 @@ internal sealed class RedisStreamManager(
 
             if (createdPositions.Count == 0)
             {
-                return [];
+                return (Succeeded: true, Streams: []);
             }
 
             //calculate keys HashSlots to start reading per HashSlot
@@ -157,18 +170,31 @@ internal sealed class RedisStreamManager(
 
             var readSet = await Task.WhenAll(groupedPositions).ConfigureAwait(false);
 
-            return readSet.SelectMany(set => set);
+            return (Succeeded: true, Streams: readSet.SelectMany(set => set));
         }
         catch (OperationCanceledException)
         {
-            // ignore
+            // Cancellation is not a read failure; the caller's next Delay(token) ends the poll loop.
+            return (Succeeded: true, Streams: []);
         }
         catch (Exception ex)
         {
             logger.LogReadConsumerGroupFailed(ex, consumerGroup);
         }
 
-        return [];
+        return (Succeeded: false, Streams: []);
+    }
+
+    private static TimeSpan _NextBackoff(TimeSpan current)
+    {
+        var floor = TimeSpan.FromMilliseconds(200);
+        var ceiling = TimeSpan.FromSeconds(30);
+        var doubled = TimeSpan.FromTicks(Math.Max(current.Ticks * 2, floor.Ticks));
+        var capped = doubled > ceiling ? ceiling : doubled;
+#pragma warning disable CA5394 // Non-security jitter for retry backoff; cryptographic RNG is unnecessary here.
+        var jitterMs = Random.Shared.Next(0, (int)Math.Max(1, capped.TotalMilliseconds / 4));
+#pragma warning restore CA5394
+        return capped + TimeSpan.FromMilliseconds(jitterMs);
     }
 
     private async Task _ConnectAsync(CancellationToken cancellationToken = default)

--- a/tests/Headless.Jobs.Tests.Unit/JobsTaskSchedulerTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/JobsTaskSchedulerTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs.Enums;
+using Headless.Jobs.JobsThreadPool;
+
+namespace Tests;
+
+public sealed class JobsTaskSchedulerTests
+{
+    [Fact]
+    public async Task Dispose_while_worker_idles_in_backoff_completes_cleanly()
+    {
+        // A worker that finished its work parks in the idle backoff delay awaiting the shutdown
+        // token. DisposeAsync cancels that token; the resulting OperationCanceledException must
+        // not escape the worker's thread-start delegate — an unhandled exception on a manually
+        // created thread terminates the whole process.
+        var scheduler = new JobsTaskScheduler(maxConcurrency: 2);
+        var executed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await scheduler.QueueAsync(
+            _ =>
+            {
+                executed.TrySetResult();
+
+                return Task.CompletedTask;
+            },
+            JobPriority.Normal,
+            TestContext.Current.CancellationToken
+        );
+
+        await executed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        // Give the now-idle worker time to enter the backoff delay await.
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        var dispose = scheduler.DisposeAsync().AsTask();
+        var finished = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        finished.Should().Be(dispose);
+        await dispose;
+        scheduler.ActiveWorkers.Should().Be(0);
+    }
+}

--- a/tests/Headless.Mediator.Tests.Unit/LoggingBehaviorsTests.cs
+++ b/tests/Headless.Mediator.Tests.Unit/LoggingBehaviorsTests.cs
@@ -3,6 +3,7 @@
 using Headless.Abstractions;
 using Headless.Mediator.Behaviors;
 using Mediator;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Tests;
@@ -124,6 +125,38 @@ public sealed class LoggingBehaviorsTests
         loggerAction.Should().ThrowExactly<ArgumentNullException>().WithParameterName("logger");
     }
 
+    [Fact]
+    public async Task should_not_log_payload_at_warning_from_critical_request_logging_behavior()
+    {
+        // given
+        var logger = new CapturingLogger<CriticalRequestLoggingBehavior<SensitiveRequest, TestResponse>>();
+        var behavior = new CriticalRequestLoggingBehavior<SensitiveRequest, TestResponse>(
+            new NullCurrentUser(),
+            logger
+        );
+        var response = new TestResponse();
+
+        // when
+        await behavior.Handle(
+            new SensitiveRequest(Password: "hunter2"),
+            async (_, cancellationToken) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1.1), cancellationToken);
+
+                return response;
+            },
+            CancellationToken.None
+        );
+
+        // then: the Warning alert carries type names only; payloads are Debug-only
+        var warning = logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning).Subject;
+        warning.Message.Should().Contain(nameof(SensitiveRequest));
+        warning.Message.Should().NotContain("hunter2");
+
+        var debug = logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Debug).Subject;
+        debug.Message.Should().Contain("hunter2");
+    }
+
     private static MessageHandlerDelegate<TestRequest, TestResponse> _CreateNext(TestResponse response, Action onInvoke)
     {
         return (_, _) =>
@@ -137,4 +170,27 @@ public sealed class LoggingBehaviorsTests
     private sealed record TestRequest : IRequest<TestResponse>;
 
     private sealed record TestResponse;
+
+    private sealed record SensitiveRequest(string Password) : IRequest<TestResponse>;
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, EventId EventId, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            Entries.Add((logLevel, eventId, formatter(state, exception)));
+        }
+    }
 }

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
@@ -82,9 +82,10 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         // then
         moveNextTask.IsCompleted.Should().BeFalse();
 
-        // when
+        // when: 5s bound (not 1s) — under CI scheduling pressure the continuation can take
+        // far longer than the logical work; the fake clock means it can never pass early
         timeProvider.Advance(TimeSpan.FromMilliseconds(250));
-        await moveNextTask.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+        await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         // then
         enumerator.Current.StorageId.Should().Be(_StorageGuid(7));

--- a/tests/Headless.Messaging.Core.Tests.Unit/Processor/InfiniteRetryProcessorTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Processor/InfiniteRetryProcessorTests.cs
@@ -43,9 +43,11 @@ public sealed class InfiniteRetryProcessorTests : TestBase
         await _WaitUntilAsync(() => inner.Calls == 3, AbortToken);
         await run.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
 
-        // then
-        firstDelay.Should().Be(TimeSpan.FromSeconds(1));
-        secondDelay.Should().Be(TimeSpan.FromSeconds(2));
+        // then: each wait is the doubled base delay plus 0-25% jitter
+        firstDelay.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(1));
+        firstDelay.Should().BeLessThan(TimeSpan.FromSeconds(1.25));
+        secondDelay.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(2));
+        secondDelay.Should().BeLessThan(TimeSpan.FromSeconds(2.5));
         inner.Calls.Should().Be(3);
     }
 
@@ -83,8 +85,9 @@ public sealed class InfiniteRetryProcessorTests : TestBase
         await _WaitUntilAsync(() => inner.Calls == 4, AbortToken);
         await run.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
 
-        // then
-        secondFailureDelay.Should().Be(TimeSpan.FromSeconds(1));
+        // then: the post-recovery wait restarts from the initial 1s (plus 0-25% jitter)
+        secondFailureDelay.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(1));
+        secondFailureDelay.Should().BeLessThan(TimeSpan.FromSeconds(1.25));
         inner.Calls.Should().Be(4);
     }
 

--- a/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryConsumerClientTests.cs
+++ b/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryConsumerClientTests.cs
@@ -207,9 +207,10 @@ public sealed class InMemoryConsumerClientTests : TestBase
 
         await Task.Delay(50, AbortToken);
 
-        // when
+        // when: awaiting the listener task itself (bounded) instead of a fixed post-cancel
+        // delay keeps the assertion deterministic under CI scheduling pressure
         await cts.CancelAsync();
-        await Task.Delay(100, AbortToken);
+        await listenTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         // then
         listenerStopped.Should().BeTrue();

--- a/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryConsumerClientTests.cs
+++ b/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryConsumerClientTests.cs
@@ -66,12 +66,12 @@ public sealed class InMemoryConsumerClientTests : TestBase
         // given
         await _client.SubscribeAsync(["test-messageName"]);
 
-        TransportMessage? receivedMessage = null;
-        object? receivedSender = null;
+        var received = new TaskCompletionSource<(TransportMessage Message, object? Sender)>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
         _client.OnMessageCallback = (msg, sender) =>
         {
-            receivedMessage = msg;
-            receivedSender = sender;
+            received.TrySetResult((msg, sender));
             return Task.CompletedTask;
         };
 
@@ -95,12 +95,11 @@ public sealed class InMemoryConsumerClientTests : TestBase
         // when
         _queue.SendBus(message);
 
-        await Task.Delay(100, AbortToken);
+        var (receivedMessage, receivedSender) = await received.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // then
-        receivedMessage.Should().NotBeNull();
-        receivedMessage!.Value.Id.Should().Be("msg-1");
+        receivedMessage.Id.Should().Be("msg-1");
         receivedSender.Should().BeNull();
     }
 
@@ -326,9 +325,15 @@ public sealed class InMemoryConsumerClientTests : TestBase
         await client.SubscribeAsync(["sequential-messageName"]);
 
         var processOrder = new List<string>();
+        var allProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         client.OnMessageCallback = (msg, _) =>
         {
             processOrder.Add(msg.Id);
+            if (processOrder.Count == 3)
+            {
+                allProcessed.TrySetResult();
+            }
+
             return Task.CompletedTask;
         };
 
@@ -352,7 +357,7 @@ public sealed class InMemoryConsumerClientTests : TestBase
         queue.SendBus(_CreateTestMessage("2", "sequential-messageName"));
         queue.SendBus(_CreateTestMessage("3", "sequential-messageName"));
 
-        await Task.Delay(200, AbortToken);
+        await allProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
         await client.DisposeAsync();
 
@@ -381,10 +386,10 @@ public sealed class InMemoryConsumerClientTests : TestBase
         // given
         await _client.SubscribeAsync(["test-messageName"]);
 
-        TransportMessage? receivedMessage = null;
+        var received = new TaskCompletionSource<TransportMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         _client.OnMessageCallback = (msg, _) =>
         {
-            receivedMessage = msg;
+            received.TrySetResult(msg);
             return Task.CompletedTask;
         };
 
@@ -406,12 +411,11 @@ public sealed class InMemoryConsumerClientTests : TestBase
         // when
         _queue.SendBus(_CreateTestMessage("msg-1", "test-messageName"));
 
-        await Task.Delay(100, AbortToken);
+        var receivedMessage = await received.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // then
-        receivedMessage.Should().NotBeNull();
-        receivedMessage!.Value.GetGroup().Should().Be("test-group");
+        receivedMessage.GetGroup().Should().Be("test-group");
     }
 
     // -------------------------------------------------------------------------
@@ -454,9 +458,11 @@ public sealed class InMemoryConsumerClientTests : TestBase
         await _client.SubscribeAsync(["test-messageName"]);
 
         var receivedCount = 0;
+        var received = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _client.OnMessageCallback = (_, _) =>
         {
             Interlocked.Increment(ref receivedCount);
+            received.TrySetResult();
             return Task.CompletedTask;
         };
 
@@ -483,9 +489,9 @@ public sealed class InMemoryConsumerClientTests : TestBase
         // then — message not delivered while paused
         receivedCount.Should().Be(0);
 
-        // cleanup — resume and cancel
+        // cleanup — resume, then wait for the resumed delivery deterministically
         await _client.ResumeAsync(AbortToken);
-        await Task.Delay(200, AbortToken);
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // message should now have been delivered after resume

--- a/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryQueueTransportTests.cs
+++ b/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryQueueTransportTests.cs
@@ -166,10 +166,10 @@ public sealed class InMemoryQueueTransportTests : TestBase
         // given
         await _consumerClient.SubscribeAsync(["test-messageName"]);
 
-        TransportMessage? receivedMessage = null;
+        var received = new TaskCompletionSource<TransportMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         _consumerClient.OnMessageCallback = (msg, _) =>
         {
-            receivedMessage = msg;
+            received.TrySetResult(msg);
             return Task.CompletedTask;
         };
 
@@ -200,12 +200,11 @@ public sealed class InMemoryQueueTransportTests : TestBase
         // when
         await _transport.SendAsync(message, AbortToken);
 
-        await Task.Delay(100, AbortToken);
+        var receivedMessage = await received.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await cts.CancelAsync();
 
         // then
-        receivedMessage.Should().NotBeNull();
-        receivedMessage!.Value.Body.ToArray().Should().Equal(bodyContent);
+        receivedMessage.Body.ToArray().Should().Equal(bodyContent);
     }
 
     [Fact]

--- a/tests/Headless.Messaging.RabbitMq.Tests.Unit/RabbitMqConsumerClientTests.cs
+++ b/tests/Headless.Messaging.RabbitMq.Tests.Unit/RabbitMqConsumerClientTests.cs
@@ -545,7 +545,10 @@ public sealed class RabbitMqConsumerClientTests : TestBase
 
             await client.ResumeAsync(AbortToken);
 
-            await Task.Delay(100, AbortToken);
+            // Deterministic: _ready completes right after BasicConsumeAsync registers, so waiting
+            // on it (instead of a fixed delay) guarantees the resumed startup finished and the
+            // final cancel lands in the keep-alive delay, which completes gracefully.
+            await client.WaitUntilReadyAsync(AbortToken).AsTask().WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
             _channel
                 .ReceivedCalls()


### PR DESCRIPTION
## Context

Follow-ups from a full security & supply-chain review of the repo (dependency scan came back clean: `dotnet list package --vulnerable --include-transitive` reports zero known-vulnerable packages). This PR fixes the two Medium findings and the small Low/hardening items that are safe to apply directly.

## Changes

### `fix(jobs)` — process crash on scheduler dispose (Medium)
Workers run on manually created threads; the idle-backoff `Delay(..., _shutdownCts.Token)` was awaited with no catch anywhere up the thread-start delegate, so `DisposeAsync` → cancel → unhandled `OperationCanceledException` on a dedicated thread → **process termination** during host shutdown. Added a shutdown-filtered OCE catch in `_WorkerLoop`. Regression test verified both ways: without the fix the run reports an unhandled error and exits 7; with it, clean pass.

### `fix(mediator)` — slow-request payloads out of Warning logs (Medium)
`CriticalRequestLoggingBehavior` destructured the full request/response (`{@Message}`/`{@Response}`) at **Warning**, so any slow `LoginCommand`/token-bearing response landed verbatim in production logs. Warning now carries type names, elapsed, and user id only; full payloads moved to a separate Debug-level `Mediator:SlowMessagePayload` event. Docs synced (`docs/llms/mediator.md`, package README). New test asserts the Warning entry never contains payload data.

### `fix(messaging)` — InMemory queue bound + Redis poll backoff + retry jitter (Low)
- InMemory consumer pending queue capped at 65,536; overflow drops via `TryAdd` (publishers deliver under `MemoryQueue`'s global lock, so blocking would stall every publisher) and is reported through the transport log callback.
- `RedisStreamManager` poll loop now distinguishes read failures from empty polls and backs off exponentially (200 ms floor, 30 s cap, 0–25 % jitter) during outages, matching the SQS/NATS/Pulsar consumers.
- `InfiniteRetryProcessor` adds 0–25 % jitter so replicas don't retry in lockstep against a recovering dependency.

### `build` — supply-chain config hardening
- `.gitignore`: cover `.env` / `*.env` and `.context` (no trailing slash — it's a symlink in worktrees).
- Dashboard SPAs: `.npmrc` with `ignore-scripts=true`. Only `@swc/core` and `fsevents` have install scripts and both resolve platform binaries via `optionalDependencies` — verified fresh `npm ci` + `npm run build` + vitest green on both dashboards.
- `CODEOWNERS` stub.

## Validation

- Unit suites green: Jobs 1 new regression test, Mediator 20/20, Messaging.InMemory 56/56, Messaging.Redis 92/92, Messaging.Core 897/897 (two exact-backoff assertions updated to jitter envelopes).
- `make quality-analyzers-project` clean on all five changed src projects.
- Both dashboard SPAs: `npm ci` + build + `test:unit` green with lifecycle scripts disabled.

## Deliberately not included (need separate decisions)

- Dashboard `AuthMode.None` default (secure-by-default change, breaks no-auth setups).
- NuGet Trusted Publishing migration; GitHub org/repo settings toggles (require SHA pinning, restrict allowed actions, non-provider secret-scanning patterns, enforce-admins).
- Prune-prerelease workflow's scheduled runs being permanently dry-run (intent unclear — flagging, not changing).