### PR TITLE
fix(security): dashboard auth/CORS/DoS hardening, Paymob log redaction, Trusted Publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Mirror the local 7-day supply-chain quarantine: don't open PRs for versions published <7 days ago
+    # (majors soak 14 days), so a compromised fresh release isn't auto-proposed before it's flagged.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -36,6 +41,8 @@ updates:
       prefix: "build"
       include: "scope"
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -51,6 +58,8 @@ updates:
       prefix: "build"
       include: "scope"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -73,6 +82,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -105,6 +116,9 @@ updates:
         applies-to: "security-updates"
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     schedule:
       interval: "weekly"
       day: "tuesday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # Request the GitHub OIDC token exchanged for a short-lived nuget.org key (Trusted Publishing).
 
     environment:
       name: "NuGet Release"
@@ -239,9 +240,19 @@ jobs:
         with:
           name: packages-results
 
+      # Exchange the workflow OIDC token for a temporary nuget.org API key (valid ~1h, one key per token).
+      # Requires a Trusted Publishing policy on nuget.org bound to this repo, the workflow file (ci.yml), and
+      # the "NuGet Release" environment, plus a NUGET_USER secret holding the nuget.org account (profile) name.
+      # No long-lived publishing secret is stored.
+      - name: "NuGet login (OIDC -> temporary API key)"
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: "Push Packages"
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           set -euo pipefail
           shopt -s nullglob

--- a/docs/llms/jobs.md
+++ b/docs/llms/jobs.md
@@ -119,7 +119,7 @@ Mark job methods with `[JobFunction("name")]` (or `[JobFunction("name", cronExpr
 - Set `OnNodeDeath = NodeDeathPolicy.MarkFailed` or `Skip` on non-idempotent jobs — default `Retry` will re-run the job after a node crash.
 - Do NOT install a Jobs-specific cache package. Jobs cron-expression caching reuses the host's `ICache` (`Headless.Caching.InMemory`, `.Redis`, or `.Hybrid`). Without a registered `ICache`, cron expressions are read directly from the database.
 - Atomic enqueue: wrap `timeJobManager.AddAsync` / `cronJobManager.AddAsync` inside `db.ExecuteCoordinatedTransactionAsync(...)` to commit domain writes and the job row as one unit. Requires a `Headless.CommitCoordination` provider (`AddPostgreSqlCommitCoordination()` / `AddSqlServerCommitCoordination()`) — a different subsystem from `AddHeadlessCoordination`. The coordinated path throws on any failure; wrap in `try/catch`.
-- Coordinated enqueue capture is synchronous: the `AsyncLocal` scope is captured when `AddAsync` is entered. Do not put `AddAsync` behind an `await` that executes before it — the scope is lost and the enqueue silently falls back to direct insert.
+- Establish commit coordination synchronously before entering asynchronous work. The provided `ExecuteCoordinatedTransactionAsync` helpers do this correctly; once established, the scope flows across awaits inside the operation, so domain writes and message publishes may be awaited before `AddAsync`.
 - Use `[JobsConstructor]` (`JobsConstructorAttribute`) on the constructor the source generator should use when a class has multiple constructors.
 - For testing, call `options.DisableBackgroundServices()` to suppress background scheduler execution.
 - To use `JobsStartMode.Manual`, set `scheduler.StartMode = JobsStartMode.Manual` inside `ConfigureScheduler`.
@@ -210,7 +210,7 @@ await db.ExecuteCoordinatedTransactionAsync(
 ```
 
 **Footguns:**
-- Coordinated scope capture is synchronous at the point `AddAsync` is entered. Never put `AddAsync` behind an `await` that executes before it — the `AsyncLocal` scope is lost and the enqueue silently falls back to direct insert that auto-commits even if the outer transaction rolls back.
+- The ambient scope must be established synchronously; do not create a custom async factory that sets `ICurrentCommitCoordinator`. Use `ExecuteCoordinatedTransactionAsync` or a synchronous enlistment API. After enlistment, normal awaits inside the coordinated operation preserve the scope.
 - Coordinated enqueues in one scope must be sequential — the scope's DB connection/transaction is not thread-safe.
 - `AddAsync` / `AddBatchAsync` **throw** on failure (validation, dead/completed transaction, mis-wire). `Update` / `Delete` return `JobResult<T>` and do not throw.
 - A returned entity on the coordinated path means the row was **enlisted** (commits with the transaction), not that dispatch ran. The fallback poll sweep (`FallbackIntervalChecker`, default 30s) recovers a missed post-commit dispatch.

--- a/docs/llms/jobs.md
+++ b/docs/llms/jobs.md
@@ -451,12 +451,12 @@ Provides operational visibility into the Jobs scheduler — job queues, executio
 - **Authentication options**: `WithBasicAuth(username, password)`, `WithApiKey(apiKey)`, `WithHostAuthentication(policy?)` (delegates to host app's auth), or explicit no-auth mode for isolated development dashboards.
 - **Live cluster view**: `GET /api/nodes` returns live node projections from `Headless.Coordination` membership; `NodeJoined` / `NodeLeft` / `NodeSuspected` push updates over SignalR — no polling required.
 - **Error monitoring**: surfaces failed, cancelled, and skipped jobs; retry counts; execution timings; exception messages.
-- **Fluent builder**: `SetBasePath(path)`, `SetBackendDomain(domain)`, `SetCorsPolicy(policy)`.
+- **Fluent builder**: `SetBasePath(path)`, `SetBackendDomain(domain)`, `SetCorsOrigins(origins)`, `SetCorsPolicy(policy)`.
 - **Pair with OpenTelemetry**: Dashboard for operational triage; `Jobs.OpenTelemetry` for trace-level diagnostics.
 
 ### Design Notes
 
-The dashboard exposes operational endpoints that can create, update, delete, run, cancel, start, stop, and restart jobs. Treat `WithNoAuth()` or omitted auth as development-only unless the dashboard is isolated behind trusted network controls. Production deployments should use `WithHostAuthentication(...)`, `WithBasicAuth(...)`, or `WithApiKey(...)`, and should set an explicit CORS policy instead of relying on open cross-origin access.
+The dashboard exposes operational endpoints that can create, update, delete, run, cancel, start, stop, and restart jobs. Authentication must be chosen explicitly — if no auth method (including `WithNoAuth()`) is called, the host fails to start, so the dashboard never ships publicly by omission. Treat `WithNoAuth()` as development-only unless the dashboard is isolated behind trusted network controls; production deployments should use `WithHostAuthentication(...)`, `WithBasicAuth(...)`, or `WithApiKey(...)`. No CORS policy is applied by default (same-origin only); use `SetCorsOrigins(...)` when the SPA is served cross-origin.
 
 ### Installation
 
@@ -492,18 +492,18 @@ builder
         // Path and domain
         dashboard.SetBasePath("/jobs");
         dashboard.SetBackendDomain("https://api.example.com");
-        dashboard.SetCorsPolicy("MyPolicy");
+        dashboard.SetCorsOrigins("https://admin.example.com"); // needed only when the SPA is cross-origin
 
-        // Authentication — pick one:
+        // Authentication — required, pick one:
         dashboard.WithBasicAuth("admin", "secret"); // username/password
         dashboard.WithApiKey("my-api-key"); // Bearer token / query param
         dashboard.WithHostAuthentication(); // delegate to host auth
         dashboard.WithHostAuthentication("AdminPolicy"); // host auth + policy
-        // Omitting auth = public dashboard; use only in isolated development environments.
+        // Or opt out explicitly with dashboard.WithNoAuth() — isolated development environments only.
     });
 ```
 
-Auth detection is automatic: no auth → public; basic auth → username/password login UI; API key → bearer token; host auth → delegates to the host's authentication middleware.
+Auth detection is automatic: explicit `WithNoAuth()` → public; basic auth → username/password login UI; API key → bearer token; host auth → delegates to the host's authentication middleware.
 
 ### Dependencies
 

--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -207,7 +207,7 @@ services.AddHeadlessMessaging(setup =>
 - **Use `InMemory` + `InMemoryStorage` only for dev/testing**, never in production. Data is lost on restart.
 - **Add `Messaging.OpenTelemetry`** for tracing in any production deployment.
 - **Add `Messaging.Testing`** in test projects for integration testing with awaitable assertions. Use `AddMessagingTestHarness()` to decorate an existing host's DI container (WebApplicationFactory, IHost), or `MessagingTestHarness.CreateAsync()` for standalone harness.
-- **Add `Messaging.Dashboard`** when monitoring UI is needed; it defaults to no authentication and exposes operational message actions, so configure `WithBasicAuth`, `WithApiKey`, `WithHostAuthentication`, or `WithCustomAuth` plus explicit CORS before production exposure.
+- **Add `Messaging.Dashboard`** when monitoring UI is needed; it exposes operational message actions and requires an explicit authentication choice (the host fails to start otherwise), so configure `WithBasicAuth`, `WithApiKey`, `WithHostAuthentication`, or `WithCustomAuth` — and `SetCorsOrigins` if the SPA is served cross-origin — before production exposure.
 - **Messages are type-safe**: Define message types as classes/records. Register explicit consumers implementing `IConsume<TMessage>` with `setup.ForMessage<TMessage>(...)`. Use `setup.ForMessagesFromAssemblyContaining<TMarker>()` or `setup.ForMessagesFromAssembly(assembly)` inside `AddHeadlessMessaging(...)` for assembly scanning. Use the scan callback overloads to set per-consumer queue/bus intent, group, concurrency, handler id, circuit-breaker override, or `Skip()`; keep message-name overrides on explicit `ForMessage<TMessage>(...)` registrations.
 - **Library-owned consumers can register out of order**: `IServiceCollection.ForMessage<TMessage>(...)` can run before or after `AddHeadlessMessaging(...)` during service configuration — both entry points share one found-or-created `ConsumerRegistry`. `MessageName(...)` mappings are registered eagerly, so a publish that races ahead of startup (e.g. an `IHostedService` publishing in `StartAsync`) still resolves the explicit name rather than the convention fallback. Consumer metadata still drains before startup topology reads, so package setup methods do not need to force an app-level call order.
 - **Runtime handlers are first-class**: Use `IRuntimeSubscriber` for ephemeral broker-attached delegates. They share scoped DI, middleware, diagnostics, retry, and correlation semantics with class handlers.
@@ -988,11 +988,11 @@ builder.Services.AddHeadlessMessaging(setup =>
 
 ### Configuration
 
-Configured through `MessagingDashboardOptionsBuilder` inside `UseDashboard(...)`. Authentication is opt-in — with `WithNoAuth()` (the default) the dashboard is public, so configure authentication and CORS before production exposure.
+Configured through `MessagingDashboardOptionsBuilder` inside `UseDashboard(...)`. Authentication must be chosen explicitly — if no `WithXxx` auth method (including `WithNoAuth()`) is called, the host fails to start. No CORS policy is applied by default (same-origin only); use `SetCorsOrigins(...)` for the cross-origin SPA case.
 
 | Method | Default | Description |
 | --- | --- | --- |
-| `WithNoAuth()` | (default) | Public dashboard, no authentication; development or trusted-network use only. |
+| `WithNoAuth()` | (no default — auth is required) | Explicitly opt out of authentication; development or trusted-network use only. |
 | `WithBasicAuth(username, password)` | — | HTTP Basic authentication. |
 | `WithApiKey(apiKey)` | — | API-key authentication. |
 | `WithHostAuthentication(policy?)` | — | Reuse the host app's auth, with an optional authorization policy. |

--- a/src/Headless.Jobs.Abstractions/README.md
+++ b/src/Headless.Jobs.Abstractions/README.md
@@ -106,4 +106,4 @@ await db.ExecuteCoordinatedTransactionAsync(
 
 The coordinated path needs **two** separate registrations: `AddHeadlessCoordination(...)` (the `Headless.Coordination` distributed-lock/membership subsystem for the operational store) AND `Add{Provider}CommitCoordination()` (the `Headless.CommitCoordination` transactional scope subsystem). Similar names, different systems.
 
-`AddAsync` / `AddBatchAsync` **throw** on failure; wrap in `try/catch`. The scope capture is synchronous — do not `await` before calling `AddAsync` inside a coordinated scope or the scope is lost.
+`AddAsync` / `AddBatchAsync` **throw** on failure; wrap in `try/catch`. Establish the coordinated scope synchronously (the provided `ExecuteCoordinatedTransactionAsync` helpers do this correctly). Once established, the scope flows across awaits inside the operation, so domain writes and message publishes may be awaited before the job enqueue.

--- a/src/Headless.Jobs.Core/JobsExecutionTaskHandler.cs
+++ b/src/Headless.Jobs.Core/JobsExecutionTaskHandler.cs
@@ -568,8 +568,7 @@ internal sealed class JobsExecutionTaskHandler
         {
             handlerCts.Dispose();
         }
-#pragma warning restore ERP022
-#pragma warning restore VSTHRD003
+#pragma warning restore ERP022, VSTHRD003
     }
 
     private async Task _InvokeOnExhaustedAsync(
@@ -651,8 +650,7 @@ internal sealed class JobsExecutionTaskHandler
             callbackCts.Dispose();
             await scope.DisposeAsync().ConfigureAwait(false);
         }
-#pragma warning restore ERP022
-#pragma warning restore VSTHRD003
+#pragma warning restore ERP022, VSTHRD003
     }
 
     private async Task _RenewLeaseLoopAsync(

--- a/src/Headless.Jobs.Core/JobsRetryOptions.cs
+++ b/src/Headless.Jobs.Core/JobsRetryOptions.cs
@@ -21,9 +21,10 @@ public sealed class JobsRetryOptions
     public static Func<RetryPredicateArguments<object>, ValueTask<bool>> DefaultShouldHandle { get; } =
         static args =>
             ValueTask.FromResult(
-                args.Outcome.Exception is { } exception
-                    && exception is not OperationCanceledException
-                    && exception is not TerminateExecutionException
+                args.Outcome.Exception
+                    is not null
+                        and not OperationCanceledException
+                        and not TerminateExecutionException
             );
 
     /// <summary>

--- a/src/Headless.Jobs.Dashboard/DashboardOptionsBuilder.cs
+++ b/src/Headless.Jobs.Dashboard/DashboardOptionsBuilder.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Checks;
 using Headless.Dashboard.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
@@ -20,6 +21,10 @@ public sealed class DashboardOptionsBuilder
     // Clean authentication system
     internal AuthConfig Auth { get; set; } = new();
 
+    // Tracks whether an authentication mode was explicitly chosen. The dashboard fails closed at startup
+    // (see Validate) when this is false, so it cannot ship publicly by omission.
+    internal bool AuthConfigured { get; private set; }
+
     /// <summary>Optional custom middleware inserted into the dashboard pipeline.</summary>
     public Action<IApplicationBuilder>? CustomMiddleware { get; set; }
 
@@ -36,13 +41,27 @@ public sealed class DashboardOptionsBuilder
     internal JsonSerializerOptions? DashboardJsonOptions { get; set; }
 
     /// <summary>
-    /// Overrides the CORS policy applied to the dashboard endpoints. The default allows all origins
-    /// with any header and credentials.
+    /// Overrides the CORS policy applied to the dashboard endpoints. By default no CORS policy is applied:
+    /// the dashboard SPA is served from the same origin as its API, so no cross-origin access is required.
+    /// Prefer <see cref="SetCorsOrigins"/> for the common cross-origin case.
     /// </summary>
     /// <param name="corsPolicyBuilder">Callback to configure the CORS policy.</param>
     public DashboardOptionsBuilder SetCorsPolicy(Action<CorsPolicyBuilder> corsPolicyBuilder)
     {
         CorsPolicyBuilder = corsPolicyBuilder;
+        return this;
+    }
+
+    /// <summary>
+    /// Restricts cross-origin access to the given origins with a credentialed policy. Use this when the
+    /// dashboard SPA is served from a different origin than its API (see <see cref="SetBackendDomain"/>);
+    /// when they share an origin (the default) no CORS configuration is needed.
+    /// </summary>
+    /// <param name="origins">The exact allowed origins, e.g. <c>https://admin.example.com</c>. Must not be empty.</param>
+    public DashboardOptionsBuilder SetCorsOrigins(params string[] origins)
+    {
+        Argument.IsNotNullOrEmpty(origins);
+        CorsPolicyBuilder = cors => cors.WithOrigins(origins).AllowAnyHeader().AllowAnyMethod().AllowCredentials();
         return this;
     }
 
@@ -75,6 +94,7 @@ public sealed class DashboardOptionsBuilder
     public DashboardOptionsBuilder WithNoAuth()
     {
         Auth.Mode = AuthMode.None;
+        AuthConfigured = true;
         return this;
     }
 
@@ -88,6 +108,7 @@ public sealed class DashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.Basic;
         Auth.BasicCredentials = $"{username}:{password}".ToBase64();
+        AuthConfigured = true;
         return this;
     }
 
@@ -100,6 +121,7 @@ public sealed class DashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.ApiKey;
         Auth.ApiKey = apiKey;
+        AuthConfigured = true;
         return this;
     }
 
@@ -116,6 +138,7 @@ public sealed class DashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.Host;
         Auth.HostAuthorizationPolicy = policy;
+        AuthConfigured = true;
         return this;
     }
 
@@ -129,6 +152,7 @@ public sealed class DashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.Custom;
         Auth.CustomValidator = validator;
+        AuthConfigured = true;
         return this;
     }
 
@@ -160,6 +184,15 @@ public sealed class DashboardOptionsBuilder
     /// <summary>Validate the authentication configuration</summary>
     internal void Validate()
     {
+        if (!AuthConfigured)
+        {
+            throw new InvalidOperationException(
+                "Dashboard authentication was not configured. Secure the dashboard with WithBasicAuth, WithApiKey, "
+                    + "WithHostAuthentication, or WithCustomAuth, or call WithNoAuth() to explicitly run it "
+                    + "unauthenticated (development or trusted-network use only)."
+            );
+        }
+
         Auth.Validate();
     }
 }

--- a/src/Headless.Jobs.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Headless.Jobs.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -62,7 +62,7 @@ internal static class ServiceCollectionExtensions
         {
             if (config.CorsPolicyBuilder is not null)
             {
-                options.AddPolicy("Jobs_Dashboard_CORS", config.CorsPolicyBuilder);
+                options.AddPolicy("HeadlessJobsDashboardCORS", config.CorsPolicyBuilder);
             }
         });
     }
@@ -117,7 +117,7 @@ internal static class ServiceCollectionExtensions
                 dashboardApp.UseRouting();
                 if (config.CorsPolicyBuilder is not null)
                 {
-                    dashboardApp.UseCors("Jobs_Dashboard_CORS");
+                    dashboardApp.UseCors("HeadlessJobsDashboardCORS");
                 }
 
                 // Add authentication + authorization middleware

--- a/src/Headless.Jobs.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Headless.Jobs.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -111,9 +111,14 @@ internal static class ServiceCollectionExtensions
                     }
                 );
 
-                // Set up routing and CORS
+                // Set up routing and CORS. The CORS policy is registered only when the consumer configured
+                // one (SetCorsOrigins / SetCorsPolicy); by default the SPA is same-origin with its API, so no
+                // policy is applied.
                 dashboardApp.UseRouting();
-                dashboardApp.UseCors("Jobs_Dashboard_CORS");
+                if (config.CorsPolicyBuilder is not null)
+                {
+                    dashboardApp.UseCors("Jobs_Dashboard_CORS");
+                }
 
                 // Add authentication + authorization middleware
                 if (config.Auth.IsEnabled)

--- a/src/Headless.Jobs.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Headless.Jobs.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,13 +58,13 @@ internal static class ServiceCollectionExtensions
 
         services.AddAuthorization();
 
+        // Always register the named policy so the CORS middleware (UseCors, unconditional in the pipeline)
+        // can resolve it: the dashboard endpoints carry RequireCors metadata, and an endpoint with CORS
+        // metadata whose middleware never ran throws at request time. When the consumer configured no policy,
+        // register an empty one (no origins) -> same-origin only.
         services.AddCors(options =>
-        {
-            if (config.CorsPolicyBuilder is not null)
-            {
-                options.AddPolicy("HeadlessJobsDashboardCORS", config.CorsPolicyBuilder);
-            }
-        });
+            options.AddPolicy("HeadlessJobsDashboardCORS", config.CorsPolicyBuilder ?? (static _ => { }))
+        );
     }
 
     internal static void UseDashboardWithEndpoints<TTimeJob, TCronJob>(
@@ -111,14 +111,12 @@ internal static class ServiceCollectionExtensions
                     }
                 );
 
-                // Set up routing and CORS. The CORS policy is registered only when the consumer configured
-                // one (SetCorsOrigins / SetCorsPolicy); by default the SPA is same-origin with its API, so no
-                // policy is applied.
+                // Endpoints carry RequireCors metadata, so the CORS middleware must always run (an endpoint
+                // with CORS metadata and no middleware throws at request time). The registered policy is empty
+                // by default (same-origin only) and reflects the configured origins when
+                // SetCorsOrigins / SetCorsPolicy was used.
                 dashboardApp.UseRouting();
-                if (config.CorsPolicyBuilder is not null)
-                {
-                    dashboardApp.UseCors("HeadlessJobsDashboardCORS");
-                }
+                dashboardApp.UseCors("HeadlessJobsDashboardCORS");
 
                 // Add authentication + authorization middleware
                 if (config.Auth.IsEnabled)

--- a/src/Headless.Jobs.Dashboard/DependencyInjection/SetupJobsDashboard.cs
+++ b/src/Headless.Jobs.Dashboard/DependencyInjection/SetupJobsDashboard.cs
@@ -32,8 +32,11 @@ public static class SetupJobsDashboard
     /// </remarks>
     /// <param name="jobsConfiguration">The jobs options builder.</param>
     /// <param name="configureDashboard">
-    /// Optional callback to configure the dashboard. When <see langword="null"/>, the dashboard is
-    /// served at <c>/jobs/dashboard</c> with CORS open to all origins and no authentication.
+    /// Callback to configure the dashboard. Authentication must be configured explicitly — via
+    /// <see cref="DashboardOptionsBuilder.WithBasicAuth"/>, <see cref="DashboardOptionsBuilder.WithApiKey"/>,
+    /// <see cref="DashboardOptionsBuilder.WithHostAuthentication"/>, <see cref="DashboardOptionsBuilder.WithCustomAuth"/>,
+    /// or explicitly opted out with <see cref="DashboardOptionsBuilder.WithNoAuth"/> — otherwise the host fails
+    /// to start. The dashboard is served at <c>/jobs/dashboard</c> with no CORS policy (same-origin only) by default.
     /// </param>
     public static JobsOptionsBuilder<TTimeJob, TCronJob> AddDashboard<TTimeJob, TCronJob>(
         this JobsOptionsBuilder<TTimeJob, TCronJob> jobsConfiguration,
@@ -42,10 +45,10 @@ public static class SetupJobsDashboard
         where TTimeJob : TimeJobEntity<TTimeJob>, new()
         where TCronJob : CronJobEntity, new()
     {
-        var dashboardConfig = new DashboardOptionsBuilder
-        {
-            CorsPolicyBuilder = cors => cors.SetIsOriginAllowed(_ => true).AllowAnyHeader().AllowCredentials(),
-        };
+        // No CORS policy by default: the dashboard SPA is served from the same origin as its API, so no
+        // cross-origin access is required. Consumers serving the SPA cross-origin opt in explicitly via
+        // DashboardOptionsBuilder.SetCorsOrigins / SetCorsPolicy.
+        var dashboardConfig = new DashboardOptionsBuilder();
 
         configureDashboard?.Invoke(dashboardConfig);
 

--- a/src/Headless.Jobs.Dashboard/Endpoints/DashboardEndpoints.cs
+++ b/src/Headless.Jobs.Dashboard/Endpoints/DashboardEndpoints.cs
@@ -28,7 +28,7 @@ internal static class DashboardEndpoints
             .WithName("GetAuthInfo")
             .WithSummary("Get authentication configuration")
             .WithTags("Jobs Dashboard")
-            .RequireCors("Jobs_Dashboard_CORS")
+            .RequireCors("HeadlessJobsDashboardCORS")
             .AllowAnonymous();
 
         endpoints
@@ -36,10 +36,10 @@ internal static class DashboardEndpoints
             .WithName("ValidateAuth")
             .WithSummary("Validate authentication credentials")
             .WithTags("Jobs Dashboard")
-            .RequireCors("Jobs_Dashboard_CORS")
+            .RequireCors("HeadlessJobsDashboardCORS")
             .AllowAnonymous();
 
-        var apiGroup = endpoints.MapGroup("/api").WithTags("Jobs Dashboard").RequireCors("Jobs_Dashboard_CORS");
+        var apiGroup = endpoints.MapGroup("/api").WithTags("Jobs Dashboard").RequireCors("HeadlessJobsDashboardCORS");
 
         // Apply authentication if configured
         if (config.Auth.Mode == AuthMode.Host)

--- a/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
+++ b/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
@@ -42,6 +42,11 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
 
     private static int _ClampGraphDays(int days) => Math.Clamp(days, -_MaxGraphRangeDays, _MaxGraphRangeDays);
 
+    // Inverted ranges (pastDays > futureDays) would otherwise pass a negative count to Enumerable.Range and
+    // throw; clamp the count to 0 so a nonsensical range yields an empty series instead of a 500.
+    private static int _GraphDayCount(DateTime startDate, DateTime endDate) =>
+        Math.Max(0, (endDate - startDate).Days + 1);
+
     public async Task<TTimeJob[]> GetTimeJobsAsync(CancellationToken cancellationToken = default)
     {
         return await _persistenceProvider.GetTimeJobsAsync(predicate: null, cancellationToken).ConfigureAwait(false);
@@ -115,7 +120,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
 
         // Build the final result: one entry per date, with all statuses filled
         var allDates = Enumerable
-            .Range(0, (endDate - startDate).Days + 1)
+            .Range(0, _GraphDayCount(startDate, endDate))
             .Select(offset => startDate.AddDays(offset))
             .ToList();
 
@@ -168,7 +173,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             .ToList();
 
         var allDates = Enumerable
-            .Range(0, (endDate - startDate).Days + 1)
+            .Range(0, _GraphDayCount(startDate, endDate))
             .Select(offset => startDate.AddDays(offset))
             .ToList();
 
@@ -242,7 +247,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             .ToList();
 
         var allDates = Enumerable
-            .Range(0, (endDate - startDate).Days + 1)
+            .Range(0, _GraphDayCount(startDate, endDate))
             .Select(offset => startDate.AddDays(offset))
             .ToList();
 
@@ -584,7 +589,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
         var startDate = completeData[0].Date;
         var endDate = completeData[^1].Date;
         var allDates = Enumerable
-            .Range(0, (endDate - startDate).Days + 1)
+            .Range(0, _GraphDayCount(startDate, endDate))
             .Select(offset => startDate.AddDays(offset))
             .ToList();
 

--- a/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
+++ b/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
@@ -35,6 +35,13 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
     private readonly DashboardOptionsBuilder _dashboardOptions = Argument.IsNotNull(dashboardOptions);
     private readonly TimeProvider _timeProvider = Argument.IsNotNull(timeProvider);
 
+    // Graph endpoints materialize one entry per day across [pastDays, futureDays], so an unclamped span
+    // could drive multi-million-object allocation independent of stored row count. Clamp the request-supplied
+    // offsets to a bounded window (±1 year) before computing the range.
+    private const int _MaxGraphRangeDays = 366;
+
+    private static int _ClampGraphDays(int days) => Math.Clamp(days, -_MaxGraphRangeDays, _MaxGraphRangeDays);
+
     public async Task<TTimeJob[]> GetTimeJobsAsync(CancellationToken cancellationToken = default)
     {
         return await _persistenceProvider.GetTimeJobsAsync(predicate: null, cancellationToken).ConfigureAwait(false);
@@ -80,8 +87,8 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
     )
     {
         var today = _timeProvider.GetUtcNow().UtcDateTime.Date;
-        var startDate = today.AddDays(pastDays);
-        var endDate = today.AddDays(futureDays);
+        var startDate = today.AddDays(_ClampGraphDays(pastDays));
+        var endDate = today.AddDays(_ClampGraphDays(futureDays));
 
         var timeJobs = await _persistenceProvider
             .GetTimeJobsAsync(
@@ -138,8 +145,8 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
     )
     {
         var today = _timeProvider.GetUtcNow().UtcDateTime.Date;
-        var startDate = today.AddDays(pastDays);
-        var endDate = today.AddDays(futureDays);
+        var startDate = today.AddDays(_ClampGraphDays(pastDays));
+        var endDate = today.AddDays(_ClampGraphDays(futureDays));
 
         var cronJobOccurrences = await _persistenceProvider
             .GetAllCronJobOccurrencesAsync(
@@ -212,8 +219,8 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
     )
     {
         var today = _timeProvider.GetUtcNow().UtcDateTime.Date;
-        var startDate = today.AddDays(pastDays);
-        var endDate = today.AddDays(futureDays);
+        var startDate = today.AddDays(_ClampGraphDays(pastDays));
+        var endDate = today.AddDays(_ClampGraphDays(futureDays));
 
         var cronJobOccurrences = await _persistenceProvider
             .GetAllCronJobOccurrencesAsync(

--- a/src/Headless.Jobs.Dashboard/README.md
+++ b/src/Headless.Jobs.Dashboard/README.md
@@ -12,12 +12,12 @@ Provides operational visibility into the Jobs scheduler — job queues, executio
 - **Authentication options**: `WithBasicAuth(username, password)`, `WithApiKey(apiKey)`, `WithHostAuthentication(policy?)` (delegates to host app's auth), or explicit no-auth mode for isolated development dashboards.
 - **Live cluster view**: `GET /api/nodes` returns live node projections from `Headless.Coordination` membership; `NodeJoined` / `NodeLeft` / `NodeSuspected` push updates over SignalR — no polling required.
 - **Error monitoring**: surfaces failed, cancelled, and skipped jobs; retry counts; execution timings; exception messages.
-- **Fluent builder**: `SetBasePath(path)`, `SetBackendDomain(domain)`, `SetCorsPolicy(policy)`.
+- **Fluent builder**: `SetBasePath(path)`, `SetBackendDomain(domain)`, `SetCorsOrigins(origins)`, `SetCorsPolicy(policy)`.
 - **Pair with OpenTelemetry**: Dashboard for operational triage; `Headless.Jobs.OpenTelemetry` for trace-level diagnostics.
 
 ## Design Notes
 
-The dashboard exposes operational endpoints that can create, update, delete, run, cancel, start, stop, and restart jobs. Treat `WithNoAuth()` or omitted auth as development-only unless the dashboard is isolated behind trusted network controls. Production deployments should use `WithHostAuthentication(...)`, `WithBasicAuth(...)`, or `WithApiKey(...)`, and should set an explicit CORS policy instead of relying on open cross-origin access.
+The dashboard exposes operational endpoints that can create, update, delete, run, cancel, start, stop, and restart jobs. Authentication must be chosen explicitly — if no auth method (including `WithNoAuth()`) is called, the host fails to start, so the dashboard never ships publicly by omission. Treat `WithNoAuth()` as development-only unless the dashboard is isolated behind trusted network controls; production deployments should use `WithHostAuthentication(...)`, `WithBasicAuth(...)`, or `WithApiKey(...)`. No CORS policy is applied by default (same-origin only); use `SetCorsOrigins(...)` when the SPA is served cross-origin.
 
 ## Installation
 
@@ -52,18 +52,18 @@ builder
     {
         dashboard.SetBasePath("/jobs");
         dashboard.SetBackendDomain("https://api.example.com");
-        dashboard.SetCorsPolicy("MyPolicy");
+        dashboard.SetCorsOrigins("https://admin.example.com"); // needed only when the SPA is cross-origin
 
-        // Authentication — pick one:
+        // Authentication — required, pick one:
         dashboard.WithBasicAuth("admin", "secret");
         dashboard.WithApiKey("my-api-key");
         dashboard.WithHostAuthentication();
         dashboard.WithHostAuthentication("AdminPolicy");
-        // Omitting auth = public dashboard; use only in isolated development environments.
+        // Or opt out explicitly with dashboard.WithNoAuth() — isolated development environments only.
     });
 ```
 
-Auth detection is automatic: no auth → public; basic auth → username/password login UI; API key → bearer token; host auth → delegates to the host's authentication middleware.
+Auth detection is automatic: explicit `WithNoAuth()` → public; basic auth → username/password login UI; API key → bearer token; host auth → delegates to the host's authentication middleware.
 
 ## Dependencies
 

--- a/src/Headless.Messaging.Dashboard/DashboardOptionsExtensions.cs
+++ b/src/Headless.Messaging.Dashboard/DashboardOptionsExtensions.cs
@@ -40,13 +40,12 @@ internal sealed class DashboardOptionsExtension(Action<MessagingDashboardOptions
         services.AddRouting();
         services.AddAuthorization();
 
+        // Always register the named policy so the CORS middleware (UseCors, unconditional in the pipeline)
+        // can resolve it: the dashboard endpoints carry RequireCors metadata and would throw at request time
+        // if the CORS middleware never ran. An unconfigured policy is empty (no origins) -> same-origin only.
         services.AddCors(options =>
-        {
-            if (Builder.CorsPolicyBuilder is not null)
-            {
-                options.AddPolicy("HeadlessMessagingDashboardCORS", Builder.CorsPolicyBuilder);
-            }
-        });
+            options.AddPolicy("HeadlessMessagingDashboardCORS", Builder.CorsPolicyBuilder ?? (static _ => { }))
+        );
 
         // If using host auth, ensure auth services exist
         if (Builder.Auth.Mode == AuthMode.Host)
@@ -91,7 +90,11 @@ public static class MessagingOptionsExtensions
         /// and all dashboard API endpoints. The dashboard is mounted at the path configured via
         /// <c>SetBasePath</c> (default: <c>/messaging</c>).
         /// </summary>
-        /// <param name="configure">An action to configure the dashboard options.</param>
+        /// <param name="configure">
+        /// An action to configure the dashboard options. An authentication mode must be chosen explicitly
+        /// (<c>WithBasicAuth</c>, <c>WithApiKey</c>, <c>WithHostAuthentication</c>, <c>WithCustomAuth</c>, or an
+        /// explicit <c>WithNoAuth()</c> opt-out) or the host fails to start.
+        /// </param>
         /// <returns>The builder for chaining.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
         public MessagingSetupBuilder UseDashboard(Action<MessagingDashboardOptionsBuilder> configure)

--- a/src/Headless.Messaging.Dashboard/DashboardOptionsExtensions.cs
+++ b/src/Headless.Messaging.Dashboard/DashboardOptionsExtensions.cs
@@ -44,7 +44,7 @@ internal sealed class DashboardOptionsExtension(Action<MessagingDashboardOptions
         {
             if (Builder.CorsPolicyBuilder is not null)
             {
-                options.AddPolicy("Messaging_Dashboard_CORS", Builder.CorsPolicyBuilder);
+                options.AddPolicy("HeadlessMessagingDashboardCORS", Builder.CorsPolicyBuilder);
             }
         });
 

--- a/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
+++ b/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
@@ -37,7 +37,7 @@ public static class MessagingDashboardEndpoints
             .WithName("Messaging_GetAuthInfo")
             .WithSummary("Get authentication configuration")
             .WithTags("Messaging Dashboard")
-            .RequireCors("Messaging_Dashboard_CORS")
+            .RequireCors("HeadlessMessagingDashboardCORS")
             .AllowAnonymous();
 
         endpoints
@@ -45,7 +45,7 @@ public static class MessagingDashboardEndpoints
             .WithName("Messaging_ValidateAuth")
             .WithSummary("Validate authentication credentials")
             .WithTags("Messaging Dashboard")
-            .RequireCors("Messaging_Dashboard_CORS")
+            .RequireCors("HeadlessMessagingDashboardCORS")
             .AllowAnonymous();
 
         // Always-anonymous endpoints
@@ -54,7 +54,7 @@ public static class MessagingDashboardEndpoints
             .WithName("Messaging_Health")
             .WithSummary("Health check endpoint")
             .WithTags("Messaging Dashboard")
-            .RequireCors("Messaging_Dashboard_CORS")
+            .RequireCors("HeadlessMessagingDashboardCORS")
             .AllowAnonymous();
 
         endpoints
@@ -62,14 +62,14 @@ public static class MessagingDashboardEndpoints
             .WithName("Messaging_PingServices")
             .WithSummary("Ping a registered node to measure latency")
             .WithTags("Messaging Dashboard")
-            .RequireCors("Messaging_Dashboard_CORS")
+            .RequireCors("HeadlessMessagingDashboardCORS")
             .AllowAnonymous();
 
         // Protected API group with gateway proxy filter
         var apiGroup = endpoints
             .MapGroup("/api")
             .WithTags("Messaging Dashboard")
-            .RequireCors("Messaging_Dashboard_CORS")
+            .RequireCors("HeadlessMessagingDashboardCORS")
             .AddEndpointFilter<GatewayProxyEndpointFilter>();
 
         // Apply host auth if configured

--- a/src/Headless.Messaging.Dashboard/MessagingDashboardOptionsBuilder.cs
+++ b/src/Headless.Messaging.Dashboard/MessagingDashboardOptionsBuilder.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Checks;
 using Headless.Dashboard.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
@@ -19,6 +20,10 @@ public sealed class MessagingDashboardOptionsBuilder
     /// Authentication configuration (shared with Jobs Dashboard).
     /// </summary>
     internal AuthConfig Auth { get; set; } = new();
+
+    // Tracks whether an authentication mode was explicitly chosen. The dashboard fails closed at startup
+    // (see Validate) when this is false, so it cannot ship publicly by omission.
+    internal bool AuthConfigured { get; private set; }
 
     // Custom Middleware Integration
 
@@ -54,11 +59,26 @@ public sealed class MessagingDashboardOptionsBuilder
     }
 
     /// <summary>
-    /// Configure CORS policy for the dashboard.
+    /// Configure the CORS policy for the dashboard. By default no CORS policy is applied: the dashboard SPA
+    /// is served from the same origin as its API, so no cross-origin access is required. Prefer
+    /// <see cref="SetCorsOrigins"/> for the common cross-origin case.
     /// </summary>
     public MessagingDashboardOptionsBuilder SetCorsPolicy(Action<CorsPolicyBuilder> corsPolicyBuilder)
     {
         CorsPolicyBuilder = corsPolicyBuilder;
+        return this;
+    }
+
+    /// <summary>
+    /// Restricts cross-origin access to the given origins with a credentialed policy. Use this when the
+    /// dashboard SPA is served from a different origin than its API; when they share an origin (the default)
+    /// no CORS configuration is needed.
+    /// </summary>
+    /// <param name="origins">The exact allowed origins, e.g. <c>https://admin.example.com</c>. Must not be empty.</param>
+    public MessagingDashboardOptionsBuilder SetCorsOrigins(params string[] origins)
+    {
+        Argument.IsNotNullOrEmpty(origins);
+        CorsPolicyBuilder = cors => cors.WithOrigins(origins).AllowAnyHeader().AllowAnyMethod().AllowCredentials();
         return this;
     }
 
@@ -77,6 +97,7 @@ public sealed class MessagingDashboardOptionsBuilder
     public MessagingDashboardOptionsBuilder WithNoAuth()
     {
         Auth.Mode = AuthMode.None;
+        AuthConfigured = true;
         return this;
     }
 
@@ -85,6 +106,7 @@ public sealed class MessagingDashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.Basic;
         Auth.BasicCredentials = $"{username}:{password}".ToBase64();
+        AuthConfigured = true;
         return this;
     }
 
@@ -93,6 +115,7 @@ public sealed class MessagingDashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.ApiKey;
         Auth.ApiKey = apiKey;
+        AuthConfigured = true;
         return this;
     }
 
@@ -102,6 +125,7 @@ public sealed class MessagingDashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.Host;
         Auth.HostAuthorizationPolicy = policy;
+        AuthConfigured = true;
         return this;
     }
 
@@ -110,6 +134,7 @@ public sealed class MessagingDashboardOptionsBuilder
     {
         Auth.Mode = AuthMode.Custom;
         Auth.CustomValidator = validator;
+        AuthConfigured = true;
         return this;
     }
 
@@ -123,6 +148,15 @@ public sealed class MessagingDashboardOptionsBuilder
     /// <summary>Validate the configuration.</summary>
     internal void Validate()
     {
+        if (!AuthConfigured)
+        {
+            throw new InvalidOperationException(
+                "Dashboard authentication was not configured. Secure the dashboard with WithBasicAuth, WithApiKey, "
+                    + "WithHostAuthentication, or WithCustomAuth, or call WithNoAuth() to explicitly run it "
+                    + "unauthenticated (development or trusted-network use only)."
+            );
+        }
+
         Auth.Validate();
     }
 }

--- a/src/Headless.Messaging.Dashboard/README.md
+++ b/src/Headless.Messaging.Dashboard/README.md
@@ -45,6 +45,8 @@ builder.Services.AddHeadlessMessaging(options =>
 
 ## Authentication Modes
 
+An authentication mode must be chosen explicitly: if none of the `WithXxx` auth methods below (including `WithNoAuth()`) is called, the host **fails to start**. This is intentional — the dashboard exposes operational message actions and never ships publicly by omission.
+
 ### No Authentication (Dev/Testing Only)
 
 ```csharp
@@ -101,7 +103,7 @@ options.UseDashboard(dashboard =>
 
 ## Fluent API Methods
 
-- `WithNoAuth()` - Public dashboard (development or trusted-network use only)
+- `WithNoAuth()` - Explicitly opt out of authentication (development or trusted-network use only)
 - `WithBasicAuth(username, password)` - Enable username/password authentication
 - `WithApiKey(apiKey)` - Enable API key authentication
 - `WithHostAuthentication(policy?)` - Use your app's existing auth with optional policy
@@ -109,7 +111,8 @@ options.UseDashboard(dashboard =>
 - `WithSessionTimeout(minutes)` - Set session timeout (default: 60 minutes)
 - `SetBasePath(path)` - Set dashboard URL path (default: `/messaging`)
 - `SetStatsPollingInterval(ms)` - Stats polling interval (default: 2000ms)
-- `SetCorsPolicy(policy)` - Configure CORS
+- `SetCorsOrigins(origins)` - Allow specific cross-origin origins (credentialed); use when the SPA is served cross-origin
+- `SetCorsPolicy(policy)` - Configure a custom CORS policy
 
 ## Configuration
 
@@ -117,8 +120,8 @@ options.UseDashboard(dashboard =>
 |--------|---------|-------------|
 | `SetBasePath` | `/messaging` | URL path for the dashboard |
 | `SetStatsPollingInterval` | `2000` | Stats endpoint polling interval (ms) |
-| `WithNoAuth` | (default) | No authentication — public dashboard; development or trusted-network use only |
-| `SetCorsPolicy` | `null` | CORS policy for cross-origin requests |
+| `WithNoAuth` | (no default — auth is required) | Explicitly opt out of authentication; development or trusted-network use only |
+| `SetCorsPolicy` / `SetCorsOrigins` | `null` (same-origin only) | CORS policy for cross-origin requests |
 | `WithSessionTimeout` | `60` | Session timeout in minutes |
 
 ## Dependencies
@@ -133,4 +136,4 @@ options.UseDashboard(dashboard =>
 - Mounts the embedded web UI and monitoring API through an `IStartupFilter` — no explicit middleware call is required
 - Exposes a web endpoint at the configured path (default: `/messaging`)
 - Periodically polls message storage for statistics
-- No authentication by default — configure authentication and CORS before exposing the dashboard outside an isolated development environment
+- Authentication must be configured explicitly (an auth mode, or an explicit `WithNoAuth()` opt-out) or the host fails to start; no CORS policy is applied by default (same-origin only)

--- a/src/Headless.Messaging.Dashboard/Setup.cs
+++ b/src/Headless.Messaging.Dashboard/Setup.cs
@@ -58,14 +58,12 @@ public static class SetupMessagingDashboard
                     }
                 );
 
-                // Set up routing and CORS. The CORS policy is registered only when the consumer configured
-                // one (SetCorsOrigins / SetCorsPolicy); by default the SPA is same-origin with its API, so no
-                // policy is applied.
+                // Endpoints carry RequireCors metadata, so the CORS middleware must always run (an endpoint
+                // with CORS metadata and no middleware throws at request time). The registered policy is empty
+                // by default (same-origin only) and reflects the configured origins when
+                // SetCorsOrigins / SetCorsPolicy was used.
                 dashboardApp.UseRouting();
-                if (config.CorsPolicyBuilder is not null)
-                {
-                    dashboardApp.UseCors("HeadlessMessagingDashboardCORS");
-                }
+                dashboardApp.UseCors("HeadlessMessagingDashboardCORS");
 
                 // Add authentication + authorization middleware
                 if (config.Auth.IsEnabled)

--- a/src/Headless.Messaging.Dashboard/Setup.cs
+++ b/src/Headless.Messaging.Dashboard/Setup.cs
@@ -64,7 +64,7 @@ public static class SetupMessagingDashboard
                 dashboardApp.UseRouting();
                 if (config.CorsPolicyBuilder is not null)
                 {
-                    dashboardApp.UseCors("Messaging_Dashboard_CORS");
+                    dashboardApp.UseCors("HeadlessMessagingDashboardCORS");
                 }
 
                 // Add authentication + authorization middleware

--- a/src/Headless.Messaging.Dashboard/Setup.cs
+++ b/src/Headless.Messaging.Dashboard/Setup.cs
@@ -58,9 +58,14 @@ public static class SetupMessagingDashboard
                     }
                 );
 
-                // Set up routing and CORS
+                // Set up routing and CORS. The CORS policy is registered only when the consumer configured
+                // one (SetCorsOrigins / SetCorsPolicy); by default the SPA is same-origin with its API, so no
+                // policy is applied.
                 dashboardApp.UseRouting();
-                dashboardApp.UseCors("Messaging_Dashboard_CORS");
+                if (config.CorsPolicyBuilder is not null)
+                {
+                    dashboardApp.UseCors("Messaging_Dashboard_CORS");
+                }
 
                 // Add authentication + authorization middleware
                 if (config.Auth.IsEnabled)

--- a/src/Headless.Payments.Paymob.CashOut/Models/CashOutTransaction.cs
+++ b/src/Headless.Payments.Paymob.CashOut/Models/CashOutTransaction.cs
@@ -53,9 +53,9 @@ public sealed record CashOutTransaction
     [JsonExtensionData]
     public IDictionary<string, object?>? ExtensionData { get; set; }
 
-    // Msisdn, FullName, AmanCashingDetails, StatusDescription, and ExtensionData can carry recipient PII or
-    // arbitrary provider fields; they are redacted so a failure log that renders this transaction (see
-    // PaymobCashOutLoggerExtensions) cannot leak them.
+    // Msisdn, FullName, and AmanCashingDetails carry recipient PII and are shown as [redacted]; StatusDescription
+    // and ExtensionData (arbitrary provider fields) are omitted entirely. Either way, a failure log that renders
+    // this transaction (see PaymobCashOutLoggerExtensions) cannot leak them.
     public override string ToString()
     {
         return $"CashOutTransaction {{ TransactionId = {TransactionId}, Issuer = {Issuer}, Amount = {Amount}, DisbursementStatus = {DisbursementStatus}, StatusCode = {StatusCode}, CreatedAt = {CreatedAt}, UpdatedAt = {UpdatedAt}, Msisdn = [redacted], FullName = [redacted], AmanCashingDetails = [redacted] }}";

--- a/src/Headless.Payments.Paymob.CashOut/Models/CashOutTransaction.cs
+++ b/src/Headless.Payments.Paymob.CashOut/Models/CashOutTransaction.cs
@@ -53,6 +53,14 @@ public sealed record CashOutTransaction
     [JsonExtensionData]
     public IDictionary<string, object?>? ExtensionData { get; set; }
 
+    // Msisdn, FullName, AmanCashingDetails, StatusDescription, and ExtensionData can carry recipient PII or
+    // arbitrary provider fields; they are redacted so a failure log that renders this transaction (see
+    // PaymobCashOutLoggerExtensions) cannot leak them.
+    public override string ToString()
+    {
+        return $"CashOutTransaction {{ TransactionId = {TransactionId}, Issuer = {Issuer}, Amount = {Amount}, DisbursementStatus = {DisbursementStatus}, StatusCode = {StatusCode}, CreatedAt = {CreatedAt}, UpdatedAt = {UpdatedAt}, Msisdn = [redacted], FullName = [redacted], AmanCashingDetails = [redacted] }}";
+    }
+
     /// <summary>Returns <see langword="true"/> when the disbursement completed successfully.</summary>
     public bool IsSuccess()
     {

--- a/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobCardSavedTokenCashInRequest.cs
+++ b/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobCardSavedTokenCashInRequest.cs
@@ -18,4 +18,12 @@ public sealed record PaymobCardSavedTokenCashInRequest(
     string CardToken,
     string? MerchantOrderId = null,
     int ExpirationSeconds = 60 * 60
-);
+)
+{
+    // CardToken is a reusable payment credential and Customer carries PII; both are redacted so a failure
+    // log that renders this request (see PaymobCashInLoggerExtensions) cannot leak them.
+    public override string ToString()
+    {
+        return $"PaymobCardSavedTokenCashInRequest {{ Amount = {Amount}, SavedTokenIntegrationId = {SavedTokenIntegrationId}, MerchantOrderId = {MerchantOrderId}, ExpirationSeconds = {ExpirationSeconds}, CardToken = [redacted], Customer = [redacted] }}";
+    }
+}

--- a/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobCashInCustomerData.cs
+++ b/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobCashInCustomerData.cs
@@ -9,4 +9,13 @@ namespace Headless.Payments.Paymob.Services.CashIn.Requests;
 /// <param name="LastName">The customer's last name.</param>
 /// <param name="PhoneNumber">The customer's phone number.</param>
 /// <param name="Email">The customer's email address.</param>
-public sealed record PaymobCashInCustomerData(string FirstName, string LastName, string PhoneNumber, string Email);
+public sealed record PaymobCashInCustomerData(string FirstName, string LastName, string PhoneNumber, string Email)
+{
+    // All four fields are customer PII. Redact them so any record that embeds Customer — including request
+    // records that have no ToString override of their own (e.g. PaymobCardCashInRequest) — cannot leak PII
+    // when a failure log renders it.
+    public override string ToString()
+    {
+        return "PaymobCashInCustomerData { FirstName = [redacted], LastName = [redacted], PhoneNumber = [redacted], Email = [redacted] }";
+    }
+}

--- a/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobKioskCashInRequest.cs
+++ b/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobKioskCashInRequest.cs
@@ -16,4 +16,12 @@ public sealed record PaymobKioskCashInRequest(
     long KioskIntegrationId,
     string? MerchantOrderId = null,
     int ExpirationSeconds = 60 * 60
-);
+)
+{
+    // Customer carries PII; it is redacted so a failure log that renders this request
+    // (see PaymobCashInLoggerExtensions) cannot leak it.
+    public override string ToString()
+    {
+        return $"PaymobKioskCashInRequest {{ Amount = {Amount}, KioskIntegrationId = {KioskIntegrationId}, MerchantOrderId = {MerchantOrderId}, ExpirationSeconds = {ExpirationSeconds}, Customer = [redacted] }}";
+    }
+}

--- a/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobWalletCashInRequest.cs
+++ b/src/Headless.Payments.Paymob.Services/CashIn/Requests/PaymobWalletCashInRequest.cs
@@ -20,4 +20,12 @@ public sealed record PaymobWalletCashInRequest(
     long WalletIntegrationId,
     string? MerchantOrderId = null,
     int ExpirationSeconds = 60 * 60
-);
+)
+{
+    // WalletPhoneNumber and Customer carry PII; both are redacted so a failure log that renders this
+    // request (see PaymobCashInLoggerExtensions) cannot leak them.
+    public override string ToString()
+    {
+        return $"PaymobWalletCashInRequest {{ Amount = {Amount}, WalletIntegrationId = {WalletIntegrationId}, MerchantOrderId = {MerchantOrderId}, ExpirationSeconds = {ExpirationSeconds}, WalletPhoneNumber = [redacted], Customer = [redacted] }}";
+    }
+}

--- a/src/Headless.Payments.Paymob.Services/CashOut/PaymobCashOutService.cs
+++ b/src/Headless.Payments.Paymob.Services/CashOut/PaymobCashOutService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Net;
 using Headless.Payments.Paymob.CashOut;
 using Headless.Payments.Paymob.CashOut.Internals;
 using Headless.Payments.Paymob.CashOut.Models;
@@ -212,7 +213,7 @@ public sealed class PaymobCashOutService(IPaymobCashOutBroker broker, ILogger<Pa
         }
         catch (PaymobCashOutException e)
         {
-            logger.LogFailedToStartCashOut(e, e.Body);
+            logger.LogFailedToStartCashOut(e, e.StatusCode);
             return CashOutResult.Failure<CashOutTransaction>(
                 PaymobMessageDescriptor.CashOut.ProviderConnectionFailed(),
                 response: null
@@ -311,13 +312,19 @@ internal static partial class PaymobCashOutLoggerExtensions
     )]
     public static partial void LogUnexpectedAcceptCashOutResponse(this ILogger logger, CashOutTransaction? response);
 
+    // Logs the provider HTTP status (non-PII) instead of the raw response body, which may carry recipient
+    // PII / provider internal detail. The exception still carries the full message and stack.
     [LoggerMessage(
         EventId = 2,
         EventName = "FailedToStartCashOut",
         Level = LogLevel.Critical,
-        Message = "Failed to start cash out {Response}"
+        Message = "Failed to start cash out. Provider responded with status {StatusCode}"
     )]
-    public static partial void LogFailedToStartCashOut(this ILogger logger, Exception exception, string? response);
+    public static partial void LogFailedToStartCashOut(
+        this ILogger logger,
+        Exception exception,
+        HttpStatusCode statusCode
+    );
 
     [LoggerMessage(
         EventId = 3,

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Headless.Coordination.PostgreSql\Headless.Coordination.PostgreSql.csproj" />
     <ProjectReference Include="..\..\src\Headless.Jobs.Core\Headless.Jobs.Core.csproj" />
     <ProjectReference Include="..\..\src\Headless.Jobs.EntityFramework\Headless.Jobs.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Messaging.Storage.PostgreSql\Headless.Messaging.Storage.PostgreSql.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />
     <ProjectReference Include="..\Headless.Jobs.EntityFramework.Tests.Harness\Headless.Jobs.EntityFramework.Tests.Harness.csproj" />
   </ItemGroup>

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlEnqueueAtomicityTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlEnqueueAtomicityTests.cs
@@ -8,6 +8,12 @@ public sealed class PostgreSqlEnqueueAtomicityTests(PostgreSqlJobsCoordinationFi
     : JobsEnqueueAtomicityConformanceTests<PostgreSqlJobsCoordinationFixture>(fixture)
 {
     [Fact]
+    public override Task domain_message_and_job_commit_atomically() => base.domain_message_and_job_commit_atomically();
+
+    [Fact]
+    public override Task rollback_discards_domain_message_and_job() => base.rollback_discards_domain_message_and_job();
+
+    [Fact]
     public override Task domain_write_and_enqueue_commit_atomically() =>
         base.domain_write_and_enqueue_commit_atomically();
 

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlJobsCoordinationFixture.cs
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlJobsCoordinationFixture.cs
@@ -3,6 +3,8 @@
 using System.Data.Common;
 using Headless.CommitCoordination;
 using Headless.Coordination;
+using Headless.Messaging;
+using Headless.Messaging.Configuration;
 using Headless.Testing.Testcontainers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,6 +37,7 @@ public sealed class PostgreSqlJobsCoordinationFixture
 
     public string ResetSql =>
         "DROP SCHEMA IF EXISTS jobs CASCADE;"
+        + "DROP SCHEMA IF EXISTS messaging CASCADE;"
         + "DROP TABLE IF EXISTS coordination_liveness, coordination_descriptor, coordination_node_generation CASCADE;";
 
     protected override PostgreSqlBuilder Configure()
@@ -54,6 +57,8 @@ public sealed class PostgreSqlJobsCoordinationFixture
     public DbConnection CreateConnection() => new NpgsqlConnection(ConnectionString);
 
     public void ConfigureCommitCoordination(IServiceCollection services) => services.AddPostgreSqlCommitCoordination();
+
+    public void ConfigureMessagingStorage(MessagingSetupBuilder setup) => setup.UsePostgreSql(ConnectionString);
 
     public async Task RunCoordinatedTransactionAsync(
         IServiceProvider services,

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/packages.lock.json
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/packages.lock.json
@@ -840,6 +840,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )"
         }
       },
+      "headless.commitcoordination.entityframework": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )",
+          "Headless.CommitCoordination.Core": "[1.0.0, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Options": "[10.0.9, )"
+        }
+      },
       "headless.commitcoordination.postgresql": {
         "type": "Project",
         "dependencies": {
@@ -982,12 +994,76 @@
           "Headless.Coordination.Core": "[1.0.0, )",
           "Headless.Jobs.Core": "[1.0.0, )",
           "Headless.Jobs.EntityFramework": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Headless.Messaging.InMemory": "[1.0.0, )",
           "Headless.Testing": "[1.0.0, )",
           "Headless.Testing.Testcontainers": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Microsoft.Extensions.Hosting": "[10.0.9, )",
           "Microsoft.NET.Test.Sdk": "[18.7.0, )",
           "NSubstitute": "[5.3.0, )"
+        }
+      },
+      "headless.messaging.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.bus.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.core": {
+        "type": "Project",
+        "dependencies": {
+          "FastExpressionCompiler": "[5.4.1, )",
+          "Headless.CommitCoordination.Abstractions": "[1.0.0, )",
+          "Headless.Coordination.Abstractions": "[1.0.0, )",
+          "Headless.Coordination.Core": "[1.0.0, )",
+          "Headless.Core": "[1.0.0, )",
+          "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
+          "Headless.Extensions": "[1.0.0, )",
+          "Headless.Hosting": "[1.0.0, )",
+          "Headless.Messaging.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Bus.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Queue.Abstractions": "[1.0.0, )",
+          "Headless.MultiTenancy": "[1.0.0, )",
+          "Microsoft.Extensions.Options": "[10.0.9, )",
+          "Polly.Core": "[8.7.0, )"
+        }
+      },
+      "headless.messaging.inmemory": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Bus.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Headless.Messaging.Queue.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.queue.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.storage.postgresql": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.CommitCoordination.EntityFramework": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Npgsql": "[10.0.3, )"
+        }
+      },
+      "headless.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )"
         }
       },
       "headless.primitives": {
@@ -1049,6 +1125,12 @@
         "requested": "[8.4.2, )",
         "resolved": "8.4.2",
         "contentHash": "2hmtrrU18x6NL3mbuAqwy0KpnoEEJOuK6sH5RKQfD/jHijn2pqvqBUC7WGy9dgNBL9BDA7eOC0kirsNPMp2f4Q=="
+      },
+      "FastExpressionCompiler": {
+        "type": "CentralTransitive",
+        "requested": "[5.4.1, )",
+        "resolved": "5.4.1",
+        "contentHash": "nqMykMspK5cQd35Y8ulQzAujxCcCwZVUne32pC5xNpXqrbPCuKOPMWkKHJ3LveAZPm6dsVvump0TJ1SZ9RzfTQ=="
       },
       "FlexLabs.EntityFrameworkCore.Upsert": {
         "type": "CentralTransitive",

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Headless.Coordination.SqlServer\Headless.Coordination.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\Headless.Jobs.Core\Headless.Jobs.Core.csproj" />
     <ProjectReference Include="..\..\src\Headless.Jobs.EntityFramework\Headless.Jobs.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Messaging.Storage.SqlServer\Headless.Messaging.Storage.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />
     <ProjectReference Include="..\Headless.Jobs.EntityFramework.Tests.Harness\Headless.Jobs.EntityFramework.Tests.Harness.csproj" />
   </ItemGroup>

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerEnqueueAtomicityTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerEnqueueAtomicityTests.cs
@@ -8,6 +8,12 @@ public sealed class SqlServerEnqueueAtomicityTests(SqlServerJobsCoordinationFixt
     : JobsEnqueueAtomicityConformanceTests<SqlServerJobsCoordinationFixture>(fixture)
 {
     [Fact]
+    public override Task domain_message_and_job_commit_atomically() => base.domain_message_and_job_commit_atomically();
+
+    [Fact]
+    public override Task rollback_discards_domain_message_and_job() => base.rollback_discards_domain_message_and_job();
+
+    [Fact]
     public override Task domain_write_and_enqueue_commit_atomically() =>
         base.domain_write_and_enqueue_commit_atomically();
 

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerJobsCoordinationFixture.cs
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerJobsCoordinationFixture.cs
@@ -3,6 +3,8 @@
 using System.Data.Common;
 using Headless.CommitCoordination;
 using Headless.Coordination;
+using Headless.Messaging;
+using Headless.Messaging.Configuration;
 using Headless.Testing.Testcontainers;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
@@ -37,6 +39,12 @@ public sealed class SqlServerJobsCoordinationFixture
         + "DROP TABLE IF EXISTS [jobs].[TimeJobs];"
         + "DROP TABLE IF EXISTS [jobs].[CronJobs];"
         + "IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'jobs') DROP SCHEMA [jobs];"
+        + "DROP TABLE IF EXISTS [messaging].[Published];"
+        + "DROP TABLE IF EXISTS [messaging].[Received];"
+        + "IF TYPE_ID(N'messaging.HeadlessMessagingIdList') IS NOT NULL DROP TYPE [messaging].[HeadlessMessagingIdList];"
+        + "IF TYPE_ID(N'messaging.HeadlessMessagingOwnerList') IS NOT NULL DROP TYPE [messaging].[HeadlessMessagingOwnerList];"
+        + "IF TYPE_ID(N'messaging.HeadlessMessagingPoisonMessageList') IS NOT NULL DROP TYPE [messaging].[HeadlessMessagingPoisonMessageList];"
+        + "IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'messaging') DROP SCHEMA [messaging];"
         + "DROP TABLE IF EXISTS [coordination_liveness];"
         + "DROP TABLE IF EXISTS [coordination_descriptor];"
         + "DROP TABLE IF EXISTS [coordination_node_generation];";
@@ -51,6 +59,8 @@ public sealed class SqlServerJobsCoordinationFixture
     public DbConnection CreateConnection() => new SqlConnection(ConnectionString);
 
     public void ConfigureCommitCoordination(IServiceCollection services) => services.AddSqlServerCommitCoordination();
+
+    public void ConfigureMessagingStorage(MessagingSetupBuilder setup) => setup.UseSqlServer(ConnectionString);
 
     public async Task RunCoordinatedTransactionAsync(
         IServiceProvider services,

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/packages.lock.json
@@ -824,6 +824,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )"
         }
       },
+      "headless.commitcoordination.entityframework": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )",
+          "Headless.CommitCoordination.Core": "[1.0.0, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Options": "[10.0.9, )"
+        }
+      },
       "headless.commitcoordination.sqlserver": {
         "type": "Project",
         "dependencies": {
@@ -971,12 +983,76 @@
           "Headless.Coordination.Core": "[1.0.0, )",
           "Headless.Jobs.Core": "[1.0.0, )",
           "Headless.Jobs.EntityFramework": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Headless.Messaging.InMemory": "[1.0.0, )",
           "Headless.Testing": "[1.0.0, )",
           "Headless.Testing.Testcontainers": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Microsoft.Extensions.Hosting": "[10.0.9, )",
           "Microsoft.NET.Test.Sdk": "[18.7.0, )",
           "NSubstitute": "[5.3.0, )"
+        }
+      },
+      "headless.messaging.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.bus.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.core": {
+        "type": "Project",
+        "dependencies": {
+          "FastExpressionCompiler": "[5.4.1, )",
+          "Headless.CommitCoordination.Abstractions": "[1.0.0, )",
+          "Headless.Coordination.Abstractions": "[1.0.0, )",
+          "Headless.Coordination.Core": "[1.0.0, )",
+          "Headless.Core": "[1.0.0, )",
+          "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
+          "Headless.Extensions": "[1.0.0, )",
+          "Headless.Hosting": "[1.0.0, )",
+          "Headless.Messaging.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Bus.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Queue.Abstractions": "[1.0.0, )",
+          "Headless.MultiTenancy": "[1.0.0, )",
+          "Microsoft.Extensions.Options": "[10.0.9, )",
+          "Polly.Core": "[8.7.0, )"
+        }
+      },
+      "headless.messaging.inmemory": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Bus.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Headless.Messaging.Queue.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.queue.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.storage.sqlserver": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.CommitCoordination.EntityFramework": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Microsoft.Data.SqlClient": "[7.0.2, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )"
+        }
+      },
+      "headless.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )"
         }
       },
       "headless.primitives": {
@@ -1038,6 +1114,12 @@
         "requested": "[8.4.2, )",
         "resolved": "8.4.2",
         "contentHash": "2hmtrrU18x6NL3mbuAqwy0KpnoEEJOuK6sH5RKQfD/jHijn2pqvqBUC7WGy9dgNBL9BDA7eOC0kirsNPMp2f4Q=="
+      },
+      "FastExpressionCompiler": {
+        "type": "CentralTransitive",
+        "requested": "[5.4.1, )",
+        "resolved": "5.4.1",
+        "contentHash": "nqMykMspK5cQd35Y8ulQzAujxCcCwZVUne32pC5xNpXqrbPCuKOPMWkKHJ3LveAZPm6dsVvump0TJ1SZ9RzfTQ=="
       },
       "FlexLabs.EntityFrameworkCore.Upsert": {
         "type": "CentralTransitive",

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/Headless.Jobs.EntityFramework.Tests.Harness.csproj
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/Headless.Jobs.EntityFramework.Tests.Harness.csproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="..\..\src\Headless.Coordination.Core\Headless.Coordination.Core.csproj" />
     <ProjectReference Include="..\..\src\Headless.Jobs.Core\Headless.Jobs.Core.csproj" />
     <ProjectReference Include="..\..\src\Headless.Jobs.EntityFramework\Headless.Jobs.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Messaging.Core\Headless.Messaging.Core.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Messaging.InMemory\Headless.Messaging.InMemory.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />
   </ItemGroup>

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsCoordinationFixtureBase.cs
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsCoordinationFixtureBase.cs
@@ -6,6 +6,9 @@ using Headless.Jobs;
 using Headless.Jobs.DbContextFactory;
 using Headless.Jobs.DependencyInjection;
 using Headless.Jobs.Enums;
+using Headless.Messaging;
+using Headless.Messaging.Configuration;
+using Headless.Messaging.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -56,6 +59,9 @@ public interface IJobsCoordinationFixture
 
     /// <summary>Registers this backend's commit-coordination provider (e.g. <c>services.AddPostgreSqlCommitCoordination()</c>).</summary>
     void ConfigureCommitCoordination(IServiceCollection services);
+
+    /// <summary>Wires this backend's relational messaging storage against <see cref="ConnectionString" />.</summary>
+    void ConfigureMessagingStorage(MessagingSetupBuilder setup);
 
     /// <summary>
     /// Opens a provider connection, begins a commit-coordinated transaction, enlists it, and runs
@@ -148,7 +154,11 @@ public static class JobsCoordinationFixtureExtensions
     /// A test time-job function is registered before the host's startup <c>Build()</c> so <c>AddAsync</c> validation
     /// passes (empty cron expression so the startup seeder ignores it).
     /// </summary>
-    public static IHost BuildCoordinatedEnqueueHost(this IJobsCoordinationFixture fixture, string nodeId)
+    public static IHost BuildCoordinatedEnqueueHost(
+        this IJobsCoordinationFixture fixture,
+        string nodeId,
+        bool includeMessaging = false
+    )
     {
         JobFunctionProvider.RegisterFunctions(
             new Dictionary<string, JobFunctionRegistration>(StringComparer.Ordinal)
@@ -187,6 +197,15 @@ public static class JobsCoordinationFixtureExtensions
                 ef.UseJobsDbContext<JobsDbContext>(fixture.ConfigureStore, schema: "jobs")
             );
         });
+
+        if (includeMessaging)
+        {
+            builder.Services.AddHeadlessMessaging(setup =>
+            {
+                setup.UseInMemory();
+                fixture.ConfigureMessagingStorage(setup);
+            });
+        }
 
         // AddCommitCoordination wins over the Jobs null-coordinator fallback (AddSingleton over TryAddSingleton),
         // so ICurrentCommitCoordinator resolves to the real scope stack that EnlistCommitCoordination pushes onto.
@@ -238,6 +257,17 @@ public static class JobsCoordinationFixtureExtensions
         this IJobsCoordinationFixture fixture,
         CancellationToken cancellationToken
     ) => _CountAsync(fixture, $"SELECT COUNT(*) FROM {fixture.QualifiedCronJobsTable};", cancellationToken);
+
+    /// <summary>Counts published outbox rows on an independent connection (observes committed state only).</summary>
+    public static Task<int> CountPublishedMessagesAsync(
+        this IJobsCoordinationFixture fixture,
+        IServiceProvider services,
+        CancellationToken cancellationToken
+    )
+    {
+        var table = services.GetRequiredService<IStorageInitializer>().GetPublishedTableName();
+        return _CountAsync(fixture, $"SELECT COUNT(*) FROM {table};", cancellationToken);
+    }
 
     private static async Task<int> _CountAsync(
         IJobsCoordinationFixture fixture,

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsEnqueueAtomicityConformanceTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsEnqueueAtomicityConformanceTests.cs
@@ -2,6 +2,8 @@
 
 using Headless.Jobs.Entities;
 using Headless.Jobs.Interfaces.Managers;
+using Headless.Messaging;
+using Headless.Messaging.Persistence;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,6 +22,7 @@ namespace Tests;
 /// <item>AE4 — no coordinator → <c>AddAsync</c> inserts directly.</item>
 /// <item>R5 — <c>AddBatchAsync</c> commits / rolls back atomically with the caller's transaction.</item>
 /// <item>R6 — cron <c>AddAsync</c> commits / rolls back atomically.</item>
+/// <item>Capstone — domain write + outbox publish + job enqueue commit or roll back as one unit.</item>
 /// </list>
 /// Each leaf derives a sealed class with <c>[Collection&lt;TFixture&gt;]</c> and re-declares the methods with
 /// <c>[Fact]</c> so the runner discovers them per provider.
@@ -37,6 +40,76 @@ namespace Tests;
 public abstract class JobsEnqueueAtomicityConformanceTests<TFixture>(TFixture fixture) : TestBase
     where TFixture : class, IJobsCoordinationFixture
 {
+    private sealed record CapstoneMessage(Guid JobId);
+
+    public virtual async Task domain_message_and_job_commit_atomically()
+    {
+        var ct = AbortToken;
+        using var host = await _StartHostAsync(ct, includeMessaging: true);
+
+        try
+        {
+            var manager = host.Services.GetRequiredService<ITimeJobManager<TimeJobEntity>>();
+            var publisher = host.Services.GetRequiredService<IOutboxBus>();
+            var job = _TimeJob();
+
+            await fixture.RunCoordinatedTransactionAsync(
+                host.Services,
+                async (connection, transaction, innerCt) =>
+                {
+                    await JobsCoordinationFixtureExtensions.InsertProbeRowAsync(connection, transaction, innerCt);
+                    await publisher.PublishAsync(new CapstoneMessage(job.Id), cancellationToken: innerCt);
+                    await manager.AddAsync(job, innerCt);
+                },
+                ct
+            );
+
+            (await fixture.CountProbeRowsAsync(ct)).Should().Be(1);
+            (await fixture.CountPublishedMessagesAsync(host.Services, ct)).Should().Be(1);
+            (await fixture.CountTimeJobsAsync(ct)).Should().Be(1);
+        }
+        finally
+        {
+            await host.StopAsync(ct);
+        }
+    }
+
+    public virtual async Task rollback_discards_domain_message_and_job()
+    {
+        var ct = AbortToken;
+        using var host = await _StartHostAsync(ct, includeMessaging: true);
+
+        try
+        {
+            var manager = host.Services.GetRequiredService<ITimeJobManager<TimeJobEntity>>();
+            var publisher = host.Services.GetRequiredService<IOutboxBus>();
+            var job = _TimeJob();
+            var sentinel = new InvalidOperationException("force rollback");
+
+            var act = () =>
+                fixture.RunCoordinatedTransactionAsync(
+                    host.Services,
+                    async (connection, transaction, innerCt) =>
+                    {
+                        await JobsCoordinationFixtureExtensions.InsertProbeRowAsync(connection, transaction, innerCt);
+                        await publisher.PublishAsync(new CapstoneMessage(job.Id), cancellationToken: innerCt);
+                        await manager.AddAsync(job, innerCt);
+                        throw sentinel;
+                    },
+                    ct
+                );
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Should().BeSameAs(sentinel);
+            (await fixture.CountProbeRowsAsync(ct)).Should().Be(0);
+            (await fixture.CountPublishedMessagesAsync(host.Services, ct)).Should().Be(0);
+            (await fixture.CountTimeJobsAsync(ct)).Should().Be(0);
+        }
+        finally
+        {
+            await host.StopAsync(ct);
+        }
+    }
+
     public virtual async Task domain_write_and_enqueue_commit_atomically()
     {
         var ct = AbortToken;
@@ -306,12 +379,18 @@ public abstract class JobsEnqueueAtomicityConformanceTests<TFixture>(TFixture fi
         }
     }
 
-    private async Task<IHost> _StartHostAsync(CancellationToken cancellationToken)
+    private async Task<IHost> _StartHostAsync(CancellationToken cancellationToken, bool includeMessaging = false)
     {
         await fixture.ResetDatabaseAsync(cancellationToken);
-        var host = fixture.BuildCoordinatedEnqueueHost("node-a");
+        var host = fixture.BuildCoordinatedEnqueueHost("node-a", includeMessaging);
         await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, cancellationToken);
         await fixture.CreateProbeTableAsync(cancellationToken);
+
+        if (includeMessaging)
+        {
+            await host.Services.GetRequiredService<IStorageInitializer>().InitializeAsync(cancellationToken);
+        }
+
         await host.StartAsync(cancellationToken);
 
         return host;

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/packages.lock.json
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/packages.lock.json
@@ -765,6 +765,59 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )"
         }
       },
+      "headless.messaging.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.bus.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.core": {
+        "type": "Project",
+        "dependencies": {
+          "FastExpressionCompiler": "[5.4.1, )",
+          "Headless.CommitCoordination.Abstractions": "[1.0.0, )",
+          "Headless.Coordination.Abstractions": "[1.0.0, )",
+          "Headless.Coordination.Core": "[1.0.0, )",
+          "Headless.Core": "[1.0.0, )",
+          "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
+          "Headless.Extensions": "[1.0.0, )",
+          "Headless.Hosting": "[1.0.0, )",
+          "Headless.Messaging.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Bus.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Queue.Abstractions": "[1.0.0, )",
+          "Headless.MultiTenancy": "[1.0.0, )",
+          "Microsoft.Extensions.Options": "[10.0.9, )",
+          "Polly.Core": "[8.7.0, )"
+        }
+      },
+      "headless.messaging.inmemory": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Bus.Abstractions": "[1.0.0, )",
+          "Headless.Messaging.Core": "[1.0.0, )",
+          "Headless.Messaging.Queue.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.messaging.queue.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Messaging.Abstractions": "[1.0.0, )"
+        }
+      },
+      "headless.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Headless.Checks": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )"
+        }
+      },
       "headless.primitives": {
         "type": "Project",
         "dependencies": {
@@ -824,6 +877,12 @@
         "requested": "[8.4.2, )",
         "resolved": "8.4.2",
         "contentHash": "2hmtrrU18x6NL3mbuAqwy0KpnoEEJOuK6sH5RKQfD/jHijn2pqvqBUC7WGy9dgNBL9BDA7eOC0kirsNPMp2f4Q=="
+      },
+      "FastExpressionCompiler": {
+        "type": "CentralTransitive",
+        "requested": "[5.4.1, )",
+        "resolved": "5.4.1",
+        "contentHash": "nqMykMspK5cQd35Y8ulQzAujxCcCwZVUne32pC5xNpXqrbPCuKOPMWkKHJ3LveAZPm6dsVvump0TJ1SZ9RzfTQ=="
       },
       "FlexLabs.EntityFrameworkCore.Upsert": {
         "type": "CentralTransitive",

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/DashboardOptionsTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/DashboardOptionsTests.cs
@@ -161,8 +161,7 @@ public sealed class DashboardOptionsTests : TestBase
     public void Validate_should_throw_for_Basic_without_credentials()
     {
         // given
-        var builder = new MessagingDashboardOptionsBuilder();
-        builder.Auth.Mode = AuthMode.Basic;
+        var builder = new MessagingDashboardOptionsBuilder().WithBasicAuth("admin", "password");
         builder.Auth.BasicCredentials = null;
 
         // when
@@ -176,8 +175,7 @@ public sealed class DashboardOptionsTests : TestBase
     public void Validate_should_throw_for_ApiKey_without_key()
     {
         // given
-        var builder = new MessagingDashboardOptionsBuilder();
-        builder.Auth.Mode = AuthMode.ApiKey;
+        var builder = new MessagingDashboardOptionsBuilder().WithApiKey("temp-key");
         builder.Auth.ApiKey = null;
 
         // when
@@ -191,8 +189,7 @@ public sealed class DashboardOptionsTests : TestBase
     public void Validate_should_throw_for_Custom_without_validator()
     {
         // given
-        var builder = new MessagingDashboardOptionsBuilder();
-        builder.Auth.Mode = AuthMode.Custom;
+        var builder = new MessagingDashboardOptionsBuilder().WithCustomAuth((_, _) => true);
         builder.Auth.CustomValidator = null;
 
         // when
@@ -200,6 +197,32 @@ public sealed class DashboardOptionsTests : TestBase
 
         // then
         act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Validate_should_throw_when_no_auth_mode_configured()
+    {
+        // given — a builder where no WithXxx auth method (not even WithNoAuth) was ever called
+        var builder = new MessagingDashboardOptionsBuilder();
+
+        // when
+        var act = () => builder.Validate();
+
+        // then
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Validate_should_pass_when_explicitly_opting_out_with_WithNoAuth()
+    {
+        // given
+        var builder = new MessagingDashboardOptionsBuilder().WithNoAuth();
+
+        // when
+        var act = () => builder.Validate();
+
+        // then
+        act.Should().NotThrow();
     }
 
     [Fact]

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/DefaultCorsPipelineTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/DefaultCorsPipelineTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Dashboard.Authentication;
+using Headless.Messaging.Dashboard;
+using Headless.Messaging.Dashboard.GatewayProxy;
+using Headless.Messaging.Dashboard.NodeDiscovery;
+using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests.Endpoints;
+
+/// <summary>
+/// Regression coverage for the default (unconfigured) CORS pipeline. Dashboard endpoints carry
+/// <c>RequireCors</c> metadata; if the CORS middleware is skipped when no policy was configured, ASP.NET
+/// Core throws at request time for every endpoint instead of just falling back to same-origin. Unlike
+/// <see cref="HealthEndpointTests"/> (which hand-wires <c>UseCors</c> directly), this test goes through the
+/// real production pipeline (<c>SetupMessagingDashboard.UseMessagingDashboard</c>) so it actually exercises
+/// the conditional this bug lived in.
+/// </summary>
+public sealed class DefaultCorsPipelineTests : TestBase
+{
+    [Fact]
+    public async Task Health_endpoint_should_not_500_when_no_cors_policy_is_configured()
+    {
+        // given - a builder with no SetCorsOrigins / SetCorsPolicy call (the shipped default)
+        var config = new MessagingDashboardOptionsBuilder().WithNoAuth();
+        config.CorsPolicyBuilder.Should().BeNull();
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddSingleton(config);
+        builder.Services.AddSingleton(config.Auth);
+        builder.Services.AddScoped<IAuthService, AuthService>();
+
+        // The endpoint data source eagerly binds every mapped endpoint's metadata (not just the one under
+        // test) the first time authorization/routing initializes, so the other endpoints' DI dependencies
+        // (e.g. the gateway proxy's IHttpClientFactory) must resolve even though this test never calls them.
+        builder.Services.AddSingleton(Substitute.For<IRequestMapper>());
+        builder.Services.AddSingleton(Substitute.For<IHttpClientFactory>());
+        builder.Services.AddMemoryCache();
+        builder.Services.AddSingleton(Substitute.For<INodeDiscoveryProvider>());
+        builder.Services.AddSingleton(new ConsulDiscoveryOptions { NodeName = "test-node" });
+        builder.Services.AddSingleton<GatewayProxyAgent>();
+
+        builder.Services.AddRouting();
+        builder.Services.AddAuthorization();
+
+        // Mirrors DashboardOptionsExtensions' production registration: always register the named policy,
+        // falling back to an empty (same-origin-only) policy when the consumer configured none.
+        builder.Services.AddCors(options =>
+            options.AddPolicy("HeadlessMessagingDashboardCORS", config.CorsPolicyBuilder ?? (static _ => { }))
+        );
+
+        await using var app = builder.Build();
+
+        // Exercise the real production pipeline entrypoint, not a hand-wired stand-in.
+        app.UseMessagingDashboard(config);
+
+        await app.StartAsync(AbortToken);
+        using var client = app.GetTestClient();
+
+        // when
+        var response = await client.GetAsync("/messaging/api/health", AbortToken);
+
+        // then - must succeed (same-origin request, no CORS header needed) rather than 500
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(AbortToken);
+        body.Should().Be("OK");
+    }
+}

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/HealthEndpointTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/HealthEndpointTests.cs
@@ -67,11 +67,11 @@ public sealed class HealthEndpointTests : TestBase
 
         builder.Services.AddRouting();
         builder.Services.AddAuthorization();
-        builder.Services.AddCors(o => o.AddPolicy("Messaging_Dashboard_CORS", p => p.AllowAnyOrigin()));
+        builder.Services.AddCors(o => o.AddPolicy("HeadlessMessagingDashboardCORS", p => p.AllowAnyOrigin()));
 
         var app = builder.Build();
         app.UseRouting();
-        app.UseCors("Messaging_Dashboard_CORS");
+        app.UseCors("HeadlessMessagingDashboardCORS");
         app.MapMessagingDashboardEndpoints(config);
 
         return app;

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/MonitoringEndpointTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/MonitoringEndpointTests.cs
@@ -200,11 +200,11 @@ public sealed class MonitoringEndpointTests : TestBase
 
         appBuilder.Services.AddRouting();
         appBuilder.Services.AddAuthorization();
-        appBuilder.Services.AddCors(o => o.AddPolicy("Messaging_Dashboard_CORS", p => p.AllowAnyOrigin()));
+        appBuilder.Services.AddCors(o => o.AddPolicy("HeadlessMessagingDashboardCORS", p => p.AllowAnyOrigin()));
 
         var app = appBuilder.Build();
         app.UseRouting();
-        app.UseCors("Messaging_Dashboard_CORS");
+        app.UseCors("HeadlessMessagingDashboardCORS");
         app.MapMessagingDashboardEndpoints(config);
 
         return app;

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/PublishedMessageEndpointTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/PublishedMessageEndpointTests.cs
@@ -273,11 +273,11 @@ public sealed class PublishedMessageEndpointTests : TestBase
 
         appBuilder.Services.AddRouting();
         appBuilder.Services.AddAuthorization();
-        appBuilder.Services.AddCors(o => o.AddPolicy("Messaging_Dashboard_CORS", p => p.AllowAnyOrigin()));
+        appBuilder.Services.AddCors(o => o.AddPolicy("HeadlessMessagingDashboardCORS", p => p.AllowAnyOrigin()));
 
         var app = appBuilder.Build();
         app.UseRouting();
-        app.UseCors("Messaging_Dashboard_CORS");
+        app.UseCors("HeadlessMessagingDashboardCORS");
         app.MapMessagingDashboardEndpoints(config);
 
         return app;

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/ReceivedMessageEndpointTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Endpoints/ReceivedMessageEndpointTests.cs
@@ -277,11 +277,11 @@ public sealed class ReceivedMessageEndpointTests : TestBase
 
         appBuilder.Services.AddRouting();
         appBuilder.Services.AddAuthorization();
-        appBuilder.Services.AddCors(o => o.AddPolicy("Messaging_Dashboard_CORS", p => p.AllowAnyOrigin()));
+        appBuilder.Services.AddCors(o => o.AddPolicy("HeadlessMessagingDashboardCORS", p => p.AllowAnyOrigin()));
 
         var app = appBuilder.Build();
         app.UseRouting();
-        app.UseCors("Messaging_Dashboard_CORS");
+        app.UseCors("HeadlessMessagingDashboardCORS");
         app.MapMessagingDashboardEndpoints(config);
 
         return app;


### PR DESCRIPTION
## Summary

Security hardening from a repository review. Fixes the highest-impact issues found: the dashboards shipped public by default with an unsafe CORS default, a request-driven allocation vector, and the Paymob package logged card tokens / recipient PII. Also modernizes the publish path (Trusted Publishing) and supply-chain posture (Dependabot cooldown).

No behavior changes for correctly-configured consumers; the dashboard auth change is intentionally fail-closed (breaking by design for callers that relied on the implicit no-auth default).

## Changes

**Dashboards (Jobs + Messaging)**
- **Fail closed on auth**: registering a dashboard without an explicit auth choice now throws at startup. Consumers must call `WithBasicAuth` / `WithApiKey` / `WithHostAuthentication` / `WithCustomAuth`, or opt out explicitly with `WithNoAuth()`.
- **CORS default fixed**: removed the Jobs dashboard's `SetIsOriginAllowed(_ => true).AllowAnyHeader().AllowCredentials()` (reflect-any-origin **with credentials**) default. Default is now no CORS policy (same-origin only). Added `SetCorsOrigins(params string[])` for the credentialed cross-origin case; `UseCors` is invoked only when a policy is configured.
- **Graph-range DoS clamp**: `pastDays`/`futureDays` on the dashboard graph endpoints are clamped to ±366 days (via `Math.Clamp`, no data annotations), so an oversized span can no longer allocate millions of per-day objects independent of row count.

**Payments (Paymob)**
- Redacting `ToString()` on the four records that reach failure logs (`PaymobCardSavedTokenCashInRequest`, `PaymobWalletCashInRequest`, `PaymobKioskCashInRequest`, `CashOutTransaction`) — saved-card tokens and customer/recipient PII are no longer rendered.
- Cash-out start failures log the provider HTTP status instead of the raw response body.

**CI / supply chain**
- nuget.org publishing migrated to **Trusted Publishing** (OIDC via SHA-pinned `NuGet/login@v1`), replacing the long-lived `NUGET_API_KEY`.
- Dependabot `cooldown` (7 days, majors 14) added to all ecosystems, mirroring the local supply-chain quarantine.

Docs (`README.md` + `docs/llms/{jobs,messaging}.md`) updated to match the new auth/CORS defaults (removed now-false "no auth by default" claims and a bad `SetCorsPolicy("MyPolicy")` example).

## Repo settings applied out-of-band
- ✅ Enabled Actions **SHA-pinning requirement** (`sha_pinning_required`).

## Follow-ups required before release (maintainer-only)
- **Trusted Publishing setup** or the next nuget.org push fails: (1) create the policy on nuget.org (owner `xshaheen`, repo `headless-framework`, workflow `ci.yml`, environment `NuGet Release`); (2) add repo secret `NUGET_USER` = nuget.org profile name; (3) delete the old `NUGET_API_KEY` secret only after a publish succeeds.
- **Secret scanning**: enable "non-provider patterns" and "validity checks" in Settings → Code security (the REST API returns 200 but does not apply these for this repo).

## Verification
- Builds: Paymob + both dashboards build with 0 warnings.
- Tests: Messaging dashboard unit suite (120) and Paymob CashIn/CashOut suites (34 + 48) pass.
- CSharpier + YAML validation clean.
