### PR TITLE
test(messaging): cover null-body callbacks

### DIFF
--- a/tests/Headless.Messaging.Core.Tests.Harness/CallbackTestFixtures.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/CallbackTestFixtures.cs
@@ -80,6 +80,8 @@ public enum CallbackRequestMode
     Normal,
     Rewrite,
     Remove,
+    TypedNull,
+    HeadersOnly,
 }
 
 public sealed record CallbackQueueRequestMessage(string Id);
@@ -123,6 +125,11 @@ public sealed class CallbackRequestConsumer : IConsume<CallbackRequestMessage>
             case CallbackRequestMode.Remove:
                 context.Headers.RemoveCallback();
                 context.SetResponse(new CallbackResponse(context.Message.Id, context.IntentType.ToString()));
+                break;
+            case CallbackRequestMode.TypedNull:
+                context.SetResponse<CallbackResponse>(null!);
+                break;
+            case CallbackRequestMode.HeadersOnly:
                 break;
             default:
                 context.SetResponse(new CallbackResponse(context.Message.Id, context.IntentType.ToString()));

--- a/tests/Headless.Messaging.Core.Tests.Harness/MessagingIntegrationTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/MessagingIntegrationTestsBase.cs
@@ -548,6 +548,62 @@ public abstract class MessagingIntegrationTestsBase : TestBase
         context.Headers[Headers.Type].Should().Be(nameof(CallbackResponse));
     }
 
+    public virtual async Task should_publish_typed_null_callback_response()
+    {
+        // given
+        var requestMessageId = $"typed-null-{Guid.NewGuid():N}";
+        var request = new CallbackRequestMessage(Guid.NewGuid().ToString("N"), CallbackRequestMode.TypedNull);
+
+        // when
+        await Publisher.PublishAsync(
+            request,
+            new PublishOptions
+            {
+                MessageId = requestMessageId,
+                MessageName = "callback-request",
+                CallbackName = "callback-response",
+            },
+            AbortToken
+        );
+
+        var callback = await _WaitForStoredCallbackAsync(requestMessageId, TimeSpan.FromSeconds(20));
+
+        // then
+        callback.Should().NotBeNull("the typed-null callback should reach transport and durable receive storage");
+        callback!.Origin.Value.Should().BeNull();
+        callback.Origin.Headers[Headers.Type].Should().Be(nameof(CallbackResponse));
+        callback.Origin.Headers[Headers.CorrelationId].Should().Be(requestMessageId);
+        callback.ExceptionInfo.Should().Contain($"Failed to deserialize message of type {nameof(CallbackResponse)}");
+    }
+
+    public virtual async Task should_publish_headers_only_callback_response()
+    {
+        // given
+        var requestMessageId = $"headers-only-{Guid.NewGuid():N}";
+        var request = new CallbackRequestMessage(Guid.NewGuid().ToString("N"), CallbackRequestMode.HeadersOnly);
+
+        // when
+        await Publisher.PublishAsync(
+            request,
+            new PublishOptions
+            {
+                MessageId = requestMessageId,
+                MessageName = "callback-request",
+                CallbackName = "callback-response",
+            },
+            AbortToken
+        );
+
+        var callback = await _WaitForStoredCallbackAsync(requestMessageId, TimeSpan.FromSeconds(20));
+
+        // then
+        callback.Should().NotBeNull("the headers-only callback should reach transport and durable receive storage");
+        callback!.Origin.Value.Should().BeNull();
+        callback.Origin.Headers[Headers.Type].Should().Be(nameof(Object));
+        callback.Origin.Headers[Headers.CorrelationId].Should().Be(requestMessageId);
+        callback.ExceptionInfo.Should().Contain($"Failed to deserialize message of type {nameof(CallbackResponse)}");
+    }
+
     public virtual async Task should_rewrite_callback_when_response_is_set()
     {
         // given
@@ -724,6 +780,47 @@ public abstract class MessagingIntegrationTestsBase : TestBase
 
         var succeeded = await _FindReceivedMessagesAsync(messageId, StatusName.Succeeded, AbortToken);
         succeeded.Should().BeEmpty("response serialization failure must not mark the request consume as succeeded");
+    }
+
+    private async Task<MediumMessage?> _WaitForStoredCallbackAsync(string correlationId, TimeSpan timeout)
+    {
+        var monitoringApi = DataStorage.GetMonitoringApi();
+        var timeProvider = ServiceProvider.GetRequiredService<TimeProvider>();
+        var deadline = timeProvider.GetUtcNow() + timeout;
+
+        while (timeProvider.GetUtcNow() < deadline)
+        {
+            var page = await monitoringApi.GetMessagesAsync(
+                new MessageQuery
+                {
+                    MessageType = MessageType.Subscribe,
+                    Name = ResolveMessageName("callback-response"),
+                    CurrentPage = 0,
+                    PageSize = 100,
+                },
+                AbortToken
+            );
+
+            page.TotalItems.Should()
+                .BeLessThan(100, "callback correlation filtering is in-memory; rows beyond one page risk truncation");
+
+            foreach (var candidate in page.Items)
+            {
+                var stored = await monitoringApi.GetReceivedMessageAsync(candidate.StorageId, AbortToken);
+                if (
+                    stored?.ExceptionInfo is not null
+                    && stored.Origin.Headers.TryGetValue(Headers.CorrelationId, out var storedCorrelationId)
+                    && string.Equals(storedCorrelationId, correlationId, StringComparison.Ordinal)
+                )
+                {
+                    return stored;
+                }
+            }
+
+            await timeProvider.Delay(TimeSpan.FromMilliseconds(100), AbortToken);
+        }
+
+        return null;
     }
 
     protected async Task EnsureTestSubscriberReadyAsync(

--- a/tests/Headless.Messaging.NatsPostgreSql.Tests.Integration/NatsPostgreSqlMessagingIntegrationTests.cs
+++ b/tests/Headless.Messaging.NatsPostgreSql.Tests.Integration/NatsPostgreSqlMessagingIntegrationTests.cs
@@ -90,6 +90,14 @@ public sealed class NatsPostgreSqlMessagingIntegrationTests(NatsPostgreSqlFixtur
         base.should_publish_callback_response_for_queue_request();
 
     [Fact]
+    public override Task should_publish_typed_null_callback_response() =>
+        base.should_publish_typed_null_callback_response();
+
+    [Fact]
+    public override Task should_publish_headers_only_callback_response() =>
+        base.should_publish_headers_only_callback_response();
+
+    [Fact]
     public override Task should_rewrite_callback_when_response_is_set() =>
         base.should_rewrite_callback_when_response_is_set();
 


### PR DESCRIPTION
## Summary

Null-body callbacks now have end-to-end regression coverage for both typed-null responses and callbacks where the consumer omits `SetResponse`. The tests inspect the durable received message directly, proving the callback reaches transport/storage with a null payload and the expected type and correlation headers.

They also lock in the current consume-side outcome: typed consumers reject both null payload variants before invocation. This keeps the issue test-only while making any future decision to support nullable callback consumption explicit.

## Validation

- NATS/PostgreSQL typed-null and headers-only integration scenarios: 2 passed
- Focused provider build: 0 warnings, 0 errors
- Focused analyzers and CSharpier checks passed
- Pre-push incremental solution build: 0 warnings, 0 errors

Closes #399
