### PR TITLE
fix(fluentvalidation): preserve validation severity (#484)

### DIFF
--- a/docs/llms/utilities.md
+++ b/docs/llms/utilities.md
@@ -170,6 +170,10 @@ RuleFor(x => x.Total)
     .WithErrorDescriptor(new ErrorDescriptor("ORDER_TOTAL_INVALID", "Total must be positive."));
 ```
 
+`ErrorDescriptor` defaults to error severity. Pass `ValidationSeverity.Warning` or
+`ValidationSeverity.Information` explicitly for non-error rules; severity is preserved by both
+`WithErrorDescriptor(...)` and `ToErrorDescriptors()`.
+
 #### Processing Validation Results
 
 ```csharp

--- a/src/Headless.FluentValidation/FluentValidationExtensions.cs
+++ b/src/Headless.FluentValidation/FluentValidationExtensions.cs
@@ -10,8 +10,8 @@ namespace FluentValidation;
 public static class FluentValidationExtensions
 {
     /// <summary>
-    /// Applies an <see cref="ErrorDescriptor"/> to the rule, setting both the error code and the
-    /// error message in a single call.
+    /// Applies an <see cref="ErrorDescriptor"/> to the rule, setting the error code, error message,
+    /// and severity in a single call.
     /// </summary>
     /// <typeparam name="T">The type being validated.</typeparam>
     /// <typeparam name="TProperty">The property type being validated.</typeparam>
@@ -27,7 +27,9 @@ public static class FluentValidationExtensions
             ? errorDescriptor.Code
             : errorDescriptor.Description;
 
-        return rule.WithErrorCode(errorDescriptor.Code).WithMessage(description);
+        return rule.WithErrorCode(errorDescriptor.Code)
+            .WithMessage(description)
+            .WithSeverity(errorDescriptor.Severity.ToSeverity());
     }
 
     /// <summary>Converts a FluentValidation <see cref="ValidationSeverity"/> to the Headless <see cref="Severity"/> equivalent.</summary>
@@ -91,7 +93,8 @@ public static class FluentValidationExtensions
                     return new ErrorDescriptor(
                         code: errorCode,
                         description: failure.ErrorMessage,
-                        paramsDictionary: paramsDictionary
+                        paramsDictionary: paramsDictionary,
+                        severity: _ToValidationSeverity(failure.Severity)
                     );
                 },
                 StringComparer.Ordinal
@@ -101,5 +104,15 @@ public static class FluentValidationExtensions
                 IReadOnlyList<ErrorDescriptor> (failureGroup) => failureGroup.ToList(),
                 StringComparer.Ordinal
             );
+    }
+
+    private static ValidationSeverity _ToValidationSeverity(Severity severity)
+    {
+        return severity switch
+        {
+            Severity.Info => ValidationSeverity.Information,
+            Severity.Warning => ValidationSeverity.Warning,
+            _ => ValidationSeverity.Error,
+        };
     }
 }

--- a/src/Headless.FluentValidation/README.md
+++ b/src/Headless.FluentValidation/README.md
@@ -86,14 +86,19 @@ RuleFor(x => x.Total)
     .WithErrorDescriptor(new ErrorDescriptor("ORDER_TOTAL_INVALID", "Total must be positive."));
 ```
 
+`ErrorDescriptor` defaults to error severity. Pass `ValidationSeverity.Warning` or
+`ValidationSeverity.Information` explicitly when defining a non-error rule; `WithErrorDescriptor(...)` carries
+that severity into the FluentValidation failure.
+
 ### Processing Validation Results
 
 ```csharp
 var errors = result.Errors.ToErrorDescriptors(); // IReadOnlyDictionary<string, IReadOnlyList<ErrorDescriptor>>
 ```
 
-`ToErrorDescriptors()` normalizes every failure's `ErrorCode` to the framework-standard `g:snake_case`
-shape: FluentValidation built-in codes are mapped by `FluentValidationErrorCodeMapper` (for example
+`ToErrorDescriptors()` preserves each failure's severity and normalizes its `ErrorCode` to the
+framework-standard `g:snake_case` shape. FluentValidation built-in codes are mapped by
+`FluentValidationErrorCodeMapper` (for example
 `EmailValidator` → `g:invalid_email`), and the Headless validators in this package emit `g:`-prefixed
 codes via `FluentValidatorErrorDescriber` (for example `Ipv4()` → `g:invalid_ipv4`). Clients therefore
 see a single consistent code namespace in `errors[].code`. Codes you supply yourself through

--- a/src/Headless.Primitives/ErrorDescriptor.cs
+++ b/src/Headless.Primitives/ErrorDescriptor.cs
@@ -12,11 +12,11 @@ public sealed class ErrorDescriptor
     /// <summary>Initializes a new <see cref="ErrorDescriptor"/> without parameters.</summary>
     /// <param name="code">A distinct code indicating the cause of the error.</param>
     /// <param name="description">A human-readable description of the error.</param>
-    /// <param name="severity">The severity of the error. Defaults to <see cref="ValidationSeverity.Information"/>.</param>
+    /// <param name="severity">The severity of the error. Defaults to <see cref="ValidationSeverity.Error"/>.</param>
     public ErrorDescriptor(
         string code,
         [LocalizationRequired] string description,
-        ValidationSeverity severity = ValidationSeverity.Information
+        ValidationSeverity severity = ValidationSeverity.Error
     )
     {
         Code = code;
@@ -28,12 +28,12 @@ public sealed class ErrorDescriptor
     /// <param name="code">A distinct code indicating the cause of the error.</param>
     /// <param name="description">A human-readable description of the error.</param>
     /// <param name="paramsDictionary">Parameter values related to the error, stored as the descriptor's parameter bag.</param>
-    /// <param name="severity">The severity of the error. Defaults to <see cref="ValidationSeverity.Information"/>.</param>
+    /// <param name="severity">The severity of the error. Defaults to <see cref="ValidationSeverity.Error"/>.</param>
     public ErrorDescriptor(
         string code,
         [LocalizationRequired] string description,
         Dictionary<string, object?> paramsDictionary,
-        ValidationSeverity severity = ValidationSeverity.Information
+        ValidationSeverity severity = ValidationSeverity.Error
     )
     {
         Code = code;

--- a/src/Headless.Primitives/README.md
+++ b/src/Headless.Primitives/README.md
@@ -35,6 +35,9 @@ descending.
 `ExtraProperties` and `Locales` derive from `Dictionary<,>` (an established repo pattern for the
 `IHasExtraProperties` bag); both are `sealed`.
 
+`ErrorDescriptor` defaults to `ValidationSeverity.Error`, matching its role as an expected failure. Pass
+`ValidationSeverity.Warning` or `ValidationSeverity.Information` explicitly for non-error diagnostics.
+
 ## Installation
 
 ```bash

--- a/tests/Headless.Extensions.Tests.Unit/Primitives/ErrorDescriptorTests.cs
+++ b/tests/Headless.Extensions.Tests.Unit/Primitives/ErrorDescriptorTests.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Primitives;
+
+namespace Tests.Primitives;
+
+public sealed class ErrorDescriptorTests
+{
+    [Fact]
+    public void should_default_to_error_severity_for_every_constructor()
+    {
+        var descriptor = new ErrorDescriptor("code", "description");
+        var descriptorWithParams = new ErrorDescriptor(
+            "code",
+            "description",
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+        );
+
+        descriptor.Severity.Should().Be(ValidationSeverity.Error);
+        descriptorWithParams.Severity.Should().Be(ValidationSeverity.Error);
+    }
+}

--- a/tests/Headless.FluentValidation.Tests.Unit/FluentValidationExtensionsTests.cs
+++ b/tests/Headless.FluentValidation.Tests.Unit/FluentValidationExtensionsTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using FluentValidation;
+using FluentValidation.Results;
+using Headless.Primitives;
+using FluentSeverity = FluentValidation.Severity;
+using HeadlessValidationSeverity = Headless.Primitives.ValidationSeverity;
+
+namespace Tests;
+
+public sealed class FluentValidationExtensionsTests
+{
+    [Theory]
+    [InlineData(HeadlessValidationSeverity.Information, FluentSeverity.Info)]
+    [InlineData(HeadlessValidationSeverity.Warning, FluentSeverity.Warning)]
+    [InlineData(HeadlessValidationSeverity.Error, FluentSeverity.Error)]
+    public void should_apply_error_descriptor_severity_to_validation_failure(
+        HeadlessValidationSeverity descriptorSeverity,
+        FluentSeverity expectedSeverity
+    )
+    {
+        var validator = new InlineValidator<TestModel>();
+        var descriptor = new ErrorDescriptor("custom:failure", "Value is required.", descriptorSeverity);
+        validator.RuleFor(x => x.Value).NotEmpty().WithErrorDescriptor(descriptor);
+
+        var failure = validator.Validate(new TestModel(Value: "")).Errors.Single();
+
+        failure.Severity.Should().Be(expectedSeverity);
+    }
+
+    [Theory]
+    [InlineData(FluentSeverity.Info, HeadlessValidationSeverity.Information)]
+    [InlineData(FluentSeverity.Warning, HeadlessValidationSeverity.Warning)]
+    [InlineData(FluentSeverity.Error, HeadlessValidationSeverity.Error)]
+    public void should_preserve_failure_severity_when_converting_to_error_descriptors(
+        FluentSeverity failureSeverity,
+        HeadlessValidationSeverity expectedSeverity
+    )
+    {
+        var failure = new ValidationFailure(nameof(TestModel.Value), "Value is invalid.")
+        {
+            ErrorCode = "custom:failure",
+            Severity = failureSeverity,
+        };
+
+        var descriptor = new[] { failure }.ToErrorDescriptors().Single().Value.Single();
+
+        descriptor.Severity.Should().Be(expectedSeverity);
+    }
+
+    private sealed record TestModel(string Value);
+}

--- a/tests/Headless.FluentValidation.Tests.Unit/PhoneNumberValidators_PhoneNumberTests.cs
+++ b/tests/Headless.FluentValidation.Tests.Unit/PhoneNumberValidators_PhoneNumberTests.cs
@@ -2,6 +2,7 @@
 
 using FluentValidation;
 using FluentValidation.TestHelper;
+using FluentSeverity = FluentValidation.Severity;
 
 namespace Tests;
 
@@ -46,6 +47,6 @@ public sealed class PhoneNumberValidatorsPhoneNumberTests
     {
         var model = new TestModel(countryCode, phoneNumber);
         var result = _sut.TestValidate(model);
-        result.ShouldHaveValidationErrorFor(x => x.PhoneNumber);
+        result.ShouldHaveValidationErrorFor(x => x.PhoneNumber).Only().WithSeverity(FluentSeverity.Error);
     }
 }

--- a/tests/Headless.FluentValidation.Tests.Unit/UrlValidators_CorsOriginTests.cs
+++ b/tests/Headless.FluentValidation.Tests.Unit/UrlValidators_CorsOriginTests.cs
@@ -2,6 +2,7 @@
 
 using FluentValidation;
 using FluentValidation.TestHelper;
+using FluentSeverity = FluentValidation.Severity;
 
 namespace Tests;
 
@@ -40,7 +41,10 @@ public sealed class UrlValidatorsCorsOriginTests
     public void should_report_invalid_format_for_non_uri(string origin)
     {
         var result = _sut.TestValidate(new TestModel(origin));
-        result.ShouldHaveValidationErrorFor(x => x.Origin).WithErrorCode("g:invalid_origin_format");
+        result
+            .ShouldHaveValidationErrorFor(x => x.Origin)
+            .WithErrorCode("g:invalid_origin_format")
+            .WithSeverity(FluentSeverity.Error);
     }
 
     // Regression: a non-http(s) absolute scheme previously threw NullReferenceException while


### PR DESCRIPTION
## Summary

- default `ErrorDescriptor` instances to `ValidationSeverity.Error`
- carry descriptor severity into FluentValidation failures and preserve it when converting failures back to descriptors
- add regression coverage for all severity values plus the phone-number and CORS validator paths
- document the severity contract in package and LLM-facing guidance

## Validation

- `make test-project TEST_PROJECT=tests/Headless.Extensions.Tests.Unit/Headless.Extensions.Tests.Unit.csproj` (1,489 passed)
- `make test-project TEST_PROJECT=tests/Headless.FluentValidation.Tests.Unit/Headless.FluentValidation.Tests.Unit.csproj` (487 passed)
- `make test-project TEST_PROJECT=tests/Headless.Api.MinimalApi.Tests.Unit/Headless.Api.MinimalApi.Tests.Unit.csproj` (29 passed)
- `make test-project TEST_PROJECT=tests/Headless.Api.Tests.Unit/Headless.Api.Tests.Unit.csproj` (302 passed)
- `make quality-analyzers-project PROJECT=src/Headless.Primitives/Headless.Primitives.csproj`
- `make quality-analyzers-project PROJECT=src/Headless.FluentValidation/Headless.FluentValidation.csproj`
- `make format-check`
- `make build`

The repository-wide `make quality-analyzers` gate still exits non-zero on existing informational diagnostics in unrelated projects; both changed production projects pass their scoped analyzer gates.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a library-level validation contract correction covered by focused and downstream API tests. Downstream package CI should remain green; rollback is reverting this commit if consumers report unexpected severity changes.

Fixes #484
