### PR TITLE
fix: repair Paymob runtime deserialization and close coverage gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,5 +197,6 @@ After creating the project, attach it to [headless-framework.slnx](headless-fram
 
 ## Learnings
 
+- `[JsonExtensionData]` properties must be `{ get; set; }` (never `init`) and every source-gen `JsonSerializerContext` whose models carry extension data needs `[JsonSerializable(typeof(object))]` + `[JsonSerializable(typeof(JsonElement))]`. `init` binding throws on EVERY deserialization; missing object metadata throws on any unknown response field — both at runtime only, build stays green. Found via Paymob CashOut/CashIn unit tests. (2026-07-07)
 - `Range<T>` uses `null` bounds as infinities; range-to-range operations must compare lower and upper bounds with side-specific semantics instead of reusing value containment. (2026-07-04)
 - Kafka concurrent consumers must commit offsets by per-partition contiguous completed watermark; committing a high completed offset directly can acknowledge lower in-flight messages and lose them after a crash. (2026-07-06)

--- a/src/Headless.Payments.Paymob.CashIn/Internals/PaymobCashInJsonSerializerContext.cs
+++ b/src/Headless.Payments.Paymob.CashIn/Internals/PaymobCashInJsonSerializerContext.cs
@@ -92,4 +92,8 @@ namespace Headless.Payments.Paymob.CashIn.Internals;
 [JsonSerializable(typeof(CashInTransactionSourceData))]
 [JsonSerializable(typeof(CashInTransactionsPage))]
 [JsonSerializable(typeof(CashInTransactionsPageRequest))]
+// object/JsonElement metadata is required for [JsonExtensionData] values; without it
+// any unknown field in a Paymob response throws NotSupportedException.
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(JsonElement))]
 internal sealed partial class PaymobCashInJsonSerializerContext : JsonSerializerContext;

--- a/src/Headless.Payments.Paymob.CashOut/Internals/PaymobCashOutJsonSerializerContext.cs
+++ b/src/Headless.Payments.Paymob.CashOut/Internals/PaymobCashOutJsonSerializerContext.cs
@@ -12,4 +12,8 @@ namespace Headless.Payments.Paymob.CashOut.Internals;
 [JsonSerializable(typeof(CashOutTransaction))]
 [JsonSerializable(typeof(CashOutGetTransactionsRequest))]
 [JsonSerializable(typeof(CashOutAuthenticationResponse))]
+// object/JsonElement metadata is required for [JsonExtensionData] values and the
+// polymorphic status_description field; without it unknown response fields throw.
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(JsonElement))]
 internal sealed partial class PaymobCashOutJsonSerializerContext : JsonSerializerContext;

--- a/src/Headless.Payments.Paymob.CashOut/Models/CashOutAuthenticationResponse.cs
+++ b/src/Headless.Payments.Paymob.CashOut/Models/CashOutAuthenticationResponse.cs
@@ -31,6 +31,7 @@ public sealed record CashOutAuthenticationResponse
     [JsonPropertyName("expires_in")]
     public int ExpiresIn { get; init; }
 
+    // set (not init): [JsonExtensionData] cannot bind through init-only metadata and fails deserialization
     [JsonExtensionData]
-    public IDictionary<string, object?>? ExtensionData { get; init; }
+    public IDictionary<string, object?>? ExtensionData { get; set; }
 }

--- a/src/Headless.Payments.Paymob.CashOut/Models/CashOutDisburseResponseAmanCashingDetails.cs
+++ b/src/Headless.Payments.Paymob.CashOut/Models/CashOutDisburseResponseAmanCashingDetails.cs
@@ -22,6 +22,7 @@ public sealed record CashOutDisburseResponseAmanCashingDetails
     [JsonPropertyName("is_paid")]
     public bool IsPaid { get; init; }
 
+    // set (not init): [JsonExtensionData] cannot bind through init-only metadata and fails deserialization
     [JsonExtensionData]
-    public IDictionary<string, object?>? ExtensionData { get; init; }
+    public IDictionary<string, object?>? ExtensionData { get; set; }
 }

--- a/src/Headless.Payments.Paymob.CashOut/Models/CashOutTransaction.cs
+++ b/src/Headless.Payments.Paymob.CashOut/Models/CashOutTransaction.cs
@@ -48,8 +48,9 @@ public sealed record CashOutTransaction
     [JsonPropertyName("updated_at")]
     public string? UpdatedAt { get; init; }
 
+    // set (not init): [JsonExtensionData] cannot bind through init-only metadata and fails deserialization
     [JsonExtensionData]
-    public IDictionary<string, object?>? ExtensionData { get; init; }
+    public IDictionary<string, object?>? ExtensionData { get; set; }
 
     /// <summary>Returns <see langword="true"/> when the disbursement completed successfully.</summary>
     public bool IsSuccess()

--- a/tests/Headless.AuditLog.Core.Tests.Unit/AuditLogSetupTests.cs
+++ b/tests/Headless.AuditLog.Core.Tests.Unit/AuditLogSetupTests.cs
@@ -48,4 +48,71 @@ public sealed class AuditLogSetupTests
         // then
         options.Value.SensitiveValueTransformer.Should().NotBeNull();
     }
+
+    [Fact]
+    public void add_headless_audit_log_with_setup_throws_when_no_storage_provider_is_registered()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        var act = () => services.AddHeadlessAuditLog((HeadlessAuditLogSetupBuilder _) => { });
+
+        // then
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*requires exactly one storage provider*UseEntityFramework*");
+    }
+
+    [Fact]
+    public void add_headless_audit_log_with_setup_throws_when_multiple_storage_providers_are_registered()
+    {
+        // given
+        var services = new ServiceCollection();
+
+        // when
+        var act = () =>
+            services.AddHeadlessAuditLog(setup =>
+            {
+                setup.RegisterExtension(new NoopStorageExtension());
+                setup.RegisterExtension(new NoopStorageExtension());
+            });
+
+        // then
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Multiple storage providers were configured*");
+    }
+
+    [Fact]
+    public void configure_options_composes_delegates_in_registration_order()
+    {
+        // given
+        var services = new ServiceCollection();
+        bool? auditByDefaultSeenBySecondDelegate = null;
+
+        services.AddHeadlessAuditLog(setup =>
+        {
+            setup.RegisterExtension(new NoopStorageExtension());
+            setup.ConfigureOptions(options => options.AuditByDefault = true);
+            setup.ConfigureOptions(options =>
+            {
+                auditByDefaultSeenBySecondDelegate = options.AuditByDefault;
+                options.IsEnabled = false;
+            });
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        // when
+        var options = provider.GetRequiredService<IOptions<AuditLogOptions>>().Value;
+
+        // then - both delegates ran in registration order against the same options instance
+        auditByDefaultSeenBySecondDelegate.Should().BeTrue();
+        options.AuditByDefault.Should().BeTrue();
+        options.IsEnabled.Should().BeFalse();
+    }
+
+    private sealed class NoopStorageExtension : IAuditLogStorageOptionsExtension
+    {
+        public void AddServices(IServiceCollection services) { }
+    }
 }

--- a/tests/Headless.AuditLog.Tests.Unit/AuditStoreDbContext.cs
+++ b/tests/Headless.AuditLog.Tests.Unit/AuditStoreDbContext.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.AuditLog;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Tests;
+
+/// <summary>
+/// Minimal DbContext exposing the <see cref="AuditLogEntry"/> model for store/log unit tests.
+/// SQLite cannot autoincrement a member of the shipped composite (CreatedAt, Id) primary key,
+/// so the key is overridden to a single-column PK on Id — the documented SQLite consumer override.
+/// </summary>
+public sealed class AuditStoreDbContext(DbContextOptions<AuditStoreDbContext> options) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.AddHeadlessAuditLog(new AuditLogStorageOptions());
+        modelBuilder.Entity<AuditLogEntry>().HasKey(e => e.Id);
+    }
+
+    // Each test gets its own in-memory SQLite connection so databases are isolated
+    public static (AuditStoreDbContext db, SqliteConnection conn) Create()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+
+        var builder = new DbContextOptionsBuilder<AuditStoreDbContext>().UseSqlite(conn);
+
+        var db = new AuditStoreDbContext(builder.Options);
+#pragma warning disable MA0045 // Do not use blocking calls, even when the calling method must become async
+        db.Database.EnsureCreated();
+#pragma warning restore MA0045
+        return (db, conn);
+    }
+}

--- a/tests/Headless.AuditLog.Tests.Unit/EfAuditChangeCaptureTests.cs
+++ b/tests/Headless.AuditLog.Tests.Unit/EfAuditChangeCaptureTests.cs
@@ -1155,6 +1155,104 @@ public sealed class EfAuditChangeCaptureTests : TestBase
         }
     }
 
+    [Fact]
+    public async Task updated_entity_with_only_ignored_property_change_produces_no_entry()
+    {
+        // given - LastComputedAt is [AuditIgnore] and is the only modified property
+        var (db, conn) = _CreateDb();
+        await using (conn)
+        await using (db)
+        {
+            var order = new Order
+            {
+                Id = Guid.NewGuid(),
+                CustomerName = "Alice",
+                Email = "a@b.com",
+                Phone = "555",
+                LastComputedAt = DateTime.UtcNow,
+            };
+            db.Orders.Add(order);
+            await db.SaveChangesAsync(AbortToken);
+
+            order.LastComputedAt = DateTime.UtcNow.AddMinutes(5);
+            db.ChangeTracker.DetectChanges();
+
+            var sut = _CreateSut();
+
+            // when
+            var result = _Capture(sut, db);
+
+            // then - an update whose only changes are non-audited yields no audit entry at all
+            result.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task updated_entity_with_only_excluded_sensitive_property_change_produces_no_entry()
+    {
+        // given - Phone is [AuditSensitive(Exclude)] and is the only modified property
+        var (db, conn) = _CreateDb();
+        await using (conn)
+        await using (db)
+        {
+            var order = new Order
+            {
+                Id = Guid.NewGuid(),
+                CustomerName = "Alice",
+                Email = "a@b.com",
+                Phone = "555",
+            };
+            db.Orders.Add(order);
+            await db.SaveChangesAsync(AbortToken);
+
+            order.Phone = "555-new";
+            db.ChangeTracker.DetectChanges();
+
+            var sut = _CreateSut();
+
+            // when
+            var result = _Capture(sut, db);
+
+            // then - the excluded property produces no changed field, so the update is suppressed
+            result.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task audit_sensitive_redact_on_update_masks_old_and_new_values_but_keeps_changed_field()
+    {
+        // given - Email has [AuditSensitive] with the default Redact strategy
+        var (db, conn) = _CreateDb();
+        await using (conn)
+        await using (db)
+        {
+            var order = new Order
+            {
+                Id = Guid.NewGuid(),
+                CustomerName = "Alice",
+                Email = "alice@secret.com",
+                Phone = "555",
+            };
+            db.Orders.Add(order);
+            await db.SaveChangesAsync(AbortToken);
+
+            order.Email = "bob@secret.com";
+            db.ChangeTracker.DetectChanges();
+
+            var sut = _CreateSut();
+
+            // when
+            var result = _Capture(sut, db);
+
+            // then - the change is recorded but both values are masked
+            result.Should().ContainSingle();
+            var entry = result[0];
+            entry.ChangedFields.Should().Contain("Email");
+            entry.OldValues.Should().ContainKey("Email").WhoseValue.Should().Be("***");
+            entry.NewValues.Should().ContainKey("Email").WhoseValue.Should().Be("***");
+        }
+    }
+
     private static bool _IsDisabledAuditWarningLog(ICall call)
     {
         var arguments = call.GetArguments();

--- a/tests/Headless.AuditLog.Tests.Unit/EfAuditLogStoreTests.cs
+++ b/tests/Headless.AuditLog.Tests.Unit/EfAuditLogStoreTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.AuditLog;
+using Headless.Testing.Tests;
+using Microsoft.EntityFrameworkCore;
+
+namespace Tests;
+
+public sealed class EfAuditLogStoreTests : TestBase
+{
+    private static readonly DateTimeOffset _Timestamp = new(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static AuditLogEntryData _CreateEntryData(string action = "entity.created")
+    {
+        return new AuditLogEntryData { Action = action, CreatedAt = _Timestamp };
+    }
+
+    // ---------------------------------------------------------------------------
+    // PrepareForRetry
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task should_detach_added_entries_and_support_clean_retry_when_prepare_for_retry_runs()
+    {
+        // given - a first save attempt left audit rows in Added state
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var store = new EfAuditLogStore();
+            IReadOnlyList<AuditLogEntryData> entries = [_CreateEntryData("first"), _CreateEntryData("second")];
+
+            var handles = store.Save(entries, db);
+
+            handles.Should().HaveCount(2);
+            db.ChangeTracker.Entries<AuditLogEntry>()
+                .Should()
+                .HaveCount(2)
+                .And.OnlyContain(e => e.State == EntityState.Added);
+
+            // when - the execution strategy prepares the context for a retry
+            store.PrepareForRetry(db);
+
+            // then - stale audit rows are detached so the retry cannot double-insert them
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().BeEmpty();
+
+            // and a full retry Save/commit/Release cycle works without duplicated rows
+            var retryHandles = store.Save(entries, db);
+
+            retryHandles.Should().HaveCount(2);
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().HaveCount(2);
+
+            await db.SaveChangesAsync(AbortToken);
+
+            foreach (var handle in retryHandles)
+            {
+                handle.ReleaseAfterCommit();
+            }
+
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().BeEmpty();
+            (await db.Set<AuditLogEntry>().AsNoTracking().CountAsync(AbortToken)).Should().Be(2);
+        }
+    }
+
+    [Fact]
+    public async Task should_not_throw_when_prepare_for_retry_runs_for_context_without_tracked_entries()
+    {
+        // given - a context the store never saved into
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var store = new EfAuditLogStore();
+
+            // when
+            var act = () => store.PrepareForRetry(db);
+
+            // then
+            act.Should().NotThrow();
+        }
+    }
+
+    [Fact]
+    public async Task should_keep_committed_entries_attached_when_prepare_for_retry_runs_after_save_changes()
+    {
+        // given - entries already committed (Unchanged) but not yet released
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var store = new EfAuditLogStore();
+            _ = store.Save([_CreateEntryData()], db);
+            await db.SaveChangesAsync(AbortToken);
+
+            // when
+            store.PrepareForRetry(db);
+
+            // then - only stale Added entries are detached; committed rows stay attached
+            db.ChangeTracker.Entries<AuditLogEntry>()
+                .Should()
+                .ContainSingle()
+                .Which.State.Should()
+                .Be(EntityState.Unchanged);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Handle idempotency (IAuditLogStoreEntry contract)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task should_stay_detached_and_keep_state_clean_when_discard_pending_changes_called_twice()
+    {
+        // given
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var store = new EfAuditLogStore();
+            var handle = store.Save([_CreateEntryData()], db).Single();
+
+            // when
+            handle.DiscardPendingChanges();
+            var act = () => handle.DiscardPendingChanges();
+
+            // then - second discard is a no-op and the entry stays detached
+            act.Should().NotThrow();
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().BeEmpty();
+
+            // and store state is not corrupted: a fresh Save/commit cycle persists exactly one row
+            var retryHandle = store.Save([_CreateEntryData()], db).Single();
+            await db.SaveChangesAsync(AbortToken);
+            retryHandle.ReleaseAfterCommit();
+
+            (await db.Set<AuditLogEntry>().AsNoTracking().CountAsync(AbortToken)).Should().Be(1);
+        }
+    }
+
+    [Fact]
+    public async Task should_keep_committed_row_when_release_after_commit_called_twice()
+    {
+        // given - a committed audit row
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var store = new EfAuditLogStore();
+            var handle = store.Save([_CreateEntryData()], db).Single();
+            await db.SaveChangesAsync(AbortToken);
+
+            // when
+            handle.ReleaseAfterCommit();
+            var act = () => handle.ReleaseAfterCommit();
+
+            // then - second release is a no-op; local tracking is gone, the committed row survives
+            act.Should().NotThrow();
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().BeEmpty();
+            (await db.Set<AuditLogEntry>().AsNoTracking().CountAsync(AbortToken)).Should().Be(1);
+        }
+    }
+
+    [Fact]
+    public async Task should_not_delete_committed_row_when_discard_called_after_release()
+    {
+        // given - a committed and released audit row
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var store = new EfAuditLogStore();
+            var handle = store.Save([_CreateEntryData()], db).Single();
+            await db.SaveChangesAsync(AbortToken);
+            handle.ReleaseAfterCommit();
+
+            // when - rollback cleanup runs on an already-released handle
+            var act = () => handle.DiscardPendingChanges();
+
+            // then - it must not throw and must not undo the committed row
+            act.Should().NotThrow();
+            (await db.Set<AuditLogEntry>().AsNoTracking().CountAsync(AbortToken)).Should().Be(1);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // savingContext type guard
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void should_throw_argument_exception_when_save_saving_context_is_not_a_db_context()
+    {
+        // given
+        var store = new EfAuditLogStore();
+
+        // when
+        var act = () => store.Save([_CreateEntryData()], new object());
+
+        // then
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task should_throw_argument_exception_when_save_async_saving_context_is_not_a_db_context()
+    {
+        // given
+        var store = new EfAuditLogStore();
+
+        // when
+        var act = () => store.SaveAsync([_CreateEntryData()], new object(), AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/Headless.AuditLog.Tests.Unit/EfAuditLogTests.cs
+++ b/tests/Headless.AuditLog.Tests.Unit/EfAuditLogTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.AuditLog;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+public sealed class EfAuditLogTests : TestBase
+{
+    private static readonly DateTimeOffset _Timestamp = new(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static EfAuditLog<AuditStoreDbContext> _CreateSut(
+        AuditStoreDbContext db,
+        IOptions<AuditLogOptions>? options = null
+    )
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+        var currentTenant = Substitute.For<ICurrentTenant>();
+        var correlationIdProvider = Substitute.For<ICorrelationIdProvider>();
+        var clock = Substitute.For<IClock>();
+        clock.UtcNow.Returns(_Timestamp);
+
+        return new EfAuditLog<AuditStoreDbContext>(
+            db,
+            currentUser,
+            currentTenant,
+            correlationIdProvider,
+            clock,
+            options ?? Options.Create(new AuditLogOptions())
+        );
+    }
+
+    [Fact]
+    public async Task should_throw_operation_canceled_before_reading_options_when_token_is_pre_canceled()
+    {
+        // given - options that blow up if the IsEnabled check runs before the cancellation check
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var options = Substitute.For<IOptions<AuditLogOptions>>();
+            options.Value.Returns(_ => throw new InvalidOperationException("IsEnabled was read before cancellation"));
+            var sut = _CreateSut(db, options);
+
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            // when
+            var act = () => sut.LogAsync("user.login", cancellationToken: cts.Token);
+
+            // then - cancellation wins over the IsEnabled short-circuit and nothing is tracked
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task should_not_track_any_entry_when_audit_logging_is_disabled()
+    {
+        // given
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var sut = _CreateSut(db, Options.Create(new AuditLogOptions { IsEnabled = false }));
+
+            // when
+            await sut.LogAsync("user.login", cancellationToken: AbortToken);
+
+            // then
+            db.ChangeTracker.Entries<AuditLogEntry>().Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task should_truncate_over_limit_fields_when_logging_explicit_event()
+    {
+        // given - values longer than the AuditLogFieldLimits column limits
+        // (Action=256, EntityType=512, EntityId=256, ErrorCode=256)
+        var (db, conn) = AuditStoreDbContext.Create();
+        await using (conn)
+        await using (db)
+        {
+            var sut = _CreateSut(db);
+
+            var action = new string('a', 300);
+            var entityType = new string('b', 600);
+            var entityId = new string('c', 300);
+            var errorCode = new string('d', 300);
+
+            // when
+            await sut.LogAsync(
+                action,
+                entityType,
+                entityId,
+                data: null,
+                success: false,
+                errorCode: errorCode,
+                cancellationToken: AbortToken
+            );
+
+            // then - the tracked entity holds the truncated values so inserts cannot exceed column DDL
+            var entity = db.ChangeTracker.Entries<AuditLogEntry>().Should().ContainSingle().Which.Entity;
+            entity.Action.Should().Be(action[..256]);
+            entity.EntityType.Should().Be(entityType[..512]);
+            entity.EntityId.Should().Be(entityId[..256]);
+            entity.ErrorCode.Should().Be(errorCode[..256]);
+            entity.Success.Should().BeFalse();
+            entity.CreatedAt.Should().Be(_Timestamp.UtcDateTime);
+        }
+    }
+}

--- a/tests/Headless.MultiTenancy.Tests.Unit/HeadlessTenancyStartupValidatorTests.cs
+++ b/tests/Headless.MultiTenancy.Tests.Unit/HeadlessTenancyStartupValidatorTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Tests;
+
+public sealed class HeadlessTenancyStartupValidatorTests
+{
+    [Fact]
+    public async Task should_complete_startup_when_validators_return_only_warning_and_information_diagnostics()
+    {
+        // Only Error severity blocks startup; Warning/Information must be logged and let the host start.
+        var logger = new CapturingLogger();
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        var validator = new HeadlessTenancyStartupValidator(
+            [new WarnInfoValidator()],
+            provider,
+            new TenantPostureManifest(),
+            logger
+        );
+
+        var act = () => validator.StartingAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        logger.Entries.Should().ContainSingle(entry => entry.Level == LogLevel.Warning);
+        logger.Entries.Should().ContainSingle(entry => entry.Level == LogLevel.Information);
+        logger.Entries.Should().NotContain(entry => entry.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task should_stop_running_remaining_validators_when_token_cancelled_mid_run()
+    {
+        // The per-iteration ThrowIfCancellationRequested must honor host shutdown between validators,
+        // without converting the cancellation into a synthetic VALIDATOR_THREW diagnostic.
+        using var cts = new CancellationTokenSource();
+        var second = new CountingValidator();
+        var logger = new CapturingLogger();
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        var validator = new HeadlessTenancyStartupValidator(
+            [new CancelSourceValidator(cts), second],
+            provider,
+            new TenantPostureManifest(),
+            logger
+        );
+
+        var act = () => validator.StartingAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        second.Calls.Should().Be(0);
+        logger.Entries.Should().NotContain(entry => entry.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task should_hand_validators_the_same_manifest_instance_that_setup_recorded()
+    {
+        // Guards the split-manifest hazard documented on GetOrAddTenantPostureManifest: the manifest
+        // written by AddHeadlessTenancy seam recording must be the instance validators receive and
+        // the instance resolved from DI.
+        var builder = Host.CreateApplicationBuilder();
+        var capturing = new ManifestCapturingValidator();
+        builder.Services.AddSingleton<IHeadlessTenancyValidator>(capturing);
+        builder.AddHeadlessTenancy(tenancy =>
+            tenancy.RecordSeam("Http", TenantPostureStatus.Enforcing, "require-tenant")
+        );
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        var hostedService = (IHostedLifecycleService)
+            provider
+                .GetServices<IHostedService>()
+                .Single(service =>
+                    string.Equals(service.GetType().Name, "HeadlessTenancyStartupValidator", StringComparison.Ordinal)
+                );
+
+        await hostedService.StartingAsync(TestContext.Current.CancellationToken);
+
+        capturing.SeenManifest.Should().BeSameAs(provider.GetRequiredService<TenantPostureManifest>());
+        var seam = capturing.SeenManifest!.GetSeam("Http");
+        seam.Should().NotBeNull();
+        seam!.Status.Should().Be(TenantPostureStatus.Enforcing);
+        seam.Capabilities.Should().Equal("require-tenant");
+    }
+
+    private sealed class WarnInfoValidator : IHeadlessTenancyValidator
+    {
+        public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
+        {
+            yield return HeadlessTenancyDiagnostic.Warning("Http", "HEADLESS_WARN", "Non-blocking warning.");
+            yield return HeadlessTenancyDiagnostic.Information("Http", "HEADLESS_INFO", "Non-blocking info.");
+        }
+    }
+
+    private sealed class CancelSourceValidator(CancellationTokenSource cancellationTokenSource)
+        : IHeadlessTenancyValidator
+    {
+        public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
+        {
+            cancellationTokenSource.Cancel();
+
+            return [];
+        }
+    }
+
+    private sealed class CountingValidator : IHeadlessTenancyValidator
+    {
+        public int Calls { get; private set; }
+
+        public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
+        {
+            Calls++;
+
+            return [];
+        }
+    }
+
+    private sealed class ManifestCapturingValidator : IHeadlessTenancyValidator
+    {
+        public TenantPostureManifest? SeenManifest { get; private set; }
+
+        public IEnumerable<HeadlessTenancyDiagnostic> Validate(HeadlessTenancyValidationContext context)
+        {
+            SeenManifest = context.Manifest;
+
+            return [];
+        }
+    }
+
+    private sealed class CapturingLogger : ILogger<HeadlessTenancyStartupValidator>
+    {
+        private readonly List<(LogLevel Level, string Message)> _entries = [];
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries
+        {
+            get
+            {
+                lock (_entries)
+                {
+                    return [.. _entries];
+                }
+            }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            lock (_entries)
+            {
+                _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+    }
+}

--- a/tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs
+++ b/tests/Headless.MultiTenancy.Tests.Unit/SetupHeadlessTenancyTests.cs
@@ -335,6 +335,47 @@ public sealed class SetupHeadlessTenancyTests
             .BeSameAs(manifest);
     }
 
+    [Fact]
+    public void should_return_pre_registered_manifest_instance_without_adding_a_second_descriptor()
+    {
+        // given — a consumer pre-registers a manifest instance before AddHeadlessTenancy runs
+        var services = new ServiceCollection();
+        var custom = new TenantPostureManifest();
+        services.AddSingleton(custom);
+
+        // when
+        var manifest = services.GetOrAddTenantPostureManifest();
+
+        // then — the consumer's instance is reused, not shadowed by a second registration
+        manifest.Should().BeSameAs(custom);
+        services.Where(descriptor => descriptor.ServiceType == typeof(TenantPostureManifest)).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void should_discard_pre_registered_instance_when_a_later_factory_registration_exists()
+    {
+        // given — pins the documented footgun: reconciliation inspects the LAST registration, so an
+        // instance followed by a factory loses both the instance and any posture recorded on it
+        var services = new ServiceCollection();
+        var custom = new TenantPostureManifest();
+        custom.RecordSeam("Http", TenantPostureStatus.Enforcing);
+        services.AddSingleton(custom);
+        services.AddSingleton<TenantPostureManifest>(_ => new TenantPostureManifest());
+
+        // when
+        var manifest = services.GetOrAddTenantPostureManifest();
+
+        // then — a fresh manifest replaces all prior registrations; the recorded posture is gone
+        manifest.Should().NotBeSameAs(custom);
+        manifest.GetSeam("Http").Should().BeNull();
+        services
+            .Where(descriptor => descriptor.ServiceType == typeof(TenantPostureManifest))
+            .Should()
+            .ContainSingle()
+            .Which.ImplementationInstance.Should()
+            .BeSameAs(manifest);
+    }
+
     [Theory]
     [InlineData(TenantPostureStatus.Guarded, TenantPostureStatus.Enforcing, TenantPostureStatus.Enforcing)]
     [InlineData(TenantPostureStatus.Enforcing, TenantPostureStatus.Guarded, TenantPostureStatus.Enforcing)]

--- a/tests/Headless.MultiTenancy.Tests.Unit/TenantPostureManifestTests.cs
+++ b/tests/Headless.MultiTenancy.Tests.Unit/TenantPostureManifestTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.ComponentModel;
+using Headless.MultiTenancy;
+
+namespace Tests;
+
+public sealed class TenantPostureManifestTests
+{
+    [Fact]
+    public void should_store_undefined_status_on_first_record_then_throw_on_next_record()
+    {
+        // Characterization pin of the documented asymmetry: status is validated only when merged
+        // with an existing seam (see RecordSeam XML docs). The first record of an undefined value
+        // is stored silently; the *next* record on the same seam throws far from the original cause.
+        var manifest = new TenantPostureManifest();
+
+        manifest.RecordSeam("Seam", (TenantPostureStatus)99);
+        manifest.GetSeam("Seam")!.Status.Should().Be((TenantPostureStatus)99);
+
+        var act = () => manifest.RecordSeam("Seam", TenantPostureStatus.Configured);
+        act.Should().Throw<InvalidEnumArgumentException>();
+    }
+
+    [Fact]
+    public void should_drop_blank_capability_labels_and_deduplicate_within_one_record()
+    {
+        var manifest = new TenantPostureManifest();
+
+        manifest.RecordSeam("Seam", TenantPostureStatus.Configured, "a", " ", "", null!, "a");
+
+        manifest.GetSeam("Seam")!.Capabilities.Should().Equal("a");
+    }
+
+    [Fact]
+    public void should_not_duplicate_capabilities_when_same_label_recorded_across_calls()
+    {
+        var manifest = new TenantPostureManifest();
+
+        manifest.RecordSeam("Seam", TenantPostureStatus.Configured, "propagate-tenant");
+        manifest.RecordSeam("Seam", TenantPostureStatus.Configured, "propagate-tenant");
+
+        manifest.GetSeam("Seam")!.Capabilities.Should().Equal("propagate-tenant");
+    }
+
+    [Fact]
+    public void should_not_duplicate_runtime_markers_when_same_marker_applied_twice()
+    {
+        var manifest = new TenantPostureManifest();
+
+        manifest.MarkRuntimeApplied("Seam", "UseHeadlessTenancy");
+        manifest.MarkRuntimeApplied("Seam", "UseHeadlessTenancy");
+
+        manifest.GetSeam("Seam")!.RuntimeMarkers.Should().Equal("UseHeadlessTenancy");
+    }
+
+    [Fact]
+    public void should_throw_when_capabilities_array_is_null()
+    {
+        var manifest = new TenantPostureManifest();
+
+        var act = () => manifest.RecordSeam("Seam", TenantPostureStatus.Configured, capabilities: null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void should_return_decoupled_snapshot_when_seams_accessed_before_later_writes()
+    {
+        var manifest = new TenantPostureManifest();
+        manifest.RecordSeam("First", TenantPostureStatus.Configured);
+
+        var snapshot = manifest.Seams;
+        manifest.RecordSeam("Second", TenantPostureStatus.Enforcing);
+        manifest.MarkRuntimeApplied("First", "late-marker");
+
+        snapshot.Should().ContainSingle().Which.Seam.Should().Be("First");
+        snapshot.Single().RuntimeMarkers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_record_all_contributions_when_one_seam_written_concurrently()
+    {
+        // The manifest's headline contract is thread-safe writes from multiple package seams.
+        var manifest = new TenantPostureManifest();
+        const int contributions = 100;
+
+        await Parallel.ForAsync(
+            0,
+            contributions,
+            TestContext.Current.CancellationToken,
+            (i, _) =>
+            {
+                manifest.RecordSeam("Seam", (TenantPostureStatus)(i % 4), $"capability-{i}");
+                manifest.MarkRuntimeApplied("Seam", $"marker-{i}");
+                return ValueTask.CompletedTask;
+            }
+        );
+
+        var seam = manifest.GetSeam("Seam");
+        seam.Should().NotBeNull();
+        seam!.Status.Should().Be(TenantPostureStatus.Enforcing);
+        seam.Capabilities.Should().HaveCount(contributions);
+        seam.RuntimeMarkers.Should().HaveCount(contributions);
+    }
+
+    [Fact]
+    public void should_report_unknown_seam_as_not_configured_without_throwing()
+    {
+        var manifest = new TenantPostureManifest();
+        manifest.RecordSeam("Known", TenantPostureStatus.Configured);
+
+        manifest.GetSeam("Unknown").Should().BeNull();
+        manifest.IsConfigured("Unknown").Should().BeFalse();
+        manifest.IsConfigured("Known").Should().BeTrue();
+        manifest.HasRuntimeMarker("Unknown", "marker").Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_compare_runtime_markers_with_ordinal_case_sensitivity()
+    {
+        var manifest = new TenantPostureManifest();
+        manifest.MarkRuntimeApplied("Seam", "Marker");
+        manifest.MarkRuntimeApplied("Other", "elsewhere");
+
+        manifest.HasRuntimeMarker("Seam", "Marker").Should().BeTrue();
+        manifest.HasRuntimeMarker("Seam", "marker").Should().BeFalse();
+        manifest.HasRuntimeMarker("Seam", "elsewhere").Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_validate_marker_argument_even_when_seam_does_not_exist()
+    {
+        var manifest = new TenantPostureManifest();
+
+        var act = () => manifest.HasRuntimeMarker("Unknown", " ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Headless.Payments.Paymob.CashIn.Tests.Unit/PaymobCashInAuthenticatorTests.ExtensionData.cs
+++ b/tests/Headless.Payments.Paymob.CashIn.Tests.Unit/PaymobCashInAuthenticatorTests.ExtensionData.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Payments.Paymob.CashIn;
+using Headless.Payments.Paymob.CashIn.Models.Auth;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace Tests;
+
+public sealed partial class PaymobCashInAuthenticatorTests : TestBase
+{
+    [Fact]
+    public async Task should_capture_unknown_response_fields_in_extension_data_when_token_requested()
+    {
+        // given - Paymob responses routinely carry fields not present in the model;
+        // they must land in [JsonExtensionData] instead of failing deserialization
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var apiKey = fixture.AutoFixture.Create<string>();
+        var token = fixture.AutoFixture.Create<string>();
+        var config = fixture.CashInOptions with { ApiKey = apiKey };
+        fixture.OptionsAccessor.CurrentValue.Returns(config);
+        var request = new CashInAuthenticationTokenRequest { ApiKey = apiKey };
+        var requestJson = JsonSerializer.Serialize(request);
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/auth/tokens").UsingPost().WithBody(requestJson))
+            .RespondWith(Response.Create().WithBody($$$"""{"token":"{{{token}}}","unknown_field":{"nested":123}}"""));
+
+        // when
+        using var authenticator = new PaymobCashInAuthenticator(
+            fixture.HttpClientFactory,
+            timeProvider,
+            fixture.OptionsAccessor
+        );
+        var result = await authenticator.RequestAuthenticationTokenAsync();
+
+        // then
+        result.Token.Should().Be(token);
+        result.ExtensionData.Should().ContainKey("unknown_field");
+    }
+}

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/CashOutTransactionTests.cs
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/CashOutTransactionTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Payments.Paymob.CashOut.Models;
+
+namespace Tests;
+
+public sealed class CashOutTransactionTests
+{
+    [Theory]
+    [InlineData("success", true)]
+    [InlineData("successful", true)]
+    [InlineData("failed", false)]
+    [InlineData("pending", false)]
+    [InlineData("SUCCESS", false)] // exact-match contract: Paymob sends lowercase statuses
+    public void should_report_success_only_for_success_statuses(string status, bool expected)
+    {
+        var transaction = _Transaction(status, statusCode: "200");
+
+        transaction.IsSuccess().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("pending", "8000", true)]
+    [InlineData("pending", "200", false)]
+    [InlineData("failed", "8000", false)]
+    public void should_report_pending_only_when_pending_status_with_8000_code(
+        string status,
+        string statusCode,
+        bool expected
+    )
+    {
+        var transaction = _Transaction(status, statusCode);
+
+        transaction.IsPending().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("failed", "401", true)]
+    [InlineData("failed", "400", false)]
+    [InlineData("success", "401", false)]
+    public void should_report_authentication_error_only_when_failed_with_401(
+        string status,
+        string statusCode,
+        bool expected
+    )
+    {
+        var transaction = _Transaction(status, statusCode);
+
+        transaction.IsAuthenticationError().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("failed", "vodafone", "618", true)]
+    [InlineData("failed", "etisalat", "618", false)]
+    [InlineData("failed", "vodafone", "619", false)]
+    [InlineData("success", "vodafone", "618", false)]
+    public void should_report_vodafone_wallet_error_only_for_vodafone_618(
+        string status,
+        string issuer,
+        string statusCode,
+        bool expected
+    )
+    {
+        var transaction = _Transaction(status, statusCode, issuer);
+
+        transaction.IsNotHaveVodafoneCashError().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("failed", "etisalat", "90040", true)]
+    [InlineData("failed", "vodafone", "90040", false)]
+    [InlineData("failed", "etisalat", "90041", false)]
+    public void should_report_etisalat_wallet_error_only_for_etisalat_90040(
+        string status,
+        string issuer,
+        string statusCode,
+        bool expected
+    )
+    {
+        var transaction = _Transaction(status, statusCode, issuer);
+
+        transaction.IsNotHaveEtisalatCashError().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("vodafone", "501", true)]
+    [InlineData("vodafone", "6097", true)]
+    [InlineData("etisalat", "90005", true)]
+    [InlineData("etisalat", "90006", true)]
+    [InlineData("vodafone", "90005", false)] // codes are issuer-specific
+    [InlineData("etisalat", "501", false)]
+    [InlineData("aman", "501", false)]
+    public void should_report_provider_down_only_for_issuer_specific_codes(
+        string issuer,
+        string statusCode,
+        bool expected
+    )
+    {
+        var transaction = _Transaction("failed", statusCode, issuer);
+
+        transaction.IsProviderDownError().Should().Be(expected);
+    }
+
+    [Fact]
+    public void should_not_report_provider_down_when_not_failed()
+    {
+        var transaction = _Transaction("success", statusCode: "501", issuer: "vodafone");
+
+        transaction.IsProviderDownError().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("failed", "400", true)]
+    [InlineData("failed", "401", false)]
+    [InlineData("pending", "400", false)]
+    public void should_report_request_validation_error_only_when_failed_with_400(
+        string status,
+        string statusCode,
+        bool expected
+    )
+    {
+        var transaction = _Transaction(status, statusCode);
+
+        transaction.IsRequestValidationError().Should().Be(expected);
+    }
+
+    private static CashOutTransaction _Transaction(string status, string statusCode, string? issuer = null)
+    {
+        return new CashOutTransaction
+        {
+            DisbursementStatus = status,
+            StatusCode = statusCode,
+            Issuer = issuer,
+        };
+    }
+}

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/Headless.Payments.Paymob.CashOut.Tests.Unit.csproj
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/Headless.Payments.Paymob.CashOut.Tests.Unit.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Headless.Payments.Paymob.CashOut\Headless.Payments.Paymob.CashOut.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutAuthenticatorTests.cs
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutAuthenticatorTests.cs
@@ -1,0 +1,369 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Net;
+using System.Text;
+using AutoFixture;
+using Headless.Payments.Paymob.CashOut;
+using Headless.Payments.Paymob.CashOut.Models;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+#pragma warning disable MA0045 // Do not use blocking calls, even when the calling method must become async
+namespace Tests;
+
+public sealed class PaymobCashOutAuthenticatorTests(PaymobCashOutFixture fixture)
+    : TestBase,
+        IClassFixture<PaymobCashOutFixture>
+{
+    [Fact]
+    public async Task should_post_password_grant_with_basic_auth_when_no_cached_token()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var accessToken = fixture.AutoFixture.Create<string>();
+
+        fixture
+            .Server.Given(
+                Request
+                    .Create()
+                    .WithPath("/o/token/")
+                    .UsingPost()
+                    .WithHeader("Authorization", _ExpectedBasicHeader(options))
+                    .WithBody(_PasswordGrantBody(options))
+            )
+            .RespondWith(Response.Create().WithBody(_AuthJson(accessToken)));
+
+        // when
+        using var authenticator = _CreateAuthenticator(monitor);
+        var result = await authenticator.GetAccessTokenAsync(AbortToken);
+
+        // then
+        result.Should().Be(accessToken);
+    }
+
+    [Fact]
+    public async Task should_return_cached_token_without_new_request_when_token_still_valid()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var accessToken = fixture.AutoFixture.Create<string>();
+        var callCount = 0;
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithBody(_ =>
+                    {
+                        Interlocked.Increment(ref callCount);
+                        return _AuthJson(accessToken);
+                    })
+            );
+
+        // when - second call still inside the refresh buffer (default 10 minutes)
+        using var authenticator = _CreateAuthenticator(monitor, timeProvider);
+        var first = await authenticator.GetAccessTokenAsync(AbortToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(9));
+        var second = await authenticator.GetAccessTokenAsync(AbortToken);
+
+        // then
+        callCount.Should().Be(1);
+        first.Should().Be(accessToken);
+        second.Should().Be(accessToken);
+    }
+
+    [Fact]
+    public async Task should_request_new_token_when_cached_token_expired()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var callCount = 0;
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(Response.Create().WithBody(_ => _AuthJson($"token-{Interlocked.Increment(ref callCount)}")));
+
+        // when - second call after the refresh buffer elapsed
+        using var authenticator = _CreateAuthenticator(monitor, timeProvider);
+        var first = await authenticator.GetAccessTokenAsync(AbortToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(10) + TimeSpan.FromSeconds(1));
+        var second = await authenticator.GetAccessTokenAsync(AbortToken);
+
+        // then
+        callCount.Should().Be(2);
+        first.Should().Be("token-1");
+        second.Should().Be("token-2");
+    }
+
+    [Fact]
+    public async Task should_make_single_token_request_when_concurrent_callers_race_on_empty_cache()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var accessToken = fixture.AutoFixture.Create<string>();
+        var callCount = 0;
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithBody(_ =>
+                    {
+                        Interlocked.Increment(ref callCount);
+                        Thread.Sleep(50); // Simulate network latency so callers overlap
+                        return _AuthJson(accessToken);
+                    })
+            );
+
+        // when
+        using var authenticator = _CreateAuthenticator(monitor);
+        var tasks = Enumerable.Range(0, 10).Select(_ => authenticator.GetAccessTokenAsync(AbortToken).AsTask());
+        var results = await Task.WhenAll(tasks);
+
+        // then - double-checked lock allows exactly one refresh call
+        callCount.Should().Be(1);
+        results.Should().AllBe(accessToken);
+    }
+
+    [Fact]
+    public async Task should_discard_cached_token_when_options_change()
+    {
+        // given
+        var (options, _) = _CreateOptions();
+        var monitor = new ChangeableOptionsMonitor(options);
+        var callCount = 0;
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(Response.Create().WithBody(_ => _AuthJson($"token-{Interlocked.Increment(ref callCount)}")));
+
+        // when - options change (e.g. credential rotation) invalidates the cached token
+        using var authenticator = _CreateAuthenticator(monitor);
+        var first = await authenticator.GetAccessTokenAsync(AbortToken);
+        monitor.Change(options);
+        var second = await authenticator.GetAccessTokenAsync(AbortToken);
+
+        // then
+        callCount.Should().Be(2);
+        first.Should().Be("token-1");
+        second.Should().Be("token-2");
+    }
+
+    [Fact]
+    public async Task should_throw_paymob_cash_out_exception_with_status_and_body_when_token_request_fails()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var body = fixture.AutoFixture.Create<string>();
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.Unauthorized).WithBody(body));
+
+        // when
+        using var authenticator = _CreateAuthenticator(monitor);
+        var act = () => authenticator.GetAccessTokenAsync(AbortToken).AsTask();
+
+        // then
+        var assertion = await act.Should().ThrowAsync<PaymobCashOutException>();
+        assertion.Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        assertion.Which.Body.Should().Be(body);
+        assertion.Which.Message.Should().Be("Paymob Cash Out - Http request failed with status code (401).");
+    }
+
+    [Fact]
+    public async Task should_cache_new_access_token_when_refresh_token_exchanged()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var refreshToken = fixture.AutoFixture.Create<string>();
+        var accessToken = fixture.AutoFixture.Create<string>();
+        var newRefreshToken = fixture.AutoFixture.Create<string>();
+        var passwordGrantCalls = 0;
+
+        fixture
+            .Server.Given(
+                Request
+                    .Create()
+                    .WithPath("/o/token")
+                    .UsingPost()
+                    .WithHeader("Authorization", _ExpectedBasicHeader(options))
+                    .WithBody($"grant_type=refresh_token&refresh_token={refreshToken}")
+            )
+            .RespondWith(Response.Create().WithBody(_AuthJson(accessToken, newRefreshToken)));
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithBody(_ =>
+                    {
+                        Interlocked.Increment(ref passwordGrantCalls);
+                        return _AuthJson("unexpected");
+                    })
+            );
+
+        // when
+        using var authenticator = _CreateAuthenticator(monitor);
+        var response = await authenticator.RefreshTokenAsync(refreshToken, AbortToken);
+        var cached = await authenticator.GetAccessTokenAsync(AbortToken);
+
+        // then - the refreshed token is cached, so no password-grant request is made
+        response.AccessToken.Should().Be(accessToken);
+        response.RefreshToken.Should().Be(newRefreshToken);
+        cached.Should().Be(accessToken);
+        passwordGrantCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_throw_paymob_cash_out_exception_when_refresh_token_request_fails()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+        var refreshToken = fixture.AutoFixture.Create<string>();
+        var body = fixture.AutoFixture.Create<string>();
+
+        fixture
+            .Server.Given(
+                Request
+                    .Create()
+                    .WithPath("/o/token")
+                    .UsingPost()
+                    .WithBody($"grant_type=refresh_token&refresh_token={refreshToken}")
+            )
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.BadRequest).WithBody(body));
+
+        // when
+        using var authenticator = _CreateAuthenticator(monitor);
+        var act = () => authenticator.RefreshTokenAsync(refreshToken, AbortToken);
+
+        // then
+        var assertion = await act.Should().ThrowAsync<PaymobCashOutException>();
+        assertion.Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        assertion.Which.Body.Should().Be(body);
+    }
+
+    [Fact]
+    public async Task should_cancel_token_request_when_cancellation_requested()
+    {
+        // given
+        var (options, monitor) = _CreateOptions();
+
+        fixture
+            .Server.Given(Request.Create().WithPath("/o/token/").UsingPost().WithBody(_PasswordGrantBody(options)))
+            .RespondWith(Response.Create().WithDelay(TimeSpan.FromSeconds(5)).WithBody(_AuthJson("late")));
+
+        // when
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        using var authenticator = _CreateAuthenticator(monitor);
+        var act = () => authenticator.GetAccessTokenAsync(cts.Token).AsTask();
+
+        // then
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task should_throw_object_disposed_exception_when_used_after_dispose()
+    {
+        // given
+        var (_, monitor) = _CreateOptions();
+        var authenticator = _CreateAuthenticator(monitor);
+
+        // when
+        authenticator.Dispose();
+
+        // then - empty cache forces the semaphore path, which is disposed
+        var act = () => authenticator.GetAccessTokenAsync(AbortToken).AsTask();
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    private (PaymobCashOutOptions options, IOptionsMonitor<PaymobCashOutOptions> monitor) _CreateOptions()
+    {
+        var options = new PaymobCashOutOptions
+        {
+            ApiBaseUrl = fixture.Server.Urls[0],
+            UserName = fixture.AutoFixture.Create<string>(),
+            Password = fixture.AutoFixture.Create<string>(),
+            ClientId = fixture.AutoFixture.Create<string>(),
+            ClientSecret = fixture.AutoFixture.Create<string>(),
+        };
+
+        var monitor = Substitute.For<IOptionsMonitor<PaymobCashOutOptions>>();
+        monitor.CurrentValue.Returns(options);
+
+        return (options, monitor);
+    }
+
+    private PaymobCashOutAuthenticator _CreateAuthenticator(
+        IOptionsMonitor<PaymobCashOutOptions> monitor,
+        TimeProvider? timeProvider = null
+    )
+    {
+        return new PaymobCashOutAuthenticator(
+            fixture.HttpClientFactory,
+            timeProvider ?? new FakeTimeProvider(DateTimeOffset.UtcNow),
+            monitor
+        );
+    }
+
+    private static string _PasswordGrantBody(PaymobCashOutOptions options)
+    {
+        return $"grant_type=password&username={options.UserName}&password={options.Password}";
+    }
+
+    private static string _ExpectedBasicHeader(PaymobCashOutOptions options)
+    {
+        return "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{options.ClientId}:{options.ClientSecret}"));
+    }
+
+    private static string _AuthJson(string accessToken, string refreshToken = "refresh-token")
+    {
+        var response = new CashOutAuthenticationResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshToken,
+            Scope = "read write",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+        };
+
+        return JsonSerializer.Serialize(response);
+    }
+
+    private sealed class ChangeableOptionsMonitor(PaymobCashOutOptions initial) : IOptionsMonitor<PaymobCashOutOptions>
+    {
+        private readonly List<Action<PaymobCashOutOptions, string?>> _listeners = [];
+
+        public PaymobCashOutOptions CurrentValue { get; private set; } = initial;
+
+        public PaymobCashOutOptions Get(string? name)
+        {
+            return CurrentValue;
+        }
+
+        public IDisposable? OnChange(Action<PaymobCashOutOptions, string?> listener)
+        {
+            _listeners.Add(listener);
+
+            return null;
+        }
+
+        public void Change(PaymobCashOutOptions value)
+        {
+            CurrentValue = value;
+
+            foreach (var listener in _listeners)
+            {
+                listener(value, null);
+            }
+        }
+    }
+}

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutBrokerTests.cs
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutBrokerTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Net;
+using System.Text.Encodings.Web;
+using AutoFixture;
+using Headless.Payments.Paymob.CashOut;
+using Headless.Payments.Paymob.CashOut.Models;
+using Headless.Testing.Tests;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace Tests;
+
+public sealed class PaymobCashOutBrokerTests(PaymobCashOutFixture fixture)
+    : TestBase,
+        IClassFixture<PaymobCashOutFixture>
+{
+    // Mirrors the wire shape produced by the package-internal CashOutJsonOptions
+    private static readonly JsonSerializerOptions _WireOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    [Fact]
+    public async Task should_post_disburse_with_bearer_token_and_return_transaction()
+    {
+        // given
+        var (authenticator, token) = _SetupAuthenticator();
+        var request = CashOutDisburseRequest.Vodafone(amount: 150.25m, phoneNumber: "01012345678");
+        var requestJson = JsonSerializer.Serialize(request, _WireOptions);
+        var transactionId = fixture.AutoFixture.Create<string>();
+        var responseJson =
+            $$"""{"transaction_id":"{{transactionId}}","issuer":"vodafone","msisdn":"01012345678","amount":150.25,"disbursement_status":"success","status_code":"200"}""";
+
+        fixture
+            .Server.Given(
+                Request
+                    .Create()
+                    .WithPath("/disburse")
+                    .UsingPost()
+                    .WithHeader("Authorization", $"Bearer {token}")
+                    .WithBody(requestJson)
+            )
+            .RespondWith(Response.Create().WithBody(responseJson));
+
+        // when
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+        var result = await broker.Disburse(request, AbortToken);
+
+        // then
+        result.TransactionId.Should().Be(transactionId);
+        result.Amount.Should().Be(150.25);
+        result.IsSuccess().Should().BeTrue();
+        result.IsFailed().Should().BeFalse();
+        result.IsPending().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_read_disburse_response_when_paymob_uses_string_numbers_and_object_description()
+    {
+        // given - Paymob quirks: numeric fields as strings, status_description as object, unknown fields
+        var (authenticator, token) = _SetupAuthenticator();
+        var request = CashOutDisburseRequest.Etisalat(amount: 75m, phoneNumber: "01112345678");
+        const string responseJson =
+            """{"transaction_id":"tx-quirks","issuer":"etisalat","amount":"75.5","disbursement_status":"failed","status_code":"400","status_description":{"msisdn":["invalid"]},"unknown_field":"kept"}""";
+
+        fixture
+            .Server.Given(
+                Request.Create().WithPath("/disburse").UsingPost().WithHeader("Authorization", $"Bearer {token}")
+            )
+            .RespondWith(Response.Create().WithBody(responseJson));
+
+        // when
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+        var result = await broker.Disburse(request, AbortToken);
+
+        // then
+        result.TransactionId.Should().Be("tx-quirks");
+        result.Amount.Should().Be(75.5);
+        result.IsRequestValidationError().Should().BeTrue();
+        result.StatusDescription.Should().NotBeNull();
+        result.ExtensionData.Should().ContainKey("unknown_field");
+    }
+
+    [Fact]
+    public async Task should_throw_paymob_cash_out_exception_with_status_and_body_when_disburse_fails()
+    {
+        // given
+        var (authenticator, token) = _SetupAuthenticator();
+        var request = CashOutDisburseRequest.Vodafone(amount: 10m, phoneNumber: "01099999999");
+        var errorBody = fixture.AutoFixture.Create<string>();
+
+        fixture
+            .Server.Given(
+                Request.Create().WithPath("/disburse").UsingPost().WithHeader("Authorization", $"Bearer {token}")
+            )
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.InternalServerError).WithBody(errorBody));
+
+        // when
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+        var act = () => broker.Disburse(request, AbortToken);
+
+        // then
+        var assertion = await act.Should().ThrowAsync<PaymobCashOutException>();
+        assertion.Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        assertion.Which.Body.Should().Be(errorBody);
+        assertion.Which.Message.Should().Be("Paymob Cash Out - Http request failed with status code (500).");
+    }
+
+    [Fact]
+    public async Task should_get_budget_with_bearer_token_and_return_raw_body()
+    {
+        // given
+        var (authenticator, token) = _SetupAuthenticator();
+        const string budgetJson = """{"budget":1234.5}""";
+
+        fixture
+            .Server.Given(
+                Request.Create().WithPath("/budget/inquire/").UsingGet().WithHeader("Authorization", $"Bearer {token}")
+            )
+            .RespondWith(Response.Create().WithBody(budgetJson));
+
+        // when
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+        var result = await broker.GetBudgetAsync(AbortToken);
+
+        // then
+        result.Should().Be(budgetJson);
+    }
+
+    [Fact]
+    public async Task should_get_transactions_with_page_query_and_serialized_request_body()
+    {
+        // given
+        var (authenticator, token) = _SetupAuthenticator();
+        string[] ids = ["tx-1", "tx-2"];
+        var expectedBody = JsonSerializer.Serialize(
+            new CashOutGetTransactionsRequest { TransactionsIds = ids, IsBankTransactions = true },
+            _WireOptions
+        );
+        var responseBody = fixture.AutoFixture.Create<string>();
+
+        fixture
+            .Server.Given(
+                Request
+                    .Create()
+                    .WithPath("/transaction/inquire/")
+                    .UsingGet()
+                    .WithParam("page", "3")
+                    .WithHeader("Authorization", $"Bearer {token}")
+                    .WithBody(expectedBody)
+            )
+            .RespondWith(Response.Create().WithBody(responseBody));
+
+        // when
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+        var result = await broker.GetTransactionsAsync(ids, isBankTransactions: true, page: 3, AbortToken);
+
+        // then
+        result.Should().Be(responseBody);
+    }
+
+    [Fact]
+    public async Task should_throw_argument_exception_without_calling_api_when_transactions_ids_empty()
+    {
+        // given
+        var (authenticator, _) = _SetupAuthenticator();
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+
+        // when
+        var act = () => broker.GetTransactionsAsync([], isBankTransactions: false, page: 1, AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ArgumentException>();
+        _ = await authenticator.DidNotReceive().GetAccessTokenAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_throw_argument_out_of_range_exception_when_page_not_positive()
+    {
+        // given
+        var (authenticator, _) = _SetupAuthenticator();
+        var broker = new PaymobCashOutBroker(fixture.HttpClient, authenticator);
+
+        // when
+        var act = () => broker.GetTransactionsAsync(["tx-1"], isBankTransactions: false, page: 0, AbortToken);
+
+        // then
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+        _ = await authenticator.DidNotReceive().GetAccessTokenAsync(Arg.Any<CancellationToken>());
+    }
+
+    private (IPaymobCashOutAuthenticator authenticator, string token) _SetupAuthenticator()
+    {
+        var token = fixture.AutoFixture.Create<string>();
+        var authenticator = Substitute.For<IPaymobCashOutAuthenticator>();
+        authenticator.GetAccessTokenAsync(Arg.Any<CancellationToken>()).Returns(token);
+
+        return (authenticator, token);
+    }
+}

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutFixture.cs
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutFixture.cs
@@ -4,6 +4,7 @@ using AutoFixture;
 using Headless.Payments.Paymob.CashOut.Models;
 using Microsoft.Extensions.Options;
 using WireMock.Server;
+using WireMock.Settings;
 
 namespace Tests;
 
@@ -11,8 +12,10 @@ public sealed class PaymobCashOutFixture : IDisposable
 {
     public PaymobCashOutFixture()
     {
-        Server = WireMockServer.Start();
-        HttpClient = new HttpClient();
+        // Paymob's transaction inquiry is a GET with a JSON body; WireMock only parses
+        // bodies for non-GET methods unless this setting is enabled.
+        Server = WireMockServer.Start(new WireMockServerSettings { AllowBodyForAllHttpMethods = true });
+        HttpClient = new HttpClient { BaseAddress = new Uri(Server.Urls[0]) };
         AutoFixture.Register(() => JsonSerializer.Deserialize<object?>("null"));
         CashOutOptions = new PaymobCashOutOptions
         {
@@ -25,6 +28,8 @@ public sealed class PaymobCashOutFixture : IDisposable
         OptionsAccessor = Substitute.For<IOptionsMonitor<PaymobCashOutOptions>>();
         OptionsAccessor.CurrentValue.Returns(CashOutOptions);
         TimeProvider = TimeProvider.System;
+        HttpClientFactory = Substitute.For<IHttpClientFactory>();
+        HttpClientFactory.CreateClient(Arg.Any<string>()).Returns(HttpClient);
     }
 
     public Fixture AutoFixture { get; } = new();
@@ -32,6 +37,8 @@ public sealed class PaymobCashOutFixture : IDisposable
     public WireMockServer Server { get; }
 
     public HttpClient HttpClient { get; }
+
+    public IHttpClientFactory HttpClientFactory { get; }
 
     public PaymobCashOutOptions CashOutOptions { get; }
 

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutFixtureTests.cs
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/PaymobCashOutFixtureTests.cs
@@ -2,10 +2,8 @@
 
 namespace Tests;
 
-// Smoke test placeholder. The project ships only a fixture today; this verifies the
-// fixture wires up cleanly so the test runner has at least one discoverable test
-// (Microsoft Testing Platform reports exit code 8 for empty test assemblies). Replace
-// or supplement with broker/authenticator coverage mirroring the CashIn sibling.
+// Smoke test verifying the shared fixture wires up cleanly. Broker/authenticator
+// coverage lives in PaymobCashOutBrokerTests and PaymobCashOutAuthenticatorTests.
 public sealed class PaymobCashOutFixtureTests(PaymobCashOutFixture fixture) : IClassFixture<PaymobCashOutFixture>
 {
     [Fact]

--- a/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/packages.lock.json
+++ b/tests/Headless.Payments.Paymob.CashOut.Tests.Unit/packages.lock.json
@@ -1597,6 +1597,17 @@
       "headless.checks": {
         "type": "Project"
       },
+      "headless.core": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )",
+          "Headless.Extensions": "[1.0.0, )",
+          "Headless.Serializer.Json": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
+          "Snappier": "[1.3.1, )"
+        }
+      },
       "headless.extensions": {
         "type": "Project",
         "dependencies": {
@@ -1641,6 +1652,29 @@
         "dependencies": {
           "Headless.Hosting": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.7.0, )"
+        }
+      },
+      "headless.serializer.abstractions": {
+        "type": "Project"
+      },
+      "headless.serializer.json": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Serializer.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.testing": {
+        "type": "Project",
+        "dependencies": {
+          "AwesomeAssertions": "[9.4.0, )",
+          "Bogus": "[35.6.5, )",
+          "Headless.Core": "[1.0.0, )",
+          "Headless.Extensions": "[1.0.0, )",
+          "Meziantou.Extensions.Logging.Xunit.v3": "[2.0.3, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Logging": "[10.0.9, )",
+          "Microsoft.Extensions.TimeProvider.Testing": "[10.7.0, )",
+          "xunit.v3.extensibility.core": "[3.2.2, )"
         }
       },
       "CommunityToolkit.HighPerformance": {
@@ -1725,6 +1759,16 @@
         "requested": "[9.0.34, )",
         "resolved": "9.0.34",
         "contentHash": "QmwQQk2ca/E3qyTTwmTnIoNj2sQ8daRWBQt4+6bkNkDyHgCjgggNGgvFqS6Gm9HQ1EbYkyKn58RjUC2jVM+RQw=="
+      },
+      "Meziantou.Extensions.Logging.Xunit.v3": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "bX85l/ptbh1z+Q2t/I5bXK0JuClpWUxBlIh9Kx0bAqOw0FmRbYvKoCfNdBrmojecqFSTdx3xTEG6xsHUj4jLLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "xunit.v3.extensibility.core": "3.2.2"
+        }
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "CentralTransitive",
@@ -2048,6 +2092,12 @@
         "requested": "[7.2.5, )",
         "resolved": "7.2.5",
         "contentHash": "Fu1AjcAyrZIAW9LIhxVgVyo5EMVdwLhXagKKI2A1UZoI0Wvz2CiRT+VXp1tuiMq2JhlkjVyebj/JQcF4koZacg=="
+      },
+      "Snappier": {
+        "type": "CentralTransitive",
+        "requested": "[1.3.1, )",
+        "resolved": "1.3.1",
+        "contentHash": "DOdDQiO8YZ5rBtVLY+6CmR1yp9WYoJRgEEktPBrR0tEj9QO2djA/zv0O3DX0OZpEAfosbY8pytQ9tQUogwQsEA=="
       },
       "System.Reactive": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Paymob CashOut was unusable at runtime: every token fetch and every `Disburse` call threw before reading the payload, because `[JsonExtensionData]` on init-only properties cannot be configured by System.Text.Json. On top of that, both Paymob packages (CashOut *and* CashIn) crashed with `NotSupportedException` whenever Paymob returned a field not present in the model — the exact situation extension data exists to absorb — because the source-gen contexts carried no `object`/`JsonElement` metadata. Both failures are invisible to the compiler and analyzers; they only surface on a live response.

The fixes are minimal and sibling-consistent: settable extension-data properties (the pattern CashIn's models already used) and `object`/`JsonElement` registrations in both serializer contexts. A repo-wide sweep found no other package with either pattern.

The bugs were exposed by the first real unit tests for CashOut — its only prior test was a fixture smoke test whose own comment asked for broker/authenticator coverage. The rest of the PR closes coverage gaps identified by a survey of the weakest test projects.

## What the new tests protect

- **Paymob CashOut (19) + CashIn (1)** — OAuth password-grant wire format (form body, Basic auth), token caching and expiry via `FakeTimeProvider`, single-flight refresh under 10 concurrent callers, cache invalidation on credential rotation, `PaymobCashOutException` carrying status + raw body, cancellation and dispose semantics, refresh-token grant seeding the cache, Bearer propagation, exact request JSON shapes, Paymob response quirks (numbers-as-strings, object-shaped `status_description`, unknown fields), argument validation short-circuiting before any HTTP call, and the issuer-specific status-code helpers.
- **MultiTenancy (15)** — the severity contract that only `Error` diagnostics block host startup (Warning/Information log and proceed — previously every validator test ended in a throw, so a regression here was invisible), cooperative cancellation between validators, validator/DI manifest identity (the documented split-manifest hazard), `TenantPostureManifest` thread-safety under 100 parallel writers, snapshot decoupling, whitespace-drop/ordinal-dedup normalization, ordinal case-sensitivity of runtime markers, `GetOrAddTenantPostureManifest` instance reuse plus its instance-then-factory footgun, and a characterization pin of the undefined-enum first-record asymmetry.
- **AuditLog (17)** — `EfAuditLogStore.PrepareForRetry` detaching stale rows so execution-strategy retries do not duplicate audit rows (previously untested at any level), the MUST-be-idempotent store-handle contract (double discard/release, discard-after-release), `EfAuditLog.LogAsync` cancellation ordering, disabled no-op, and field truncation, the non-`DbContext` saving-context guard, empty-update suppression when only ignored/excluded properties change, redaction shape on updates, and Core setup single-provider guard plus `ConfigureOptions` composition order.

## Validation

- Full non-incremental solution rebuild: 0 warnings, 0 errors.
- All five touched test projects green: CashOut 47/47, CashIn 32/32, MultiTenancy 37/37, AuditLog 46/46, AuditLog.Core 5/5 (167 total).
- `make quality-analyzers-project` clean on both modified Paymob packages; CSharpier applied.
- The CashOut test lock change is purely the added `Headless.Testing` project-reference graph.

## Follow-up candidates (not in this PR)

`HeadlessAuditPersistence` suppress/restore snapshot fidelity and capture-error strategies, `DurableWorkBuffer` happy path, `EfReadAuditLog.QueryAsync` boundary semantics, and the remaining thin projects (`Messaging.PackageReference`, `PushNotifications.Dev`, `Logging.Serilog`, `Emails.Aws`/`Mailkit`).
