### PR TITLE
test: fix the two red unit tests blocking CI

### DIFF
--- a/tests/Headless.Emails.Tests.Unit/AwsSesEmailSenderTests.cs
+++ b/tests/Headless.Emails.Tests.Unit/AwsSesEmailSenderTests.cs
@@ -127,12 +127,31 @@ public sealed class AwsSesEmailSenderTests : TestBase
     [Fact]
     public async Task operation_canceled_should_propagate()
     {
+        // Only the CALLER's own cancellation propagates. The sender rethrows under
+        // `when (cancellationToken.IsCancellationRequested)`, so the caller's token must actually be cancelled --
+        // asserting the throw while passing an uncancelled token tests the other branch by accident.
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
         _ses.SendEmailAsync(Arg.Any<SendEmailRequest>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<SendEmailResponse>(new OperationCanceledException()));
 
-        var act = async () => await _sender.SendAsync(_Request(), AbortToken);
+        var act = async () => await _sender.SendAsync(_Request(), cancellation.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task provider_side_cancellation_should_return_failed_when_the_caller_did_not_cancel()
+    {
+        // The other side of that guard, previously untested: an AWS SDK internal timeout surfaces as a
+        // TaskCanceledException while the caller's token is untouched. That is a delivery failure, not a
+        // cancellation, so it must become a failed response rather than propagate.
+        _ses.SendEmailAsync(Arg.Any<SendEmailRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SendEmailResponse>(new TaskCanceledException("SDK timeout")));
+
+        var result = await _sender.SendAsync(_Request(), AbortToken);
+
+        result.Success.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Headless.Messaging.Nats.Tests.Unit/NatsConsumerClientTests.cs
+++ b/tests/Headless.Messaging.Nats.Tests.Unit/NatsConsumerClientTests.cs
@@ -532,7 +532,7 @@ public sealed class NatsConsumerClientTests : TestBase
         var listeningTask = client.ListeningAsync(TimeSpan.FromMilliseconds(50), cts.Token).AsTask();
         try
         {
-            await nakCalled.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await nakCalled.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
             // then — message should be nacked, callback should not be invoked
             callbackInvoked.Should().BeFalse();
@@ -639,11 +639,11 @@ public sealed class NatsConsumerClientTests : TestBase
         var listeningTask = client.ListeningAsync(TimeSpan.FromMilliseconds(50), cts.Token).AsTask();
         try
         {
-            await nextStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+            await nextStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             await client.PauseAsync(AbortToken);
 
             // then
-            await fetchCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+            await fetchCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         }
         finally
         {
@@ -718,14 +718,14 @@ public sealed class NatsConsumerClientTests : TestBase
             await client
                 .ListeningAsync(TimeSpan.FromMilliseconds(50), AbortToken)
                 .AsTask()
-                .WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+                .WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         // then
         await act.Should().ThrowAsync<NatsConnectionFailedException>();
-        var logged = await connectError.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+        var logged = await connectError.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         logged.Reason.Should().Contain("orders");
         logged.Reason.Should().Contain("connection failed after startup");
-        await siblingCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+        await siblingCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         await failedConsumer
             .Received(1)
             .NextAsync(
@@ -880,14 +880,14 @@ public sealed class NatsConsumerClientTests : TestBase
         var listeningTask = client.ListeningAsync(TimeSpan.FromMilliseconds(50), cts.Token).AsTask();
         try
         {
-            await startedSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+            await startedSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             await client.PauseAsync(AbortToken);
-            await canceledSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+            await canceledSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
             await client.ResumeAsync(AbortToken);
-            await startedSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await startedSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             await client.PauseAsync(AbortToken);
-            await canceledSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await canceledSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
             // then
             seenTokens.Should().HaveCountGreaterThanOrEqualTo(2);
@@ -980,7 +980,7 @@ public sealed class NatsConsumerClientTests : TestBase
 
         try
         {
-            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
             // when — dispose must drain the still-running handler before completing
             var disposeTask = client.DisposeAsync().AsTask();
@@ -989,7 +989,7 @@ public sealed class NatsConsumerClientTests : TestBase
 
             // then — releasing the handler lets dispose complete
             releaseHandler.TrySetResult();
-            await disposeTask.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         }
         finally
         {
@@ -997,7 +997,7 @@ public sealed class NatsConsumerClientTests : TestBase
             await cts.CancelAsync();
             try
             {
-                await listeningTask.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+                await listeningTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             }
             catch (OperationCanceledException) { }
             catch (ObjectDisposedException) { }
@@ -1030,7 +1030,7 @@ public sealed class NatsConsumerClientTests : TestBase
         shutdown.IsCompleted.Should().BeFalse();
 
         timeProvider.Advance(TimeSpan.FromSeconds(2));
-        await shutdown.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+        await shutdown.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
         stuckHandler.TrySetResult();
     }
@@ -1094,12 +1094,12 @@ public sealed class NatsConsumerClientTests : TestBase
         try
         {
             // when
-            await firstFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await firstFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             timeProvider.Advance(TimeSpan.FromSeconds(5)); // release the backoff so the second fetch runs
-            await terminationLogged.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await terminationLogged.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
             // then — the second consecutive failure escalates to a supervised-restart termination
-            var act = async () => await listening.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            var act = async () => await listening.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             await act.Should()
                 .ThrowAsync<BrokerConnectionException>()
                 .WithInnerException<BrokerConnectionException, InvalidOperationException>();
@@ -1187,14 +1187,14 @@ public sealed class NatsConsumerClientTests : TestBase
         try
         {
             // when — first failure, then release its backoff so the heartbeat and second failure run
-            await firstFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await firstFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             timeProvider.Advance(TimeSpan.FromSeconds(5));
-            await secondFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await secondFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             timeProvider.Advance(TimeSpan.FromSeconds(2));
 
             // then — the loop reached the idle 4th fetch after only the initial backoff, proving both the
             // failure streak and the retry delay reset on the heartbeat
-            await idled.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await idled.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             prematureTermination.Task.IsCompleted.Should().BeFalse("the streak reset on the heartbeat fetch");
             listening.IsCompleted.Should().BeFalse();
         }
@@ -1249,11 +1249,11 @@ public sealed class NatsConsumerClientTests : TestBase
         var listening = client.ListeningAsync(TimeSpan.FromMilliseconds(50), cts.Token).AsTask();
         try
         {
-            await firstFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await firstFailureLogged.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             timeProvider.Advance(TimeSpan.FromSeconds(2));
-            await terminationLogged.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            await terminationLogged.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
 
-            var act = async () => await listening.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+            var act = async () => await listening.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
             await act.Should()
                 .ThrowAsync<BrokerConnectionException>()
                 .WithInnerException<BrokerConnectionException, InvalidOperationException>();
@@ -1309,7 +1309,7 @@ public sealed class NatsConsumerClientTests : TestBase
 
         try
         {
-            await listeningTask.WaitAsync(TimeSpan.FromSeconds(1), AbortToken);
+            await listeningTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {


### PR DESCRIPTION
## Summary

CI has been red on `main` and on every branch cut from it. Two unrelated test failures, both test-side — no production code changes.

### 1. `AwsSesEmailSenderTests.operation_canceled_should_propagate` — real, persistent

`AwsSesEmailSender` only rethrows `OperationCanceledException` under `when (cancellationToken.IsCancellationRequested)`. That guard is deliberate and documented in place: an AWS SDK internal timeout surfacing as a `TaskCanceledException` while the caller's token is untouched is a *delivery failure*, not a cancellation, and must become a failed response.

The test made SES throw but passed an **uncancelled** token. The guard correctly declined, the general handler returned a failed response, and the asserted throw never came — the test was exercising the opposite branch from the one it names.

Both the guard and the test last moved in #654 ("pre-v1.0 public API hardening"); the guard was tightened and the test was not updated. `main` has been red ever since.

- Cancel the caller's token so the test covers the branch it claims.
- Add `provider_side_cancellation_should_return_failed_when_the_caller_did_not_cancel` for the other side of the guard, which had **no coverage at all** — which is why the tightening slipped through.

### 2. `NatsConsumerClientTests` — flaky

`PauseAsync_and_ResumeAsync_should_restart_fetch_with_a_fresh_receive_token` failed with a `TimeoutException`. The signalling is deterministic (`TaskCompletionSource`, no fixed sleeps), but the waits were bounded at 1–2s, which is not enough headroom on a loaded runner.

Raised all 24 waits in the file to the 5s bound this codebase already settled on for exactly this failure shape. Every one is a positive wait-until-ready gate; none asserts a timeout, so a wider bound cannot mask a real failure — it only stops a slow runner from being reported as a broken one.

## Validation

- `Headless.Emails.Tests.Unit` — 54/54 pass (was 1 failing).
- `Headless.Messaging.Nats.Tests.Unit` — 114/114 pass across 3 consecutive runs.
- Full-solution restore + build clean.

## Note

This unblocks the merge gate for #660, which is otherwise green — that branch was inheriting both failures and could not fix them.