### PR TITLE
perf(caching): SE.Redis 3.x pooled-lease reads + zero-concat writes (#580)

### DIFF
--- a/benchmarks/Headless.Caching.Benchmarks/Scenarios/CacheOperationBenchmarksBase.cs
+++ b/benchmarks/Headless.Caching.Benchmarks/Scenarios/CacheOperationBenchmarksBase.cs
@@ -9,7 +9,11 @@ namespace Headless.Caching.Benchmarks.Scenarios;
 public abstract class CacheOperationBenchmarksBase
 {
     private const int _Seed = 2112;
-    private readonly TimeSpan _expiration = TimeSpan.FromMinutes(1);
+
+    // Must comfortably exceed a full BenchmarkDotNet case (pilot + warmup + actual iterations can pass a minute):
+    // the hot keys are seeded once in GlobalSetup, and a shorter TTL lets them expire mid-case, silently turning
+    // the tail of HotGetAsync into a miss benchmark (bimodal distribution, miss-sized allocations).
+    private readonly TimeSpan _expiration = TimeSpan.FromHours(1);
     private ICacheBenchmarkClient? _client;
     private BenchmarkPayload? _payload;
     private string[] _keys = [];

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -665,9 +665,10 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // #580: pooled-lease read — the value buffer is rented from the ArrayPool instead of allocated per GET.
         var redisKey = _GetKey(key);
-        var redisValue = await _database.StringGetAsync(redisKey, cacheOptions.ReadMode).ConfigureAwait(false);
-        return await _RedisValueToCacheValueAsync<T>(redisKey, redisValue).ConfigureAwait(false);
+        var lease = await _database.StringGetLeaseAsync(redisKey, cacheOptions.ReadMode).ConfigureAwait(false);
+        return await _LeaseToCacheValueAsync<T>(redisKey, lease).ConfigureAwait(false);
     }
 
     public async ValueTask<IDictionary<string, CacheValue<T>>> GetAllAsync<T>(
@@ -730,7 +731,7 @@ public sealed class RedisCache(
         {
             var rawValue = rawValues[i];
 
-            // Mirror the previous _RedisValueToCacheValueAsync contract: a missing key surfaces as NoValue so
+            // Mirror the previous _LeaseToCacheValueAsync contract: a missing key surfaces as NoValue so
             // every requested key is present in the result.
             result[originalKeys[i]] = rawValue.HasValue
                 ? await _DecodedToCacheValueAsync<T>(decodedFrames[i]!.Value, rawValue, now).ConfigureAwait(false)
@@ -741,7 +742,7 @@ public sealed class RedisCache(
     }
 
     /// <summary>
-    /// Bulk-read conversion from an already-decoded frame: mirrors <see cref="_RedisValueToCacheValueAsync{T}"/>
+    /// Bulk-read conversion from an already-decoded frame: mirrors <see cref="_LeaseToCacheValueAsync{T}"/>
     /// with <c>rearm: false</c> (no sliding re-arm on bulk reads) but skips the redundant re-decode. Marker
     /// resolution hits the warm <see cref="_markerCache"/> populated by the batched
     /// <see cref="_PrefetchTagMarkersAsync"/>, so no extra Redis round-trip is paid per entry. (#12)
@@ -1036,10 +1037,11 @@ public sealed class RedisCache(
 
         // Fetch the value rather than KeyExists: a fail-safe reserve keeps its Redis TTL aligned to PHYSICAL
         // expiration, so the key can still exist after its LOGICAL expiration. A key-existence check would
-        // report such a logically-expired reserve as present; _RedisValueIsLogicallyPresent applies the same
-        // logical-expiry rule the read methods use.
-        var redisValue = await _database.StringGetAsync(_GetKey(key), cacheOptions.ReadMode).ConfigureAwait(false);
-        return await _RedisValueIsLogicallyPresentAsync(redisValue).ConfigureAwait(false);
+        // report such a logically-expired reserve as present; _LeaseIsLogicallyPresentAsync applies the same
+        // logical-expiry rule the read methods use. Lease read (#580): only the header is inspected, so the
+        // value bytes never become a per-call heap allocation.
+        var lease = await _database.StringGetLeaseAsync(_GetKey(key), cacheOptions.ReadMode).ConfigureAwait(false);
+        return await _LeaseIsLogicallyPresentAsync(lease).ConfigureAwait(false);
     }
 
     public async ValueTask<long> GetCountAsync(string prefix = "", CancellationToken cancellationToken = default)
@@ -1104,48 +1106,57 @@ public sealed class RedisCache(
 
         // #11: cache prefixed key to avoid repeated _GetKey allocations (called up to 3x previously)
         var prefixedKey = _GetKey(key);
-        var redisValue = await _database.StringGetAsync(prefixedKey, cacheOptions.ReadMode).ConfigureAwait(false);
 
-        if (!redisValue.HasValue)
+        // Lease read (#580): only frame metadata is inspected, so the value bytes stay pooled.
+        var lease = await _database.StringGetLeaseAsync(prefixedKey, cacheOptions.ReadMode).ConfigureAwait(false);
+
+        if (lease is null)
         {
             return null;
         }
 
-        var frame = RedisCacheEntryFrame.Decode(redisValue);
-
-        if (!frame.IsFramed)
+        try
         {
-            // Non-framed (legacy/raw) keys carry no logical metadata, so fall back to the server TTL. Only
-            // legacy keys pay this second round trip; framed keys return below from the decoded frame.
-            return await _database.KeyTimeToLiveAsync(prefixedKey).ConfigureAwait(false);
+            var frame = RedisCacheEntryFrame.Decode((ReadOnlyMemory<byte>)lease.Memory);
+
+            if (!frame.IsFramed)
+            {
+                // Non-framed (legacy/raw) keys carry no logical metadata, so fall back to the server TTL. Only
+                // legacy keys pay this second round trip; framed keys return below from the decoded frame.
+                return await _database.KeyTimeToLiveAsync(prefixedKey).ConfigureAwait(false);
+            }
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+
+            if (_IsExpired(frame.PhysicalExpiresAt, now))
+            {
+                return null;
+            }
+
+            // Family-2: a tag/clear-invalidated entry has no remaining logical expiration for direct reads.
+            var newestMarker = await _ResolveNewestMarkerAsync(frame.Tags).ConfigureAwait(false);
+
+            if (CacheTagInvalidation.IsInvalidated(frame.CreatedAt, newestMarker))
+            {
+                return null;
+            }
+
+            if (frame.SlidingExpiration.HasValue)
+            {
+                return await _database.KeyTimeToLiveAsync(prefixedKey).ConfigureAwait(false);
+            }
+
+            if (_IsExpired(frame.LogicalExpiresAt, now))
+            {
+                return null;
+            }
+
+            return frame.LogicalExpiresAt?.Subtract(now);
         }
-
-        var now = timeProvider.GetUtcNow().UtcDateTime;
-
-        if (_IsExpired(frame.PhysicalExpiresAt, now))
+        finally
         {
-            return null;
+            lease.Dispose();
         }
-
-        // Family-2: a tag/clear-invalidated entry has no remaining logical expiration for direct reads.
-        var newestMarker = await _ResolveNewestMarkerAsync(frame.Tags).ConfigureAwait(false);
-
-        if (CacheTagInvalidation.IsInvalidated(frame.CreatedAt, newestMarker))
-        {
-            return null;
-        }
-
-        if (frame.SlidingExpiration.HasValue)
-        {
-            return await _database.KeyTimeToLiveAsync(prefixedKey).ConfigureAwait(false);
-        }
-
-        if (_IsExpired(frame.LogicalExpiresAt, now))
-        {
-            return null;
-        }
-
-        return frame.LogicalExpiresAt?.Subtract(now);
     }
 
     /// <inheritdoc/>
@@ -1157,18 +1168,20 @@ public sealed class RedisCache(
         Argument.IsNotNullOrEmpty(key);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Lease read (#580): the value buffer is pool-rented; returned in the finally after deserialization.
         var redisKey = _GetKey(key);
-        var rawValue = await _database.StringGetAsync(redisKey, cacheOptions.ReadMode).ConfigureAwait(false);
+        var lease = await _database.StringGetLeaseAsync(redisKey, cacheOptions.ReadMode).ConfigureAwait(false);
 
-        if (!rawValue.HasValue)
+        if (lease is null)
         {
             return new CacheValueWithExpiration<T>(CacheValue<T>.NoValue, expiration: null);
         }
 
         try
         {
+            ReadOnlyMemory<byte> raw = lease.Memory;
             var now = timeProvider.GetUtcNow().UtcDateTime;
-            var frame = RedisCacheEntryFrame.Decode(rawValue);
+            var frame = RedisCacheEntryFrame.Decode(raw);
 
             if (frame.IsFramed)
             {
@@ -1222,10 +1235,9 @@ public sealed class RedisCache(
 
             // Non-framed (legacy/raw) entry: value is present but carries no logical expiry metadata.
             // Fall back to the live server TTL for the expiration component.
-            var legacyValue =
-                rawValue == _NullValue
-                    ? CacheValue<T>.Null
-                    : new CacheValue<T>(_FromRedisValue<T>(rawValue), hasValue: true);
+            var legacyValue = _IsNullSentinel(raw.Span)
+                ? CacheValue<T>.Null
+                : new CacheValue<T>(_DeserializeValueSegment<T>(raw), hasValue: true);
 
             var legacyTtl = await _database.KeyTimeToLiveAsync(redisKey).ConfigureAwait(false);
 
@@ -1238,8 +1250,12 @@ public sealed class RedisCache(
         }
         catch (Exception e)
         {
-            _logger.LogDeserializationFailed(e, rawValue.Length(), typeof(T).FullName);
+            _logger.LogDeserializationFailed(e, lease.Length, typeof(T).FullName);
             throw;
+        }
+        finally
+        {
+            lease.Dispose();
         }
     }
 
@@ -2220,20 +2236,31 @@ public sealed class RedisCache(
         return serializer.Deserialize<T>((ReadOnlySequence<byte>)redisValue!);
     }
 
-    private async ValueTask<CacheValue<T>> _RedisValueToCacheValueAsync<T>(
+    // Byte-level mirror of the _NullValue comparison for the lease/memory read paths (#580). The u8 literal must
+    // stay in sync with _NullValue ("@@NULL"); RedisValue equality is content-based, so both compare identically.
+    private static bool _IsNullSentinel(ReadOnlySpan<byte> value) => value.SequenceEqual("@@NULL"u8);
+
+    /// <summary>
+    /// Single-key read conversion from a pooled <see cref="Lease{T}"/> (#580). The lease buffer is ArrayPool-owned
+    /// and dispose-controlled, so holding the decoded frame's <c>ValueSegment</c> (a slice of the lease) across the
+    /// marker-resolve and sliding re-arm awaits is safe; the buffer returns to the pool in the finally after every
+    /// consumer (deserializer, sentinel check) has fully materialized its result.
+    /// </summary>
+    private async ValueTask<CacheValue<T>> _LeaseToCacheValueAsync<T>(
         RedisKey redisKey,
-        RedisValue redisValue,
+        Lease<byte>? lease,
         bool rearm = true
     )
     {
-        if (!redisValue.HasValue)
+        if (lease is null)
         {
             return CacheValue<T>.NoValue;
         }
 
         try
         {
-            var frame = RedisCacheEntryFrame.Decode(redisValue);
+            ReadOnlyMemory<byte> raw = lease.Memory;
+            var frame = RedisCacheEntryFrame.Decode(raw);
 
             if (frame.IsFramed)
             {
@@ -2273,23 +2300,27 @@ public sealed class RedisCache(
                 return new CacheValue<T>(framedValue, hasValue: true);
             }
 
-            if (redisValue == _NullValue)
+            if (_IsNullSentinel(raw.Span))
             {
                 return CacheValue<T>.Null;
             }
 
-            var value = _FromRedisValue<T>(redisValue);
+            var value = _DeserializeValueSegment<T>(raw);
             return new CacheValue<T>(value, hasValue: true);
         }
         catch (Exception e)
         {
-            _logger.LogDeserializationFailed(e, redisValue.Length(), typeof(T).FullName);
+            _logger.LogDeserializationFailed(e, lease.Length, typeof(T).FullName);
             throw;
+        }
+        finally
+        {
+            lease.Dispose();
         }
     }
 
     /// <summary>
-    /// Zero-intermediate-copy buffer read. Mirrors <see cref="_RedisValueToCacheValueAsync{T}"/> exactly (expiry,
+    /// Zero-intermediate-copy buffer read. Mirrors <see cref="_LeaseToCacheValueAsync{T}"/> exactly (expiry,
     /// Family-2 tag/clear invalidation, single-key sliding re-arm), but writes the validated payload straight into
     /// <paramref name="destination"/> instead of deserializing it — so the generic path's intermediate
     /// <c>byte[]</c> materialization is skipped and only one copy (frame slice -> caller buffer) is paid.
@@ -2304,17 +2335,20 @@ public sealed class RedisCache(
         Argument.IsNotNull(destination);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Lease read (#580): the value buffer is pool-rented; the single copy below goes straight from the
+        // leased frame slice into the caller's buffer, then the lease returns to the pool in the finally.
         var redisKey = _GetKey(key);
-        var redisValue = await _database.StringGetAsync(redisKey, cacheOptions.ReadMode).ConfigureAwait(false);
+        var lease = await _database.StringGetLeaseAsync(redisKey, cacheOptions.ReadMode).ConfigureAwait(false);
 
-        if (!redisValue.HasValue)
+        if (lease is null)
         {
             return false;
         }
 
         try
         {
-            var frame = RedisCacheEntryFrame.Decode(redisValue);
+            ReadOnlyMemory<byte> raw = lease.Memory;
+            var frame = RedisCacheEntryFrame.Decode(raw);
 
             if (frame.IsFramed)
             {
@@ -2351,24 +2385,22 @@ public sealed class RedisCache(
             }
 
             // Legacy non-framed entry: the whole stored value is the raw payload.
-            if (redisValue == _NullValue)
+            if (_IsNullSentinel(raw.Span))
             {
                 return false;
             }
 
-            // Write the value straight from its native ReadOnlySequence<byte> storage (SE.Redis 3.0+), avoiding the
-            // intermediate byte[] that (byte[])redisValue would materialize — keeping this path's single-copy intent.
-            foreach (var segment in (ReadOnlySequence<byte>)redisValue!)
-            {
-                destination.Write(segment.Span);
-            }
-
+            destination.Write(raw.Span);
             return true;
         }
         catch (Exception e)
         {
-            _logger.LogDeserializationFailed(e, redisValue.Length(), typeof(byte[]).FullName);
+            _logger.LogDeserializationFailed(e, lease.Length, typeof(byte[]).FullName);
             throw;
+        }
+        finally
+        {
+            lease.Dispose();
         }
     }
 
@@ -2693,7 +2725,16 @@ public sealed class RedisCache(
         Span<byte> header = stackalloc byte[RedisCacheEntryFrame.HeaderLength];
         sequence.Slice(0, length).CopyTo(header);
 
-        return $"b64:{header[..length].ToBase64()}";
+        return _ToConcurrencyStamp(header[..length]);
+    }
+
+    // Contiguous-bytes overload for the lease/memory read paths (#580): both encode the SAME header slice as the
+    // sequence overload above, so stamps from either path stay comparable.
+    private static string _ToConcurrencyStamp(ReadOnlySpan<byte> value)
+    {
+        var length = Math.Min(value.Length, RedisCacheEntryFrame.HeaderLength);
+
+        return $"b64:{value[..length].ToBase64()}";
     }
 
     private static bool _TryDecodeConcurrencyStamp(string stamp, out RedisValue value)
@@ -2749,17 +2790,26 @@ public sealed class RedisCache(
 
     private async ValueTask<CacheStoreEntry<T>> _TryGetEntryAsync<T>(string key)
     {
-        var redisValue = await _database.StringGetAsync(_GetKey(key), cacheOptions.ReadMode).ConfigureAwait(false);
+        // Lease read (#580): the value buffer is pool-rented; returned in the finally after the entry is built.
+        var lease = await _database.StringGetLeaseAsync(_GetKey(key), cacheOptions.ReadMode).ConfigureAwait(false);
 
-        if (!redisValue.HasValue)
+        if (lease is null)
         {
             return CacheStoreEntry<T>.NotFound;
         }
 
-        var now = timeProvider.GetUtcNow().UtcDateTime;
-        var frame = RedisCacheEntryFrame.Decode(redisValue);
+        try
+        {
+            ReadOnlyMemory<byte> raw = lease.Memory;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            var frame = RedisCacheEntryFrame.Decode(raw);
 
-        return await _BuildStoreEntryFromDecodedAsync<T>(redisValue, frame, now).ConfigureAwait(false);
+            return await _BuildStoreEntryFromDecodedAsync<T>(raw, frame, now).ConfigureAwait(false);
+        }
+        finally
+        {
+            lease.Dispose();
+        }
     }
 
     // #554: bulk framed cold read. Fetches every key in one MGET (one per hash slot on cluster), decodes all
@@ -2795,7 +2845,10 @@ public sealed class RedisCache(
         var now = timeProvider.GetUtcNow().UtcDateTime;
 
         // Decode all frames up-front so the tag-marker prefetch can gather every stale tag across the batch.
+        // Bulk reads stay on the materialized-array path (there is no batch lease API); the array is cast out
+        // of each RedisValue ONCE here and reused by the per-entry build below.
         var decodedFrames = new RedisCacheEntryFrame.DecodedFrame?[count];
+        var rawBytes = new ReadOnlyMemory<byte>[count];
 
         for (var i = 0; i < count; i++)
         {
@@ -2803,7 +2856,8 @@ public sealed class RedisCache(
             {
                 try
                 {
-                    decodedFrames[i] = RedisCacheEntryFrame.Decode(rawValues[i]);
+                    rawBytes[i] = (byte[])rawValues[i]!;
+                    decodedFrames[i] = RedisCacheEntryFrame.Decode(rawBytes[i]);
                 }
                 catch (Exception e)
                 {
@@ -2828,7 +2882,7 @@ public sealed class RedisCache(
                 continue;
             }
 
-            result[i] = await _BuildStoreEntryFromDecodedAsync<T>(rawValues[i], decodedFrames[i]!.Value, now)
+            result[i] = await _BuildStoreEntryFromDecodedAsync<T>(rawBytes[i], decodedFrames[i]!.Value, now)
                 .ConfigureAwait(false);
         }
 
@@ -2837,19 +2891,20 @@ public sealed class RedisCache(
 
     /// <summary>
     /// Builds a <see cref="CacheStoreEntry{T}"/> from an already-fetched, already-decoded present value. Shared by
-    /// the single-key <see cref="_TryGetEntryAsync{T}"/> and the bulk <see cref="_TryGetAllEntriesAsync{T}"/> paths
-    /// so both apply the exact same freshness, remove/clear/tag invalidation, and metadata-mapping rules. The caller
-    /// guarantees <paramref name="redisValue"/> is present (<see cref="RedisValue.HasValue"/>) and that
-    /// <paramref name="frame"/> is its decoded form. Marker resolution goes through the process-local marker cache;
-    /// the bulk caller pre-warms it so this pays no per-entry round-trip.
+    /// the single-key <see cref="_TryGetEntryAsync{T}"/> (which passes pooled lease memory, #580) and the bulk
+    /// <see cref="_TryGetAllEntriesAsync{T}"/> paths so both apply the exact same freshness, remove/clear/tag
+    /// invalidation, and metadata-mapping rules. The caller guarantees <paramref name="rawValue"/> holds the
+    /// present value's bytes, that <paramref name="frame"/> is its decoded form, and that the backing buffer stays
+    /// alive until this method completes. Marker resolution goes through the process-local marker cache; the bulk
+    /// caller pre-warms it so this pays no per-entry round-trip.
     /// </summary>
     private async ValueTask<CacheStoreEntry<T>> _BuildStoreEntryFromDecodedAsync<T>(
-        RedisValue redisValue,
+        ReadOnlyMemory<byte> rawValue,
         RedisCacheEntryFrame.DecodedFrame frame,
         DateTime now
     )
     {
-        var concurrencyStamp = _ToConcurrencyStamp(redisValue);
+        var concurrencyStamp = _ToConcurrencyStamp(rawValue.Span);
 
         if (frame.IsFramed)
         {
@@ -2864,7 +2919,7 @@ public sealed class RedisCache(
             // (KeyExpire bumps the key TTL but does not rewrite the frame), so reporting it would make the
             // coordinator treat a live, recently-touched key as logically expired and spuriously re-run the
             // factory. Drop it and let freshness rely on key existence + the physical cap, mirroring the
-            // other sliding read paths (_RedisValueToCacheValueAsync, _RedisValueIsLogicallyPresentAsync).
+            // other sliding read paths (_LeaseToCacheValueAsync, _LeaseIsLogicallyPresentAsync).
             var logicalExpiresAt = frame.SlidingExpiration.HasValue ? null : frame.LogicalExpiresAt;
             var slidingExpiration = frame.SlidingExpiration;
 
@@ -2910,7 +2965,7 @@ public sealed class RedisCache(
             };
         }
 
-        if (redisValue == _NullValue)
+        if (_IsNullSentinel(rawValue.Span))
         {
             return new CacheStoreEntry<T>(
                 Found: true,
@@ -2928,7 +2983,7 @@ public sealed class RedisCache(
         return new CacheStoreEntry<T>(
             Found: true,
             IsNull: false,
-            Value: _FromRedisValue<T>(redisValue),
+            Value: _DeserializeValueSegment<T>(rawValue),
             LogicalExpiresAt: null,
             PhysicalExpiresAt: null,
             SlidingExpiration: null
@@ -2938,34 +2993,41 @@ public sealed class RedisCache(
         };
     }
 
-    private async ValueTask<bool> _RedisValueIsLogicallyPresentAsync(RedisValue redisValue)
+    private async ValueTask<bool> _LeaseIsLogicallyPresentAsync(Lease<byte>? lease)
     {
-        if (!redisValue.HasValue)
+        if (lease is null)
         {
             return false;
         }
 
-        var frame = RedisCacheEntryFrame.Decode(redisValue);
-
-        if (!frame.IsFramed)
+        try
         {
-            return true;
+            var frame = RedisCacheEntryFrame.Decode((ReadOnlyMemory<byte>)lease.Memory);
+
+            if (!frame.IsFramed)
+            {
+                return true;
+            }
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+
+            if (
+                _IsExpired(frame.PhysicalExpiresAt, now)
+                || (!frame.SlidingExpiration.HasValue && _IsExpired(frame.LogicalExpiresAt, now))
+            )
+            {
+                return false;
+            }
+
+            // Family-2: a tag/clear-invalidated entry is logically absent for direct reads (Exists), even though
+            // its physical reserve survives for fail-safe serving.
+            var newestMarker = await _ResolveNewestMarkerAsync(frame.Tags).ConfigureAwait(false);
+            return !CacheTagInvalidation.IsInvalidated(frame.CreatedAt, newestMarker);
         }
-
-        var now = timeProvider.GetUtcNow().UtcDateTime;
-
-        if (
-            _IsExpired(frame.PhysicalExpiresAt, now)
-            || (!frame.SlidingExpiration.HasValue && _IsExpired(frame.LogicalExpiresAt, now))
-        )
+        finally
         {
-            return false;
+            lease.Dispose();
         }
-
-        // Family-2: a tag/clear-invalidated entry is logically absent for direct reads (Exists), even though its
-        // physical reserve survives for fail-safe serving.
-        var newestMarker = await _ResolveNewestMarkerAsync(frame.Tags).ConfigureAwait(false);
-        return !CacheTagInvalidation.IsInvalidated(frame.CreatedAt, newestMarker);
     }
 
     private ValueTask _TryRearmSlidingEntryAsync(

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -395,7 +395,19 @@ public sealed class RedisCache(
 
         var now = timeProvider.GetUtcNow();
         var normalizedExpiration = _NormalizeExpiration(expiration);
-        var redisValue = _ToFramedRedisValue(value, normalizedExpiration, now);
+        var expiresAt = _GetExpirationDateTime(normalizedExpiration, now);
+
+        // #580 zero-concat write: the using scope extends past the EVALSHA await because the pooled payload
+        // buffer backs the outgoing value until the command is written to the socket.
+        using var framed = _EncodeFramedWrite(
+            value,
+            isNull: value is null,
+            logicalExpiresAt: expiresAt,
+            physicalExpiresAt: expiresAt,
+            slidingExpiration: null,
+            createdAt: now.UtcDateTime
+        );
+
         var expectedValue = _ToRedisValue(expected);
 
         var expiresMs = _GetExpirationMilliseconds(expiration, now);
@@ -408,7 +420,7 @@ public sealed class RedisCache(
                 new
                 {
                     key = (RedisKey)_GetKey(key),
-                    value = redisValue,
+                    value = framed.Value,
                     expected = expectedValue,
                     expectedIsNull = expected is null ? 1 : 0,
                     expires = expiresArg,
@@ -2510,9 +2522,23 @@ public sealed class RedisCache(
         }
 
         expiresIn = _NormalizeExpiration(expiresIn);
-        var redisValue = _ToFramedRedisValue(value, expiresIn, timeProvider.GetUtcNow());
+        var now = timeProvider.GetUtcNow();
+        var expiresAt = _GetExpirationDateTime(expiresIn, now);
 
-        return await _database.StringSetAsync(key, redisValue, expiresIn, when).ConfigureAwait(false);
+        // #580 zero-concat write: the using scope extends past the SET await because the pooled payload buffer
+        // backs the outgoing value until the command is written to the socket.
+        using var framed = _EncodeFramedWrite(
+            value,
+            isNull: value is null,
+            logicalExpiresAt: expiresAt,
+            physicalExpiresAt: expiresAt,
+            slidingExpiration: null,
+            // Direct upsert path stamps the birth time so a prior tag/clear marker does not invalidate the new
+            // value (Family-2 version-pinning compares CreatedAt against the newest applicable marker).
+            createdAt: now.UtcDateTime
+        );
+
+        return await _database.StringSetAsync(key, framed.Value, expiresIn, when).ConfigureAwait(false);
     }
 
     private RedisValue _ToFramedRedisValue<T>(T? value, TimeSpan? expiresIn, DateTimeOffset now)
@@ -2582,6 +2608,81 @@ public sealed class RedisCache(
             tags,
             createdAt
         );
+    }
+
+    /// <summary>
+    /// Pairs a wire-ready <see cref="RedisValue"/> with the pooled serializer buffer backing its value segment
+    /// (#580 zero-concat writes). SE.Redis reads the value when the socket write fires, so the buffer must stay
+    /// rented until the write command's await completes: writers scope this in a <c>using</c> that extends past
+    /// the await. A null owner means the value is a self-contained <c>byte[]</c> with nothing to return.
+    /// </summary>
+    private readonly struct FramedValueWrite(RedisValue value, PooledByteBufferWriter? payloadOwner) : IDisposable
+    {
+        public RedisValue Value { get; } = value;
+
+        public void Dispose() => payloadOwner?.Dispose();
+    }
+
+    // #580 zero-concat write: same value-segment fast paths as _EncodeFramedValue, but a serialized payload stays
+    // in its pooled buffer and rides the wire as the second ReadOnlySequence segment instead of being concatenated
+    // with the header into a fresh byte[] per write. Single-key writers use this; bulk writes (UpsertAllAsync)
+    // stay on _EncodeFramedValue because their N pooled buffers would all have to outlive one batched await.
+    private FramedValueWrite _EncodeFramedWrite<T>(
+        T? value,
+        bool isNull,
+        DateTime? logicalExpiresAt,
+        DateTime? physicalExpiresAt,
+        TimeSpan? slidingExpiration,
+        DateTime? eagerRefreshAt = null,
+        string? etag = null,
+        DateTime? lastModifiedAt = null,
+        IReadOnlyCollection<string>? tags = null,
+        DateTime? createdAt = null
+    )
+    {
+        if (isNull || value is null or string or byte[])
+        {
+            var framed = RedisCacheEntryFrame.Encode(
+                isNull ? RedisValue.EmptyString : _ToRedisValue(value),
+                isNull,
+                logicalExpiresAt,
+                physicalExpiresAt,
+                slidingExpiration,
+                eagerRefreshAt,
+                etag,
+                lastModifiedAt,
+                tags,
+                createdAt
+            );
+
+            return new FramedValueWrite(framed, payloadOwner: null);
+        }
+
+        var buffer = new PooledByteBufferWriter();
+
+        try
+        {
+            serializer.Serialize(value, buffer);
+
+            var spliced = RedisCacheEntryFrame.EncodeSpliced(
+                buffer.WrittenMemory,
+                logicalExpiresAt,
+                physicalExpiresAt,
+                slidingExpiration,
+                eagerRefreshAt,
+                etag,
+                lastModifiedAt,
+                tags,
+                createdAt
+            );
+
+            return new FramedValueWrite(spliced, buffer);
+        }
+        catch
+        {
+            buffer.Dispose();
+            throw;
+        }
     }
 
     // Single-tier (L2 only): the per-tier readOptions have no meaning here and are ignored.
@@ -2658,7 +2759,9 @@ public sealed class RedisCache(
             return true;
         }
 
-        var redisValue = _EncodeFramedValue(
+        // #580 zero-concat write: the using scope extends past the SET/EVALSHA await because the pooled payload
+        // buffer backs the outgoing value until the command is written to the socket.
+        using var framed = _EncodeFramedWrite(
             entry.Value,
             entry.IsNull,
             entry.LogicalExpiresAt,
@@ -2683,7 +2786,7 @@ public sealed class RedisCache(
         // markers, not a reverse index — so there is no per-tag index to reconcile and no cluster restriction).
         if (!hasExpectedStamp)
         {
-            await _database.StringSetAsync(redisKey, redisValue, expiresIn).ConfigureAwait(false);
+            await _database.StringSetAsync(redisKey, framed.Value, expiresIn).ConfigureAwait(false);
             return true;
         }
 
@@ -2698,7 +2801,7 @@ public sealed class RedisCache(
                 new
                 {
                     key = (RedisKey)redisKey,
-                    value = (RedisValue)redisValue,
+                    value = framed.Value,
                     expectedValue,
                     keyTtlMs,
                     headerLen = RedisCacheEntryFrame.HeaderLength,

--- a/src/Headless.Caching.Redis/RedisCache.cs
+++ b/src/Headless.Caching.Redis/RedisCache.cs
@@ -40,6 +40,11 @@ public sealed class RedisCache(
 {
     /// <summary>Legacy null sentinel retained only for raw pre-envelope payloads and collection entries.</summary>
     private static readonly RedisValue _NullValue = "@@NULL";
+
+    // Single source of truth for the null-sentinel bytes: the lease/memory read paths compare against these
+    // instead of a hand-copied "@@NULL"u8 literal, so the sentinel can never drift between the RedisValue writers
+    // (which store _NullValue) and the byte-level readers. Derived once from _NullValue at type init.
+    private static readonly byte[] _NullValueBytes = (byte[])_NullValue!;
     private const int _BatchSize = 250;
 
     /// <summary>
@@ -1129,7 +1134,7 @@ public sealed class RedisCache(
 
         try
         {
-            var frame = RedisCacheEntryFrame.Decode((ReadOnlyMemory<byte>)lease.Memory);
+            var frame = RedisCacheEntryFrame.DecodeMemory(lease.Memory);
 
             if (!frame.IsFramed)
             {
@@ -1193,7 +1198,7 @@ public sealed class RedisCache(
         {
             ReadOnlyMemory<byte> raw = lease.Memory;
             var now = timeProvider.GetUtcNow().UtcDateTime;
-            var frame = RedisCacheEntryFrame.Decode(raw);
+            var frame = RedisCacheEntryFrame.DecodeMemory(raw);
 
             if (frame.IsFramed)
             {
@@ -2248,9 +2253,10 @@ public sealed class RedisCache(
         return serializer.Deserialize<T>((ReadOnlySequence<byte>)redisValue!);
     }
 
-    // Byte-level mirror of the _NullValue comparison for the lease/memory read paths (#580). The u8 literal must
-    // stay in sync with _NullValue ("@@NULL"); RedisValue equality is content-based, so both compare identically.
-    private static bool _IsNullSentinel(ReadOnlySpan<byte> value) => value.SequenceEqual("@@NULL"u8);
+    // Byte-level mirror of the _NullValue comparison for the lease/memory read paths (#580). Compares against
+    // _NullValueBytes (derived from _NullValue at init) so there is a single sentinel source of truth; RedisValue
+    // equality is content-based, so this matches the RedisValue-path comparison exactly.
+    private static bool _IsNullSentinel(ReadOnlySpan<byte> value) => value.SequenceEqual(_NullValueBytes);
 
     /// <summary>
     /// Single-key read conversion from a pooled <see cref="Lease{T}"/> (#580). The lease buffer is ArrayPool-owned
@@ -2272,7 +2278,7 @@ public sealed class RedisCache(
         try
         {
             ReadOnlyMemory<byte> raw = lease.Memory;
-            var frame = RedisCacheEntryFrame.Decode(raw);
+            var frame = RedisCacheEntryFrame.DecodeMemory(raw);
 
             if (frame.IsFramed)
             {
@@ -2360,7 +2366,7 @@ public sealed class RedisCache(
         try
         {
             ReadOnlyMemory<byte> raw = lease.Memory;
-            var frame = RedisCacheEntryFrame.Decode(raw);
+            var frame = RedisCacheEntryFrame.DecodeMemory(raw);
 
             if (frame.IsFramed)
             {
@@ -2905,7 +2911,7 @@ public sealed class RedisCache(
         {
             ReadOnlyMemory<byte> raw = lease.Memory;
             var now = timeProvider.GetUtcNow().UtcDateTime;
-            var frame = RedisCacheEntryFrame.Decode(raw);
+            var frame = RedisCacheEntryFrame.DecodeMemory(raw);
 
             return await _BuildStoreEntryFromDecodedAsync<T>(raw, frame, now).ConfigureAwait(false);
         }
@@ -2960,7 +2966,7 @@ public sealed class RedisCache(
                 try
                 {
                     rawBytes[i] = (byte[])rawValues[i]!;
-                    decodedFrames[i] = RedisCacheEntryFrame.Decode(rawBytes[i]);
+                    decodedFrames[i] = RedisCacheEntryFrame.DecodeMemory(rawBytes[i]);
                 }
                 catch (Exception e)
                 {
@@ -3105,7 +3111,7 @@ public sealed class RedisCache(
 
         try
         {
-            var frame = RedisCacheEntryFrame.Decode((ReadOnlyMemory<byte>)lease.Memory);
+            var frame = RedisCacheEntryFrame.DecodeMemory(lease.Memory);
 
             if (!frame.IsFramed)
             {

--- a/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
+++ b/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
@@ -362,7 +362,7 @@ internal static class RedisCacheEntryFrame
             return DecodedFrame.Unframed;
         }
 
-        return Decode((ReadOnlyMemory<byte>)_ToBytes(value));
+        return DecodeMemory(_ToBytes(value));
     }
 
     /// <summary>
@@ -370,9 +370,11 @@ internal static class RedisCacheEntryFrame
     /// <c>StringGetLeaseAsync</c>) without materializing a <see cref="RedisValue"/> <c>byte[]</c>. The returned
     /// <see cref="DecodedFrame.ValueSegment"/> is a slice of <paramref name="bytes"/> — its lifetime is the
     /// caller's buffer lifetime, so pooled callers must not return the buffer to the pool while the segment is
-    /// still consumed.
+    /// still consumed. Named distinctly from <see cref="Decode(RedisValue)"/> because <c>byte[]</c> converts
+    /// implicitly to both <see cref="RedisValue"/> and <see cref="ReadOnlyMemory{T}"/>, so a shared name would
+    /// make every <c>byte[]</c> call site ambiguous (CS0121) and force an explicit cast.
     /// </summary>
-    public static DecodedFrame Decode(ReadOnlyMemory<byte> bytes)
+    public static DecodedFrame DecodeMemory(ReadOnlyMemory<byte> bytes)
     {
         var span = bytes.Span;
 

--- a/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
+++ b/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
@@ -124,6 +124,60 @@ internal static class RedisCacheEntryFrame
     }
 
     /// <summary>
+    /// Encodes a framed entry as a two-segment <see cref="ReadOnlySequence{T}"/> — the header/section prefix in
+    /// its own buffer, the caller's <paramref name="payload"/> spliced in as the second segment with NO copy
+    /// (#580 zero-concat writes). The frame layout has no value-length field (the value segment is implicitly
+    /// "to the end"), so the wire bytes are identical to the single-buffer <c>Encode</c> overloads'. The caller
+    /// owns the payload buffer and must keep it alive until the sequence is fully consumed — for a SE.Redis
+    /// write command that means until the command's await completes, since the sequence is read when the socket
+    /// write fires. A null value has no payload; encode it through the <see cref="RedisValue"/> overload instead.
+    /// </summary>
+    public static ReadOnlySequence<byte> EncodeSpliced(
+        ReadOnlyMemory<byte> payload,
+        DateTime? logicalExpiresAt,
+        DateTime? physicalExpiresAt,
+        TimeSpan? slidingExpiration,
+        DateTime? eagerRefreshAt = null,
+        string? etag = null,
+        DateTime? lastModifiedAt = null,
+        IReadOnlyCollection<string>? tags = null,
+        DateTime? createdAt = null
+    )
+    {
+        // valueLength: 0 sizes the buffer to exactly the header + optional-sections prefix.
+        var header = _BuildFrame(
+            0,
+            isNull: false,
+            logicalExpiresAt,
+            physicalExpiresAt,
+            slidingExpiration,
+            eagerRefreshAt,
+            etag,
+            lastModifiedAt,
+            tags,
+            createdAt,
+            out _
+        );
+
+        var first = new MemorySegment(header);
+        var last = first.Append(payload);
+
+        return new ReadOnlySequence<byte>(first, 0, last, payload.Length);
+    }
+
+    private sealed class MemorySegment : ReadOnlySequenceSegment<byte>
+    {
+        public MemorySegment(ReadOnlyMemory<byte> memory) => Memory = memory;
+
+        public MemorySegment Append(ReadOnlyMemory<byte> memory)
+        {
+            var next = new MemorySegment(memory) { RunningIndex = RunningIndex + Memory.Length };
+            Next = next;
+            return next;
+        }
+    }
+
+    /// <summary>
     /// Builds the framed buffer sized <c>payloadOffset + valueLength</c> with the full header and every present
     /// optional section written, leaving the value segment (from <paramref name="payloadOffset"/> to the end)
     /// uninitialized for the caller to fill. This is the payload-agnostic core shared by both <c>Encode</c>

--- a/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
+++ b/src/Headless.Caching.Redis/RedisCacheEntryFrame.cs
@@ -308,21 +308,33 @@ internal static class RedisCacheEntryFrame
             return DecodedFrame.Unframed;
         }
 
-        var bytes = _ToBytes(value);
+        return Decode((ReadOnlyMemory<byte>)_ToBytes(value));
+    }
 
-        if (bytes.Length < HeaderLength || bytes[0] != Magic)
+    /// <summary>
+    /// Decodes a frame directly from caller-owned contiguous bytes (e.g. a pooled <c>Lease&lt;byte&gt;</c> from
+    /// <c>StringGetLeaseAsync</c>) without materializing a <see cref="RedisValue"/> <c>byte[]</c>. The returned
+    /// <see cref="DecodedFrame.ValueSegment"/> is a slice of <paramref name="bytes"/> — its lifetime is the
+    /// caller's buffer lifetime, so pooled callers must not return the buffer to the pool while the segment is
+    /// still consumed.
+    /// </summary>
+    public static DecodedFrame Decode(ReadOnlyMemory<byte> bytes)
+    {
+        var span = bytes.Span;
+
+        if (span.Length < HeaderLength || span[0] != Magic)
         {
             return DecodedFrame.Unframed;
         }
 
         // Any other version (including the retired v1) reads as unframed legacy bytes: the value segment
         // layout is unknown, so the safe interpretation is a decode miss rather than a partial parse.
-        if (bytes[1] != Version)
+        if (span[1] != Version)
         {
             return DecodedFrame.Unframed;
         }
 
-        var flags = bytes[2];
+        var flags = span[2];
 
         var hasLogical = (flags & HasLogicalExpiresAtFlag) is not 0;
         var hasPhysical = (flags & HasPhysicalExpiresAtFlag) is not 0;
@@ -332,41 +344,41 @@ internal static class RedisCacheEntryFrame
         var hasLastModified = (flags & HasLastModifiedAtFlag) is not 0;
         var hasTags = (flags & HasTagsFlag) is not 0;
 
-        var logicalMs = hasLogical ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(3, sizeof(long))) : 0L;
-        var physicalMs = hasPhysical ? BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(11, sizeof(long))) : 0L;
+        var logicalMs = hasLogical ? BinaryPrimitives.ReadInt64LittleEndian(span.Slice(3, sizeof(long))) : 0L;
+        var physicalMs = hasPhysical ? BinaryPrimitives.ReadInt64LittleEndian(span.Slice(11, sizeof(long))) : 0L;
 
         // CreatedAt occupies a fixed v3 slot in the header (always present, gated by version not a flag). The
         // HeaderLength guard above already proved these bytes exist. The absent-sentinel decodes back to null.
-        var createdAtMs = BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(_CreatedAtOffset, sizeof(long)));
+        var createdAtMs = BinaryPrimitives.ReadInt64LittleEndian(span.Slice(_CreatedAtOffset, sizeof(long)));
         var hasCreatedAt = createdAtMs != CreatedAtAbsentSentinel;
 
         var offset = HeaderLength;
 
-        if (!_TryReadInt64(bytes, hasSliding, ref offset, out var slidingMs))
+        if (!_TryReadInt64(span, hasSliding, ref offset, out var slidingMs))
         {
             return DecodedFrame.Unframed;
         }
 
-        if (!_TryReadInt64(bytes, hasEagerRefresh, ref offset, out var eagerRefreshMs))
+        if (!_TryReadInt64(span, hasEagerRefresh, ref offset, out var eagerRefreshMs))
         {
             return DecodedFrame.Unframed;
         }
 
-        if (!_TryReadInt64(bytes, hasLastModified, ref offset, out var lastModifiedMs))
+        if (!_TryReadInt64(span, hasLastModified, ref offset, out var lastModifiedMs))
         {
             return DecodedFrame.Unframed;
         }
 
         string? etag = null;
 
-        if (hasETag && !_TryReadString(bytes, ref offset, out etag))
+        if (hasETag && !_TryReadString(span, ref offset, out etag))
         {
             return DecodedFrame.Unframed;
         }
 
         string[]? decodedTags = null;
 
-        if (hasTags && !_TryReadTags(bytes, ref offset, out decodedTags))
+        if (hasTags && !_TryReadTags(span, ref offset, out decodedTags))
         {
             return DecodedFrame.Unframed;
         }
@@ -394,7 +406,7 @@ internal static class RedisCacheEntryFrame
             LastModifiedAt: hasLastModified ? _FromUnixTimeMilliseconds(lastModifiedMs) : null,
             Tags: decodedTags is { Length: > 0 } ? decodedTags : null,
             CreatedAt: hasCreatedAt ? _FromUnixTimeMilliseconds(createdAtMs) : null,
-            ValueSegment: bytes.AsMemory(offset)
+            ValueSegment: bytes[offset..]
         );
     }
 
@@ -516,7 +528,7 @@ internal static class RedisCacheEntryFrame
         }
     }
 
-    private static bool _TryReadInt64(byte[] bytes, bool present, ref int offset, out long value)
+    private static bool _TryReadInt64(ReadOnlySpan<byte> bytes, bool present, ref int offset, out long value)
     {
         value = 0L;
 
@@ -530,12 +542,12 @@ internal static class RedisCacheEntryFrame
             return false;
         }
 
-        value = BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(offset, sizeof(long)));
+        value = BinaryPrimitives.ReadInt64LittleEndian(bytes.Slice(offset, sizeof(long)));
         offset += sizeof(long);
         return true;
     }
 
-    private static bool _TryReadString(byte[] bytes, ref int offset, out string? value)
+    private static bool _TryReadString(ReadOnlySpan<byte> bytes, ref int offset, out string? value)
     {
         value = null;
 
@@ -544,7 +556,7 @@ internal static class RedisCacheEntryFrame
             return false;
         }
 
-        int length = BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(offset, sizeof(ushort)));
+        int length = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(offset, sizeof(ushort)));
         offset += sizeof(ushort);
 
         if (bytes.Length < offset + length)
@@ -552,12 +564,12 @@ internal static class RedisCacheEntryFrame
             return false;
         }
 
-        value = Encoding.UTF8.GetString(bytes.AsSpan(offset, length));
+        value = Encoding.UTF8.GetString(bytes.Slice(offset, length));
         offset += length;
         return true;
     }
 
-    private static bool _TryReadTags(byte[] bytes, ref int offset, out string[]? tags)
+    private static bool _TryReadTags(ReadOnlySpan<byte> bytes, ref int offset, out string[]? tags)
     {
         tags = null;
 
@@ -566,7 +578,7 @@ internal static class RedisCacheEntryFrame
             return false;
         }
 
-        int count = BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(offset, sizeof(ushort)));
+        int count = BinaryPrimitives.ReadUInt16LittleEndian(bytes.Slice(offset, sizeof(ushort)));
         offset += sizeof(ushort);
 
         var decoded = new string[count];

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Buffers;
 using System.Buffers.Binary;
 using Headless.Caching;
 using StackExchange.Redis;
@@ -380,6 +381,79 @@ public sealed class RedisCacheEntryFrameTests
         var decoded = _Decode(_RedisValue(bytes));
 
         decoded.IsFramed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_encode_spliced_frames_byte_identical_to_single_buffer_encode()
+    {
+        // EncodeSpliced feeds the wire directly (two-segment RedisValue, #580); the CAS scripts slice these
+        // exact bytes, so the spliced encoding must be byte-identical to the single-buffer Encode output.
+        var payload = Encoding.UTF8.GetBytes("spliced-payload");
+        var logical = new DateTime(2026, 06, 03, 12, 00, 00, DateTimeKind.Utc);
+        var physical = logical.AddMinutes(5);
+        var eager = logical.AddMinutes(2);
+        var lastModified = logical.AddMinutes(-3);
+        var created = logical.AddMinutes(-10);
+        string[] tags = ["tenant:1", "profile"];
+
+        var single = _Encode(
+            _RedisValue(payload),
+            isNull: false,
+            logical,
+            physical,
+            TimeSpan.FromSeconds(30),
+            eager,
+            etag: "etag-value",
+            lastModified,
+            tags,
+            created
+        );
+
+        var spliced = RedisCacheEntryFrame.EncodeSpliced(
+            payload,
+            logical,
+            physical,
+            TimeSpan.FromSeconds(30),
+            eager,
+            etag: "etag-value",
+            lastModified,
+            tags,
+            created
+        );
+
+        spliced.ToArray().Should().Equal(single);
+    }
+
+    [Fact]
+    public void should_encode_spliced_minimal_frame_byte_identical_to_single_buffer_encode()
+    {
+        var payload = Encoding.UTF8.GetBytes("v");
+
+        var single = _Encode(_RedisValue(payload), isNull: false, logicalExpiresAt: null, physicalExpiresAt: null);
+        var spliced = RedisCacheEntryFrame.EncodeSpliced(
+            payload,
+            logicalExpiresAt: null,
+            physicalExpiresAt: null,
+            slidingExpiration: null
+        );
+
+        spliced.ToArray().Should().Equal(single);
+    }
+
+    [Fact]
+    public void should_decode_frames_from_contiguous_memory()
+    {
+        // The lease read path (#580) decodes straight off pooled memory; the ValueSegment must be a slice of
+        // the supplied buffer with the same content the RedisValue decode path produces.
+        var value = Encoding.UTF8.GetBytes("memory-decoded");
+        var logical = new DateTime(2026, 06, 03, 12, 00, 00, DateTimeKind.Utc);
+
+        var encoded = _Encode(_RedisValue(value), isNull: false, logical, logical.AddMinutes(5));
+        var decoded = RedisCacheEntryFrame.Decode((ReadOnlyMemory<byte>)encoded.AsMemory());
+
+        decoded.IsFramed.Should().BeTrue();
+        decoded.LogicalExpiresAt.Should().Be(logical);
+        decoded.ValueSegment.ToArray().Should().Equal(value);
     }
 
     private static byte[] _Encode(

--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheEntryFrameTests.cs
@@ -449,7 +449,7 @@ public sealed class RedisCacheEntryFrameTests
         var logical = new DateTime(2026, 06, 03, 12, 00, 00, DateTimeKind.Utc);
 
         var encoded = _Encode(_RedisValue(value), isNull: false, logical, logical.AddMinutes(5));
-        var decoded = RedisCacheEntryFrame.Decode((ReadOnlyMemory<byte>)encoded.AsMemory());
+        var decoded = RedisCacheEntryFrame.DecodeMemory(encoded);
 
         decoded.IsFramed.Should().BeTrue();
         decoded.LogicalExpiresAt.Should().Be(logical);


### PR DESCRIPTION
Implements levers 1 and 2 of #580 (lever 3 — RESP3 `CLIENT TRACKING` — stays a separate design issue per that issue's own scoping).

## What changed

- **Lever 1 — pooled-lease reads**: single-key read paths (`GetAsync`, `GetWithExpirationAsync`, `TryGetToAsync`, `ExistsAsync`, `GetExpirationAsync`, factory-store `TryGetEntryAsync`) switch to `StringGetLeaseAsync`; the value buffer is ArrayPool-rented and returned after decode/deserialize instead of being a per-read heap allocation. New `RedisCacheEntryFrame.Decode(ReadOnlyMemory<byte>)` overload decodes straight off the lease. Bulk MGET reads stay on the materialized-array path (no batch lease API).
- **Lever 2 — zero-concat typed writes**: `_SetInternalAsync`, `_SetEntryCoreAsync`, and `TryReplaceIfEqualAsync` no longer concatenate frame header + serialized payload into a fresh `byte[]` per write. `RedisCacheEntryFrame.EncodeSpliced` builds a two-segment `ReadOnlySequence<byte>` (header buffer + pooled serializer payload) assigned directly to `RedisValue` (SE.Redis 3.x); the pooled buffer stays rented until the write await completes. Bulk writes (`UpsertAllAsync`) stay on the concatenating path.
- **Benchmark harness fix**: hot-key seed TTL was 1 minute, shorter than a full BenchmarkDotNet case — hot keys expired mid-case and the PayloadSize=4096 `HotGetAsync` "baseline" was silently measuring misses (miss-sized 896 B allocations, multimodal distributions). Seed TTL is now 1 hour.

Wire format is unchanged — `EncodeSpliced` output is unit-tested byte-identical to the single-buffer `Encode` (the CAS Lua scripts slice those exact bytes).

## Benchmark gate (issue #580 requirement)

`DistributedOnlyCacheBenchmarks`, `headless-redis`, local Redis 7, M4 Max, Job.Default + MemoryDiagnoser. A = corrected baseline (`aa08df2ad`), B = lever 1, C = levers 1+2. Allocations per op:

| op | payload | A | B | C | C vs A |
|---|---|---:|---:|---:|---:|
| HotGetAsync | 128 | 1,664 B | 1,376 B | 1,376 B | **−17%** |
| HotGetAsync | 4096 | 10,920 B | 5,344 B | 5,344 B | **−51%** |
| SetThenGetAsync | 128 | 3,145 B | 2,856 B | 2,729 B | **−13%** |
| SetThenGetAsync | 4096 | 17,689 B | 12,112 B | 6,696 B | **−62%** |
| RemoveAsync (set+del) | 4096 | 7,552 B | 7,552 B | 2,136 B | **−72%** |
| MissGetAsync | any | 896 B | 880 B | 880 B | −2% |

Gen0/1k-ops mirrors the drops (HotGet 4096: 1.46 → 0.73; Remove 4096: 0.49 → 0). Timings were flat within ±3% on the quiet A/B runs; the C runs landed on a loaded machine (untouched paths like `MissGetAsync` inflated 10–40%), so C timing means are noise — allocations are deterministic and are the gate metric. The issue's wash-out concern for ShortBlob-range values did not materialize (128 B payloads still net −17% with flat timing).

**Lever 1 gate: PASS. Lever 2: kept (large win at 4 KB, small net win even at 128 B).**

## Validation

- 239/239 `Headless.Caching.Redis.Tests.Integration` green (236 existing + 3 new frame-codec tests: spliced/single-buffer byte parity ×2, memory-based decode).
- `make quality-analyzers-project PROJECT=src/Headless.Caching.Redis` clean.
- Lease lifetime rules: decoded `ValueSegment` slices are consumed before the lease's `finally` dispose; pooled write buffers outlive their command await (`FramedValueWrite` using-scope). `UpsertRawAsync` intentionally keeps its copy path — its documented contract is that the caller's sequence is consumed before the first yield.

Closes #580 (levers 1–2; lever 3 to be filed as its own design issue).