### PR TITLE
fix: harden redis messaging recovery

### DIFF
--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -976,6 +976,13 @@ internal sealed class ConsumerRegister(
                 catch (Exception ex)
                 {
                     Logger.LogPauseNewlyAddedClientFailed(ex, GroupName);
+                    lock (_clientsLock)
+                    {
+                        _clients.Remove(client);
+                    }
+
+                    await client.DisposeAsync().ConfigureAwait(false);
+                    throw;
                 }
             }
         }

--- a/src/Headless.Messaging.Redis/IRedisStreamManager.cs
+++ b/src/Headless.Messaging.Redis/IRedisStreamManager.cs
@@ -14,19 +14,40 @@ internal interface IRedisStreamManager
 
     Task PublishAsync(string stream, NameValueEntry[] message, CancellationToken cancellationToken = default);
 
-    IAsyncEnumerable<IEnumerable<RedisStream>> PollStreamsLatestMessagesAsync(
+    IAsyncEnumerable<IEnumerable<RedisStreamMessages>> PollStreamsLatestMessagesAsync(
         string[] streams,
         string consumerGroup,
+        string consumerName,
         TimeSpan pollDelay,
         CancellationToken token
     );
 
-    IAsyncEnumerable<IEnumerable<RedisStream>> PollStreamsPendingMessagesAsync(
+    IAsyncEnumerable<IEnumerable<RedisStreamMessages>> PollStreamsPendingMessagesAsync(
         string[] streams,
         string consumerGroup,
+        string consumerName,
+        TimeSpan pollDelay,
+        CancellationToken token
+    );
+
+    IAsyncEnumerable<IEnumerable<RedisStreamMessages>> PollStreamsStalePendingMessagesAsync(
+        string[] streams,
+        string consumerGroup,
+        string consumerName,
+        TimeSpan claimMinIdleTime,
         TimeSpan pollDelay,
         CancellationToken token
     );
 
     Task Ack(string stream, string consumerGroup, string messageId, CancellationToken cancellationToken = default);
+
+    Task RequeueAndAck(
+        string stream,
+        string consumerGroup,
+        string messageId,
+        NameValueEntry[] entries,
+        CancellationToken cancellationToken = default
+    );
 }
+
+internal readonly record struct RedisStreamMessages(RedisKey Key, StreamEntry[] Entries);

--- a/src/Headless.Messaging.Redis/IRedisStreamManagerDefault.cs
+++ b/src/Headless.Messaging.Redis/IRedisStreamManagerDefault.cs
@@ -44,9 +44,10 @@ internal sealed class RedisStreamManager(
         await _redis!.GetDatabase().StreamAddAsync(stream, message).ConfigureAwait(false);
     }
 
-    public async IAsyncEnumerable<IEnumerable<RedisStream>> PollStreamsLatestMessagesAsync(
+    public async IAsyncEnumerable<IEnumerable<RedisStreamMessages>> PollStreamsLatestMessagesAsync(
         string[] streams,
         string consumerGroup,
+        string consumerName,
         TimeSpan pollDelay,
         [EnumeratorCancellation] CancellationToken token
     )
@@ -59,7 +60,7 @@ internal sealed class RedisStreamManager(
 
         while (true)
         {
-            var (succeeded, result) = await _TryReadConsumerGroupAsync(consumerGroup, positions, token)
+            var (succeeded, result) = await _TryReadConsumerGroupAsync(consumerGroup, consumerName, positions, token)
                 .ConfigureAwait(false);
 
             yield return result;
@@ -80,9 +81,10 @@ internal sealed class RedisStreamManager(
         // ReSharper disable once IteratorNeverReturns
     }
 
-    public async IAsyncEnumerable<IEnumerable<RedisStream>> PollStreamsPendingMessagesAsync(
+    public async IAsyncEnumerable<IEnumerable<RedisStreamMessages>> PollStreamsPendingMessagesAsync(
         string[] streams,
         string consumerGroup,
+        string consumerName,
         TimeSpan pollDelay,
         [EnumeratorCancellation] CancellationToken token
     )
@@ -98,7 +100,7 @@ internal sealed class RedisStreamManager(
             // Materialize the lazy SelectMany result once: it is both yielded to the consumer and
             // re-inspected by the All() check below, so leaving it deferred would flatten it twice.
             var result = (
-                await _TryReadConsumerGroupAsync(consumerGroup, positions, token).ConfigureAwait(false)
+                await _TryReadConsumerGroupAsync(consumerGroup, consumerName, positions, token).ConfigureAwait(false)
             ).Streams.ToArray();
 
             yield return result;
@@ -113,6 +115,49 @@ internal sealed class RedisStreamManager(
         }
     }
 
+    public async IAsyncEnumerable<IEnumerable<RedisStreamMessages>> PollStreamsStalePendingMessagesAsync(
+        string[] streams,
+        string consumerGroup,
+        string consumerName,
+        TimeSpan claimMinIdleTime,
+        TimeSpan pollDelay,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        var positions = streams.Select(stream => new StreamPosition(stream, StreamPosition.Beginning)).ToArray();
+        var nextStartIds = streams.ToDictionary(stream => (RedisKey)stream, _ => (RedisValue)StreamPosition.Beginning);
+        var errorDelay = pollDelay;
+
+        while (true)
+        {
+            var (succeeded, result) = await _TryAutoClaimStalePendingAsync(
+                    consumerGroup,
+                    consumerName,
+                    positions,
+                    nextStartIds,
+                    claimMinIdleTime,
+                    _options.StreamEntriesCount,
+                    token
+                )
+                .ConfigureAwait(false);
+
+            yield return result;
+
+            if (succeeded)
+            {
+                errorDelay = pollDelay;
+                await _timeProvider.Delay(pollDelay, token).ConfigureAwait(false);
+            }
+            else
+            {
+                errorDelay = _NextBackoff(errorDelay);
+                await _timeProvider.Delay(errorDelay, token).ConfigureAwait(false);
+            }
+        }
+
+        // ReSharper disable once IteratorNeverReturns
+    }
+
     public async Task Ack(
         string stream,
         string consumerGroup,
@@ -125,8 +170,27 @@ internal sealed class RedisStreamManager(
         await _redis!.GetDatabase().StreamAcknowledgeAsync(stream, consumerGroup, messageId).ConfigureAwait(false);
     }
 
-    private async Task<(bool Succeeded, IEnumerable<RedisStream> Streams)> _TryReadConsumerGroupAsync(
+    public async Task RequeueAndAck(
+        string stream,
         string consumerGroup,
+        string messageId,
+        NameValueEntry[] entries,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await _ConnectAsync(cancellationToken).ConfigureAwait(false);
+
+        var database = _redis!.GetDatabase();
+
+        // Preserve at-least-once semantics: if requeue succeeds and ack fails, Redis may redeliver
+        // both entries; if requeue fails, the original entry remains pending for stale-claim recovery.
+        await database.StreamAddAsync(stream, entries).ConfigureAwait(false);
+        await database.StreamAcknowledgeAsync(stream, consumerGroup, messageId).ConfigureAwait(false);
+    }
+
+    private async Task<(bool Succeeded, IEnumerable<RedisStreamMessages> Streams)> _TryReadConsumerGroupAsync(
+        string consumerGroup,
+        string consumerName,
         StreamPosition[] positions,
         CancellationToken token
     )
@@ -160,12 +224,23 @@ internal sealed class RedisStreamManager(
             var groupedPositions = createdPositions
                 .GroupBy(s => _redis.GetHashSlot(s.Key))
                 .Select(group =>
-                    database.StreamReadGroupAsync([.. group], consumerGroup, consumerGroup, _options.StreamEntriesCount)
+                    database.StreamReadGroupAsync(
+                        [.. group],
+                        consumerGroup,
+                        consumerName,
+                        _options.StreamEntriesCount,
+                        noAck: false
+                    )
                 );
 
             var readSet = await Task.WhenAll(groupedPositions).ConfigureAwait(false);
 
-            return (Succeeded: true, Streams: readSet.SelectMany(set => set));
+            return (
+                Succeeded: true,
+                Streams: readSet.SelectMany(set =>
+                    set.Select(stream => new RedisStreamMessages(stream.Key, stream.Entries))
+                )
+            );
         }
         catch (OperationCanceledException)
         {
@@ -178,6 +253,82 @@ internal sealed class RedisStreamManager(
         }
 
         return (Succeeded: false, Streams: []);
+    }
+
+    private async Task<(bool Succeeded, IEnumerable<RedisStreamMessages> Streams)> _TryAutoClaimStalePendingAsync(
+        string consumerGroup,
+        string consumerName,
+        StreamPosition[] positions,
+        Dictionary<RedisKey, RedisValue> nextStartIds,
+        TimeSpan claimMinIdleTime,
+        int count,
+        CancellationToken token
+    )
+    {
+        try
+        {
+            token.ThrowIfCancellationRequested();
+
+            List<RedisStreamMessages> streams = [];
+
+            await _ConnectAsync(token).ConfigureAwait(false);
+
+            var database = _redis!.GetDatabase();
+            var minIdleTimeMilliseconds = _ToRedisMilliseconds(claimMinIdleTime);
+
+            await foreach (
+                var position in database
+                    .TryGetOrCreateConsumerGroupPositionsAsync(positions, consumerGroup, logger)
+                    .ConfigureAwait(false)
+                    .WithCancellation(token)
+            )
+            {
+                if (!nextStartIds.TryGetValue(position.Key, out var startId))
+                {
+                    startId = StreamPosition.Beginning;
+                }
+
+                var result = await database
+                    .StreamAutoClaimAsync(
+                        position.Key,
+                        consumerGroup,
+                        consumerName,
+                        minIdleTimeMilliseconds,
+                        startId,
+                        count
+                    )
+                    .ConfigureAwait(false);
+
+                if (result.IsNull)
+                {
+                    continue;
+                }
+
+                nextStartIds[position.Key] = result.NextStartId;
+
+                if (result.ClaimedEntries.Length > 0)
+                {
+                    streams.Add(new RedisStreamMessages(position.Key, result.ClaimedEntries));
+                }
+            }
+
+            return (Succeeded: true, Streams: streams);
+        }
+        catch (OperationCanceledException)
+        {
+            return (Succeeded: true, Streams: []);
+        }
+        catch (Exception ex)
+        {
+            logger.LogAutoClaimConsumerGroupFailed(ex, consumerGroup);
+        }
+
+        return (Succeeded: false, Streams: []);
+    }
+
+    private static long _ToRedisMilliseconds(TimeSpan value)
+    {
+        return Math.Max(1, (long)Math.Ceiling(value.TotalMilliseconds));
     }
 
     private static TimeSpan _NextBackoff(TimeSpan current)
@@ -207,6 +358,18 @@ internal static partial class RedisStreamManagerLog
         Message = "Redis error when trying read consumer group {ConsumerGroup}"
     )]
     public static partial void LogReadConsumerGroupFailed(
+        this ILogger logger,
+        Exception exception,
+        string consumerGroup
+    );
+
+    [LoggerMessage(
+        EventId = 2,
+        EventName = "AutoClaimConsumerGroupFailed",
+        Level = LogLevel.Error,
+        Message = "Redis error when trying to auto-claim pending messages for consumer group {ConsumerGroup}"
+    )]
+    public static partial void LogAutoClaimConsumerGroupFailed(
         this ILogger logger,
         Exception exception,
         string consumerGroup

--- a/src/Headless.Messaging.Redis/RedisConsumerClient.cs
+++ b/src/Headless.Messaging.Redis/RedisConsumerClient.cs
@@ -14,6 +14,7 @@ internal sealed class RedisConsumerClient(
     IRedisStreamManager redis,
     IOptions<RedisMessagingOptions> options,
     ILogger<RedisConsumerClient> logger,
+    TimeSpan? stalePendingClaimMinIdleTime = null,
     TimeProvider? timeProvider = null
 ) : IConsumerClient
 {
@@ -21,6 +22,8 @@ internal sealed class RedisConsumerClient(
     private readonly ConsumerPauseGate _pauseGate = new();
     private readonly TaskCompletionSource _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly TimeSpan _stalePendingClaimMinIdleTime = stalePendingClaimMinIdleTime ?? TimeSpan.FromMinutes(5);
+    private readonly string _consumerName = $"{groupId}:{Environment.MachineName}:{Guid.NewGuid():N}";
     private int _disposed;
     private string[] _messageNames = null!;
 
@@ -66,14 +69,22 @@ internal sealed class RedisConsumerClient(
 
     public async ValueTask CommitAsync(object? sender)
     {
-        var (stream, group, id) = ((string stream, string group, string id))sender!;
+        if (!_TryGetDelivery(sender, out var delivery))
+        {
+            return;
+        }
 
-        await redis.Ack(stream, group, id).ConfigureAwait(false);
+        await redis.Ack(delivery.Stream, delivery.Group, delivery.Id).ConfigureAwait(false);
     }
 
-    public ValueTask RejectAsync(object? sender)
+    public async ValueTask RejectAsync(object? sender)
     {
-        return ValueTask.CompletedTask;
+        if (sender is not RedisConsumerDelivery delivery)
+        {
+            return;
+        }
+
+        await redis.RequeueAndAck(delivery.Stream, delivery.Group, delivery.Id, delivery.Entries).ConfigureAwait(false);
     }
 
     public async ValueTask PauseAsync(CancellationToken cancellationToken = default) =>
@@ -113,18 +124,40 @@ internal sealed class RedisConsumerClient(
     private async Task _ListeningForMessagesAsync(TimeSpan timeout, CancellationToken cancellationToken)
     {
         //first time, we want to read our pending messages, in case we crashed and are recovering.
-        var pendingMsgs = redis.PollStreamsPendingMessagesAsync(_messageNames, groupId, timeout, cancellationToken);
+        var pendingMsgs = redis.PollStreamsPendingMessagesAsync(
+            _messageNames,
+            groupId,
+            _consumerName,
+            timeout,
+            cancellationToken
+        );
 
         await _ConsumeMessages(pendingMsgs, StreamPosition.Beginning, cancellationToken).ConfigureAwait(false);
 
+        var stalePendingMsgs = redis.PollStreamsStalePendingMessagesAsync(
+            _messageNames,
+            groupId,
+            _consumerName,
+            _stalePendingClaimMinIdleTime,
+            timeout,
+            cancellationToken
+        );
+        _ObserveBackgroundHandler(_ConsumeMessages(stalePendingMsgs, StreamPosition.Beginning, cancellationToken));
+
         //Once we consumed our history, we can start getting new messages.
-        var newMsgs = redis.PollStreamsLatestMessagesAsync(_messageNames, groupId, timeout, cancellationToken);
+        var newMsgs = redis.PollStreamsLatestMessagesAsync(
+            _messageNames,
+            groupId,
+            _consumerName,
+            timeout,
+            cancellationToken
+        );
 
         _ObserveBackgroundHandler(_ConsumeMessages(newMsgs, StreamPosition.NewMessages, cancellationToken));
     }
 
     private async Task _ConsumeMessages(
-        IAsyncEnumerable<IEnumerable<RedisStream>> streamsSet,
+        IAsyncEnumerable<IEnumerable<RedisStreamMessages>> streamsSet,
         RedisValue position,
         CancellationToken cancellationToken
     )
@@ -169,7 +202,7 @@ internal sealed class RedisConsumerClient(
             }
         }
 
-        async Task consumeAsync(RedisValue position, RedisStream stream, StreamEntry entry)
+        async Task consumeAsync(RedisValue position, RedisStreamMessages stream, StreamEntry entry)
         {
             try
             {
@@ -208,7 +241,10 @@ internal sealed class RedisConsumerClient(
                     return;
                 }
 
-                await OnMessageCallback!(message, (stream.Key.ToString(), groupId, entry.Id.ToString()))
+                await OnMessageCallback!(
+                    message,
+                    new RedisConsumerDelivery(stream.Key.ToString(), groupId, entry.Id.ToString(), [.. entry.Values])
+                )
                     .ConfigureAwait(false);
             }
             finally
@@ -238,7 +274,27 @@ internal sealed class RedisConsumerClient(
             TaskScheduler.Default
         );
     }
+
+    private static bool _TryGetDelivery(object? sender, out RedisConsumerDelivery delivery)
+    {
+        switch (sender)
+        {
+            case RedisConsumerDelivery redisDelivery:
+                delivery = redisDelivery;
+                return true;
+
+            case (string stream, string group, string id):
+                delivery = new RedisConsumerDelivery(stream, group, id, []);
+                return true;
+
+            default:
+                delivery = default;
+                return false;
+        }
+    }
 }
+
+internal readonly record struct RedisConsumerDelivery(string Stream, string Group, string Id, NameValueEntry[] Entries);
 
 internal static partial class RedisConsumerClientLog
 {

--- a/src/Headless.Messaging.Redis/RedisConsumerClientFactory.cs
+++ b/src/Headless.Messaging.Redis/RedisConsumerClientFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Messaging.Configuration;
 using Headless.Messaging.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -8,6 +9,7 @@ namespace Headless.Messaging.Redis;
 
 internal sealed class RedisConsumerClientFactory(
     IOptions<RedisMessagingOptions> redisOptions,
+    IOptions<MessagingOptions> messagingOptions,
     IRedisStreamManager redis,
     ILogger<RedisConsumerClient> logger
 ) : IIntentAwareConsumerClientFactory
@@ -26,7 +28,14 @@ internal sealed class RedisConsumerClientFactory(
             );
         }
 
-        var client = new RedisConsumerClient(groupName, groupConcurrent, redis, redisOptions, logger);
+        var client = new RedisConsumerClient(
+            groupName,
+            groupConcurrent,
+            redis,
+            redisOptions,
+            logger,
+            messagingOptions.Value.RetryPolicy.DispatchTimeout
+        );
         return Task.FromResult<IConsumerClient>(client);
     }
 }

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
@@ -71,6 +71,35 @@ public sealed class ConsumerRegisterTests : TestBase
     }
 
     [Fact]
+    public async Task add_client_async_disposes_and_forgets_new_client_when_initial_pause_fails()
+    {
+        var expected = new InvalidOperationException("pause failed");
+        var client = Substitute.For<IConsumerClient>();
+
+        client.PauseAsync(Arg.Any<CancellationToken>()).Returns(_ => ValueTask.FromException(expected));
+        client.DisposeAsync().Returns(ValueTask.CompletedTask);
+
+        var handleType = typeof(ConsumerRegister).GetNestedType("GroupHandle", BindingFlags.NonPublic)!;
+        var handle = Activator.CreateInstance(handleType, nonPublic: true)!;
+        using var cts = new CancellationTokenSource();
+        handleType.GetProperty("Logger")!.SetValue(handle, NullLogger<ConsumerRegister>.Instance);
+        handleType.GetProperty("Cts")!.SetValue(handle, cts);
+        handleType.GetProperty("GroupName")!.SetValue(handle, "payments");
+        handleType.GetProperty("ConsumerTasks")!.SetValue(handle, new ConcurrentBag<Task>());
+        handleType.GetProperty("IsPaused")!.SetValue(handle, true);
+
+        var addClient = handleType.GetMethod("AddClientAsync")!;
+
+        var act = async () => await (ValueTask)addClient.Invoke(handle, [client])!;
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("pause failed");
+        await client.Received(1).DisposeAsync();
+
+        var snapshot = (IConsumerClient[])handleType.GetMethod("SnapshotClients")!.Invoke(handle, null)!;
+        snapshot.Should().BeEmpty("a client that was never successfully paused must not remain registered");
+    }
+
+    [Fact]
     public async Task restart_disposes_cts_when_execute_async_throws()
     {
         await using var provider = _CreateProvider();

--- a/tests/Headless.Messaging.Redis.Tests.Unit/RedisConsumerClientFactoryTests.cs
+++ b/tests/Headless.Messaging.Redis.Tests.Unit/RedisConsumerClientFactoryTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Messaging;
+using Headless.Messaging.Configuration;
 using Headless.Messaging.Redis;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging;
@@ -22,9 +23,10 @@ public sealed class RedisConsumerClientFactoryTests : TestBase
         var options = Options.Create(
             new RedisMessagingOptions { Configuration = ConfigurationOptions.Parse("localhost:6379") }
         );
+        var messagingOptions = Options.Create(new MessagingOptions());
         var logger = LoggerFactory.CreateLogger<RedisConsumerClient>();
 
-        var factory = new RedisConsumerClientFactory(options, mockStreamManager, logger);
+        var factory = new RedisConsumerClientFactory(options, messagingOptions, mockStreamManager, logger);
 
         // when
         var client = await factory.CreateAsync("my-consumer-group", 5);
@@ -43,9 +45,10 @@ public sealed class RedisConsumerClientFactoryTests : TestBase
         var options = Options.Create(
             new RedisMessagingOptions { Configuration = ConfigurationOptions.Parse("localhost:6379") }
         );
+        var messagingOptions = Options.Create(new MessagingOptions());
         var logger = LoggerFactory.CreateLogger<RedisConsumerClient>();
 
-        var factory = new RedisConsumerClientFactory(options, mockStreamManager, logger);
+        var factory = new RedisConsumerClientFactory(options, messagingOptions, mockStreamManager, logger);
 
         // when
         var client = await factory.CreateAsync("group-name", 0);
@@ -62,9 +65,10 @@ public sealed class RedisConsumerClientFactoryTests : TestBase
         var options = Options.Create(
             new RedisMessagingOptions { Configuration = ConfigurationOptions.Parse("localhost:6379") }
         );
+        var messagingOptions = Options.Create(new MessagingOptions());
         var logger = LoggerFactory.CreateLogger<RedisConsumerClient>();
 
-        var factory = new RedisConsumerClientFactory(options, mockStreamManager, logger);
+        var factory = new RedisConsumerClientFactory(options, messagingOptions, mockStreamManager, logger);
 
         // when
         var client1 = await factory.CreateAsync("group-1", 1);
@@ -82,9 +86,10 @@ public sealed class RedisConsumerClientFactoryTests : TestBase
         var options = Options.Create(
             new RedisMessagingOptions { Configuration = ConfigurationOptions.Parse("localhost:6379") }
         );
+        var messagingOptions = Options.Create(new MessagingOptions());
         var logger = LoggerFactory.CreateLogger<RedisConsumerClient>();
 
-        var factory = new RedisConsumerClientFactory(options, mockStreamManager, logger);
+        var factory = new RedisConsumerClientFactory(options, messagingOptions, mockStreamManager, logger);
 
         // when
         var act = async () => await factory.CreateAsync("group-name", 1, IntentType.Bus);

--- a/tests/Headless.Messaging.Redis.Tests.Unit/RedisConsumerClientTests.cs
+++ b/tests/Headless.Messaging.Redis.Tests.Unit/RedisConsumerClientTests.cs
@@ -101,6 +101,24 @@ public sealed class RedisConsumerClientTests : TestBase
     }
 
     [Fact]
+    public async Task should_requeue_and_ack_message_on_reject()
+    {
+        // given
+        var logger = LoggerFactory.CreateLogger<RedisConsumerClient>();
+        await using var client = new RedisConsumerClient("test-group", 1, _mockStreamManager, _options, logger);
+        var entries = new NameValueEntry[] { new("headers", "{}"), new("body", "[]") };
+        var sender = new RedisConsumerDelivery("test-stream", "test-group", "1234567-0", entries);
+
+        // when
+        await client.RejectAsync(sender);
+
+        // then
+        await _mockStreamManager
+            .Received(1)
+            .RequeueAndAck("test-stream", "test-group", "1234567-0", entries, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task should_dispose_without_error()
     {
         // given

--- a/tests/Headless.Messaging.Redis.Tests.Unit/RedisStreamManagerTests.cs
+++ b/tests/Headless.Messaging.Redis.Tests.Unit/RedisStreamManagerTests.cs
@@ -131,6 +131,50 @@ public sealed class RedisStreamManagerTests : TestBase
     }
 
     [Fact]
+    public async Task should_requeue_before_acknowledging_rejected_message()
+    {
+        // given
+        var entries = new NameValueEntry[] { new("headers", "{}"), new("body", "[]") };
+        List<string> calls = [];
+
+        _mockDatabase
+            .StreamAddAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<NameValueEntry[]>(),
+                Arg.Any<RedisValue?>(),
+                Arg.Any<long?>(),
+                Arg.Any<bool>(),
+                Arg.Any<long?>(),
+                Arg.Any<StreamTrimMode>(),
+                Arg.Any<CommandFlags>()
+            )
+            .Returns(_ =>
+            {
+                calls.Add("add");
+                return new RedisValue("7654321-0");
+            });
+
+        _mockDatabase
+            .StreamAcknowledgeAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<CommandFlags>()
+            )
+            .Returns(_ =>
+            {
+                calls.Add("ack");
+                return 1L;
+            });
+
+        // when
+        await _sut.RequeueAndAck("test-stream", "my-group", "1234567-0", entries, AbortToken);
+
+        // then
+        calls.Should().Equal("add", "ack");
+    }
+
+    [Fact]
     public async Task should_wait_asynchronously_between_latest_poll_iterations()
     {
         // given
@@ -138,7 +182,7 @@ public sealed class RedisStreamManagerTests : TestBase
         var sut = _CreateSut(timeProvider);
         var pollDelay = TimeSpan.FromMinutes(1);
 
-        await using var enumerator = sut.PollStreamsLatestMessagesAsync([], "group", pollDelay, AbortToken)
+        await using var enumerator = sut.PollStreamsLatestMessagesAsync([], "group", "consumer", pollDelay, AbortToken)
             .GetAsyncEnumerator(AbortToken);
 
         // when
@@ -152,6 +196,53 @@ public sealed class RedisStreamManagerTests : TestBase
         timeProvider.Advance(pollDelay);
 
         (await secondMoveTask).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_auto_claim_stale_pending_messages_with_min_idle_time()
+    {
+        // given
+        var claimMinIdleTime = TimeSpan.FromMinutes(5);
+        var pollDelay = TimeSpan.FromMinutes(1);
+
+        _mockDatabase
+            .StreamAutoClaimAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<long>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<int?>(),
+                Arg.Any<CommandFlags>()
+            )
+            .Returns(StreamAutoClaimResult.Null);
+
+        await using var enumerator = _sut.PollStreamsStalePendingMessagesAsync(
+                ["test-stream"],
+                "my-group",
+                "consumer-1",
+                claimMinIdleTime,
+                pollDelay,
+                AbortToken
+            )
+            .GetAsyncEnumerator(AbortToken);
+
+        // when
+        var moved = await enumerator.MoveNextAsync();
+
+        // then
+        moved.Should().BeTrue();
+        await _mockDatabase
+            .Received(1)
+            .StreamAutoClaimAsync(
+                "test-stream",
+                "my-group",
+                "consumer-1",
+                (long)claimMinIdleTime.TotalMilliseconds,
+                StreamPosition.Beginning,
+                10,
+                Arg.Any<CommandFlags>()
+            );
     }
 
     private RedisStreamManager _CreateSut(TimeProvider timeProvider)


### PR DESCRIPTION
## Summary
- Requeue rejected Redis Stream messages before acknowledging the original delivery, preserving at-least-once behavior on reject.
- Add per-client Redis consumer names and an XAUTOCLAIM-based stale pending recovery loop using `RetryPolicy.DispatchTimeout` as the idle threshold.
- Fail closed when a newly added consumer client cannot be paused during an open-circuit startup path, disposing and unregistering the failed client.
- Add focused Redis and core unit coverage for reject requeue, stale pending auto-claim, and startup pause-failure cleanup.

## Validation
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Redis.Tests.Unit/Headless.Messaging.Redis.Tests.Unit.csproj`
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj`
- Pre-push hook: changed-file format check + `dotnet build "headless-framework.slnx" --configuration "Release" --no-restore -v:q -nologo /clp:ErrorsOnly`
