### PR TITLE
chore: add bounded NuGet advisory audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ QUALITY_BUILD_ARGS = --configuration "$(CONFIGURATION)" --no-restore --no-increm
 TEST_MAX_PARALLEL ?= 3
 TEST_TIMEOUT ?= 15m
 DOTNET_OUTDATED_AUDIT_ARGS ?= --no-restore --idle-timeout $(DEPENDENCY_AUDIT_IDLE_TIMEOUT) --output "$(DEPENDENCY_AUDIT_DIR)/outdated.json" --output-format json
-NUGET_ADVISORY_AUDIT_ARGS ?= --timeout-seconds "$(NUGET_ADVISORY_AUDIT_TIMEOUT)" --output-dir "$(DEPENDENCY_AUDIT_DIR)/nuget-advisories"
+DEPENDENCY_SECURITY_AUDIT_ARGS ?= --timeout-seconds "$(DEPENDENCY_SECURITY_AUDIT_TIMEOUT)" --output-dir "$(DEPENDENCY_AUDIT_DIR)/security" --project "$(PROJECT)" --scan vulnerable --include-transitive --scan deprecated
+NUGET_ADVISORY_AUDIT_ARGS ?= --timeout-seconds "$(NUGET_ADVISORY_AUDIT_TIMEOUT)" --output-dir "$(DEPENDENCY_AUDIT_DIR)/nuget-advisories" --scan vulnerable --include-transitive
 
 COVERAGE_ARGS ?= -p:EnableCodeCoverage=true --coverage-output-format cobertura
 CI_TEST_ARGS ?= --report-trx --coverage --coverage-output-format cobertura
@@ -301,44 +302,7 @@ dependency-audit: ## Write NuGet outdated dependency JSON report without restore
 .PHONY: dependency-security-audit
 dependency-security-audit: ## Check vulnerable/deprecated NuGet packages for PROJECT without restore; fail on timeout.
 	@test -n "$(PROJECT)" || (echo "PROJECT is required. Example: make dependency-security-audit PROJECT=src/Headless.Api/Headless.Api.csproj" && exit 2)
-	@mkdir -p "$(DEPENDENCY_AUDIT_DIR)"
-	@timeout_seconds="$(DEPENDENCY_SECURITY_AUDIT_TIMEOUT)"; \
-	project_name="$$(basename "$(PROJECT)" .csproj)"; \
-	case "$$timeout_seconds" in \
-		''|*[!0-9]*) echo "DEPENDENCY_SECURITY_AUDIT_TIMEOUT must be a positive integer." >&2; exit 2 ;; \
-	esac; \
-	if [ "$$timeout_seconds" -le 0 ]; then \
-		echo "DEPENDENCY_SECURITY_AUDIT_TIMEOUT must be greater than zero." >&2; \
-		exit 2; \
-	fi; \
-	run_audit() { \
-		local name="$$1"; shift; \
-		local output="$(DEPENDENCY_AUDIT_DIR)/$${project_name}.$${name}.txt"; \
-		local pid elapsed status; \
-		printf 'Running NuGet %s audit (timeout=%ss)...\n' "$$name" "$$timeout_seconds"; \
-		$(DOTNET) list "$(PROJECT)" package "$$@" --no-restore --verbosity quiet >"$$output" 2>&1 & \
-		pid="$$!"; \
-		elapsed=0; \
-		while kill -0 "$$pid" 2>/dev/null; do \
-			if [ "$$elapsed" -ge "$$timeout_seconds" ]; then \
-				printf 'NuGet %s audit timed out after %ss.\n' "$$name" "$$timeout_seconds" | tee -a "$$output" >&2; \
-				kill "$$pid" 2>/dev/null || true; \
-				wait "$$pid" 2>/dev/null || true; \
-				return 124; \
-			fi; \
-			sleep 1; \
-			elapsed=$$((elapsed + 1)); \
-		done; \
-		if wait "$$pid"; then \
-			cat "$$output"; \
-			return 0; \
-		fi; \
-		status="$$?"; \
-		cat "$$output" >&2; \
-		return "$$status"; \
-	}; \
-	run_audit vulnerable --vulnerable --include-transitive || exit "$$?"; \
-	run_audit deprecated --deprecated || exit "$$?"
+	./scripts/audit-nuget-advisories.sh $(DEPENDENCY_SECURITY_AUDIT_ARGS)
 
 .PHONY: nuget-advisory-audit
 nuget-advisory-audit: ## Scan source packages for NuGet vulnerabilities with bounded per-project logs.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ UNIT_TEST_MODULES ?= tests/**/bin/$(CONFIGURATION)/**/*.Tests.Unit.dll
 INTEGRATION_TEST_MODULES ?= tests/**/bin/$(CONFIGURATION)/**/*.Tests.Integration.dll
 MSBUILD_ARGS ?=
 DEPENDENCY_AUDIT_IDLE_TIMEOUT ?= 120
+NUGET_ADVISORY_AUDIT_TIMEOUT ?= 90
 QUALITY_SEVERITY ?= info
 QUALITY_DIAGNOSTICS ?=
 QUALITY_FORMAT_ARGS = --no-restore --verify-no-changes --severity "$(QUALITY_SEVERITY)" -v minimal $(if $(QUALITY_DIAGNOSTICS),--diagnostics $(QUALITY_DIAGNOSTICS),)
@@ -32,6 +33,7 @@ QUALITY_BUILD_ARGS = --configuration "$(CONFIGURATION)" --no-restore --no-increm
 TEST_MAX_PARALLEL ?= 3
 TEST_TIMEOUT ?= 15m
 DOTNET_OUTDATED_AUDIT_ARGS ?= --no-restore --idle-timeout $(DEPENDENCY_AUDIT_IDLE_TIMEOUT) --output "$(DEPENDENCY_AUDIT_DIR)/outdated.json" --output-format json
+NUGET_ADVISORY_AUDIT_ARGS ?= --timeout-seconds "$(NUGET_ADVISORY_AUDIT_TIMEOUT)" --output-dir "$(DEPENDENCY_AUDIT_DIR)/nuget-advisories"
 
 COVERAGE_ARGS ?= -p:EnableCodeCoverage=true --coverage-output-format cobertura
 CI_TEST_ARGS ?= --report-trx --coverage --coverage-output-format cobertura
@@ -294,6 +296,10 @@ outdated: tools ## Check outdated NuGet dependencies.
 dependency-audit: ## Write NuGet outdated dependency JSON report without restore.
 	@mkdir -p "$(DEPENDENCY_AUDIT_DIR)"
 	$(DOTNET) outdated "$(SOLUTION)" $(DOTNET_OUTDATED_AUDIT_ARGS)
+
+.PHONY: nuget-advisory-audit
+nuget-advisory-audit: ## Scan source packages for NuGet vulnerabilities with bounded per-project logs.
+	./scripts/audit-nuget-advisories.sh $(NUGET_ADVISORY_AUDIT_ARGS)
 
 .PHONY: version
 version: tools ## Show MinVer-computed version.

--- a/scripts/audit-nuget-advisories.sh
+++ b/scripts/audit-nuget-advisories.sh
@@ -5,21 +5,27 @@ SCRIPT_NAME="$(basename "$0")"
 DOTNET_CMD="${DOTNET:-dotnet}"
 OUTPUT_DIR="artifacts/dependency-audit/nuget-advisories"
 TIMEOUT_SECONDS=90
+INCLUDE_TRANSITIVE=true
 CURRENT_PID=""
 PROJECTS=()
+SCANS=()
 
 usage() {
     cat <<'USAGE'
 Usage: audit-nuget-advisories.sh [options]
 
-Scans source package projects for NuGet vulnerability advisories with one
-bounded dotnet-list invocation per project.
+Scans source package projects for NuGet package advisories with one bounded
+dotnet-list invocation per project and scan type.
 
 Options:
-  --output-dir <path>       Directory for summary and per-project logs.
+  --output-dir <path>       Directory for summary and per-scan logs.
                             Default: artifacts/dependency-audit/nuget-advisories
-  --timeout-seconds <n>     Per-project timeout in seconds. Default: 90
+  --timeout-seconds <n>     Per-project, per-scan timeout in seconds. Default: 90
   --project <path>          Project to scan. May be repeated. Defaults to src/*/*.csproj.
+  --scan <name>             Scan to run: vulnerable or deprecated. May be repeated.
+                            Default: vulnerable
+  --include-transitive      Include transitive packages for vulnerable scans. Default.
+  --no-include-transitive   Check direct packages only for vulnerable scans.
   -h, --help                Show this help text.
 USAGE
 }
@@ -57,6 +63,16 @@ validate_positive_integer() {
     fi
 }
 
+validate_scan() {
+    case "$1" in
+        vulnerable|deprecated)
+            ;;
+        *)
+            die "--scan must be vulnerable or deprecated"
+            ;;
+    esac
+}
+
 parse_args() {
     while [ "$#" -gt 0 ]; do
         case "$1" in
@@ -74,6 +90,20 @@ parse_args() {
                 [ "$#" -ge 2 ] || die "--project requires a value"
                 PROJECTS+=("$2")
                 shift 2
+                ;;
+            --scan)
+                [ "$#" -ge 2 ] || die "--scan requires a value"
+                validate_scan "$2"
+                SCANS+=("$2")
+                shift 2
+                ;;
+            --include-transitive)
+                INCLUDE_TRANSITIVE=true
+                shift
+                ;;
+            --no-include-transitive)
+                INCLUDE_TRANSITIVE=false
+                shift
                 ;;
             -h|--help)
                 usage
@@ -98,13 +128,22 @@ discover_projects() {
     done < <(find src -mindepth 2 -maxdepth 2 -name '*.csproj' -type f | sort)
 }
 
+ensure_default_scans() {
+    if [ "${#SCANS[@]}" -gt 0 ]; then
+        return
+    fi
+
+    SCANS+=(vulnerable)
+}
+
 safe_log_name() {
     local -r project="$1"
+    local -r scan="$2"
     local name
 
     name="$(dirname "$project")"
     name="$(basename "$name")"
-    printf '%s.log\n' "$name"
+    printf '%s.%s.log\n' "$name" "$scan"
 }
 
 run_with_timeout() {
@@ -118,6 +157,7 @@ run_with_timeout() {
     local elapsed=0
     while kill -0 "$CURRENT_PID" 2>/dev/null; do
         if [ "$elapsed" -ge "$timeout_seconds" ]; then
+            printf 'Command timed out after %ss.\n' "$timeout_seconds" >>"$log_file"
             kill -15 "$CURRENT_PID" 2>/dev/null || true
             sleep 1
             if kill -0 "$CURRENT_PID" 2>/dev/null; then
@@ -138,9 +178,30 @@ run_with_timeout() {
     return "$status"
 }
 
+build_scan_command() {
+    local -r project="$1"
+    local -r scan="$2"
+
+    case "$scan" in
+        vulnerable)
+            SCAN_COMMAND=("$DOTNET_CMD" list "$project" package --vulnerable --no-restore --verbosity quiet)
+            if [ "$INCLUDE_TRANSITIVE" = true ]; then
+                SCAN_COMMAND+=(--include-transitive)
+            fi
+            ;;
+        deprecated)
+            SCAN_COMMAND=("$DOTNET_CMD" list "$project" package --deprecated --no-restore --verbosity quiet)
+            ;;
+        *)
+            die "Unsupported scan: $scan"
+            ;;
+    esac
+}
+
 classify_log() {
-    local -r status="$1"
-    local -r log_file="$2"
+    local -r scan="$1"
+    local -r status="$2"
+    local -r log_file="$3"
 
     if [ "$status" -eq 124 ]; then
         printf 'timeout'
@@ -152,10 +213,23 @@ classify_log() {
         return
     fi
 
-    if grep -qi 'has the following vulnerable packages' "$log_file"; then
-        printf 'vulnerable'
-        return
-    fi
+    case "$scan" in
+        vulnerable)
+            if grep -qi 'has the following vulnerable packages' "$log_file"; then
+                printf 'vulnerable'
+                return
+            fi
+            ;;
+        deprecated)
+            if grep -qi 'has the following deprecated packages' "$log_file"; then
+                printf 'deprecated'
+                return
+            fi
+            ;;
+        *)
+            die "Unsupported scan: $scan"
+            ;;
+    esac
 
     printf 'clean'
 }
@@ -164,25 +238,28 @@ write_summary_header() {
     local -r summary_file="$1"
     local -r summary_md="$2"
 
-    printf 'project\tstatus\tlog\n' >"$summary_file"
+    printf 'project\tscan\tstatus\tlog\n' >"$summary_file"
     {
         printf '# NuGet Advisory Audit\n\n'
-        printf -- "- Per-project timeout: \`%s\` seconds\n" "$TIMEOUT_SECONDS"
-        printf -- "- Project count: \`%s\`\n\n" "${#PROJECTS[@]}"
-        printf '| Project | Status | Log |\n'
-        printf '| --- | --- | --- |\n'
+        printf -- "- Per-project, per-scan timeout: \`%s\` seconds\n" "$TIMEOUT_SECONDS"
+        printf -- "- Include transitive vulnerable packages: \`%s\`\n" "$INCLUDE_TRANSITIVE"
+        printf -- "- Project count: \`%s\`\n" "${#PROJECTS[@]}"
+        printf -- "- Scans: \`%s\`\n\n" "${SCANS[*]}"
+        printf '| Project | Scan | Status | Log |\n'
+        printf '| --- | --- | --- | --- |\n'
     } >"$summary_md"
 }
 
 append_summary_row() {
     local -r project="$1"
-    local -r status="$2"
-    local -r log_file="$3"
-    local -r summary_file="$4"
-    local -r summary_md="$5"
+    local -r scan="$2"
+    local -r status="$3"
+    local -r log_file="$4"
+    local -r summary_file="$5"
+    local -r summary_md="$6"
 
-    printf '%s\t%s\t%s\n' "$project" "$status" "$log_file" >>"$summary_file"
-    printf "| \`%s\` | \`%s\` | \`%s\` |\n" "$project" "$status" "$log_file" >>"$summary_md"
+    printf '%s\t%s\t%s\t%s\n' "$project" "$scan" "$status" "$log_file" >>"$summary_file"
+    printf "| \`%s\` | \`%s\` | \`%s\` | \`%s\` |\n" "$project" "$scan" "$status" "$log_file" >>"$summary_md"
 }
 
 main() {
@@ -192,6 +269,7 @@ main() {
     command -v "$DOTNET_CMD" >/dev/null 2>&1 || die "dotnet command not found: $DOTNET_CMD"
 
     discover_projects
+    ensure_default_scans
     [ "${#PROJECTS[@]}" -gt 0 ] || die "No source package projects found"
 
     mkdir -p "$OUTPUT_DIR/logs"
@@ -199,37 +277,43 @@ main() {
     local -r summary_file="$OUTPUT_DIR/summary.tsv"
     local -r summary_md="$OUTPUT_DIR/summary.md"
     local project
+    local scan
     local log_file
     local status
     local result
     local failures=0
+    local SCAN_COMMAND=()
 
     write_summary_header "$summary_file" "$summary_md"
 
     for project in "${PROJECTS[@]}"; do
         [ -f "$project" ] || die "Project not found: $project"
 
-        log_file="$OUTPUT_DIR/logs/$(safe_log_name "$project")"
-        printf 'Scanning %s\n' "$project"
+        for scan in "${SCANS[@]}"; do
+            log_file="$OUTPUT_DIR/logs/$(safe_log_name "$project" "$scan")"
+            printf 'Scanning %s (%s)\n' "$project" "$scan"
 
-        if run_with_timeout "$TIMEOUT_SECONDS" "$log_file" "$DOTNET_CMD" list "$project" package --vulnerable --include-transitive --no-restore; then
-            status=0
-        else
-            status="$?"
-        fi
+            build_scan_command "$project" "$scan"
 
-        result="$(classify_log "$status" "$log_file")"
-        append_summary_row "$project" "$result" "$log_file" "$summary_file" "$summary_md"
+            if run_with_timeout "$TIMEOUT_SECONDS" "$log_file" "${SCAN_COMMAND[@]}"; then
+                status=0
+            else
+                status="$?"
+            fi
 
-        if [ "$result" != "clean" ]; then
-            failures=$((failures + 1))
-        fi
+            result="$(classify_log "$scan" "$status" "$log_file")"
+            append_summary_row "$project" "$scan" "$result" "$log_file" "$summary_file" "$summary_md"
+
+            if [ "$result" != "clean" ]; then
+                failures=$((failures + 1))
+            fi
+        done
     done
 
     printf '\nWrote %s and %s\n' "$summary_file" "$summary_md"
 
     if [ "$failures" -gt 0 ]; then
-        printf '%s: %s project(s) reported vulnerabilities, failed, or timed out.\n' "$SCRIPT_NAME" "$failures" >&2
+        printf '%s: %s scan(s) reported advisories, failed, or timed out.\n' "$SCRIPT_NAME" "$failures" >&2
         return 1
     fi
 }

--- a/scripts/audit-nuget-advisories.sh
+++ b/scripts/audit-nuget-advisories.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+DOTNET_CMD="${DOTNET:-dotnet}"
+OUTPUT_DIR="artifacts/dependency-audit/nuget-advisories"
+TIMEOUT_SECONDS=90
+CURRENT_PID=""
+PROJECTS=()
+
+usage() {
+    cat <<'USAGE'
+Usage: audit-nuget-advisories.sh [options]
+
+Scans source package projects for NuGet vulnerability advisories with one
+bounded dotnet-list invocation per project.
+
+Options:
+  --output-dir <path>       Directory for summary and per-project logs.
+                            Default: artifacts/dependency-audit/nuget-advisories
+  --timeout-seconds <n>     Per-project timeout in seconds. Default: 90
+  --project <path>          Project to scan. May be repeated. Defaults to src/*/*.csproj.
+  -h, --help                Show this help text.
+USAGE
+}
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 2
+}
+
+cleanup() {
+    if [ -n "$CURRENT_PID" ] && kill -0 "$CURRENT_PID" 2>/dev/null; then
+        kill -15 "$CURRENT_PID" 2>/dev/null || true
+        sleep 1
+        if kill -0 "$CURRENT_PID" 2>/dev/null; then
+            kill -9 "$CURRENT_PID" 2>/dev/null || true
+        fi
+    fi
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM
+
+validate_positive_integer() {
+    local -r value="$1"
+    local -r name="$2"
+
+    case "$value" in
+        ''|*[!0-9]*)
+            die "$name must be a positive integer"
+            ;;
+    esac
+
+    if [ "$value" -le 0 ]; then
+        die "$name must be greater than zero"
+    fi
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --output-dir)
+                [ "$#" -ge 2 ] || die "--output-dir requires a value"
+                OUTPUT_DIR="$2"
+                shift 2
+                ;;
+            --timeout-seconds)
+                [ "$#" -ge 2 ] || die "--timeout-seconds requires a value"
+                TIMEOUT_SECONDS="$2"
+                shift 2
+                ;;
+            --project)
+                [ "$#" -ge 2 ] || die "--project requires a value"
+                PROJECTS+=("$2")
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                die "Unknown argument: $1"
+                ;;
+        esac
+    done
+}
+
+discover_projects() {
+    local project
+
+    if [ "${#PROJECTS[@]}" -gt 0 ]; then
+        return
+    fi
+
+    while IFS= read -r project; do
+        PROJECTS+=("$project")
+    done < <(find src -mindepth 2 -maxdepth 2 -name '*.csproj' -type f | sort)
+}
+
+safe_log_name() {
+    local -r project="$1"
+    local name
+
+    name="$(dirname "$project")"
+    name="$(basename "$name")"
+    printf '%s.log\n' "$name"
+}
+
+run_with_timeout() {
+    local -r timeout_seconds="$1"
+    local -r log_file="$2"
+    shift 2
+
+    "$@" >"$log_file" 2>&1 &
+    CURRENT_PID="$!"
+
+    local elapsed=0
+    while kill -0 "$CURRENT_PID" 2>/dev/null; do
+        if [ "$elapsed" -ge "$timeout_seconds" ]; then
+            kill -15 "$CURRENT_PID" 2>/dev/null || true
+            sleep 1
+            if kill -0 "$CURRENT_PID" 2>/dev/null; then
+                kill -9 "$CURRENT_PID" 2>/dev/null || true
+            fi
+            wait "$CURRENT_PID" 2>/dev/null || true
+            CURRENT_PID=""
+            return 124
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    local status=0
+    wait "$CURRENT_PID" || status="$?"
+    CURRENT_PID=""
+    return "$status"
+}
+
+classify_log() {
+    local -r status="$1"
+    local -r log_file="$2"
+
+    if [ "$status" -eq 124 ]; then
+        printf 'timeout'
+        return
+    fi
+
+    if [ "$status" -ne 0 ]; then
+        printf 'failed'
+        return
+    fi
+
+    if grep -qi 'has the following vulnerable packages' "$log_file"; then
+        printf 'vulnerable'
+        return
+    fi
+
+    printf 'clean'
+}
+
+write_summary_header() {
+    local -r summary_file="$1"
+    local -r summary_md="$2"
+
+    printf 'project\tstatus\tlog\n' >"$summary_file"
+    {
+        printf '# NuGet Advisory Audit\n\n'
+        printf -- "- Per-project timeout: \`%s\` seconds\n" "$TIMEOUT_SECONDS"
+        printf -- "- Project count: \`%s\`\n\n" "${#PROJECTS[@]}"
+        printf '| Project | Status | Log |\n'
+        printf '| --- | --- | --- |\n'
+    } >"$summary_md"
+}
+
+append_summary_row() {
+    local -r project="$1"
+    local -r status="$2"
+    local -r log_file="$3"
+    local -r summary_file="$4"
+    local -r summary_md="$5"
+
+    printf '%s\t%s\t%s\n' "$project" "$status" "$log_file" >>"$summary_file"
+    printf "| \`%s\` | \`%s\` | \`%s\` |\n" "$project" "$status" "$log_file" >>"$summary_md"
+}
+
+main() {
+    parse_args "$@"
+    validate_positive_integer "$TIMEOUT_SECONDS" "--timeout-seconds"
+
+    command -v "$DOTNET_CMD" >/dev/null 2>&1 || die "dotnet command not found: $DOTNET_CMD"
+
+    discover_projects
+    [ "${#PROJECTS[@]}" -gt 0 ] || die "No source package projects found"
+
+    mkdir -p "$OUTPUT_DIR/logs"
+
+    local -r summary_file="$OUTPUT_DIR/summary.tsv"
+    local -r summary_md="$OUTPUT_DIR/summary.md"
+    local project
+    local log_file
+    local status
+    local result
+    local failures=0
+
+    write_summary_header "$summary_file" "$summary_md"
+
+    for project in "${PROJECTS[@]}"; do
+        [ -f "$project" ] || die "Project not found: $project"
+
+        log_file="$OUTPUT_DIR/logs/$(safe_log_name "$project")"
+        printf 'Scanning %s\n' "$project"
+
+        if run_with_timeout "$TIMEOUT_SECONDS" "$log_file" "$DOTNET_CMD" list "$project" package --vulnerable --include-transitive --no-restore; then
+            status=0
+        else
+            status="$?"
+        fi
+
+        result="$(classify_log "$status" "$log_file")"
+        append_summary_row "$project" "$result" "$log_file" "$summary_file" "$summary_md"
+
+        if [ "$result" != "clean" ]; then
+            failures=$((failures + 1))
+        fi
+    done
+
+    printf '\nWrote %s and %s\n' "$summary_file" "$summary_md"
+
+    if [ "$failures" -gt 0 ]; then
+        printf '%s: %s project(s) reported vulnerabilities, failed, or timed out.\n' "$SCRIPT_NAME" "$failures" >&2
+        return 1
+    fi
+}
+
+main "$@"

--- a/src/Headless.CommitCoordination.InMemory/README.md
+++ b/src/Headless.CommitCoordination.InMemory/README.md
@@ -2,12 +2,18 @@
 
 ## Problem Solved
 
-Provides an explicit in-process signal source for tests and owner-driven flows.
+Provides an explicit in-process signal source for tests, local development, and single-instance owner-driven flows.
 
 ## Key Features
 
 - `InMemoryCommitSignalSource`.
 - DI extension `AddInMemoryCommitCoordination()`.
+
+## Design Notes
+
+This package is process-local. It does not coordinate commit signals across app instances, machines, containers, or processes. Use it only when one process owns all commit observers, or when tests need a real signal source without an external coordinator.
+
+For multi-process or distributed commit coordination, use a durable/provider-backed coordination package instead of this in-memory implementation.
 
 ## Installation
 

--- a/src/Headless.DistributedLocks.InMemory/Headless.DistributedLocks.InMemory.csproj
+++ b/src/Headless.DistributedLocks.InMemory/Headless.DistributedLocks.InMemory.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>In-process (single-instance) implementation of the Headless distributed-lock abstractions. NOT for multi-process or distributed coordination.</Description>
-    <PackageTags>headless;distributed-locks;in-memory;in-process;testing</PackageTags>
+    <PackageTags>headless;distributed-locks;in-memory;in-process;testing;dotnet</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Headless.DistributedLocks.Core\Headless.DistributedLocks.Core.csproj" />


### PR DESCRIPTION
## Summary

NuGet package review follow-ups are now captured in-package and repeatable: the in-memory distributed-lock package advertises the shared `dotnet` tag, the in-memory commit-coordination README warns that it is process-local rather than distributed coordination, and NuGet advisory/security scanning now runs through one bounded per-project script with captured logs and summaries.

## Affected Packages

- `Headless.DistributedLocks.InMemory`
- `Headless.CommitCoordination.InMemory`
- Repo tooling: `make nuget-advisory-audit`, `make dependency-security-audit`, `scripts/audit-nuget-advisories.sh`

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation only
- [ ] Test only

## Validation

- [ ] `make build`
- [ ] `make format-check`
- [ ] `make test-unit`
- [x] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [ ] Added or updated tests for behavior changes
- [ ] Updated XML docs for public API changes
- [x] Updated package `README.md` files for public behavior/setup changes
- [ ] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
bash -n scripts/audit-nuget-advisories.sh
shellcheck scripts/audit-nuget-advisories.sh
git diff --check
./scripts/audit-nuget-advisories.sh --help
./scripts/audit-nuget-advisories.sh --timeout-seconds 30 --output-dir artifacts/dependency-audit/refactor-direct-both --project src/Headless.Checks/Headless.Checks.csproj --scan vulnerable --scan deprecated
make nuget-advisory-audit NUGET_ADVISORY_AUDIT_ARGS='--timeout-seconds 30 --output-dir artifacts/dependency-audit/refactor-nuget-advisories --project src/Headless.Checks/Headless.Checks.csproj --scan vulnerable --include-transitive'
make dependency-security-audit PROJECT=src/Headless.Checks/Headless.Checks.csproj DEPENDENCY_SECURITY_AUDIT_TIMEOUT=30
dotnet msbuild src/Headless.DistributedLocks.InMemory/Headless.DistributedLocks.InMemory.csproj -getProperty:PackageTags -nologo
dotnet pack src/Headless.DistributedLocks.InMemory/Headless.DistributedLocks.InMemory.csproj --configuration Release --no-restore --output /tmp/headless-package-quality-pack /p:GenerateSBOM=false -v:minimal -nologo
dotnet pack src/Headless.CommitCoordination.InMemory/Headless.CommitCoordination.InMemory.csproj --configuration Release --no-restore --output /tmp/headless-commitcoord-pack /p:GenerateSBOM=false -v:minimal -nologo
unzip -p /tmp/headless-package-quality-pack/Headless.DistributedLocks.InMemory.*.nupkg Headless.DistributedLocks.InMemory.nuspec | rg '<tags>|<readme>|<id>'
unzip -p /tmp/headless-commitcoord-pack/Headless.CommitCoordination.InMemory.*.nupkg README.md | rg -n 'Design Notes|process-local|multi-process|distributed commit coordination'
dotnet restore "headless-framework.slnx" -p:Configuration=Release
dotnet build "headless-framework.slnx" --configuration Release --no-restore -v:minimal -nologo /m:1
git push origin xshaheen/package-quality-audit-tools
```

The first push attempt hit an `MSB4166` child-node exit in the parallel pre-push build. After `dotnet build-server shutdown`, a sequential full Release build passed with 0 warnings and 0 errors, and a retry of the normal pre-push hook passed. After merging `origin/main`, restore was required for a new upstream test project before the hook build could run.

The new default all-src advisory sweep was not run end to end here; focused project runs validate timeout, log capture, multi-scan support, and summary generation without reintroducing the long-running full-solution review command.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
N/A
```

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This PR only changes NuGet metadata, package README content, and local/repo audit tooling; validation is covered by package inspection, focused script runs, and CI build checks.

## Release Notes

- `Headless.DistributedLocks.InMemory` package tags now include `dotnet`.
- `Headless.CommitCoordination.InMemory` README now clarifies that the in-memory provider is process-local and not distributed coordination.
- Maintainers can run `make nuget-advisory-audit` for bounded per-source-project NuGet vulnerability scans with captured logs and markdown/TSV summaries.
- Maintainers can run `make dependency-security-audit PROJECT=<path>` for the same bounded script path over vulnerable and deprecated package checks for one project.
