### PR TITLE
fix(jobs): harden execution ownership

### DIFF
--- a/docs/llms/jobs.md
+++ b/docs/llms/jobs.md
@@ -161,7 +161,7 @@ The first positional argument is the `functionName` string that must match the `
 
 Every claim of a job or cron-occurrence row stamps a pickup lease: `LockedUntil = now + SchedulerOptionsBuilder.LeaseDuration` (default 5 minutes). The deadline uses the injected `TimeProvider` (application clock), not the database server clock — this matches `Headless.Messaging` so the in-memory and EF providers share identical pickup semantics and fake clocks work in tests.
 
-**Sliding lease for running jobs (#316):** a running job renews its lease on the `LeaseRenewalInterval` cadence (defaults to `LeaseDuration / 3`; an explicit value must be positive and strictly less than `LeaseDuration`). On the EF storage path, renewals compare against the **database clock** (`now()`/`GETUTCDATE()`), not a node's local clock, so cross-node clock skew cannot reclaim a healthy renewing job. If a renewal affects zero rows (the row was reclaimed or its owner changed), or if the renewal cannot complete within the cadence (a hung store), the worker cancels that job's `CancellationToken` (cancel-on-loss).
+**Sliding lease for running jobs (#316):** before invoking user code, a job verifies that the current node still owns the row. A running job then renews its lease on the `LeaseRenewalInterval` cadence (defaults to `LeaseDuration / 3`; an explicit value must be positive and strictly less than `LeaseDuration`). On the EF storage path, renewals compare against the **database clock** (`now()`/`GETUTCDATE()`), not a node's local clock, so cross-node clock skew cannot reclaim a healthy renewing job. If a renewal affects zero rows (the row was reclaimed or its owner changed), or if the renewal cannot complete within the cadence (a hung store), the worker cancels that job's `CancellationToken` (cancel-on-loss). If the start-time check loses ownership, user code is not invoked and the row is left `InProgress` for stalled reclaim.
 
 Consequences:
 - `LeaseDuration` no longer needs to exceed the longest job runtime; a healthy long job keeps renewing.
@@ -305,8 +305,8 @@ Provides reliable background job scheduling with cron expressions, delayed execu
 
 - **`AddHeadlessJobs()`**: single DI entry point; registers managers, background services, and the in-memory persistence provider.
 - **Scheduler background service**: polls for due time jobs and cron occurrences on `FallbackIntervalChecker` cadence (default 30s); also driven by soft-notification signals for near-zero latency.
-- **Custom thread pool** (`JobsTaskScheduler`): bounded by `MaxConcurrency` (default `Environment.ProcessorCount`), with idle-worker timeout.
-- **Sliding lease renewal** (#316): running jobs extend `LockedUntil` on `LeaseRenewalInterval` cadence; cancel-on-loss if the renewal affects zero rows or errors.
+- **Custom thread pool** (`JobsTaskScheduler`): bounds active async executions by `MaxConcurrency` (default `Environment.ProcessorCount`), with idle-worker timeout.
+- **Sliding lease renewal** (#316): jobs verify ownership immediately before user code starts, then extend `LockedUntil` on `LeaseRenewalInterval` cadence; cancel-on-loss if renewal affects zero rows or errors.
 - **`DisableBackgroundServices()`**: suppresses background execution; only the managers are registered (useful for worker-side-only nodes and test projects).
 - **Seeder API**: `UseJobsSeeder(Func<ITimeJobManager<TTimeJob>, Task>)` and `UseJobsSeeder(Func<ICronJobManager<TCronJob>, Task>)` for startup data seeding; `IgnoreSeedDefinedCronJobs()` to skip auto-seeding of attribute-defined cron jobs.
 - **GZip request payloads**: `UseGZipCompression()` on `JobsOptionsBuilder` compresses serialized request bytes.
@@ -319,6 +319,8 @@ Provides reliable background job scheduling with cron expressions, delayed execu
 The pickup lease (`LockedUntil`) uses the injected `TimeProvider` (application clock) for the claim predicate, matching `Headless.Messaging`'s in-memory/SQL parity so fake clocks in tests stay honest. The EF operational store separately anchors lease comparison to the **database clock** for renewals — this is an intentional divergence: in-memory stays under the application clock (no DB), EF renewals use the DB clock to defeat cross-node skew on real clusters.
 
 `SchedulerOptionsBuilder.NodeId` is used as the row owner only on the in-memory single-process path (defaults to `Environment.MachineName`). On the durable path this value is overridden by `JobsOwnerIdentityAdapter` which reads the `node@incarnation` string from `Headless.Coordination`; `NodeId` becomes a pre-registration display fallback only.
+
+The scheduler only invokes handlers for rows whose `Queued` → `InProgress` write is still owned by the current node. The execution handler performs one more lease check before invoking user code; if ownership was lost, it leaves the row `InProgress` for stalled reclaim and skips the delegate.
 
 ### Installation
 
@@ -411,7 +413,7 @@ builder.Services.AddHeadlessJobs(options =>
 
 - Registers `ITimeJobManager<TimeJobEntity>` and `ICronJobManager<CronJobEntity>` as singletons.
 - Registers background hosted services: `JobsInitializationHostedService` (always), `JobsSchedulerBackgroundService`, `JobsFallbackBackgroundService`, and `JobsExecutionTaskHandler` (unless `DisableBackgroundServices()` is called).
-- Registers `JobsTaskScheduler` (custom thread pool bounded by `MaxConcurrency`).
+- Registers `JobsTaskScheduler` (custom thread pool bounded by active async `MaxConcurrency`).
 - Sets global `CronScheduleCache.TimeZoneInfo` and `JobsHelper` JSON/compression settings.
 
 ---

--- a/src/Headless.Jobs.Abstractions/Interfaces/IJobPersistenceProvider.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/IJobPersistenceProvider.cs
@@ -20,7 +20,12 @@ public interface IJobPersistenceProvider<TTimeJob, TCronJob>
     Task<TimeJobEntity[]> GetEarliestTimeJobsAsync(CancellationToken cancellationToken = default);
     Task<int> UpdateTimeJobAsync(JobExecutionState functionContext, CancellationToken cancellationToken = default);
     Task<byte[]> GetTimeJobRequestAsync(Guid id, CancellationToken cancellationToken = default);
-    Task UpdateTimeJobsWithUnifiedContextAsync(
+
+    /// <summary>
+    /// Applies <paramref name="functionContext"/> to still-owned time jobs and returns the IDs that were actually
+    /// stamped. Callers must execute only the returned IDs.
+    /// </summary>
+    Task<Guid[]> UpdateTimeJobsWithUnifiedContextAsync(
         Guid[] timeJobIds,
         JobExecutionState functionContext,
         CancellationToken cancellationToken = default
@@ -78,7 +83,12 @@ public interface IJobPersistenceProvider<TTimeJob, TCronJob>
     );
     Task ReleaseAcquiredCronJobOccurrencesAsync(Guid[] occurrenceIds, CancellationToken cancellationToken = default);
     Task<byte[]> GetCronJobOccurrenceRequestAsync(Guid jobId, CancellationToken cancellationToken = default);
-    Task UpdateCronJobOccurrencesWithUnifiedContextAsync(
+
+    /// <summary>
+    /// Applies <paramref name="functionContext"/> to still-owned cron occurrences and returns the IDs that were
+    /// actually stamped. Callers must execute only the returned IDs.
+    /// </summary>
+    Task<Guid[]> UpdateCronJobOccurrencesWithUnifiedContextAsync(
         Guid[] timeJobIds,
         JobExecutionState functionContext,
         CancellationToken cancellationToken = default

--- a/src/Headless.Jobs.Abstractions/Interfaces/Managers/IInternalJobManager.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/Managers/IInternalJobManager.cs
@@ -11,7 +11,10 @@ internal interface IInternalJobManager
         CancellationToken cancellationToken = default
     );
     Task ReleaseAcquiredResources(JobExecutionState[] context, CancellationToken cancellationToken = default);
-    Task SetTickersInProgress(JobExecutionState[] context, CancellationToken cancellationToken = default);
+    Task<JobExecutionState[]> SetTickersInProgress(
+        JobExecutionState[] context,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
     /// Writes the job's current status to the durable store, fenced on ownership + non-terminal status. Returns the

--- a/src/Headless.Jobs.Core/BackgroundServices/JobsFallbackBackgroundService.cs
+++ b/src/Headless.Jobs.Core/BackgroundServices/JobsFallbackBackgroundService.cs
@@ -4,6 +4,7 @@ using Headless.Jobs.Interfaces;
 using Headless.Jobs.Interfaces.Managers;
 using Headless.Jobs.JobsThreadPool;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Headless.Jobs.BackgroundServices;
@@ -14,7 +15,8 @@ internal sealed class JobsFallbackBackgroundService(
     JobsExecutionTaskHandler tickerExecutionTaskHandler,
     JobsTaskScheduler jobsTaskScheduler,
     IJobFunctionConcurrencyGate concurrencyGate,
-    TimeProvider timeProvider
+    TimeProvider timeProvider,
+    ILogger<JobsFallbackBackgroundService> logger
 ) : BackgroundService
 {
     private int _started;
@@ -136,10 +138,11 @@ internal sealed class JobsFallbackBackgroundService(
                 break;
             }
 #pragma warning disable ERP022 // Background service must continue running even if individual operations fail.
-            catch (Exception)
+            catch (Exception exception)
             {
                 // Swallow unexpected exceptions so they don't bubble up
                 // and stop the host; wait a bit before retrying.
+                logger.LogJobsFallbackTickFailed(exception, _fallbackJobPeriod);
                 await timeProvider.Delay(_fallbackJobPeriod, stoppingToken).ConfigureAwait(false);
             }
 #pragma warning restore ERP022
@@ -151,4 +154,18 @@ internal sealed class JobsFallbackBackgroundService(
         Interlocked.Exchange(ref _started, 0);
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
+}
+
+internal static partial class JobsFallbackBackgroundServiceLog
+{
+    [LoggerMessage(
+        EventId = 3200,
+        Level = LogLevel.Warning,
+        Message = "Jobs fallback tick failed; the service will retry after {FallbackPeriod}."
+    )]
+    public static partial void LogJobsFallbackTickFailed(
+        this ILogger logger,
+        Exception exception,
+        TimeSpan fallbackPeriod
+    );
 }

--- a/src/Headless.Jobs.Core/BackgroundServices/JobsSchedulerBackgroundService.cs
+++ b/src/Headless.Jobs.Core/BackgroundServices/JobsSchedulerBackgroundService.cs
@@ -122,11 +122,11 @@ internal sealed class JobsSchedulerBackgroundService : BackgroundService, IJobsH
         {
             if (_executionContext.Functions.Length != 0)
             {
-                await _internalJobsManager
+                var functionsToRun = await _internalJobsManager
                     .SetTickersInProgress(_executionContext.Functions, cancellationToken)
                     .ConfigureAwait(false);
 
-                foreach (var function in _executionContext.Functions.OrderBy(x => x.CachedPriority))
+                foreach (var function in functionsToRun.OrderBy(x => x.CachedPriority))
                 {
                     var semaphore = _concurrencyGate.GetSemaphoreOrNull(
                         function.FunctionName,

--- a/src/Headless.Jobs.Core/JobsExecutionTaskHandler.cs
+++ b/src/Headless.Jobs.Core/JobsExecutionTaskHandler.cs
@@ -156,6 +156,11 @@ internal sealed class JobsExecutionTaskHandler(
             await internalJobsManager.UpdateTickerAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
+        if (!await _VerifyLeaseBeforeExecutionAsync(context, cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
         var stopWatch = new Stopwatch();
         // CA2000: ownership is registered into JobsCancellationTokenManager and the CTS is disposed on every exit
         // path below (after StopRenewalAsync stops the renewal loop that references it).
@@ -536,6 +541,31 @@ internal sealed class JobsExecutionTaskHandler(
         }
     }
 
+    private async Task<bool> _VerifyLeaseBeforeExecutionAsync(
+        JobExecutionState context,
+        CancellationToken cancellationToken
+    )
+    {
+        var outcome = await _TryRenewLeaseAsync(context, cancellationToken).ConfigureAwait(false);
+
+        if (outcome is RenewalOutcome.Held)
+        {
+            return true;
+        }
+
+        if (outcome is RenewalOutcome.MembershipUnknown)
+        {
+            logger.LogJobStartLeaseVerificationSkippedMembershipUnknown(context.JobId, context.FunctionName);
+
+            return true;
+        }
+
+        context.LeaseLost = true;
+        logger.LogJobLeaseLostBeforeExecution(context.JobId, context.FunctionName);
+
+        return false;
+    }
+
     private async Task<bool> _WaitForRetry(
         JobExecutionState context,
         int attempt,
@@ -710,4 +740,24 @@ internal static partial class JobsExecutionTaskHandlerLog
             + "show a terminal failure that did not actually occur; reconcile before re-triggering (#462)."
     )]
     public static partial void LogJobCompletionFencedAfterSuccess(this ILogger logger, Guid jobId, string function);
+
+    [LoggerMessage(
+        EventId = 3105,
+        Level = LogLevel.Warning,
+        Message = "Job {JobId} ({Function}) lost ownership before execution started; user code was not invoked and "
+            + "the row is left InProgress for the stalled-reclaim sweep to recover per OnNodeDeath."
+    )]
+    public static partial void LogJobLeaseLostBeforeExecution(this ILogger logger, Guid jobId, string function);
+
+    [LoggerMessage(
+        EventId = 3106,
+        Level = LogLevel.Debug,
+        Message = "Start lease verification for job {JobId} ({Function}) skipped: coordination membership is not "
+            + "currently established. The job will start and the renewal loop will keep checking membership."
+    )]
+    public static partial void LogJobStartLeaseVerificationSkippedMembershipUnknown(
+        this ILogger logger,
+        Guid jobId,
+        string function
+    );
 }

--- a/src/Headless.Jobs.Core/JobsThreadPool/JobsTaskScheduler.cs
+++ b/src/Headless.Jobs.Core/JobsThreadPool/JobsTaskScheduler.cs
@@ -23,6 +23,7 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
 
     // Global state
     private volatile int _totalQueuedTasks;
+    private volatile int _activeTasks;
     private volatile int _activeWorkers;
     private volatile bool _disposed;
     private volatile bool _isFrozen;
@@ -92,26 +93,25 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
         if (priority == JobPriority.LongRunning)
         {
             // Bypass pool for long-running tasks
-            _ = Task
-                .Factory.StartNew(
-                    async () =>
-                    {
-                        try
-                        {
-                            await work(cancellationToken).ConfigureAwait(false);
-                        }
-#pragma warning disable ERP022 // Scheduler must continue running even if task execution throws.
-                        catch
-                        {
-                            /* swallow */
-                        }
-#pragma warning restore ERP022
-                    },
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default
-                )
-                .Unwrap();
+            Interlocked.Increment(ref _activeTasks);
+
+            try
+            {
+                _ = Task
+                    .Factory.StartNew(
+                        () => _ExecuteLongRunningWorkAsync(work, cancellationToken),
+                        CancellationToken.None,
+                        TaskCreationOptions.LongRunning,
+                        TaskScheduler.Default
+                    )
+                    .Unwrap();
+            }
+            catch
+            {
+                Interlocked.Decrement(ref _activeTasks);
+                throw;
+            }
+
             return;
         }
 
@@ -358,7 +358,8 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
 
     private async Task _ExecuteWorkAsync(WorkItem workItem)
     {
-        // Decrement immediately after dequeue to keep counter in sync
+        // Move the item from queued to active without exposing a false-idle gap to drains.
+        Interlocked.Increment(ref _activeTasks);
         Interlocked.Decrement(ref _totalQueuedTasks);
 
         try
@@ -366,8 +367,6 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
             // Check cancellation before executing
             if (!workItem.UserToken.IsCancellationRequested && !_shutdownCts.Token.IsCancellationRequested)
             {
-                // Start the work without awaiting it so this worker
-                // can continue processing other items while the task awaits.
                 var task = workItem.Work(workItem.UserToken);
 
                 if (task == null)
@@ -375,47 +374,7 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
                     return;
                 }
 
-                if (!task.IsCompleted)
-                {
-                    // Observe completion and exceptions without blocking the worker loop
-                    _ = task.ContinueWith(
-                        t =>
-                        {
-                            try
-                            {
-                                if (t.IsFaulted)
-                                {
-                                    _ = t.Exception;
-                                }
-                            }
-                            // ERP022: Worker thread must continue running.
-#pragma warning disable ERP022
-                            catch
-                            {
-                                // Swallow continuation exceptions
-                            }
-#pragma warning restore ERP022
-                        },
-                        CancellationToken.None,
-                        TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default
-                    );
-                }
-                else
-                {
-                    // Task already completed synchronously – observe any exception
-                    try
-                    {
-                        await task.ConfigureAwait(false);
-                    }
-                    // ERP022: Worker thread must continue running.
-#pragma warning disable ERP022
-                    catch
-                    {
-                        // Swallow exceptions to keep worker alive
-                    }
-#pragma warning restore ERP022
-                }
+                await task.ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -430,6 +389,39 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
             // Errors are swallowed to prevent worker thread crashes
         }
 #pragma warning restore ERP022, RCS1075
+        finally
+        {
+            Interlocked.Decrement(ref _activeTasks);
+        }
+    }
+
+    private async Task _ExecuteLongRunningWorkAsync(
+        Func<CancellationToken, Task> work,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            if (!cancellationToken.IsCancellationRequested && !_shutdownCts.Token.IsCancellationRequested)
+            {
+                await work(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected - task was cancelled
+        }
+        // ERP022/RCS1075: Scheduler must continue running even if task execution throws.
+#pragma warning disable ERP022, RCS1075
+        catch (Exception)
+        {
+            // Errors are swallowed to prevent worker thread crashes.
+        }
+#pragma warning restore ERP022, RCS1075
+        finally
+        {
+            Interlocked.Decrement(ref _activeTasks);
+        }
     }
 
     /// <summary>
@@ -500,6 +492,11 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
     public int TotalQueuedTasks => _totalQueuedTasks;
 
     /// <summary>
+    /// Gets the current number of active task executions.
+    /// </summary>
+    public int ActiveTasks => _activeTasks;
+
+    /// <summary>
     /// Gets whether the scheduler has been disposed.
     /// </summary>
     public bool IsDisposed => _disposed;
@@ -516,6 +513,7 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
             $"Status: {(_isFrozen ? "FROZEN" : (_disposed ? "DISPOSED" : "ACTIVE"))}\n"
         );
         builder.Append(CultureInfo.InvariantCulture, $"Workers: {_activeWorkers}/{_maxConcurrency}\n");
+        builder.Append(CultureInfo.InvariantCulture, $"Active Tasks: {_activeTasks}\n");
         builder.Append(CultureInfo.InvariantCulture, $"Total Queued (counter): {_totalQueuedTasks}\n\n");
         builder.Append("Queue Distribution:\n");
 
@@ -558,7 +556,7 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
     {
         var deadline = timeout.HasValue ? _timeProvider.GetUtcNow().UtcDateTime.Add(timeout.Value) : DateTime.MaxValue;
 
-        while (_totalQueuedTasks > 0 || _activeWorkers > 0)
+        while (_totalQueuedTasks > 0 || _activeTasks > 0)
         {
             if (_timeProvider.GetUtcNow().UtcDateTime > deadline)
             {
@@ -582,9 +580,9 @@ public sealed class JobsTaskScheduler : IAsyncDisposable
         _isFrozen = true; // Prevent new tasks
         await _shutdownCts.CancelAsync().ConfigureAwait(false);
 
-        // Wait for workers to exit gracefully
+        // Wait for workers and in-flight work to exit gracefully
         var timeout = _timeProvider.GetUtcNow().UtcDateTime.AddSeconds(5);
-        while (_activeWorkers > 0 && _timeProvider.GetUtcNow().UtcDateTime < timeout)
+        while ((_activeWorkers > 0 || _activeTasks > 0) && _timeProvider.GetUtcNow().UtcDateTime < timeout)
         {
             await _timeProvider.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None).ConfigureAwait(false);
         }

--- a/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
@@ -364,7 +364,10 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
         return (min.Value, finalWinners);
     }
 
-    public async Task SetTickersInProgress(JobExecutionState[] resources, CancellationToken cancellationToken = default)
+    public async Task<JobExecutionState[]> SetTickersInProgress(
+        JobExecutionState[] resources,
+        CancellationToken cancellationToken = default
+    )
     {
         var unifiedFunctionContext = new JobExecutionState { FunctionName = string.Empty }.SetProperty(
             x => x.Status,
@@ -373,6 +376,9 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
 
         var cronJobIds = resources.Where(x => x.Type == JobType.CronJobOccurrence).Select(x => x.JobId).ToArray();
         var timeJobIds = resources.Where(x => x.Type == JobType.TimeJob).Select(x => x.JobId).ToArray();
+
+        Guid[] stampedCronJobIds = [];
+        Guid[] stampedTimeJobIds = [];
 
         if (cronJobIds.Length != 0 && timeJobIds.Length != 0)
         {
@@ -387,12 +393,14 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
                 cancellationToken
             );
             await Task.WhenAll(updateCronJobOccurrencesTask, updateTimeJobsTask).ConfigureAwait(false);
+            stampedCronJobIds = await updateCronJobOccurrencesTask.ConfigureAwait(false);
+            stampedTimeJobIds = await updateTimeJobsTask.ConfigureAwait(false);
         }
         else
         {
             if (cronJobIds.Length != 0)
             {
-                await persistenceProvider
+                stampedCronJobIds = await persistenceProvider
                     .UpdateCronJobOccurrencesWithUnifiedContextAsync(
                         cronJobIds,
                         unifiedFunctionContext,
@@ -403,13 +411,23 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
 
             if (timeJobIds.Length != 0)
             {
-                await persistenceProvider
+                stampedTimeJobIds = await persistenceProvider
                     .UpdateTimeJobsWithUnifiedContextAsync(timeJobIds, unifiedFunctionContext, cancellationToken)
                     .ConfigureAwait(false);
             }
         }
 
-        foreach (var resource in resources)
+        var stampedCronJobIdSet = new HashSet<Guid>(stampedCronJobIds);
+        var stampedTimeJobIdSet = new HashSet<Guid>(stampedTimeJobIds);
+        var stampedResources = resources
+            .Where(resource =>
+                resource.Type == JobType.TimeJob
+                    ? stampedTimeJobIdSet.Contains(resource.JobId)
+                    : stampedCronJobIdSet.Contains(resource.JobId)
+            )
+            .ToArray();
+
+        foreach (var resource in stampedResources)
         {
             resource.Status = JobStatus.InProgress;
 
@@ -424,6 +442,8 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
                     .ConfigureAwait(false);
             }
         }
+
+        return stampedResources;
     }
 
     public async Task ReleaseAcquiredResources(
@@ -511,25 +531,68 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
         CancellationToken cancellationToken = default
     )
     {
+        var now = timeProvider.GetUtcNow().UtcDateTime;
         var unifiedFunctionContext = new JobExecutionState { FunctionName = string.Empty }
             .SetProperty(x => x.Status, JobStatus.Skipped)
-            .SetProperty(x => x.ExecutedAt, timeProvider.GetUtcNow().UtcDateTime)
+            .SetProperty(x => x.ExecutedAt, now)
             .SetProperty(x => x.ExceptionDetails, "Rule RunCondition did not match!");
 
-        if (resources.Length != 0)
+        var cronJobIds = resources.Where(x => x.Type == JobType.CronJobOccurrence).Select(x => x.JobId).ToArray();
+        var timeJobIds = resources.Where(x => x.Type == JobType.TimeJob).Select(x => x.JobId).ToArray();
+
+        Guid[] skippedCronJobIds = [];
+        Guid[] skippedTimeJobIds = [];
+
+        if (cronJobIds.Length != 0 && timeJobIds.Length != 0)
         {
-            await persistenceProvider
-                .UpdateTimeJobsWithUnifiedContextAsync(
-                    [.. resources.Select(x => x.JobId)],
-                    unifiedFunctionContext,
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
+            var updateCronJobOccurrencesTask = persistenceProvider.UpdateCronJobOccurrencesWithUnifiedContextAsync(
+                cronJobIds,
+                unifiedFunctionContext,
+                cancellationToken
+            );
+            var updateTimeJobsTask = persistenceProvider.UpdateTimeJobsWithUnifiedContextAsync(
+                timeJobIds,
+                unifiedFunctionContext,
+                cancellationToken
+            );
+            await Task.WhenAll(updateCronJobOccurrencesTask, updateTimeJobsTask).ConfigureAwait(false);
+            skippedCronJobIds = await updateCronJobOccurrencesTask.ConfigureAwait(false);
+            skippedTimeJobIds = await updateTimeJobsTask.ConfigureAwait(false);
+        }
+        else
+        {
+            if (cronJobIds.Length != 0)
+            {
+                skippedCronJobIds = await persistenceProvider
+                    .UpdateCronJobOccurrencesWithUnifiedContextAsync(
+                        cronJobIds,
+                        unifiedFunctionContext,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+            }
+
+            if (timeJobIds.Length != 0)
+            {
+                skippedTimeJobIds = await persistenceProvider
+                    .UpdateTimeJobsWithUnifiedContextAsync(timeJobIds, unifiedFunctionContext, cancellationToken)
+                    .ConfigureAwait(false);
+            }
         }
 
-        foreach (var resource in resources)
+        var skippedCronJobIdSet = new HashSet<Guid>(skippedCronJobIds);
+        var skippedTimeJobIdSet = new HashSet<Guid>(skippedTimeJobIds);
+        var skippedResources = resources
+            .Where(resource =>
+                resource.Type == JobType.TimeJob
+                    ? skippedTimeJobIdSet.Contains(resource.JobId)
+                    : skippedCronJobIdSet.Contains(resource.JobId)
+            )
+            .ToArray();
+
+        foreach (var resource in skippedResources)
         {
-            resource.ExecutedAt = timeProvider.GetUtcNow().UtcDateTime;
+            resource.ExecutedAt = now;
             resource.Status = JobStatus.Skipped;
             resource.ExceptionDetails = "Rule RunCondition did not match!";
             if (resource.Type == JobType.TimeJob)

--- a/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
+++ b/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
@@ -237,12 +237,14 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         return Task.FromResult(Array.Empty<byte>());
     }
 
-    public Task UpdateTimeJobsWithUnifiedContextAsync(
+    public Task<Guid[]> UpdateTimeJobsWithUnifiedContextAsync(
         Guid[] timeJobIds,
         JobExecutionState functionContext,
         CancellationToken cancellationToken = default
     )
     {
+        var updatedIds = new List<Guid>(timeJobIds.Length);
+
         foreach (var id in timeJobIds)
         {
             if (_timeJobs.TryGetValue(id, out var job))
@@ -258,11 +260,15 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
 
                 var updatedTicker = _CloneTicker(job);
                 _ApplyFunctionContextToTicker(updatedTicker, functionContext);
-                _timeJobs.TryUpdate(id, updatedTicker, job);
+
+                if (_timeJobs.TryUpdate(id, updatedTicker, job))
+                {
+                    updatedIds.Add(id);
+                }
             }
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(updatedIds.ToArray());
     }
 
     public Task<TimeJobEntity[]> AcquireImmediateTimeJobsAsync(
@@ -909,10 +915,10 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
     }
 
     // KTD7: cron-occurrence creation is intentionally NOT guarded by a coarse 'jobs.cron-occurrence-creation'
-    // distributed lock. Each occurrence is keyed by a deterministic id and inserted via TryAdd / updated via
-    // TryUpdate (the durable provider does the same with an id-keyed upsert), so concurrent creation converges on a
-    // single row — storage-level dedup is the correctness boundary. A coarse lock would add no correctness and only
-    // serialize independent ids. Revisit only if evidence shows storage dedup is insufficient (plan #267 follow-up).
+    // distributed lock. The durable provider deduplicates first creation by (ExecutionTime, CronJobId) and requeues
+    // existing occurrences by id; storage-level dedup is the correctness boundary. A coarse lock would add no
+    // correctness and only serialize independent occurrences. Revisit only if evidence shows storage dedup is
+    // insufficient (plan #267 follow-up).
     public async IAsyncEnumerable<CronJobOccurrenceEntity<TCronJob>> QueueCronJobOccurrencesAsync(
         (DateTime Key, JobManagerDispatchContext[] Items) cronJobOccurrences,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
@@ -1185,12 +1191,14 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         return Task.FromResult(Array.Empty<byte>());
     }
 
-    public Task UpdateCronJobOccurrencesWithUnifiedContextAsync(
+    public Task<Guid[]> UpdateCronJobOccurrencesWithUnifiedContextAsync(
         Guid[] timeJobIds,
         JobExecutionState functionContext,
         CancellationToken cancellationToken = default
     )
     {
+        var updatedIds = new List<Guid>(timeJobIds.Length);
+
         foreach (var id in timeJobIds)
         {
             if (_cronOccurrences.TryGetValue(id, out var occurrence))
@@ -1205,11 +1213,15 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
 
                 var updatedOccurrence = _CloneCronOccurrence(occurrence);
                 _ApplyFunctionContextToCronOccurrence(updatedOccurrence, functionContext);
-                _cronOccurrences.TryUpdate(id, updatedOccurrence, occurrence);
+
+                if (_cronOccurrences.TryUpdate(id, updatedOccurrence, occurrence))
+                {
+                    updatedIds.Add(id);
+                }
             }
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(updatedIds.ToArray());
     }
 
     public Task<int> ReleaseDeadNodeOccurrenceResourcesAsync(

--- a/src/Headless.Jobs.Core/README.md
+++ b/src/Headless.Jobs.Core/README.md
@@ -10,8 +10,8 @@ Provides reliable background job scheduling with cron expressions, delayed execu
 
 - **`AddHeadlessJobs()`**: single DI entry point; registers managers, background services, and the in-memory persistence provider.
 - **Scheduler background service**: polls for due time jobs and cron occurrences on `FallbackIntervalChecker` cadence (default 30s); also driven by soft-notification signals for near-zero latency.
-- **Custom thread pool** (`JobsTaskScheduler`): bounded by `MaxConcurrency` (default `Environment.ProcessorCount`), with idle-worker timeout.
-- **Sliding lease renewal** (#316): running jobs extend `LockedUntil` on `LeaseRenewalInterval` cadence; cancel-on-loss if the renewal affects zero rows or errors.
+- **Custom thread pool** (`JobsTaskScheduler`): bounds active async executions by `MaxConcurrency` (default `Environment.ProcessorCount`), with idle-worker timeout.
+- **Sliding lease renewal** (#316): jobs verify ownership immediately before user code starts, then extend `LockedUntil` on `LeaseRenewalInterval` cadence; cancel-on-loss if renewal affects zero rows or errors.
 - **`DisableBackgroundServices()`**: suppresses background execution; only the managers are registered (useful for enqueue-only nodes and test projects).
 - **Seeder API**: `UseJobsSeeder(...)` for startup data seeding; `IgnoreSeedDefinedCronJobs()` to skip auto-seeding of attribute-defined cron jobs.
 - **GZip request payloads**: `UseGZipCompression()` compresses serialized request bytes.
@@ -24,6 +24,8 @@ Provides reliable background job scheduling with cron expressions, delayed execu
 The pickup lease uses the injected `TimeProvider` (application clock) for the claim predicate, matching `Headless.Messaging`'s in-memory/SQL parity so fake clocks in tests stay honest. The EF operational store separately anchors lease comparisons to the **database clock** for renewals — an intentional divergence: in-memory has no DB, so it must use the application clock; EF uses the DB clock to defeat cross-node skew on real clusters.
 
 `SchedulerOptionsBuilder.NodeId` is used as the row owner only on the in-memory single-process path. On the durable path it is overridden by `JobsOwnerIdentityAdapter` (reads `node@incarnation` from `Headless.Coordination`); `NodeId` becomes a pre-registration display fallback only.
+
+The scheduler only invokes handlers for rows whose `Queued` → `InProgress` write is still owned by the current node. The execution handler performs one more lease check before invoking user code; if ownership was lost, it leaves the row `InProgress` for stalled reclaim and skips the delegate.
 
 There is no `app.UseJobs()` call — the scheduler starts automatically through the `IHostedService` registrations added by `AddHeadlessJobs`.
 
@@ -115,5 +117,5 @@ builder.Services.AddHeadlessJobs(options =>
 
 - Registers `ITimeJobManager<TimeJobEntity>` and `ICronJobManager<CronJobEntity>` as singletons.
 - Registers background hosted services: `JobsInitializationHostedService` (always), `JobsSchedulerBackgroundService`, `JobsFallbackBackgroundService`, and `JobsExecutionTaskHandler` (unless `DisableBackgroundServices()` is called).
-- Registers `JobsTaskScheduler` (custom thread pool bounded by `MaxConcurrency`).
+- Registers `JobsTaskScheduler` (custom thread pool bounded by active async `MaxConcurrency`).
 - Registers a scheduler-scoped cron schedule cache and sets `JobsHelper` JSON/compression settings.

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
@@ -242,7 +242,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
             .ConfigureAwait(false);
     }
 
-    public async Task UpdateTimeJobsWithUnifiedContextAsync(
+    public async Task<Guid[]> UpdateTimeJobsWithUnifiedContextAsync(
         Guid[] timeJobIds,
         JobExecutionState functionContext,
         CancellationToken cancellationToken = default
@@ -254,14 +254,14 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
         // InProgress stamp. (Cancel-on-loss + the completion fence neutralize the local job that already spun up.)
         if (!OwnerIdentity.TryGetStampOwner(out var owner))
         {
-            return;
+            return [];
         }
 
         await using var dbContext = await DbContextFactory
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        await dbContext
+        var affected = await dbContext
             .Set<TTimeJob>()
             .Where(x => ((IEnumerable<Guid>)timeJobIds).Contains(x.Id))
             .WhereOwnedBy(owner)
@@ -270,6 +270,24 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
                 cancellationToken
             )
             .ConfigureAwait(false);
+
+        if (affected == 0)
+        {
+            return [];
+        }
+
+        var updated = dbContext
+            .Set<TTimeJob>()
+            .AsNoTracking()
+            .Where(x => ((IEnumerable<Guid>)timeJobIds).Contains(x.Id))
+            .Where(x => x.OwnerId == owner);
+
+        if (functionContext.PropertiesToUpdate.Contains(nameof(JobExecutionState.Status)))
+        {
+            updated = updated.Where(x => x.Status == functionContext.Status);
+        }
+
+        return await updated.Select(x => x.Id).ToArrayAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<TimeJobEntity[]> GetEarliestTimeJobsAsync(CancellationToken cancellationToken)
@@ -1101,10 +1119,10 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
     }
 
     // KTD7: cron-occurrence creation is intentionally NOT guarded by a coarse 'jobs.cron-occurrence-creation'
-    // distributed lock. Each occurrence carries a deterministic id (NextCronOccurrence.Id) and is created via an
-    // upsert keyed on that id, so concurrent creation across nodes converges on a single row — storage-level dedup
-    // is the correctness boundary here. A coarse lock would only serialize independent occurrence ids for no benefit.
-    // Revisit only if evidence shows storage dedup is insufficient (see plan #267 deferred follow-up).
+    // distributed lock. First creation is deduplicated by (ExecutionTime, CronJobId); requeues of known occurrences
+    // update by id. Storage-level dedup is the correctness boundary here. A coarse lock would only serialize
+    // independent occurrences for no benefit. Revisit only if evidence shows storage dedup is insufficient (see plan
+    // #267 deferred follow-up).
     public async IAsyncEnumerable<CronJobOccurrenceEntity<TCronJob>> QueueCronJobOccurrencesAsync(
         (DateTime Key, JobManagerDispatchContext[] Items) cronJobOccurrences,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
@@ -1268,7 +1286,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
         return request ?? [];
     }
 
-    public async Task UpdateCronJobOccurrencesWithUnifiedContextAsync(
+    public async Task<Guid[]> UpdateCronJobOccurrencesWithUnifiedContextAsync(
         Guid[] cronOccurrenceIds,
         JobExecutionState functionContext,
         CancellationToken cancellationToken = default
@@ -1277,19 +1295,37 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
         // #316/U5 — cron mirror of UpdateTimeJobsWithUnifiedContextAsync: fence the claim→start stamp on WhereOwnedBy.
         if (!OwnerIdentity.TryGetStampOwner(out var owner))
         {
-            return;
+            return [];
         }
 
         await using var dbContext = await DbContextFactory
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        await dbContext
+        var affected = await dbContext
             .Set<CronJobOccurrenceEntity<TCronJob>>()
             .Where(x => ((IEnumerable<Guid>)cronOccurrenceIds).Contains(x.Id))
             .WhereOwnedBy(owner)
             .ExecuteUpdateAsync(setter => setter.UpdateCronJobOccurrence(functionContext), cancellationToken)
             .ConfigureAwait(false);
+
+        if (affected == 0)
+        {
+            return [];
+        }
+
+        var updated = dbContext
+            .Set<CronJobOccurrenceEntity<TCronJob>>()
+            .AsNoTracking()
+            .Where(x => ((IEnumerable<Guid>)cronOccurrenceIds).Contains(x.Id))
+            .Where(x => x.OwnerId == owner);
+
+        if (functionContext.PropertiesToUpdate.Contains(nameof(JobExecutionState.Status)))
+        {
+            updated = updated.Where(x => x.Status == functionContext.Status);
+        }
+
+        return await updated.Select(x => x.Id).ToArrayAsync(cancellationToken).ConfigureAwait(false);
     }
 
     #endregion

--- a/tests/Headless.Jobs.Tests.Unit/JobsTaskSchedulerTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/JobsTaskSchedulerTests.cs
@@ -9,6 +9,80 @@ namespace Tests;
 public sealed class JobsTaskSchedulerTests : TestBase
 {
     [Fact]
+    public async Task WaitForRunningTasksAsync_waits_for_active_async_work()
+    {
+        await using var scheduler = new JobsTaskScheduler(
+            maxConcurrency: 1,
+            idleWorkerTimeout: TimeSpan.FromMilliseconds(25)
+        );
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await scheduler.QueueAsync(
+            async _ =>
+            {
+                started.TrySetResult();
+                await release.Task.ConfigureAwait(false);
+            },
+            JobPriority.Normal,
+            AbortToken
+        );
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(10), AbortToken);
+
+        (await scheduler.WaitForRunningTasksAsync(TimeSpan.FromMilliseconds(50))).Should().BeFalse();
+
+        release.SetResult();
+
+        (await scheduler.WaitForRunningTasksAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+        scheduler.ActiveTasks.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task QueueAsync_counts_active_async_work_against_max_concurrency()
+    {
+        await using var scheduler = new JobsTaskScheduler(maxConcurrency: 2);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var twoStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startedCount = 0;
+        var activeCount = 0;
+        var maxObservedActive = 0;
+
+        for (var i = 0; i < 5; i++)
+        {
+            await scheduler.QueueAsync(
+                async _ =>
+                {
+                    var active = Interlocked.Increment(ref activeCount);
+                    _SetMaxObserved(ref maxObservedActive, active);
+
+                    if (Interlocked.Increment(ref startedCount) == 2)
+                    {
+                        twoStarted.TrySetResult();
+                    }
+
+                    await release.Task.ConfigureAwait(false);
+                    Interlocked.Decrement(ref activeCount);
+                },
+                JobPriority.Normal,
+                AbortToken
+            );
+        }
+
+        await twoStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), AbortToken);
+        await Task.Delay(100, AbortToken);
+
+        startedCount.Should().Be(2);
+        maxObservedActive.Should().BeLessThanOrEqualTo(2);
+
+        release.SetResult();
+
+        (await scheduler.WaitForRunningTasksAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+        startedCount.Should().Be(5);
+        maxObservedActive.Should().BeLessThanOrEqualTo(2);
+    }
+
+    [Fact]
     public async Task Dispose_while_worker_idles_in_backoff_completes_cleanly()
     {
         // A worker that finished its work parks in the idle backoff delay awaiting the shutdown
@@ -40,5 +114,18 @@ public sealed class JobsTaskSchedulerTests : TestBase
         finished.Should().Be(dispose);
         await dispose;
         scheduler.ActiveWorkers.Should().Be(0);
+    }
+
+    private static void _SetMaxObserved(ref int target, int value)
+    {
+        int current;
+
+        while (value > (current = Volatile.Read(ref target)))
+        {
+            if (Interlocked.CompareExchange(ref target, value, current) == current)
+            {
+                return;
+            }
+        }
     }
 }

--- a/tests/Headless.Jobs.Tests.Unit/Managers/InternalJobsManagerTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/Managers/InternalJobsManagerTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+using Headless.Jobs.Interfaces;
+using Headless.Jobs.Managers;
+using Headless.Jobs.Models;
+using Headless.Testing.Tests;
+
+namespace Tests.Managers;
+
+public sealed class InternalJobsManagerTests : TestBase
+{
+    public sealed class FakeTimeJob : TimeJobEntity<FakeTimeJob>;
+
+    public sealed class FakeCronJob : CronJobEntity;
+
+    [Fact]
+    public async Task SetTickersInProgress_returns_and_notifies_only_rows_stamped_by_provider()
+    {
+        var provider = Substitute.For<IJobPersistenceProvider<FakeTimeJob, FakeCronJob>>();
+        var sender = Substitute.For<IJobsNotificationHubSender>();
+        var manager = new InternalJobsManager<FakeTimeJob, FakeCronJob>(
+            provider,
+            TimeProvider.System,
+            sender,
+            new CronScheduleCache(TimeZoneInfo.Utc)
+        );
+
+        var owned = new JobExecutionState
+        {
+            JobId = Guid.NewGuid(),
+            FunctionName = "owned",
+            Type = JobType.TimeJob,
+            Status = JobStatus.Queued,
+        };
+        var lost = new JobExecutionState
+        {
+            JobId = Guid.NewGuid(),
+            FunctionName = "lost",
+            Type = JobType.TimeJob,
+            Status = JobStatus.Queued,
+        };
+
+        provider
+            .UpdateTimeJobsWithUnifiedContextAsync(Arg.Any<Guid[]>(), Arg.Any<JobExecutionState>(), AbortToken)
+            .Returns(Task.FromResult<Guid[]>([owned.JobId]));
+        sender.UpdateTimeJobFromExecutionState<FakeTimeJob>(Arg.Any<JobExecutionState>()).Returns(Task.CompletedTask);
+
+        var stamped = await manager.SetTickersInProgress([owned, lost], AbortToken);
+
+        stamped.Should().Equal(owned);
+        owned.Status.Should().Be(JobStatus.InProgress);
+        lost.Status.Should().Be(JobStatus.Queued);
+        await sender.Received(1).UpdateTimeJobFromExecutionState<FakeTimeJob>(owned);
+        await sender.DidNotReceive().UpdateTimeJobFromExecutionState<FakeTimeJob>(lost);
+    }
+}

--- a/tests/Headless.Jobs.Tests.Unit/Provider/SlidingLeaseProviderTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/Provider/SlidingLeaseProviderTests.cs
@@ -255,8 +255,9 @@ public sealed class SlidingLeaseProviderTests : TestBase
         await provider.AddTimeJobsAsync([job], AbortToken);
 
         var unified = new JobExecutionState { FunctionName = "fn" }.SetProperty(x => x.Status, JobStatus.InProgress);
-        await provider.UpdateTimeJobsWithUnifiedContextAsync([job.Id], unified, AbortToken);
+        var stampedIds = await provider.UpdateTimeJobsWithUnifiedContextAsync([job.Id], unified, AbortToken);
 
+        stampedIds.Should().BeEmpty();
         var row = await provider.GetTimeJobByIdAsync(job.Id, AbortToken);
         row!.Status.Should().Be(JobStatus.Queued); // untouched — still NodeB's
         row.OwnerId.Should().Be(_NodeB);
@@ -270,8 +271,9 @@ public sealed class SlidingLeaseProviderTests : TestBase
         await provider.AddTimeJobsAsync([job], AbortToken);
 
         var unified = new JobExecutionState { FunctionName = "fn" }.SetProperty(x => x.Status, JobStatus.InProgress);
-        await provider.UpdateTimeJobsWithUnifiedContextAsync([job.Id], unified, AbortToken);
+        var stampedIds = await provider.UpdateTimeJobsWithUnifiedContextAsync([job.Id], unified, AbortToken);
 
+        stampedIds.Should().Equal(job.Id);
         (await provider.GetTimeJobByIdAsync(job.Id, AbortToken))!.Status.Should().Be(JobStatus.InProgress);
     }
 

--- a/tests/Headless.Jobs.Tests.Unit/RetryBehaviorTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/RetryBehaviorTests.cs
@@ -90,10 +90,16 @@ public sealed class RetryBehaviorTests : TestBase
         services.AddSingleton(instrumentation);
         var serviceProvider = services.BuildServiceProvider();
 
-        // Renewal fires fast (100 ms cadence) and throws on the first attempt, simulating a DB outage mid-job.
+        // The first renewal proves ownership at start; the next renewal throws, simulating a DB outage mid-job.
+        var renewalCalls = 0;
         internalManager
             .RenewLeaseAsync(Arg.Any<JobExecutionState>(), Arg.Any<CancellationToken>())
-            .Returns(_ => Task.FromException<int>(new TimeoutException("simulated DB outage")));
+            .Returns(_ =>
+            {
+                return Interlocked.Increment(ref renewalCalls) == 1
+                    ? Task.FromResult(1)
+                    : Task.FromException<int>(new TimeoutException("simulated DB outage"));
+            });
 
         var handler = new JobsExecutionTaskHandler(
             serviceProvider,
@@ -128,6 +134,7 @@ public sealed class RetryBehaviorTests : TestBase
         // stalled-reclaim/OnNodeDeath sweep. So the job stops, LeaseLost is flagged, and no UpdateTicker write fires.
         context.LeaseLost.Should().BeTrue();
         context.Status.Should().NotBe(JobStatus.Cancelled);
+        renewalCalls.Should().BeGreaterThanOrEqualTo(2);
         await internalManager
             .DidNotReceive()
             .UpdateTickerAsync(Arg.Any<JobExecutionState>(), Arg.Any<CancellationToken>());
@@ -146,10 +153,21 @@ public sealed class RetryBehaviorTests : TestBase
         services.AddSingleton(instrumentation);
         var serviceProvider = services.BuildServiceProvider();
 
-        // Renewal hangs until its (linked timeout) token cancels — i.e. it never completes within the cadence.
+        // The first renewal proves ownership at start; the next renewal hangs until its linked timeout token cancels.
+        var renewalCalls = 0;
         internalManager
             .RenewLeaseAsync(Arg.Any<JobExecutionState>(), Arg.Any<CancellationToken>())
-            .Returns(async call => await Task.Delay(Timeout.Infinite, call.Arg<CancellationToken>()));
+            .Returns(async call =>
+            {
+                if (Interlocked.Increment(ref renewalCalls) == 1)
+                {
+                    return 1;
+                }
+
+                await Task.Delay(Timeout.Infinite, call.Arg<CancellationToken>());
+
+                return 1;
+            });
 
         var handler = new JobsExecutionTaskHandler(
             serviceProvider,
@@ -180,6 +198,61 @@ public sealed class RetryBehaviorTests : TestBase
         await handler.ExecuteTaskAsync(context, isDue: true, cancellationToken: AbortToken);
 
         context.LeaseLost.Should().BeTrue();
+        renewalCalls.Should().BeGreaterThanOrEqualTo(2);
+        await internalManager
+            .DidNotReceive()
+            .UpdateTickerAsync(Arg.Any<JobExecutionState>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteTaskAsync_does_not_invoke_delegate_when_start_lease_check_loses_ownership()
+    {
+        var services = new ServiceCollection();
+        var internalManager = Substitute.For<IInternalJobManager>();
+        var instrumentation = Substitute.For<IJobsInstrumentation>();
+        services.AddSingleton(internalManager);
+        services.AddSingleton(instrumentation);
+        var serviceProvider = services.BuildServiceProvider();
+
+        internalManager
+            .RenewLeaseAsync(Arg.Any<JobExecutionState>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(0));
+
+        var logger = new CapturingLogger<JobsExecutionTaskHandler>();
+        var handler = new JobsExecutionTaskHandler(
+            serviceProvider,
+            TimeProvider.System,
+            instrumentation,
+            internalManager,
+            new SchedulerOptionsBuilder(),
+            logger
+        );
+
+        var invoked = false;
+        var context = new JobExecutionState
+        {
+            JobId = Guid.NewGuid(),
+            FunctionName = "LostBeforeStart",
+            Type = JobType.CronJobOccurrence,
+            ExecutionTime = DateTime.UtcNow,
+            RetryIntervals = [0],
+            Retries = 0,
+            RetryCount = 0,
+            Status = JobStatus.Idle,
+            CachedDelegate = (_, _, _) =>
+            {
+                invoked = true;
+
+                return Task.CompletedTask;
+            },
+        };
+
+        await handler.ExecuteTaskAsync(context, isDue: true, cancellationToken: AbortToken);
+
+        invoked.Should().BeFalse();
+        context.LeaseLost.Should().BeTrue();
+        context.Status.Should().Be(JobStatus.InProgress);
+        logger.Entries.Should().Contain(e => e.EventId == 3105);
         await internalManager
             .DidNotReceive()
             .UpdateTickerAsync(Arg.Any<JobExecutionState>(), Arg.Any<CancellationToken>());


### PR DESCRIPTION
## Summary

Jobs execution now stays fenced to rows the current node still owns. The scheduler counts active async executions against `MaxConcurrency`, drains only when queued and active work are done, and only queues handlers for rows whose `Queued` to `InProgress` write actually succeeded. The execution handler also verifies the lease immediately before invoking user code, so a row that lost ownership before start is left for stalled reclaim instead of running a duplicate delegate.

Fallback loop failures are now logged, and the cron occurrence comments/docs now describe the actual storage-level dedup boundary.

## Affected Packages

- `Headless.Jobs.Abstractions`
- `Headless.Jobs.Core`
- `Headless.Jobs.EntityFramework`
- Jobs docs and unit tests

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Test only

## Validation

- [ ] `make build`
- [ ] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [x] Added or updated tests for behavior changes
- [x] Updated XML docs for public API changes
- [x] Updated package `README.md` files for public behavior/setup changes
- [x] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
git diff --check
make build-project PROJECT=src/Headless.Jobs.Core/Headless.Jobs.Core.csproj
make build-project PROJECT=src/Headless.Jobs.EntityFramework/Headless.Jobs.EntityFramework.csproj
MSBUILDDISABLENODEREUSE=1 dotnet test --project "tests/Headless.Jobs.Tests.Unit/Headless.Jobs.Tests.Unit.csproj" --configuration "Release" --results-directory "artifacts/test-results" --no-progress
make build-project PROJECT=tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj
make build-project PROJECT=tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj
pre-push hook: changed-file CSharpier check + dotnet build "headless-framework.slnx" --configuration "Release" --no-restore -v:q -nologo /clp:ErrorsOnly

Not run: DB-backed integration test execution; PostgreSQL and SQL Server jobs integration projects were build-validated only.
```

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
Custom IJobPersistenceProvider implementations must update UpdateTimeJobsWithUnifiedContextAsync and UpdateCronJobOccurrencesWithUnifiedContextAsync to return the IDs actually stamped by the still-owned unified update. The built-in in-memory and EF providers now return those IDs; scheduler execution depends on this contract to avoid invoking handlers for rows whose ownership fence rejected the start write.
```

## Release Notes

Jobs execution ownership is now rechecked at start, active async work is counted against scheduler concurrency/drain, and custom job persistence providers must return the IDs stamped by unified start/skip updates.
