### PR TITLE
perf: reduce hot path allocations and scheduler polling

### DIFF
--- a/src/Headless.DistributedLocks.PostgreSql/PostgresAdvisoryLockKey.cs
+++ b/src/Headless.DistributedLocks.PostgreSql/PostgresAdvisoryLockKey.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Data;
 using System.Runtime.InteropServices;
@@ -56,10 +58,12 @@ public readonly struct PostgresAdvisoryLockKey : IEquatable<PostgresAdvisoryLock
     private const int _HashPartLength = 8;
     private const int _HashStringLength = 16;
     private const int _SeparatedHashStringLength = _HashStringLength + 1;
+    private const int _MaxHashedKeyCacheEntries = 4096;
+    private const int _MaxStackallocUtf8Bytes = 512;
 
     // Memoizes the SHA256-hashed keys for long names so the provider's retry loop (one FromString per
-    // poll) does not re-hash the same resource string every attempt. Unbounded: the distinct-resource
-    // count is bounded in practice by the application's lock-key cardinality, which is small.
+    // poll) does not re-hash the same resource string every attempt. The soft cap avoids retaining
+    // unbounded high-cardinality resource names for the process lifetime.
     private static readonly ConcurrentDictionary<string, PostgresAdvisoryLockKey> _HashedKeyCache = new(
         StringComparer.Ordinal
     );
@@ -116,7 +120,7 @@ public readonly struct PostgresAdvisoryLockKey : IEquatable<PostgresAdvisoryLock
 
         if (allowHashing)
         {
-            return _HashedKeyCache.GetOrAdd(name, static n => new PostgresAdvisoryLockKey(_HashString(n)));
+            return _GetOrHashString(name);
         }
 
         throw new FormatException($"Name '{name}' could not be encoded as a {nameof(PostgresAdvisoryLockKey)}.");
@@ -358,15 +362,45 @@ public readonly struct PostgresAdvisoryLockKey : IEquatable<PostgresAdvisoryLock
 
     private static long _HashString(string name)
     {
-        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(name));
-        var result = 0L;
+        var byteCount = Encoding.UTF8.GetByteCount(name);
+        byte[]? rentedBytes = null;
+        Span<byte> utf8Bytes =
+            byteCount <= _MaxStackallocUtf8Bytes
+                ? stackalloc byte[byteCount]
+                : rentedBytes = ArrayPool<byte>.Shared.Rent(byteCount);
 
-        for (var i = sizeof(long) - 1; i >= 0; i--)
+        try
         {
-            result = (result << 8) | hashBytes[i];
+            var written = Encoding.UTF8.GetBytes(name, utf8Bytes);
+            Span<byte> hashBytes = stackalloc byte[SHA256.HashSizeInBytes];
+            SHA256.HashData(utf8Bytes[..written], hashBytes);
+
+            return BinaryPrimitives.ReadInt64LittleEndian(hashBytes);
+        }
+        finally
+        {
+            if (rentedBytes is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rentedBytes);
+            }
+        }
+    }
+
+    private static PostgresAdvisoryLockKey _GetOrHashString(string name)
+    {
+        if (_HashedKeyCache.TryGetValue(name, out var cached))
+        {
+            return cached;
         }
 
-        return result;
+        var hashed = new PostgresAdvisoryLockKey(_HashString(name));
+
+        if (_HashedKeyCache.Count >= _MaxHashedKeyCacheEntries)
+        {
+            return hashed;
+        }
+
+        return _HashedKeyCache.GetOrAdd(name, hashed);
     }
 
     private static string _ToHashString(long key)

--- a/src/Headless.Messaging.Core/Internal/ScheduledMediumMessageQueue.cs
+++ b/src/Headless.Messaging.Core/Internal/ScheduledMediumMessageQueue.cs
@@ -17,18 +17,28 @@ internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider) : I
         )
     );
 
-    private readonly SemaphoreSlim _semaphore = new(0);
+    private readonly SemaphoreSlim _changedSignal = new(0);
     private readonly Lock _lock = new();
     private bool _isDisposed;
 
     public void Enqueue(MediumMessage message, long sendTime)
     {
+        var shouldSignal = false;
+
         lock (_lock)
         {
-            _queue.Add((sendTime, message));
+            var previousEarliest = _queue.Count > 0 ? _queue.Min.Item1 : (long?)null;
+
+            if (_queue.Add((sendTime, message)))
+            {
+                shouldSignal = previousEarliest is null || sendTime < previousEarliest.Value;
+            }
         }
 
-        _semaphore.Release();
+        if (shouldSignal)
+        {
+            _changedSignal.Release();
+        }
     }
 
     public int Count
@@ -59,33 +69,19 @@ internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider) : I
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-            (long, MediumMessage)? nextItem = null;
-
-            lock (_lock)
-            {
-                if (_queue.Count > 0)
-                {
-                    var topMessage = _queue.First();
-                    var timeLeft = topMessage.Item1 - timeProvider.GetUtcNow().UtcDateTime.Ticks;
-                    if (timeLeft < 500000) // 50ms
-                    {
-                        nextItem = topMessage;
-                        _queue.Remove(topMessage);
-                    }
-                }
-            }
+            var nextItem = _TryDequeueDueMessage(out var delay);
 
             if (nextItem is not null)
             {
-                yield return nextItem.Value.Item2;
+                yield return nextItem;
+            }
+            else if (delay is not null)
+            {
+                await _WaitUntilDueOrChangedAsync(delay.Value, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                // Re-release the semaphore if no item is ready yet
-                _semaphore.Release();
-                await timeProvider.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+                await _changedSignal.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }
@@ -105,7 +101,7 @@ internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider) : I
 
         if (disposing)
         {
-            _semaphore.Dispose();
+            _changedSignal.Dispose();
         }
 
         _isDisposed = true;
@@ -121,5 +117,42 @@ internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider) : I
                 "ScheduledMediumMessageQueue was not disposed. Call Dispose() to release SemaphoreSlim."
             );
         }
+    }
+
+    private MediumMessage? _TryDequeueDueMessage(out TimeSpan? delay)
+    {
+        lock (_lock)
+        {
+            if (_queue.Count == 0)
+            {
+                delay = null;
+                return null;
+            }
+
+            var topMessage = _queue.Min;
+            var ticksUntilDue = topMessage.Item1 - timeProvider.GetUtcNow().UtcDateTime.Ticks;
+
+            if (ticksUntilDue > 0)
+            {
+                delay = TimeSpan.FromTicks(ticksUntilDue);
+                return null;
+            }
+
+            _queue.Remove(topMessage);
+            delay = null;
+
+            return topMessage.Item2;
+        }
+    }
+
+    private async Task _WaitUntilDueOrChangedAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var delayTask = timeProvider.Delay(delay, waitCts.Token);
+        var signalTask = _changedSignal.WaitAsync(waitCts.Token);
+        var completedTask = await Task.WhenAny(delayTask, signalTask).ConfigureAwait(false);
+        await waitCts.CancelAsync().ConfigureAwait(false);
+
+        await completedTask.ConfigureAwait(false);
     }
 }

--- a/src/Headless.Messaging.Kafka/KafkaTransport.cs
+++ b/src/Headless.Messaging.Kafka/KafkaTransport.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Runtime.InteropServices;
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 
@@ -42,7 +43,7 @@ internal sealed class KafkaTransport(ILogger<KafkaTransport> logger, IKafkaConne
                             && !string.IsNullOrEmpty(kafkaMessageKey)
                                 ? kafkaMessageKey
                                 : message.Id,
-                        Value = message.Body.ToArray(),
+                        Value = _GetMessageBodyArray(message.Body),
                     },
                     cancellationToken
                 )
@@ -75,6 +76,20 @@ internal sealed class KafkaTransport(ILogger<KafkaTransport> logger, IKafkaConne
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static byte[] _GetMessageBodyArray(ReadOnlyMemory<byte> body)
+    {
+        if (
+            MemoryMarshal.TryGetArray(body, out var segment)
+            && segment is { Array: { } array, Offset: 0 }
+            && segment.Count == array.Length
+        )
+        {
+            return array;
+        }
+
+        return body.ToArray();
+    }
 }
 
 internal static partial class KafkaTransportLog

--- a/src/Headless.Orm.EntityFramework/Extensions/QueryableExtensions.DateOnly.cs
+++ b/src/Headless.Orm.EntityFramework/Extensions/QueryableExtensions.DateOnly.cs
@@ -59,15 +59,45 @@ public static partial class QueryableExtensions
         // Query
         var predicate = greaterThanStartPredicate.And(lessThanEndPredicate);
 
-        var query = queryable
-            .Where(predicate)
-            .Select(propSelector)
-            .Select(date => new { At = date, Month = new DateOnly(date.Year, date.Month, 1) });
+        var filteredDates = queryable.Where(predicate).Select(propSelector);
 
-        var lookup = await query.ToLookupAsync(x => x.Month, x => x.At, cancellationToken: token).ConfigureAwait(false);
+        try
+        {
+            var counts = await filteredDates
+                .GroupBy(static date => new { date.Year, date.Month })
+                .Select(static group => new
+                {
+                    group.Key.Year,
+                    group.Key.Month,
+                    Count = group.Count(),
+                })
+                .ToDictionaryAsync(
+                    static x => new DateOnly(x.Year, x.Month, 1),
+                    static x => x.Count,
+                    cancellationToken: token
+                )
+                .ConfigureAwait(false);
 
-        return from n in Enumerable.Range(1, months)
-            let month = first.AddMonths(n)
-            select new EntityPerDateOnly(month, lookup[month].Count());
+            return from n in Enumerable.Range(1, months)
+                let month = first.AddMonths(n)
+                select new EntityPerDateOnly(month, counts.GetValueOrDefault(month));
+        }
+        catch (InvalidOperationException exception) when (_IsQueryTranslationFailure(exception))
+        {
+            var query = filteredDates.Select(date => new { At = date, Month = new DateOnly(date.Year, date.Month, 1) });
+
+            var lookup = await query
+                .ToLookupAsync(x => x.Month, x => x.At, cancellationToken: token)
+                .ConfigureAwait(false);
+
+            return from n in Enumerable.Range(1, months)
+                let month = first.AddMonths(n)
+                select new EntityPerDateOnly(month, lookup[month].Count());
+        }
+    }
+
+    private static bool _IsQueryTranslationFailure(InvalidOperationException exception)
+    {
+        return exception.Message.Contains("could not be translated", StringComparison.Ordinal);
     }
 }

--- a/src/Headless.Orm.EntityFramework/Extensions/QueryableExtensions.DateTimeOffset.cs
+++ b/src/Headless.Orm.EntityFramework/Extensions/QueryableExtensions.DateTimeOffset.cs
@@ -61,19 +61,44 @@ public static partial class QueryableExtensions
         // Query
         var predicate = greaterThanStartPredicate.And(lessThanEndPredicate);
 
-        var query = queryable
-            .Where(predicate)
-            .Select(propSelector)
-            .Select(date => new
+        var filteredDates = queryable.Where(predicate).Select(propSelector);
+
+        try
+        {
+            var counts = await filteredDates
+                .GroupBy(static date => new { date.Year, date.Month })
+                .Select(static group => new
+                {
+                    group.Key.Year,
+                    group.Key.Month,
+                    Count = group.Count(),
+                })
+                .ToDictionaryAsync(
+                    x => new DateTimeOffset(x.Year, x.Month, 1, 0, 0, 0, start.Offset),
+                    static x => x.Count,
+                    cancellationToken: token
+                )
+                .ConfigureAwait(false);
+
+            return from n in Enumerable.Range(1, months)
+                let month = first.AddMonths(n)
+                select new EntityPerDateTimeOffset(month, counts.GetValueOrDefault(month));
+        }
+        catch (InvalidOperationException exception) when (_IsQueryTranslationFailure(exception))
+        {
+            var query = filteredDates.Select(date => new
             {
                 At = date,
                 Month = new DateTimeOffset(date.Year, date.Month, 1, 0, 0, 0, start.Offset),
             });
 
-        var lookup = await query.ToLookupAsync(x => x.Month, x => x.At, cancellationToken: token).ConfigureAwait(false);
+            var lookup = await query
+                .ToLookupAsync(x => x.Month, x => x.At, cancellationToken: token)
+                .ConfigureAwait(false);
 
-        return from n in Enumerable.Range(1, months)
-            let month = first.AddMonths(n)
-            select new EntityPerDateTimeOffset(month, lookup[month].Count());
+            return from n in Enumerable.Range(1, months)
+                let month = first.AddMonths(n)
+                select new EntityPerDateTimeOffset(month, lookup[month].Count());
+        }
     }
 }

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
@@ -4,6 +4,7 @@ using Headless.Messaging;
 using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
 using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Tests.Internal;
 
@@ -13,14 +14,14 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
     public void unordered_items_should_reflect_all_enqueued_messages_without_removing_them()
     {
         // given
-        var timeProvider = new ManualTimeProvider();
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
         using var queue = new ScheduledMediumMessageQueue(timeProvider);
         var first = _CreateMediumMessage(1);
         var second = _CreateMediumMessage(2);
 
         // when
-        queue.Enqueue(first, timeProvider.CurrentTicks);
-        queue.Enqueue(second, timeProvider.CurrentTicks + TimeSpan.FromSeconds(1).Ticks);
+        queue.Enqueue(first, timeProvider.GetUtcNow().UtcDateTime.Ticks);
+        queue.Enqueue(second, timeProvider.GetUtcNow().UtcDateTime.Ticks + TimeSpan.FromSeconds(1).Ticks);
 
         // then
         queue.Count.Should().Be(2);
@@ -32,12 +33,12 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
     public async Task get_consuming_enumerable_should_yield_due_messages_in_send_time_then_storage_id_order()
     {
         // given
-        var timeProvider = new ManualTimeProvider();
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
         using var queue = new ScheduledMediumMessageQueue(timeProvider);
         var first = _CreateMediumMessage(1);
         var second = _CreateMediumMessage(2);
         var third = _CreateMediumMessage(3);
-        var dueAt = timeProvider.CurrentTicks;
+        var dueAt = timeProvider.GetUtcNow().UtcDateTime.Ticks;
 
         queue.Enqueue(second, dueAt);
         queue.Enqueue(first, dueAt);
@@ -68,10 +69,10 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
     public async Task get_consuming_enumerable_should_wait_until_future_message_is_due()
     {
         // given
-        var timeProvider = new ManualTimeProvider();
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
         using var queue = new ScheduledMediumMessageQueue(timeProvider);
         var message = _CreateMediumMessage(7);
-        queue.Enqueue(message, timeProvider.CurrentTicks + TimeSpan.FromMilliseconds(200).Ticks);
+        queue.Enqueue(message, timeProvider.GetUtcNow().UtcDateTime.Ticks + TimeSpan.FromMilliseconds(200).Ticks);
 
         var enumerator = queue.GetConsumingEnumerable(AbortToken).GetAsyncEnumerator(AbortToken);
 
@@ -90,6 +91,37 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         // then
         enumerator.Current.StorageId.Should().Be(_StorageGuid(7));
         queue.Count.Should().Be(0);
+
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task get_consuming_enumerable_should_reschedule_when_earlier_message_is_enqueued()
+    {
+        // given
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        using var queue = new ScheduledMediumMessageQueue(timeProvider);
+        var late = _CreateMediumMessage(8);
+        var early = _CreateMediumMessage(9);
+        var now = timeProvider.GetUtcNow().UtcDateTime.Ticks;
+
+        queue.Enqueue(late, now + TimeSpan.FromSeconds(10).Ticks);
+        var enumerator = queue.GetConsumingEnumerable(AbortToken).GetAsyncEnumerator(AbortToken);
+
+        // when
+        var moveNextTask = enumerator.MoveNextAsync().AsTask();
+        await Task.Delay(25, AbortToken);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        moveNextTask.IsCompleted.Should().BeFalse();
+
+        queue.Enqueue(early, now + TimeSpan.FromSeconds(2).Ticks);
+        await Task.Delay(25, AbortToken);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+
+        // then
+        enumerator.Current.StorageId.Should().Be(_StorageGuid(9));
+        queue.Count.Should().Be(1);
 
         await enumerator.DisposeAsync();
     }
@@ -115,15 +147,4 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
     }
 
     private static Guid _StorageGuid(int value) => Guid.Parse($"00000000-0000-0000-0000-{value:000000000000}");
-
-    private sealed class ManualTimeProvider : TimeProvider
-    {
-        private DateTimeOffset _utcNow = new(2026, 4, 1, 0, 0, 0, TimeSpan.Zero);
-
-        public long CurrentTicks => _utcNow.UtcDateTime.Ticks;
-
-        public override DateTimeOffset GetUtcNow() => _utcNow;
-
-        public void Advance(TimeSpan by) => _utcNow = _utcNow.Add(by);
-    }
 }

--- a/tests/Headless.Messaging.Kafka.Tests.Unit/KafkaTransportTests.cs
+++ b/tests/Headless.Messaging.Kafka.Tests.Unit/KafkaTransportTests.cs
@@ -302,6 +302,82 @@ public sealed class KafkaTransportTests : TestBase
     }
 
     [Fact]
+    public async Task should_reuse_whole_array_body_when_publishing()
+    {
+        // given
+        await using var transport = new KafkaTransport(_logger, _pool);
+        var body = "test-body"u8.ToArray();
+        var message = new TransportMessage(
+            headers: new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                { MessagingHeaders.MessageId, "msg-123" },
+                { MessagingHeaders.MessageName, "TestTopic" },
+            },
+            body: body
+        );
+
+        Message<string, byte[]>? producedMessage = null;
+        var deliveryResult = new DeliveryResult<string, byte[]>
+        {
+            Status = PersistenceStatus.Persisted,
+            Topic = "TestTopic",
+        };
+        _producer
+            .ProduceAsync(
+                Arg.Any<string>(),
+                Arg.Do<Message<string, byte[]>>(m => producedMessage = m),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(deliveryResult);
+
+        // when
+        await transport.SendAsync(message, AbortToken);
+
+        // then
+        producedMessage.Should().NotBeNull();
+        producedMessage!.Value.Should().BeSameAs(body);
+    }
+
+    [Fact]
+    public async Task should_copy_sliced_body_when_publishing()
+    {
+        // given
+        await using var transport = new KafkaTransport(_logger, _pool);
+        var source = "xxbodyyy"u8.ToArray();
+        var body = new ReadOnlyMemory<byte>(source, 2, 4);
+        var message = new TransportMessage(
+            headers: new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                { MessagingHeaders.MessageId, "msg-123" },
+                { MessagingHeaders.MessageName, "TestTopic" },
+            },
+            body: body
+        );
+
+        Message<string, byte[]>? producedMessage = null;
+        var deliveryResult = new DeliveryResult<string, byte[]>
+        {
+            Status = PersistenceStatus.Persisted,
+            Topic = "TestTopic",
+        };
+        _producer
+            .ProduceAsync(
+                Arg.Any<string>(),
+                Arg.Do<Message<string, byte[]>>(m => producedMessage = m),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(deliveryResult);
+
+        // when
+        await transport.SendAsync(message, AbortToken);
+
+        // then
+        producedMessage.Should().NotBeNull();
+        producedMessage!.Value.Should().Equal("body"u8.ToArray());
+        producedMessage.Value.Should().NotBeSameAs(source);
+    }
+
+    [Fact]
     public async Task should_handle_null_header_values()
     {
         // given

--- a/tests/Headless.Orm.EntityFramework.Tests.Integration/CountPerMonthExtensionsTests.cs
+++ b/tests/Headless.Orm.EntityFramework.Tests.Integration/CountPerMonthExtensionsTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Data.Common;
+using Headless.EntityFramework;
+using Headless.Testing.Tests;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Tests;
+
+public sealed class CountPerMonthExtensionsTests : TestBase
+{
+    [Fact]
+    public async Task date_only_count_per_month_should_group_counts_in_database()
+    {
+        // given
+        await using var fixture = await MonthCountFixture.CreateAsync(AbortToken);
+        fixture.CommandLog.Clear();
+
+        // when
+        var buckets = (
+            await fixture.Context.Rows.CountPerMonthAsync(
+                static row => row.DateOnlyValue,
+                new DateOnly(2026, 1, 15),
+                new DateOnly(2026, 4, 20),
+                AbortToken
+            )
+        ).ToArray();
+
+        // then
+        buckets
+            .Should()
+            .Equal(
+                new EntityPerDateOnly(new DateOnly(2026, 2, 1), 2),
+                new EntityPerDateOnly(new DateOnly(2026, 3, 1), 1),
+                new EntityPerDateOnly(new DateOnly(2026, 4, 1), 0)
+            );
+        fixture.CommandLog.Commands.Any(_IsGroupedCountSql).Should().BeTrue();
+    }
+
+    private static bool _IsGroupedCountSql(string sql)
+    {
+        return sql.Contains("GROUP BY", StringComparison.OrdinalIgnoreCase)
+            && sql.Contains("COUNT", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class MonthCountFixture : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        private MonthCountFixture(SqliteConnection connection, MonthCountDbContext context, CommandLog commandLog)
+        {
+            _connection = connection;
+            Context = context;
+            CommandLog = commandLog;
+        }
+
+        public MonthCountDbContext Context { get; }
+
+        public CommandLog CommandLog { get; }
+
+        public static async Task<MonthCountFixture> CreateAsync(CancellationToken cancellationToken)
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync(cancellationToken);
+
+            var commandLog = new CommandLog();
+            var options = new DbContextOptionsBuilder<MonthCountDbContext>()
+                .UseSqlite(connection)
+                .AddInterceptors(commandLog)
+                .Options;
+            var context = new MonthCountDbContext(options);
+
+            try
+            {
+                await context.Database.EnsureCreatedAsync(cancellationToken);
+
+                await context.Rows.AddRangeAsync(
+                    [
+                        new MonthCountRow
+                        {
+                            DateOnlyValue = new DateOnly(2026, 2, 2),
+                            DateTimeOffsetValue = new DateTimeOffset(2026, 2, 2, 0, 0, 0, TimeSpan.FromHours(2)),
+                        },
+                        new MonthCountRow
+                        {
+                            DateOnlyValue = new DateOnly(2026, 2, 20),
+                            DateTimeOffsetValue = new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.FromHours(2)),
+                        },
+                        new MonthCountRow
+                        {
+                            DateOnlyValue = new DateOnly(2026, 3, 5),
+                            DateTimeOffsetValue = new DateTimeOffset(2026, 3, 5, 0, 0, 0, TimeSpan.FromHours(2)),
+                        },
+                        new MonthCountRow
+                        {
+                            DateOnlyValue = new DateOnly(2026, 5, 1),
+                            DateTimeOffsetValue = new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.FromHours(2)),
+                        },
+                    ],
+                    cancellationToken
+                );
+
+                await context.SaveChangesAsync(cancellationToken);
+
+                return new(connection, context, commandLog);
+            }
+            catch
+            {
+                await context.DisposeAsync();
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+
+    private sealed class MonthCountDbContext(DbContextOptions<MonthCountDbContext> options) : DbContext(options)
+    {
+        public DbSet<MonthCountRow> Rows => Set<MonthCountRow>();
+    }
+
+    private sealed class MonthCountRow
+    {
+        public int Id { get; set; }
+
+        public DateOnly DateOnlyValue { get; init; }
+
+        public DateTimeOffset DateTimeOffsetValue { get; init; }
+    }
+
+    private sealed class CommandLog : DbCommandInterceptor
+    {
+        private readonly List<string> _commands = [];
+
+        public IReadOnlyList<string> Commands => _commands;
+
+        public void Clear() => _commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result
+        )
+        {
+            _commands.Add(command.CommandText);
+
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _commands.Add(command.CommandText);
+
+            return ValueTask.FromResult(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This reduces several code-inspection hot paths without changing public APIs. Delayed messaging no longer wakes every 50ms while waiting for future messages; it waits until the next due time or a newly-earlier message. Monthly count helpers now try database-side month grouping/counting and fall back to the prior client aggregation path when a provider cannot translate the grouped query. Kafka publishing reuses whole-array message bodies, and PostgreSQL advisory-lock key hashing now avoids per-hash byte arrays and caps the process-wide hash cache.

| Area | Before | After | Measurement status |
|---|---|---|---|
| Delayed scheduler | Re-release semaphore + 50ms polling for future messages | Due-time wait interrupted only by earlier messages | Covered by fake-time unit tests; no BDN run |
| Monthly counts | Materialized all matching dates before grouping | Server-side `GROUP BY`/`COUNT` when translatable | SQLite integration asserts grouped SQL for `DateOnly`; no BDN run |
| Kafka publish body | Always copied `ReadOnlyMemory<byte>` to a new array | Reuses whole backing arrays, copies slices | Unit tests cover both cases; no BDN run |
| PostgreSQL lock key hashing | Unbounded hash-name cache and transient hash byte arrays | Soft-capped cache plus stack/pool UTF-8 hashing | Existing key behavior tests pass; no BDN run |

## Validation

- `make restore` passed after switching away from concurrent restore/test runs.
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj TEST_FILTER='--filter-class Tests.Internal.ScheduledMediumMessageQueueTests'` passed.
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Kafka.Tests.Unit/Headless.Messaging.Kafka.Tests.Unit.csproj TEST_FILTER='--filter-class Tests.KafkaTransportTests'` passed.
- `make test-project TEST_PROJECT=tests/Headless.Orm.EntityFramework.Tests.Integration/Headless.Orm.EntityFramework.Tests.Integration.csproj TEST_FILTER='--filter-class Tests.CountPerMonthExtensionsTests'` passed.
- `make test-project TEST_PROJECT=tests/Headless.DistributedLocks.PostgreSql.Tests.Integration/Headless.DistributedLocks.PostgreSql.Tests.Integration.csproj TEST_FILTER='--filter-class Tests.PostgresAdvisoryLockKeyTests'` passed.
- `make format-check` passed.
- `make quality-analyzers-project` passed for `Headless.Messaging.Core`, `Headless.Messaging.Kafka`, `Headless.Orm.EntityFramework`, and `Headless.DistributedLocks.PostgreSql`.
- `make quality-analyzers` passed solution-wide.
- Pre-push hook passed changed-file format check plus Release incremental build with `0 Warning(s)` and `0 Error(s)`.

Dedicated `x-code-review` could not run because this harness exposes sub-agents with a tool-level rule forbidding agent spawning unless explicitly requested. I performed a manual diff review before committing.

## Post-Deploy Monitoring & Validation

Watch delayed-message dispatch lag/backlog, scheduler exceptions, Kafka publish failures, EF query translation exceptions, monthly-count query latency, PostgreSQL lock acquire latency/timeouts, and process memory in services using high-cardinality lock names. Useful log searches include `ScheduleDelayedMessageFailed`, `PublisherSentFailedException`, `could not be translated`, advisory-lock timeout/acquire failure messages, and unexpected delayed-message retry spikes.

Healthy signal: delayed messages dispatch near their due times, monthly count endpoints keep returning the same buckets with lower DB row transfer, Kafka publish success rate stays stable, and lock acquisition behavior remains unchanged. Roll back if delayed dispatch lag increases, EF providers start throwing translation/runtime query errors, Kafka publish failures rise, or service memory grows with lock-name cardinality during the validation window. Suggested owner: service owner for the first production rollout window after merge.
