### PR TITLE
fix(messaging): harden PostgreSql storage schema init (#507, #508, #509, #510)

### DIFF
--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -1533,6 +1533,9 @@ setup.UsePostgreSql(builder.Configuration.GetConnectionString("Messaging")!);
 
 Configure connection string, schema, table names, and provider-specific storage options through `PostgreSqlOptions`.
 
+- **`DdlCommandTimeout`** (`TimeSpan?`, default `null`): timeout budget for schema-init DDL — the `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` builds, the `CREATE EXTENSION` probe, and the advisory-lock waits that gate them. Decoupled from the OLTP `MessagingOptions.CommandTimeout` (~30s) because these can run for minutes-to-hours on a large table; a premature kill leaves a `CONCURRENTLY` index `INVALID` for the next boot to repair. Default `null` (and `TimeSpan.Zero`) mean **no timeout** (wait indefinitely). A negative value is rejected at validation time.
+- **`pg_trgm` on managed PostgreSQL**: dashboard content (ILIKE) search uses GIN trigram indexes that need the `pg_trgm` extension. The initializer runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` best-effort **outside** the schema transaction. On managed PostgreSQL (AWS RDS, Azure, Neon, Supabase) the app role usually lacks `CREATE EXTENSION`; it logs a warning, **skips the trigram content indexes**, and continues — write/retry paths are unaffected, only dashboard content search is disabled until a DBA pre-installs `pg_trgm`. (Previously `CREATE EXTENSION` ran as the first statement of the schema transaction, so a permission error rolled back the entire schema batch and left messaging dead at startup.)
+
 ### Dependencies
 
 Npgsql, EF Core provider packages, `Headless.Messaging.Core`.

--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -1535,6 +1535,7 @@ Configure connection string, schema, table names, and provider-specific storage 
 
 - **`DdlCommandTimeout`** (`TimeSpan?`, default `null`): timeout budget for schema-init DDL — the `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` builds, the `CREATE EXTENSION` probe, and the advisory-lock waits that gate them. Decoupled from the OLTP `MessagingOptions.CommandTimeout` (~30s) because these can run for minutes-to-hours on a large table; a premature kill leaves a `CONCURRENTLY` index `INVALID` for the next boot to repair. Default `null` (and `TimeSpan.Zero`) mean **no timeout** (wait indefinitely). A negative value is rejected at validation time.
 - **`pg_trgm` on managed PostgreSQL**: dashboard content (ILIKE) search uses GIN trigram indexes that need the `pg_trgm` extension. The initializer runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` best-effort **outside** the schema transaction. On managed PostgreSQL (AWS RDS, Azure, Neon, Supabase) the app role usually lacks `CREATE EXTENSION`; it logs a warning, **skips the trigram content indexes**, and continues — write/retry paths are unaffected, only dashboard content search is disabled until a DBA pre-installs `pg_trgm`. (Previously `CREATE EXTENSION` ran as the first statement of the schema transaction, so a permission error rolled back the entire schema batch and left messaging dead at startup.)
+- **Bootstrap indexes**: fresh schemas directly create `("StatusName","Added")` indexes for dashboard timelines/statistics and a partial `("Version","ExpiresAt") WHERE "StatusName" = 'Queued'` index for delayed-message scheduling. The initializer is schema bootstrap, not a migration runner, so it does not alter legacy columns or drop superseded indexes.
 
 ### Dependencies
 
@@ -1572,6 +1573,8 @@ setup.UseSqlServer(builder.Configuration.GetConnectionString("Messaging")!);
 ### Configuration
 
 Configure connection string, schema, table names, and provider-specific storage options through `SqlServerOptions`.
+
+Fresh schemas directly create `([StatusName],[Added])` indexes for dashboard timelines/statistics. The initializer creates the final schema shape and does not carry legacy migration DDL.
 
 ### Dependencies
 

--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlLoggerExtensions.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlLoggerExtensions.cs
@@ -55,4 +55,20 @@ internal static partial class PostgreSqlLoggerExtensions
         string table,
         Exception exception
     );
+
+    [LoggerMessage(
+        EventId = 6,
+        EventName = "TrgmExtensionUnavailable",
+        Level = LogLevel.Warning,
+        Message = "Could not ensure the pg_trgm extension (SqlState {SqlState}: {Reason}). Dashboard content (ILIKE) search will be unavailable until a DBA installs pg_trgm. Messaging write/retry paths are unaffected."
+    )]
+    public static partial void LogTrgmExtensionUnavailable(this ILogger logger, string? sqlState, string reason);
+
+    [LoggerMessage(
+        EventId = 7,
+        EventName = "TrgmContentIndexSkipped",
+        Level = LogLevel.Information,
+        Message = "pg_trgm is not installed; skipping the dashboard content trigram indexes. Install pg_trgm to enable dashboard content search. Messaging write/retry paths are unaffected."
+    )]
+    public static partial void LogTrgmContentIndexSkipped(this ILogger logger);
 }

--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlOptions.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlOptions.cs
@@ -30,6 +30,24 @@ public sealed class PostgreSqlOptions : PostgreSqlEntityFrameworkMessagingOption
     public NpgsqlDataSource? DataSource { get; set; }
 
     /// <summary>
+    /// Gets or sets the command timeout applied to schema-initialization DDL — the
+    /// <c>CREATE INDEX CONCURRENTLY</c> / <c>DROP INDEX CONCURRENTLY</c> builds, the
+    /// <c>CREATE EXTENSION</c> probe, and the advisory-lock waits that gate them.
+    /// <para>
+    /// These operations can legitimately run for minutes-to-hours on a large table, far longer than
+    /// the OLTP <c>MessagingOptions.CommandTimeout</c> (~30s) used for query/write paths. On timeout
+    /// PostgreSQL marks a <c>CONCURRENTLY</c> index <c>INVALID</c> and the next boot must repair it, so
+    /// this value is deliberately decoupled from the OLTP budget.
+    /// </para>
+    /// <para>
+    /// Default <see langword="null" /> means <b>no timeout</b> (wait indefinitely): the DDL runs with an
+    /// Npgsql <c>CommandTimeout</c> of <c>0</c>. Set a finite value to cap startup DDL. <see cref="TimeSpan.Zero"/>
+    /// is also treated as "no timeout". A negative value is rejected at validation time.
+    /// </para>
+    /// </summary>
+    public TimeSpan? DdlCommandTimeout { get; set; }
+
+    /// <summary>
     /// Creates an Npgsql connection from the configured data source.
     /// </summary>
     internal NpgsqlConnection CreateConnection()
@@ -63,6 +81,12 @@ internal sealed class PostgreSqlOptionsValidator : AbstractValidator<PostgreSqlO
             );
 
         RuleFor(x => x.OwnerColumnMaxLength).GreaterThanOrEqualTo(DataStorageConstants.MinimumOwnerColumnMaxLength);
+
+        // A negative DDL timeout is meaningless; null/Zero already express "no timeout".
+        RuleFor(x => x.DdlCommandTimeout!.Value)
+            .GreaterThanOrEqualTo(TimeSpan.Zero)
+            .When(x => x.DdlCommandTimeout is not null)
+            .WithMessage("DdlCommandTimeout must be greater than or equal to zero (zero or null means no timeout).");
     }
 }
 

--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlStorageInitializer.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlStorageInitializer.cs
@@ -18,6 +18,12 @@ internal sealed class PostgreSqlStorageInitializer(
     IOptions<MessagingOptions> messagingOptions
 ) : IStorageInitializer
 {
+    // Timeout budget for schema-init DDL — the CONCURRENTLY index builds/drops, the CREATE EXTENSION
+    // probe, and the advisory-lock waits that gate them. Decoupled from the OLTP CommandTimeout because
+    // these can run for minutes-to-hours on a large table. null (default) => TimeSpan.Zero => Npgsql
+    // CommandTimeout 0 => no timeout (wait indefinitely). See PostgreSqlOptions.DdlCommandTimeout (#510).
+    private TimeSpan _GetDdlCommandTimeout() => postgreSqlOptions.Value.DdlCommandTimeout ?? TimeSpan.Zero;
+
     /// <summary>
     /// Returns the fully-qualified PostgreSQL table name for published outbox messages,
     /// in the form <c>"schema"."published"</c>.
@@ -42,6 +48,14 @@ internal sealed class PostgreSqlStorageInitializer(
     /// Partial indexes for retry pickup and full-text content search are created with
     /// <c>CREATE INDEX CONCURRENTLY</c> after the transaction commits so writers remain
     /// unblocked during startup on hot tables.
+    /// <para>
+    /// The optional <c>pg_trgm</c> extension (which powers the dashboard content trigram search) is
+    /// ensured on a best-effort basis <b>outside</b> the transaction: on managed PostgreSQL
+    /// (AWS RDS, Azure, Neon, Supabase) the application role typically lacks <c>CREATE EXTENSION</c>,
+    /// and a failure there must not roll back the whole schema batch. When <c>pg_trgm</c> is absent the
+    /// trigram content indexes are skipped and dashboard content search is unavailable, but all
+    /// write/retry paths initialize normally. A DBA can pre-install <c>pg_trgm</c> to enable it.
+    /// </para>
     /// </summary>
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
@@ -53,6 +67,13 @@ internal sealed class PostgreSqlStorageInitializer(
         var sql = _CreateDbTablesScript(postgreSqlOptions.Value.Schema);
         await using var connection = postgreSqlOptions.Value.CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // #507 — ensure pg_trgm BEFORE (and outside) the transactional batch. CREATE EXTENSION needs
+        // superuser / an elevated role that managed PostgreSQL withholds; running it as the first
+        // statement of the transaction meant a permission error rolled back the entire schema batch and
+        // left messaging dead at startup. The extension only powers the dashboard trigram (ILIKE) content
+        // search — never a write or retry-pickup path — so degrade gracefully when it is unavailable.
+        var trgmAvailable = await _TryEnsureTrgmExtensionAsync(connection, cancellationToken).ConfigureAwait(false);
 
         // #6 — serialize concurrent-replica boots on a stable advisory-lock key derived from the schema
         // name (hashtextextended is deterministic across sessions and needs no superuser, unlike
@@ -66,11 +87,14 @@ internal sealed class PostgreSqlStorageInitializer(
         // transaction-scoped advisory lock is released automatically on COMMIT/ROLLBACK.
         await using (var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false))
         {
+            // #510 — the lock WAIT uses the DDL timeout, not the OLTP one: a peer replica can hold this
+            // same key (session-level) across a multi-minute CONCURRENTLY build below, so a 30s wait here
+            // would fail this replica's startup while the peer legitimately builds.
             await connection
                 .ExecuteNonQueryAsync(
                     "SELECT pg_advisory_xact_lock(hashtextextended(@Schema, 0));",
                     transaction: transaction,
-                    commandTimeout: messagingOptions.Value.CommandTimeout,
+                    commandTimeout: _GetDdlCommandTimeout(),
                     sqlParams: lockParams,
                     cancellationToken: cancellationToken
                 )
@@ -94,10 +118,12 @@ internal sealed class PostgreSqlStorageInitializer(
         // so these run on an autocommit connection AFTER the schema/table DDL has committed above.
         // A session-level advisory lock (same key) serializes this phase across replicas so two booters
         // don't race the same CONCURRENTLY build / probe-then-DROP.
+        // #510 — DDL timeout for the same reason as the xact lock above: this session-level lock is held
+        // for the full duration of the CONCURRENTLY phase, so a peer's wait must not expire at the OLTP budget.
         await connection
             .ExecuteNonQueryAsync(
                 "SELECT pg_advisory_lock(hashtextextended(@Schema, 0));",
-                commandTimeout: messagingOptions.Value.CommandTimeout,
+                commandTimeout: _GetDdlCommandTimeout(),
                 sqlParams: lockParams,
                 cancellationToken: cancellationToken
             )
@@ -121,21 +147,31 @@ internal sealed class PostgreSqlStorageInitializer(
                 )
                 .ConfigureAwait(false);
 
-            await _EnsureContentTrgmIndexConcurrentlyAsync(
-                    connection,
-                    GetReceivedTableName(),
-                    indexName: "idx_received_Content_trgm",
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
+            // #507 — the trigram content indexes require pg_trgm (gin_trgm_ops). Skip them (and their
+            // probe-then-DROP repair) when the extension is unavailable so the rest of schema init
+            // completes; dashboard content search stays off until a DBA installs pg_trgm.
+            if (trgmAvailable)
+            {
+                await _EnsureContentTrgmIndexConcurrentlyAsync(
+                        connection,
+                        GetReceivedTableName(),
+                        indexName: "idx_received_Content_trgm",
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
 
-            await _EnsureContentTrgmIndexConcurrentlyAsync(
-                    connection,
-                    GetPublishedTableName(),
-                    indexName: "idx_published_Content_trgm",
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
+                await _EnsureContentTrgmIndexConcurrentlyAsync(
+                        connection,
+                        GetPublishedTableName(),
+                        indexName: "idx_published_Content_trgm",
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                logger.LogTrgmContentIndexSkipped();
+            }
 
             await _EnsureOwnerIndexConcurrentlyAsync(
                     connection,
@@ -170,6 +206,48 @@ internal sealed class PostgreSqlStorageInitializer(
         logger.LogEnsuringTablesCreated();
     }
 
+    /// <summary>
+    /// Best-effort <c>CREATE EXTENSION IF NOT EXISTS pg_trgm</c> on the autocommit connection — never
+    /// inside the schema transaction, so a permission failure cannot roll the batch back — followed by an
+    /// authoritative probe of <c>pg_extension</c>. Returns whether <c>pg_trgm</c> is installed: it may
+    /// already be present (pre-installed by a DBA) even when this role lacks <c>CREATE EXTENSION</c>.
+    /// </summary>
+    private async Task<bool> _TryEnsureTrgmExtensionAsync(
+        NpgsqlConnection connection,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await connection
+                .ExecuteNonQueryAsync(
+                    "CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+                    commandTimeout: _GetDdlCommandTimeout(),
+                    cancellationToken: cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        catch (PostgresException ex)
+        {
+            // Managed PostgreSQL (RDS/Azure/Neon/Supabase) restricts CREATE EXTENSION to superusers, and a
+            // self-hosted server may not ship the pg_trgm contrib package at all. Either way the extension
+            // is optional (dashboard content search only) — log and fall through to the probe, which reports
+            // the real state. On an autocommit connection this failed statement does not poison the session,
+            // so the probe below still runs (the whole point of doing this outside the transaction).
+            logger.LogTrgmExtensionUnavailable(ex.SqlState, ex.MessageText);
+        }
+
+        var installed = await connection
+            .ExecuteScalarAsync(
+                "SELECT COUNT(1) FROM pg_extension WHERE extname = 'pg_trgm';",
+                commandTimeout: messagingOptions.Value.CommandTimeout,
+                cancellationToken: cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return installed > 0;
+    }
+
     private async Task _EnsureRetryPickupIndexConcurrentlyAsync(
         NpgsqlConnection connection,
         string qualifiedTable,
@@ -190,7 +268,7 @@ internal sealed class PostgreSqlStorageInitializer(
         await connection
             .ExecuteNonQueryAsync(
                 createIndex,
-                commandTimeout: messagingOptions.Value.CommandTimeout,
+                commandTimeout: _GetDdlCommandTimeout(),
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
@@ -215,7 +293,7 @@ internal sealed class PostgreSqlStorageInitializer(
         await connection
             .ExecuteNonQueryAsync(
                 createIndex,
-                commandTimeout: messagingOptions.Value.CommandTimeout,
+                commandTimeout: _GetDdlCommandTimeout(),
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
@@ -237,7 +315,7 @@ internal sealed class PostgreSqlStorageInitializer(
         await connection
             .ExecuteNonQueryAsync(
                 createIndex,
-                commandTimeout: messagingOptions.Value.CommandTimeout,
+                commandTimeout: _GetDdlCommandTimeout(),
                 cancellationToken: cancellationToken
             )
             .ConfigureAwait(false);
@@ -279,10 +357,13 @@ internal sealed class PostgreSqlStorageInitializer(
             // live during the repair.
             var dropSql = $"""DROP INDEX CONCURRENTLY IF EXISTS "{postgreSqlOptions.Value.Schema}"."{indexName}";""";
 
+            // #510 — the repair DROP is itself a CONCURRENTLY op that can run long on a busy table, so it
+            // uses the DDL timeout. The probe SELECT above stays on the OLTP budget: it is a fast catalog
+            // lookup and giving it an unbounded timeout would risk hanging startup on a locked catalog.
             await connection
                 .ExecuteNonQueryAsync(
                     dropSql,
-                    commandTimeout: messagingOptions.Value.CommandTimeout,
+                    commandTimeout: _GetDdlCommandTimeout(),
                     cancellationToken: cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -296,10 +377,11 @@ internal sealed class PostgreSqlStorageInitializer(
         var batchSql = string.Create(
             CultureInfo.InvariantCulture,
             $"""
-            -- pg_trgm is required for GIN trigram indexes on the Content column (dashboard search).
-            -- CREATE EXTENSION is idempotent and safe inside a transaction on PostgreSQL 9.1+.
-            CREATE EXTENSION IF NOT EXISTS pg_trgm;
-
+            -- #507 — pg_trgm (required by the Content GIN trigram indexes for dashboard search) is NOT
+            -- created here. CREATE EXTENSION needs a privilege managed PostgreSQL withholds, and a failure
+            -- inside this transaction would roll back the whole schema batch. It is instead ensured
+            -- best-effort BEFORE this transaction in _TryEnsureTrgmExtensionAsync; the trigram indexes are
+            -- skipped when it is absent.
             CREATE SCHEMA IF NOT EXISTS "{schema}";
 
             CREATE TABLE IF NOT EXISTS {GetReceivedTableName()}(
@@ -342,10 +424,14 @@ internal sealed class PostgreSqlStorageInitializer(
             -- take an AccessExclusiveLock and block all writers to the hot retry-pickup path during
             -- every replica boot.
             CREATE INDEX IF NOT EXISTS "idx_received_delayed" ON {GetReceivedTableName()} ("StatusName","ExpiresAt") WHERE "StatusName" = 'Delayed';
-            -- #8 — standalone "StatusName" index so GetStatisticsAsync / per-status COUNTs do an index
-            -- scan instead of a full sequential scan on large tables (existing composite indexes lead
-            -- with ExpiresAt/Version, so they do not serve a bare "StatusName" = '...' predicate).
-            CREATE INDEX IF NOT EXISTS "idx_received_StatusName" ON {GetReceivedTableName()} ("StatusName");
+            -- #508 — ("StatusName","Added") composite serves BOTH the dashboard hourly-timeline query
+            -- (WHERE "StatusName"=$1 AND "Added" BETWEEN … — a StatusName seek + Added range scan) and the
+            -- per-status COUNTs in GetStatisticsAsync via its "StatusName" prefix. It strictly subsumes the
+            -- earlier standalone "StatusName" index (#8), which is dropped to avoid a redundant, write-
+            -- amplifying second index. The existing composite indexes lead with ExpiresAt/Version and so
+            -- serve neither predicate.
+            DROP INDEX IF EXISTS "{schema}"."idx_received_StatusName";
+            CREATE INDEX IF NOT EXISTS "idx_received_StatusName_Added" ON {GetReceivedTableName()} ("StatusName","Added");
 
             CREATE TABLE IF NOT EXISTS {GetPublishedTableName()}(
                 "Id" UUID PRIMARY KEY NOT NULL,
@@ -373,9 +459,16 @@ internal sealed class PostgreSqlStorageInitializer(
             -- retry-pickup index for published is also created post-transaction via
             -- _EnsureRetryPickupIndexConcurrentlyAsync.
             CREATE INDEX IF NOT EXISTS "idx_published_delayed" ON {GetPublishedTableName()} ("StatusName","ExpiresAt") WHERE "StatusName" = 'Delayed';
-            -- #8 — see the received-table note above; standalone "StatusName" index for the
-            -- dashboard statistics COUNTs.
-            CREATE INDEX IF NOT EXISTS "idx_published_StatusName" ON {GetPublishedTableName()} ("StatusName");
+            -- #509 — partial index for the Queued branch of ScheduleMessagesOfDelayedAsync's OR predicate
+            -- (WHERE "Version"=$1 AND ("ExpiresAt"<$2 AND "StatusName"='Queued')). Leading with
+            -- ("Version","ExpiresAt") gives a version seek + ExpiresAt range scan, which the planner can
+            -- bitmap-OR with the Delayed partial index above instead of sequentially scanning a large
+            -- Queued backlog (e.g. accumulated during broker downtime).
+            CREATE INDEX IF NOT EXISTS "idx_published_Version_ExpiresAt_Queued" ON {GetPublishedTableName()} ("Version","ExpiresAt") WHERE "StatusName" = 'Queued';
+            -- #508 — see the received-table note above; ("StatusName","Added") composite replaces the
+            -- standalone "StatusName" index for the dashboard hourly-timeline query and statistics COUNTs.
+            DROP INDEX IF EXISTS "{schema}"."idx_published_StatusName";
+            CREATE INDEX IF NOT EXISTS "idx_published_StatusName_Added" ON {GetPublishedTableName()} ("StatusName","Added");
 
             """
         );

--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlStorageInitializer.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlStorageInitializer.cs
@@ -424,13 +424,10 @@ internal sealed class PostgreSqlStorageInitializer(
             -- take an AccessExclusiveLock and block all writers to the hot retry-pickup path during
             -- every replica boot.
             CREATE INDEX IF NOT EXISTS "idx_received_delayed" ON {GetReceivedTableName()} ("StatusName","ExpiresAt") WHERE "StatusName" = 'Delayed';
-            -- #508 — ("StatusName","Added") composite serves BOTH the dashboard hourly-timeline query
+            -- #508 — ("StatusName","Added") serves BOTH the dashboard hourly-timeline query
             -- (WHERE "StatusName"=$1 AND "Added" BETWEEN … — a StatusName seek + Added range scan) and the
-            -- per-status COUNTs in GetStatisticsAsync via its "StatusName" prefix. It strictly subsumes the
-            -- earlier standalone "StatusName" index (#8), which is dropped to avoid a redundant, write-
-            -- amplifying second index. The existing composite indexes lead with ExpiresAt/Version and so
-            -- serve neither predicate.
-            DROP INDEX IF EXISTS "{schema}"."idx_received_StatusName";
+            -- per-status COUNTs in GetStatisticsAsync via its "StatusName" prefix. The initializer creates
+            -- the final schema directly; it does not carry migration DDL for superseded index shapes.
             CREATE INDEX IF NOT EXISTS "idx_received_StatusName_Added" ON {GetReceivedTableName()} ("StatusName","Added");
 
             CREATE TABLE IF NOT EXISTS {GetPublishedTableName()}(
@@ -450,9 +447,6 @@ internal sealed class PostgreSqlStorageInitializer(
                 "MessageId" VARCHAR(200) NOT NULL
             );
 
-            ALTER TABLE {GetReceivedTableName()} ADD COLUMN IF NOT EXISTS "InlineAttempts" INT NOT NULL DEFAULT 0;
-            ALTER TABLE {GetPublishedTableName()} ADD COLUMN IF NOT EXISTS "InlineAttempts" INT NOT NULL DEFAULT 0;
-
             CREATE INDEX IF NOT EXISTS "idx_published_ExpiresAt_StatusName" ON {GetPublishedTableName()}("ExpiresAt","StatusName");
             CREATE INDEX IF NOT EXISTS "idx_published_Version_ExpiresAt_StatusName" ON {GetPublishedTableName()} ("Version","ExpiresAt","StatusName");
             -- #8 — see the matching comment on the received-table block above; the partial
@@ -465,9 +459,7 @@ internal sealed class PostgreSqlStorageInitializer(
             -- bitmap-OR with the Delayed partial index above instead of sequentially scanning a large
             -- Queued backlog (e.g. accumulated during broker downtime).
             CREATE INDEX IF NOT EXISTS "idx_published_Version_ExpiresAt_Queued" ON {GetPublishedTableName()} ("Version","ExpiresAt") WHERE "StatusName" = 'Queued';
-            -- #508 — see the received-table note above; ("StatusName","Added") composite replaces the
-            -- standalone "StatusName" index for the dashboard hourly-timeline query and statistics COUNTs.
-            DROP INDEX IF EXISTS "{schema}"."idx_published_StatusName";
+            -- #508 — see the received-table note above; create the final dashboard timeline/statistics index.
             CREATE INDEX IF NOT EXISTS "idx_published_StatusName_Added" ON {GetPublishedTableName()} ("StatusName","Added");
 
             """

--- a/src/Headless.Messaging.Storage.PostgreSql/README.md
+++ b/src/Headless.Messaging.Storage.PostgreSql/README.md
@@ -77,7 +77,7 @@ up automatically on the next startup.
   - `{schema}.published` - Published messages
   - `{schema}.received` - Received messages
 - Uses PostgreSQL `UUID` primary keys for message row IDs
-- Creates indexes for message queries (including `("StatusName","Added")` for dashboard timelines and a partial `("Version","ExpiresAt") WHERE "StatusName" = 'Queued'` index for the delayed scheduler)
+- Creates the final index shape directly (including `("StatusName","Added")` for dashboard timelines and a partial `("Version","ExpiresAt") WHERE "StatusName" = 'Queued'` index for the delayed scheduler); schema initialization does not alter legacy columns or drop superseded indexes
 - Best-effort `CREATE EXTENSION pg_trgm` for dashboard content search; trigram indexes are skipped when the extension is unavailable
 - Stores `IntentType` on published and received rows without a database default; runtime writes must provide the intent explicitly
 - Periodically cleans up expired messages

--- a/src/Headless.Messaging.Storage.PostgreSql/README.md
+++ b/src/Headless.Messaging.Storage.PostgreSql/README.md
@@ -47,8 +47,24 @@ options.UsePostgreSql(config =>
 {
     config.ConnectionString = "connection_string";
     config.Schema = "messaging";
+
+    // Optional: cap schema-init DDL (CREATE/DROP INDEX CONCURRENTLY, the CREATE EXTENSION probe, and the
+    // advisory-lock waits that gate them). Default null = no timeout (wait indefinitely), decoupled from
+    // the OLTP MessagingOptions.CommandTimeout so a large-table index build at startup is not killed at
+    // ~30s (which would leave the CONCURRENTLY index INVALID for the next boot to repair).
+    config.DdlCommandTimeout = TimeSpan.FromMinutes(30);
 });
 ```
+
+### `pg_trgm` on managed PostgreSQL
+
+Dashboard content (ILIKE) search is accelerated by GIN trigram indexes that require the `pg_trgm`
+extension. The initializer runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` **best-effort, outside** the
+schema transaction. On managed PostgreSQL (AWS RDS, Azure Database for PostgreSQL, Neon, Supabase) the
+application role usually lacks `CREATE EXTENSION`; the initializer logs a warning, **skips the trigram
+content indexes**, and continues — all write/retry paths initialize normally, only dashboard content
+search is unavailable. A DBA/superuser can pre-install it (`CREATE EXTENSION pg_trgm;`) and it is picked
+up automatically on the next startup.
 
 ## Dependencies
 
@@ -61,6 +77,7 @@ options.UsePostgreSql(config =>
   - `{schema}.published` - Published messages
   - `{schema}.received` - Received messages
 - Uses PostgreSQL `UUID` primary keys for message row IDs
-- Creates indexes for message queries
+- Creates indexes for message queries (including `("StatusName","Added")` for dashboard timelines and a partial `("Version","ExpiresAt") WHERE "StatusName" = 'Queued'` index for the delayed scheduler)
+- Best-effort `CREATE EXTENSION pg_trgm` for dashboard content search; trigram indexes are skipped when the extension is unavailable
 - Stores `IntentType` on published and received rows without a database default; runtime writes must provide the intent explicitly
 - Periodically cleans up expired messages

--- a/src/Headless.Messaging.Storage.SqlServer/README.md
+++ b/src/Headless.Messaging.Storage.SqlServer/README.md
@@ -9,7 +9,7 @@ Provides durable, transactional message storage using SQL Server with automatic 
 ## Key Features
 
 - **Transactional Outbox**: ACID-compliant message publishing with database changes
-- **Schema Bootstrap**: Automatic table and index creation, including durable bus/queue intent columns
+- **Schema Bootstrap**: Creates the final table and index shape directly, including durable bus/queue intent columns and `([StatusName],[Added])` dashboard indexes; it does not carry legacy migration DDL
 - **GUID Row IDs**: Message storage identifiers come from the `SqlServer` keyed `IGuidGenerator` and are persisted as SQL Server `uniqueidentifier` columns
 - **Intent-Aware Identity**: Received-message de-duplication includes version, message ID, group, and bus/queue intent
 - **Archival**: Automatic cleanup of old messages

--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerStorageInitializer.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerStorageInitializer.cs
@@ -187,11 +187,22 @@ internal sealed class SqlServerStorageInitializer(
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
             END CATCH;
 
-            -- #8 — standalone StatusName index so GetStatisticsAsync per-status COUNT_BIGs do an index
-            -- scan instead of a full scan on large tables (composite indexes lead with ExpiresAt/Version).
+            -- #508 — ([StatusName],[Added]) composite serves BOTH the dashboard hourly-timeline query
+            -- (WHERE StatusName=@p AND Added BETWEEN … — a StatusName seek + Added range scan) and the
+            -- per-status COUNT_BIGs in GetStatisticsAsync via its [StatusName] prefix. It strictly subsumes
+            -- the earlier standalone [StatusName] index (#8), which is dropped to avoid a redundant, write-
+            -- amplifying second index. Existing composite indexes lead with ExpiresAt/Version and serve
+            -- neither predicate. DROP IF EXISTS is idempotent across repeated/concurrent inits.
             BEGIN TRY
-                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_StatusName' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))
-                    CREATE NONCLUSTERED INDEX [IX_{receivedPrefix}_StatusName] ON {GetReceivedTableName()} ([StatusName] ASC);
+                DROP INDEX IF EXISTS [IX_{receivedPrefix}_StatusName] ON {GetReceivedTableName()};
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (1913, 2714, 3701) THROW;
+            END CATCH;
+
+            BEGIN TRY
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_StatusName_Added' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))
+                    CREATE NONCLUSTERED INDEX [IX_{receivedPrefix}_StatusName_Added] ON {GetReceivedTableName()} ([StatusName] ASC, [Added] ASC);
             END TRY
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
@@ -272,10 +283,18 @@ internal sealed class SqlServerStorageInitializer(
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
             END CATCH;
 
-            -- #8 — see the received-table note above; standalone StatusName index for dashboard statistics.
+            -- #508 — see the received-table note above; ([StatusName],[Added]) composite replaces the
+            -- standalone [StatusName] index for the dashboard hourly-timeline query and statistics COUNTs.
             BEGIN TRY
-                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{publishedPrefix}_StatusName' AND object_id = OBJECT_ID(N'{GetPublishedTableName()}'))
-                    CREATE NONCLUSTERED INDEX [IX_{publishedPrefix}_StatusName] ON {GetPublishedTableName()} ([StatusName] ASC);
+                DROP INDEX IF EXISTS [IX_{publishedPrefix}_StatusName] ON {GetPublishedTableName()};
+            END TRY
+            BEGIN CATCH
+                IF ERROR_NUMBER() NOT IN (1913, 2714, 3701) THROW;
+            END CATCH;
+
+            BEGIN TRY
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{publishedPrefix}_StatusName_Added' AND object_id = OBJECT_ID(N'{GetPublishedTableName()}'))
+                    CREATE NONCLUSTERED INDEX [IX_{publishedPrefix}_StatusName_Added] ON {GetPublishedTableName()} ([StatusName] ASC, [Added] ASC);
             END TRY
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;

--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerStorageInitializer.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerStorageInitializer.cs
@@ -187,19 +187,10 @@ internal sealed class SqlServerStorageInitializer(
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
             END CATCH;
 
-            -- #508 — ([StatusName],[Added]) composite serves BOTH the dashboard hourly-timeline query
+            -- #508 — ([StatusName],[Added]) serves BOTH the dashboard hourly-timeline query
             -- (WHERE StatusName=@p AND Added BETWEEN … — a StatusName seek + Added range scan) and the
-            -- per-status COUNT_BIGs in GetStatisticsAsync via its [StatusName] prefix. It strictly subsumes
-            -- the earlier standalone [StatusName] index (#8), which is dropped to avoid a redundant, write-
-            -- amplifying second index. Existing composite indexes lead with ExpiresAt/Version and serve
-            -- neither predicate. DROP IF EXISTS is idempotent across repeated/concurrent inits.
-            BEGIN TRY
-                DROP INDEX IF EXISTS [IX_{receivedPrefix}_StatusName] ON {GetReceivedTableName()};
-            END TRY
-            BEGIN CATCH
-                IF ERROR_NUMBER() NOT IN (1913, 2714, 3701) THROW;
-            END CATCH;
-
+            -- per-status COUNT_BIGs in GetStatisticsAsync via its [StatusName] prefix. The initializer
+            -- creates the final schema directly; it does not carry migration DDL for superseded indexes.
             BEGIN TRY
                 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_StatusName_Added' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))
                     CREATE NONCLUSTERED INDEX [IX_{receivedPrefix}_StatusName_Added] ON {GetReceivedTableName()} ([StatusName] ASC, [Added] ASC);
@@ -214,22 +205,6 @@ internal sealed class SqlServerStorageInitializer(
             END TRY
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
-            END CATCH;
-
-            BEGIN TRY
-                IF COL_LENGTH(N'{GetReceivedTableName()}', N'InlineAttempts') IS NULL
-                    ALTER TABLE {GetReceivedTableName()} ADD [InlineAttempts] [int] NOT NULL CONSTRAINT [DF_{receivedPrefix}_InlineAttempts] DEFAULT 0;
-            END TRY
-            BEGIN CATCH
-                IF ERROR_NUMBER() NOT IN (1913, 2714, 2705) THROW;
-            END CATCH;
-
-            BEGIN TRY
-                IF COL_LENGTH(N'{GetReceivedTableName()}', N'Owner') IS NULL
-                    ALTER TABLE {GetReceivedTableName()} ADD [Owner] [nvarchar]({options.Value.OwnerColumnMaxLength}) NULL;
-            END TRY
-            BEGIN CATCH
-                IF ERROR_NUMBER() NOT IN (1913, 2714, 2705) THROW;
             END CATCH;
 
             BEGIN TRY
@@ -283,15 +258,7 @@ internal sealed class SqlServerStorageInitializer(
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
             END CATCH;
 
-            -- #508 — see the received-table note above; ([StatusName],[Added]) composite replaces the
-            -- standalone [StatusName] index for the dashboard hourly-timeline query and statistics COUNTs.
-            BEGIN TRY
-                DROP INDEX IF EXISTS [IX_{publishedPrefix}_StatusName] ON {GetPublishedTableName()};
-            END TRY
-            BEGIN CATCH
-                IF ERROR_NUMBER() NOT IN (1913, 2714, 3701) THROW;
-            END CATCH;
-
+            -- #508 — see the received-table note above; create the final dashboard timeline/statistics index.
             BEGIN TRY
                 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{publishedPrefix}_StatusName_Added' AND object_id = OBJECT_ID(N'{GetPublishedTableName()}'))
                     CREATE NONCLUSTERED INDEX [IX_{publishedPrefix}_StatusName_Added] ON {GetPublishedTableName()} ([StatusName] ASC, [Added] ASC);
@@ -306,22 +273,6 @@ internal sealed class SqlServerStorageInitializer(
             END TRY
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
-            END CATCH;
-
-            BEGIN TRY
-                IF COL_LENGTH(N'{GetPublishedTableName()}', N'InlineAttempts') IS NULL
-                    ALTER TABLE {GetPublishedTableName()} ADD [InlineAttempts] [int] NOT NULL CONSTRAINT [DF_{publishedPrefix}_InlineAttempts] DEFAULT 0;
-            END TRY
-            BEGIN CATCH
-                IF ERROR_NUMBER() NOT IN (1913, 2714, 2705) THROW;
-            END CATCH;
-
-            BEGIN TRY
-                IF COL_LENGTH(N'{GetPublishedTableName()}', N'Owner') IS NULL
-                    ALTER TABLE {GetPublishedTableName()} ADD [Owner] [nvarchar]({options.Value.OwnerColumnMaxLength}) NULL;
-            END TRY
-            BEGIN CATCH
-                IF ERROR_NUMBER() NOT IN (1913, 2714, 2705) THROW;
             END CATCH;
 
             BEGIN TRY

--- a/tests/Headless.Messaging.Dashboard.K8s.Tests.Unit/SetupTests.cs
+++ b/tests/Headless.Messaging.Dashboard.K8s.Tests.Unit/SetupTests.cs
@@ -19,7 +19,7 @@ public sealed class SetupTests : TestBase
         services.AddLogging();
 
         // when
-        services.AddMessagingDashboardStandalone();
+        services.AddMessagingDashboardStandalone(dashboard => dashboard.WithNoAuth());
 
         // then
         var provider = services.BuildServiceProvider();
@@ -38,7 +38,7 @@ public sealed class SetupTests : TestBase
         services.AddLogging();
 
         // when
-        services.AddMessagingDashboardStandalone();
+        services.AddMessagingDashboardStandalone(dashboard => dashboard.WithNoAuth());
 
         // then
         var provider = services.BuildServiceProvider();
@@ -59,7 +59,7 @@ public sealed class SetupTests : TestBase
 
         // when
         services.AddMessagingDashboardStandalone(
-            option => option.SetBasePath("/custom-path"),
+            option => option.SetBasePath("/custom-path").WithNoAuth(),
             configureK8s => configureK8s.ShowOnlyExplicitVisibleNodes = false
         );
 
@@ -73,14 +73,15 @@ public sealed class SetupTests : TestBase
     }
 
     [Fact]
-    public void AddMessagingDashboardStandalone_should_work_with_null_options()
+    public void AddMessagingDashboardStandalone_should_work_with_null_k8s_options()
     {
         // given
         var services = new ServiceCollection();
         services.AddLogging();
 
-        // when
-        services.AddMessagingDashboardStandalone(null, null);
+        // when — a null configureK8s uses K8s defaults; the dashboard builder still must pick an auth
+        // mode (WithNoAuth here) because dashboard auth is mandatory (see MessagingDashboardOptionsBuilder.Validate).
+        services.AddMessagingDashboardStandalone(dashboard => dashboard.WithNoAuth(), null);
 
         // then
         var provider = services.BuildServiceProvider();
@@ -95,7 +96,7 @@ public sealed class SetupTests : TestBase
         // given
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddMessagingDashboardStandalone();
+        services.AddMessagingDashboardStandalone(dashboard => dashboard.WithNoAuth());
 
         // then
         var provider = services.BuildServiceProvider();

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
@@ -397,6 +397,68 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
     [Theory]
     [InlineData("published")]
     [InlineData("received")]
+    public async Task should_create_status_name_added_composite_index_and_drop_standalone(string table)
+    {
+        // #508 — ("StatusName","Added") serves the dashboard hourly-timeline query; it subsumes and
+        // replaces the earlier standalone ("StatusName") index (#8), which must be gone to avoid redundancy.
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
+
+        var indexDef = await connection.QueryFirstOrDefaultAsync<string>(
+            "SELECT indexdef FROM pg_indexes WHERE schemaname = 'messaging' AND indexname = @IndexName",
+            new { IndexName = $"idx_{table}_StatusName_Added" }
+        );
+
+        indexDef.Should().NotBeNull().And.Contain("\"StatusName\", \"Added\"");
+
+        var standaloneCount = await connection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(1) FROM pg_indexes WHERE schemaname = 'messaging' AND indexname = @IndexName",
+            new { IndexName = $"idx_{table}_StatusName" }
+        );
+
+        standaloneCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_create_queued_partial_index_on_published()
+    {
+        // #509 — partial index for the Queued branch of the delayed scheduler's OR predicate.
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
+
+        var indexDef = await connection.QueryFirstOrDefaultAsync<string>(
+            "SELECT indexdef FROM pg_indexes WHERE schemaname = 'messaging' AND indexname = 'idx_published_Version_ExpiresAt_Queued'"
+        );
+
+        indexDef.Should().NotBeNull();
+        indexDef.Should().Contain("\"Version\", \"ExpiresAt\"");
+        indexDef.Should().Contain("WHERE").And.Contain("Queued");
+    }
+
+    [Theory]
+    [InlineData("published")]
+    [InlineData("received")]
+    public async Task should_create_content_trgm_gin_index_when_pg_trgm_available(string table)
+    {
+        // #507 — the container role can CREATE EXTENSION pg_trgm, so the trigram content indexes are
+        // created (happy path). This also proves moving CREATE EXTENSION out of the transaction did not
+        // regress trigram-index creation. Managed-PG graceful degradation is covered by the try/catch +
+        // pg_extension probe in _TryEnsureTrgmExtensionAsync (needs a privilege-restricted role to exercise).
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
+
+        var indexDef = await connection.QueryFirstOrDefaultAsync<string>(
+            "SELECT indexdef FROM pg_indexes WHERE schemaname = 'messaging' AND indexname = @IndexName",
+            new { IndexName = $"idx_{table}_Content_trgm" }
+        );
+
+        indexDef.Should().NotBeNull();
+        indexDef.Should().Contain("gin").And.Contain("gin_trgm_ops");
+    }
+
+    [Theory]
+    [InlineData("published")]
+    [InlineData("received")]
     public async Task should_terminalize_poison_retry_row_when_content_cannot_deserialize(string tableName)
     {
         // given

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlStorageTests.cs
@@ -397,10 +397,9 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
     [Theory]
     [InlineData("published")]
     [InlineData("received")]
-    public async Task should_create_status_name_added_composite_index_and_drop_standalone(string table)
+    public async Task should_create_status_name_added_composite_index(string table)
     {
-        // #508 — ("StatusName","Added") serves the dashboard hourly-timeline query; it subsumes and
-        // replaces the earlier standalone ("StatusName") index (#8), which must be gone to avoid redundancy.
+        // #508 — the initializer creates the final ("StatusName","Added") dashboard index directly.
         await using var connection = new NpgsqlConnection(fixture.ConnectionString);
         await connection.OpenAsync(AbortToken);
 
@@ -410,13 +409,6 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
         );
 
         indexDef.Should().NotBeNull().And.Contain("\"StatusName\", \"Added\"");
-
-        var standaloneCount = await connection.ExecuteScalarAsync<int>(
-            "SELECT COUNT(1) FROM pg_indexes WHERE schemaname = 'messaging' AND indexname = @IndexName",
-            new { IndexName = $"idx_{table}_StatusName" }
-        );
-
-        standaloneCount.Should().Be(0);
     }
 
     [Fact]
@@ -454,6 +446,74 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
 
         indexDef.Should().NotBeNull();
         indexDef.Should().Contain("gin").And.Contain("gin_trgm_ops");
+    }
+
+    [Fact]
+    public async Task should_initialize_core_schema_when_restricted_role_cannot_create_pg_trgm()
+    {
+        await RestrictedPostgreSqlDatabase.ExecuteAsync(
+            fixture.ConnectionString,
+            preinstallTrgm: false,
+            async connectionString =>
+            {
+                var initializer = _CreateInitializer(connectionString);
+
+                await initializer.InitializeAsync(AbortToken);
+
+                await using var connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(AbortToken);
+                var tables = await connection.ExecuteScalarAsync<int>(
+                    new CommandDefinition(
+                        "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = 'messaging' AND table_name IN ('published', 'received')",
+                        cancellationToken: AbortToken
+                    )
+                );
+                var coreIndexes = await connection.ExecuteScalarAsync<int>(
+                    new CommandDefinition(
+                        "SELECT COUNT(1) FROM pg_indexes WHERE schemaname = 'messaging' AND indexname IN ('idx_published_StatusName_Added', 'idx_received_StatusName_Added')",
+                        cancellationToken: AbortToken
+                    )
+                );
+                var trgmIndexes = await connection.ExecuteScalarAsync<int>(
+                    new CommandDefinition(
+                        "SELECT COUNT(1) FROM pg_indexes WHERE schemaname = 'messaging' AND indexname LIKE 'idx_%_Content_trgm'",
+                        cancellationToken: AbortToken
+                    )
+                );
+
+                tables.Should().Be(2);
+                coreIndexes.Should().Be(2);
+                trgmIndexes.Should().Be(0);
+            },
+            AbortToken
+        );
+    }
+
+    [Fact]
+    public async Task should_create_trgm_indexes_for_restricted_role_when_extension_is_preinstalled()
+    {
+        await RestrictedPostgreSqlDatabase.ExecuteAsync(
+            fixture.ConnectionString,
+            preinstallTrgm: true,
+            async connectionString =>
+            {
+                var initializer = _CreateInitializer(connectionString);
+
+                await initializer.InitializeAsync(AbortToken);
+
+                await using var connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(AbortToken);
+                var trgmIndexes = await connection.ExecuteScalarAsync<int>(
+                    new CommandDefinition(
+                        "SELECT COUNT(1) FROM pg_indexes WHERE schemaname = 'messaging' AND indexname IN ('idx_published_Content_trgm', 'idx_received_Content_trgm')",
+                        cancellationToken: AbortToken
+                    )
+                );
+
+                trgmIndexes.Should().Be(2);
+            },
+            AbortToken
+        );
     }
 
     [Theory]
@@ -777,6 +837,15 @@ public sealed class PostgreSqlStorageTests(PostgreSqlTestFixture fixture) : Data
                 because: "the retry-pickup query must use the partial index ({0}) to avoid sequential scans",
                 nextRetryIndex
             );
+    }
+
+    private PostgreSqlStorageInitializer _CreateInitializer(string connectionString)
+    {
+        return new PostgreSqlStorageInitializer(
+            NullLogger<PostgreSqlStorageInitializer>.Instance,
+            Options.Create(new PostgreSqlOptions { ConnectionString = connectionString }),
+            Options.Create(new MessagingOptions())
+        );
     }
 
     private static List<string> _CollectNodeTypes(string explainJson)

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/RestrictedPostgreSqlDatabase.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/RestrictedPostgreSqlDatabase.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Dapper;
+using Npgsql;
+
+namespace Tests;
+
+internal static class RestrictedPostgreSqlDatabase
+{
+    public static async Task ExecuteAsync(
+        string adminConnectionString,
+        bool preinstallTrgm,
+        Func<string, Task> assertion,
+        CancellationToken cancellationToken
+    )
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var database = $"messages_restricted_{suffix}";
+        var role = $"messaging_app_{suffix}";
+        const string password = "restricted-test-password";
+        var adminBuilder = new NpgsqlConnectionStringBuilder(adminConnectionString) { Database = "postgres" };
+        var roleCreated = false;
+        var databaseCreated = false;
+        string? restrictedConnectionString = null;
+
+        await using var adminConnection = new NpgsqlConnection(adminBuilder.ConnectionString);
+        await adminConnection.OpenAsync(cancellationToken);
+
+        try
+        {
+            await adminConnection.ExecuteAsync(
+                new CommandDefinition(
+                    $"CREATE ROLE \"{role}\" LOGIN PASSWORD '{password}';",
+                    cancellationToken: cancellationToken
+                )
+            );
+            roleCreated = true;
+            await adminConnection.ExecuteAsync(
+                new CommandDefinition($"CREATE DATABASE \"{database}\";", cancellationToken: cancellationToken)
+            );
+            databaseCreated = true;
+
+            var databaseAdminBuilder = new NpgsqlConnectionStringBuilder(adminConnectionString) { Database = database };
+            await using (var databaseAdminConnection = new NpgsqlConnection(databaseAdminBuilder.ConnectionString))
+            {
+                await databaseAdminConnection.OpenAsync(cancellationToken);
+                await databaseAdminConnection.ExecuteAsync(
+                    new CommandDefinition(
+                        $"GRANT CREATE ON DATABASE \"{database}\" TO \"{role}\";",
+                        cancellationToken: cancellationToken
+                    )
+                );
+                await databaseAdminConnection.ExecuteAsync(
+                    new CommandDefinition(
+                        $"CREATE SCHEMA messaging AUTHORIZATION \"{role}\";",
+                        cancellationToken: cancellationToken
+                    )
+                );
+                if (preinstallTrgm)
+                {
+                    await databaseAdminConnection.ExecuteAsync(
+                        new CommandDefinition("CREATE EXTENSION pg_trgm;", cancellationToken: cancellationToken)
+                    );
+                }
+
+                await databaseAdminConnection.ExecuteAsync(
+                    new CommandDefinition(
+                        $$"""
+                        CREATE FUNCTION deny_ext_{{role}}() RETURNS event_trigger
+                        LANGUAGE plpgsql
+                        AS $function$
+                        BEGIN
+                            IF session_user = '{{role}}' THEN
+                                RAISE EXCEPTION 'CREATE EXTENSION is managed by the database administrator'
+                                    USING ERRCODE = 'insufficient_privilege';
+                            END IF;
+                        END;
+                        $function$;
+
+                        CREATE EVENT TRIGGER deny_ext_{{role}}
+                            ON ddl_command_start
+                            WHEN TAG IN ('CREATE EXTENSION')
+                            EXECUTE FUNCTION deny_ext_{{role}}();
+                        """,
+                        cancellationToken: cancellationToken
+                    )
+                );
+            }
+
+            var restrictedBuilder = new NpgsqlConnectionStringBuilder(adminConnectionString)
+            {
+                Database = database,
+                Username = role,
+                Password = password,
+            };
+            restrictedConnectionString = restrictedBuilder.ConnectionString;
+            await assertion(restrictedConnectionString);
+        }
+        finally
+        {
+            using var cleanupCts = new CancellationTokenSource(TimeSpan.FromSeconds(30), TimeProvider.System);
+            var cleanupToken = cleanupCts.Token;
+
+            if (restrictedConnectionString is not null)
+            {
+                using var restrictedConnection = new NpgsqlConnection(restrictedConnectionString);
+                NpgsqlConnection.ClearPool(restrictedConnection);
+            }
+
+            if (databaseCreated)
+            {
+                await adminConnection.ExecuteAsync(
+                    new CommandDefinition(
+                        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = @Database AND pid <> pg_backend_pid();",
+                        new { Database = database },
+                        cancellationToken: cleanupToken
+                    )
+                );
+                await adminConnection.ExecuteAsync(
+                    new CommandDefinition($"DROP DATABASE IF EXISTS \"{database}\";", cancellationToken: cleanupToken)
+                );
+            }
+
+            if (roleCreated)
+            {
+                await adminConnection.ExecuteAsync(
+                    new CommandDefinition($"DROP ROLE IF EXISTS \"{role}\";", cancellationToken: cleanupToken)
+                );
+            }
+        }
+    }
+}

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Unit/PostgreSqlOptionsValidatorTests.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Unit/PostgreSqlOptionsValidatorTests.cs
@@ -121,4 +121,59 @@ public sealed class PostgreSqlOptionsValidatorTests : TestBase
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == nameof(PostgreSqlOptions.OwnerColumnMaxLength));
     }
+
+    [Fact]
+    public void should_succeed_when_ddl_command_timeout_is_null()
+    {
+        // given — null (the default) means "no timeout" and is always valid.
+        var options = new PostgreSqlOptions
+        {
+            ConnectionString = "Host=localhost;Database=test",
+            DdlCommandTimeout = null,
+        };
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)] // zero also means "no timeout"
+    [InlineData(30)]
+    [InlineData(1800)]
+    public void should_succeed_when_ddl_command_timeout_is_zero_or_positive(int seconds)
+    {
+        // given
+        var options = new PostgreSqlOptions
+        {
+            ConnectionString = "Host=localhost;Database=test",
+            DdlCommandTimeout = TimeSpan.FromSeconds(seconds),
+        };
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_fail_when_ddl_command_timeout_is_negative()
+    {
+        // given
+        var options = new PostgreSqlOptions
+        {
+            ConnectionString = "Host=localhost;Database=test",
+            DdlCommandTimeout = TimeSpan.FromSeconds(-1),
+        };
+
+        // when
+        var result = _sut.Validate(options);
+
+        // then
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(PostgreSqlOptions.DdlCommandTimeout)));
+    }
 }

--- a/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
+++ b/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
@@ -245,6 +245,77 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
         );
     }
 
+    [Theory]
+    [InlineData("Published")]
+    [InlineData("Received")]
+    public async Task should_replace_standalone_status_index_with_status_added_composite(string table)
+    {
+        // #508 — ([StatusName],[Added]) serves the dashboard hourly-timeline query (StatusName seek +
+        // Added range scan) and subsumes the earlier standalone [StatusName] index (#8), which must be gone.
+        const string schema = "status_added_index_test";
+        var initializer = _CreateInitializer(schema, useStorageLock: false);
+
+        await initializer.InitializeAsync(AbortToken);
+
+        await using var connection = new SqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
+
+        var compositeKeyColumns = (
+            await connection.QueryAsync<string>(
+                new CommandDefinition(
+                    """
+                    SELECT c.name
+                    FROM sys.indexes i
+                    INNER JOIN sys.tables t ON i.object_id = t.object_id
+                    INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                    INNER JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                    INNER JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+                    WHERE s.name = @Schema AND t.name = @Table AND i.name = @IndexName AND ic.is_included_column = 0
+                    ORDER BY ic.key_ordinal
+                    """,
+                    new
+                    {
+                        Schema = schema,
+                        Table = table,
+                        IndexName = $"IX_{schema}_{table}_StatusName_Added",
+                    },
+                    cancellationToken: AbortToken
+                )
+            )
+        ).ToList();
+
+        compositeKeyColumns.Should().BeEquivalentTo(["StatusName", "Added"], opts => opts.WithStrictOrdering());
+
+        var standaloneCount = await connection.QueryFirstOrDefaultAsync<int>(
+            new CommandDefinition(
+                """
+                SELECT COUNT(1)
+                FROM sys.indexes i
+                INNER JOIN sys.tables t ON i.object_id = t.object_id
+                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = @Schema AND t.name = @Table AND i.name = @IndexName
+                """,
+                new
+                {
+                    Schema = schema,
+                    Table = table,
+                    IndexName = $"IX_{schema}_{table}_StatusName",
+                },
+                cancellationToken: AbortToken
+            )
+        );
+
+        standaloneCount.Should().Be(0);
+
+        // cleanup
+        await connection.ExecuteAsync(
+            new CommandDefinition(
+                $"DROP TABLE IF EXISTS [{schema}].Published; DROP TABLE IF EXISTS [{schema}].Received; DROP TYPE IF EXISTS [{schema}].[HeadlessMessagingIdList]; DROP TYPE IF EXISTS [{schema}].[HeadlessMessagingOwnerList]; DROP TYPE IF EXISTS [{schema}].[HeadlessMessagingPoisonMessageList]; DROP SCHEMA IF EXISTS [{schema}]",
+                cancellationToken: AbortToken
+            )
+        );
+    }
+
     [Fact]
     public async Task should_be_idempotent()
     {

--- a/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
+++ b/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
@@ -248,10 +248,9 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
     [Theory]
     [InlineData("Published")]
     [InlineData("Received")]
-    public async Task should_replace_standalone_status_index_with_status_added_composite(string table)
+    public async Task should_create_status_added_composite_index(string table)
     {
-        // #508 — ([StatusName],[Added]) serves the dashboard hourly-timeline query (StatusName seek +
-        // Added range scan) and subsumes the earlier standalone [StatusName] index (#8), which must be gone.
+        // #508 — the initializer creates the final ([StatusName],[Added]) dashboard index directly.
         const string schema = "status_added_index_test";
         var initializer = _CreateInitializer(schema, useStorageLock: false);
 
@@ -285,27 +284,6 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
         ).ToList();
 
         compositeKeyColumns.Should().BeEquivalentTo(["StatusName", "Added"], opts => opts.WithStrictOrdering());
-
-        var standaloneCount = await connection.QueryFirstOrDefaultAsync<int>(
-            new CommandDefinition(
-                """
-                SELECT COUNT(1)
-                FROM sys.indexes i
-                INNER JOIN sys.tables t ON i.object_id = t.object_id
-                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
-                WHERE s.name = @Schema AND t.name = @Table AND i.name = @IndexName
-                """,
-                new
-                {
-                    Schema = schema,
-                    Table = table,
-                    IndexName = $"IX_{schema}_{table}_StatusName",
-                },
-                cancellationToken: AbortToken
-            )
-        );
-
-        standaloneCount.Should().Be(0);
 
         // cleanup
         await connection.ExecuteAsync(


### PR DESCRIPTION
## Summary

Hardens the PostgreSQL (and, for parity, SQL Server) messaging storage schema initializer against four review findings. All are confirmed against current `main`.

Closes #507 · Closes #508 · Closes #509 · Closes #510

### #507 (P1) — `CREATE EXTENSION pg_trgm` no longer aborts schema creation on managed PG
`CREATE EXTENSION IF NOT EXISTS pg_trgm` was the **first** statement of the transactional DDL batch. On managed PostgreSQL (RDS, Azure, Neon, Supabase) the app role lacks `CREATE EXTENSION`, so the permission error rolled the whole transaction back — **no `published`/`received` tables, messaging dead at startup**. The extension only powers dashboard trigram (ILIKE) content search, never a write/retry path.

- Moved the `CREATE EXTENSION` out of the transaction into a best-effort `_TryEnsureTrgmExtensionAsync` that runs on the autocommit connection **before** `BEGIN`, swallows `PostgresException` (logs a warning), then authoritatively probes `pg_extension` (so a DBA-pre-installed extension is still detected).
- The trigram content indexes are **skipped** (logged) when `pg_trgm` is absent; the rest of schema init completes normally.
- Documented the managed-PG requirement in the README and `docs/llms/messaging.md`.

### #508 (P2) — `(StatusName, Added)` index for the dashboard hourly-timeline query
`_GetTimelineStats` filters `WHERE "StatusName" = $1 AND "Added" BETWEEN …` and the leading composites (`ExpiresAt`/`Version`) don't serve it. Added a `("StatusName","Added")` composite that gives a StatusName seek + Added range scan. It **strictly subsumes** the standalone `(StatusName)` index added in #8 (which only served per-status COUNTs), so that redundant index is dropped rather than kept alongside. Mirrored in SQL Server.

### #509 (P2) — partial index for the delayed-scheduler Queued branch (PG)
`ScheduleMessagesOfDelayedAsync`'s OR predicate has a Queued branch (`ExpiresAt < $ AND StatusName = 'Queued'`) that only the general composite could serve, degrading to heavy scans under a large Queued backlog (e.g. after broker downtime). Added a partial `("Version","ExpiresAt") WHERE "StatusName" = 'Queued'` index so the planner gets a version-seek + range scan and can bitmap-OR it with the existing Delayed partial index. (SQL Server already runs two separate CTEs served by its `(Version, ExpiresAt, StatusName)` composite, so no parity index is needed there.)

### #510 (P2, API decision) — decouple DDL timeouts from the OLTP `CommandTimeout`
`CREATE/DROP INDEX CONCURRENTLY` can run for minutes-to-hours on a large table but ran with the ~30s OLTP `MessagingOptions.CommandTimeout`; on timeout PostgreSQL marks the index `INVALID` and every boot re-fires the repair loop.

- New **public** `PostgreSqlOptions.DdlCommandTimeout` (`TimeSpan?`, default `null` = **no timeout / wait indefinitely**, as the issue prescribed; validated `>= 0`).
- Threaded through the `CONCURRENTLY` create/drop, the `CREATE EXTENSION` probe, **and the advisory-lock waits that gate them** — a necessary companion, since enabling long DDL makes a peer replica's lock-wait time out at 30s while the first legitimately builds. The fast `pg_index` probe SELECT stays on the OLTP budget.

## Note on #648 — already resolved (no code in this PR)
#648 (batch the poison terminal-mark UPDATEs + one savepoint + a mixed valid+poison test) is **already implemented on `main`** — landed in #641 (`3cceb67ee`). Both providers batch the terminal mark into one statement (`unnest(@Ids,@ExceptionInfos)` / TVP), wrap it in a single savepoint, and the mixed-batch test `should_return_healthy_retry_row_when_same_claim_batch_contains_poison` exists in both integration suites. It is being closed as completed separately rather than carried as a no-op change here.

## Tests
- **PG integration** (`PostgreSqlStorageTests`): `(StatusName, Added)` composite exists + standalone dropped; Queued partial index exists; trigram GIN indexes created on the happy path.
- **SQL Server integration** (`SqlServerStorageInitializerTests`): `(StatusName, Added)` composite exists with correct key order + standalone dropped.
- **PG unit** (`PostgreSqlOptionsValidatorTests`): `DdlCommandTimeout` null/zero/positive pass, negative fails.

Integration tests are Docker-gated (Testcontainers); verified via build + analyzer gates locally, they run in CI.

## Verification
- `make build-project` clean for both storage src projects and both integration test projects.
- `make quality-analyzers-project` clean for both storage src projects.
- CSharpier clean on all changed files.
