### PR TITLE
fix(testing): harden database reset recovery

### DIFF
--- a/docs/llms/testing.md
+++ b/docs/llms/testing.md
@@ -21,6 +21,7 @@ packages: Testing, Testing.AspNetCore, Testing.Testcontainers, Messaging.Testing
 - [Headless.Testing.AspNetCore](#headlesstestingaspnetcore)
     - [Problem Solved](#problem-solved-1)
     - [Key Features](#key-features-1)
+    - [Design Notes](#design-notes)
     - [Installation](#installation-1)
     - [Quick Start](#quick-start-2)
     - [Quick Start](#quick-start-3)
@@ -196,7 +197,22 @@ ASP.NET Core integration-test host wrapper with controllable time, DI-scope help
 - `ExecuteScopeAsync(...)` opens a DI scope (optionally with a `ClaimsPrincipal`) for scoped operations.
 - `WaitForReadiness(...)` polls a host-readiness predicate before tests run.
 - `ConfigureDatabaseReset(...)` + `ResetDatabaseAsync()` integrate Respawner with retry.
+- Database reset APIs default to the active xUnit test's cancellation token. The server retries
+  database, I/O, socket, and broken-connection failures up to three times, replacing the reset
+  connection between attempts.
 - `ResetMessagingHarness()` clears `MessagingTestHarness` observation buffers between tests.
+
+### Design Notes
+
+Respawn 7 does not expose cancellation tokens for its internal database commands. Headless closes
+the active reset connection when cancellation is requested and keeps the reset gate held until
+Respawn unwinds, preventing abandoned commands from racing the next reset. A cancelled standalone
+reset therefore leaves its caller-owned connection closed. The server replaces closed connections
+and transiently failed connections through `ConnectionProvider` before the next attempt.
+
+The built-in retry set covers `DbException`, `IOException`, `SocketException`, and exceptions that
+wrap one of those types. Use `AdditionalTransientExceptionFilter` for a provider-specific transient
+shape such as a bare `InvalidOperationException`; deterministic exceptions fail immediately.
 
 ### Installation
 
@@ -365,6 +381,7 @@ The same caveat applies to other databases with sub-tick storage precision (MySQ
 | `initializerTimeout` | `TimeSpan?` | 60 s | Per-`IInitializer` wait budget before a `TimeoutException` is thrown. |
 | `WaitForReadiness(check, timeout)` | fluent | 30 s per check | Registers a post-startup readiness probe. Must be called before `InitializeAsync()`. |
 | `ConfigureDatabaseReset(configure)` | fluent | (disabled) | Opts into Respawner-based DB reset. Must be called before `InitializeAsync()`. |
+| `ResetDatabaseAsync(cancellationToken)` | `Task` | active xUnit test token | Resets database state and retries transient database or transport failures up to three times. |
 
 `DatabaseResetOptions` properties (passed to `ConfigureDatabaseReset`):
 
@@ -373,6 +390,7 @@ The same caveat applies to other databases with sub-tick storage precision (MySQ
 | `DbAdapter` | `IDbAdapter` | `DbAdapter.Postgres` | Respawner adapter matching the target database engine. |
 | `TablesToIgnore` | `List<Table>` | `[]` | Additional tables to skip during reset. `__EFMigrationsHistory` is always excluded automatically. |
 | `ConnectionProvider` | `Func<IServiceProvider, DbConnection>?` | `null` | **Required** when using `ResetDatabaseAsync()`. Factory for an unopened `DbConnection` to the test database. |
+| `AdditionalTransientExceptionFilter` | `Func<Exception, bool>?` | `null` | Adds provider-specific transient exception shapes to the built-in database and transport retry set. |
 
 ### Dependencies
 

--- a/src/Headless.Testing.AspNetCore/DatabaseReset.cs
+++ b/src/Headless.Testing.AspNetCore/DatabaseReset.cs
@@ -40,10 +40,18 @@ public sealed class DatabaseReset
     /// Optional configuration. When <see langword="null"/>, defaults to Postgres adapter with only the
     /// EF migrations history table excluded.
     /// </param>
+    /// <param name="cancellationToken">
+    /// Token used to cancel Respawn by closing the active connection. When omitted,
+    /// <see cref="Xunit.TestContext.Current"/> supplies the active test's cancellation token.
+    /// </param>
     /// <exception cref="InvalidOperationException">
     /// Thrown when <paramref name="connection"/> is not in the <see cref="System.Data.ConnectionState.Open"/> state.
     /// </exception>
-    public static async Task<DatabaseReset> CreateAsync(DbConnection connection, DatabaseResetOptions? options = null)
+    public static async Task<DatabaseReset> CreateAsync(
+        DbConnection connection,
+        DatabaseResetOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
     {
         Ensure.True(connection.State == ConnectionState.Open, "Connection must be open to create Respawner.");
 
@@ -55,10 +63,15 @@ public sealed class DatabaseReset
         };
         tablesToIgnore.AddRange(options.TablesToIgnore);
 
-        var respawner = await Respawner
-            .CreateAsync(
+        var respawner = await DatabaseResetOperation
+            .RunAsync(
                 connection,
-                new RespawnerOptions { TablesToIgnore = [.. tablesToIgnore], DbAdapter = options.DbAdapter }
+                () =>
+                    Respawner.CreateAsync(
+                        connection,
+                        new RespawnerOptions { TablesToIgnore = [.. tablesToIgnore], DbAdapter = options.DbAdapter }
+                    ),
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -69,13 +82,19 @@ public sealed class DatabaseReset
     /// Deletes all data from non-excluded tables using the provided open <paramref name="connection"/>.
     /// </summary>
     /// <param name="connection">An <b>open</b> <see cref="DbConnection"/>.</param>
+    /// <param name="cancellationToken">
+    /// Token used to cancel Respawn by closing the active connection. When omitted,
+    /// <see cref="Xunit.TestContext.Current"/> supplies the active test's cancellation token.
+    /// </param>
     /// <exception cref="InvalidOperationException">
     /// Thrown when <paramref name="connection"/> is not in the <see cref="System.Data.ConnectionState.Open"/> state.
     /// </exception>
-    public Task ResetAsync(DbConnection connection)
+    public async Task ResetAsync(DbConnection connection, CancellationToken cancellationToken = default)
     {
         Ensure.True(connection.State == ConnectionState.Open, "Connection must be open to reset database.");
 
-        return _respawner.ResetAsync(connection);
+        await DatabaseResetOperation
+            .RunAsync(connection, () => _respawner.ResetAsync(connection), cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/src/Headless.Testing.AspNetCore/DatabaseResetOperation.cs
+++ b/src/Headless.Testing.AspNetCore/DatabaseResetOperation.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Data.Common;
+using Xunit;
+
+namespace Headless.Testing.AspNetCore;
+
+internal static class DatabaseResetOperation
+{
+    public static CancellationToken ResolveCancellationToken(CancellationToken cancellationToken) =>
+        cancellationToken.CanBeCanceled ? cancellationToken : TestContext.Current.CancellationToken;
+
+    public static async Task<T> RunAsync<T>(
+        DbConnection connection,
+        Func<Task<T>> operation,
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken = ResolveCancellationToken(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var registration = cancellationToken.Register(
+            static state => _CloseConnection((DbConnection)state!),
+            connection
+        );
+
+        try
+        {
+            var result = await operation().ConfigureAwait(false);
+            await registration.DisposeAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            return result;
+        }
+        catch (Exception ex) when (cancellationToken.IsCancellationRequested && ex is not OperationCanceledException)
+        {
+            throw new OperationCanceledException("Database reset was cancelled.", ex, cancellationToken);
+        }
+        finally
+        {
+            await registration.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    public static async Task RunAsync(
+        DbConnection connection,
+        Func<Task> operation,
+        CancellationToken cancellationToken
+    )
+    {
+        await RunAsync(
+                connection,
+                async () =>
+                {
+                    await operation().ConfigureAwait(false);
+                    return true;
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    private static void _CloseConnection(DbConnection connection)
+    {
+        try
+        {
+            // Respawn 7 has no CancellationToken overloads; closing the connection is the only
+            // provider-neutral way to interrupt its active command while still observing completion.
+            connection.Close();
+        }
+#pragma warning disable ERP022, RCS1075 // Cancellation must not be replaced by a provider close failure.
+        catch (Exception)
+        {
+            // Cancellation must win even when a broken provider throws while closing.
+        }
+#pragma warning restore ERP022, RCS1075
+    }
+}

--- a/src/Headless.Testing.AspNetCore/DatabaseResetOptions.cs
+++ b/src/Headless.Testing.AspNetCore/DatabaseResetOptions.cs
@@ -28,4 +28,11 @@ public sealed class DatabaseResetOptions
     /// not needed for standalone <see cref="DatabaseReset"/> usage.
     /// </summary>
     public Func<IServiceProvider, DbConnection>? ConnectionProvider { get; set; }
+
+    /// <summary>
+    /// Optional predicate for provider-specific transient exceptions that are not a
+    /// <see cref="DbException"/>, <see cref="IOException"/>, or <see cref="System.Net.Sockets.SocketException"/>.
+    /// The built-in transient set is always applied before this predicate.
+    /// </summary>
+    public Func<Exception, bool>? AdditionalTransientExceptionFilter { get; set; }
 }

--- a/src/Headless.Testing.AspNetCore/HeadlessTestServer.cs
+++ b/src/Headless.Testing.AspNetCore/HeadlessTestServer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Data.Common;
+using System.Net.Sockets;
 using System.Security.Claims;
 using Headless.Checks;
 using Headless.Hosting.Initialization;
@@ -41,9 +42,12 @@ public sealed class HeadlessTestServer<TProgram>(
     private volatile bool _initStarted;
     private DatabaseReset? _databaseReset;
     private DbConnection? _resetConnection;
+    private Func<IServiceProvider, DbConnection>? _resetConnectionProvider;
+    private Func<Exception, bool>? _additionalTransientExceptionFilter;
     private volatile bool _disposed;
 
-    internal Func<DatabaseReset, DbConnection, Task> ResetAction { get; set; } = (r, c) => r.ResetAsync(c);
+    internal Func<DatabaseReset, DbConnection, CancellationToken, Task> ResetAction { get; set; } =
+        (reset, connection, cancellationToken) => reset.ResetAsync(connection, cancellationToken);
 
     /// <summary>The fake time provider registered in the test host.</summary>
     public FakeTimeProvider TimeProvider { get; private set; } = null!;
@@ -146,6 +150,10 @@ public sealed class HeadlessTestServer<TProgram>(
     /// Thrown when <see cref="ConfigureDatabaseReset"/> was not called or
     /// <see cref="DatabaseResetOptions.ConnectionProvider"/> is <see langword="null"/>.
     /// </exception>
+    /// <param name="cancellationToken">
+    /// Token used to cancel connection opening, retry delays, and waiting for Respawn. When omitted,
+    /// <see cref="TestContext.Current"/> supplies the active test's cancellation token.
+    /// </param>
     public async Task ResetDatabaseAsync(CancellationToken cancellationToken = default)
     {
         if (_configureDatabaseReset is null)
@@ -155,6 +163,8 @@ public sealed class HeadlessTestServer<TProgram>(
             );
         }
 
+        cancellationToken = DatabaseResetOperation.ResolveCancellationToken(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         Ensure.NotDisposed(_disposed, this);
 
         await _resetGate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -175,36 +185,64 @@ public sealed class HeadlessTestServer<TProgram>(
                     );
                 }
 
-                _resetConnection = options.ConnectionProvider(Services);
-                await _resetConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                _resetConnectionProvider = options.ConnectionProvider;
+                _additionalTransientExceptionFilter = options.AdditionalTransientExceptionFilter;
+                _resetConnection = _resetConnectionProvider(Services);
 
-                _databaseReset = await DatabaseReset.CreateAsync(_resetConnection, options).ConfigureAwait(false);
+                try
+                {
+                    await _resetConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                    _databaseReset = await DatabaseReset
+                        .CreateAsync(_resetConnection, options, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception initializationException)
+                {
+                    var failedConnection = _resetConnection;
+                    _resetConnection = null;
+
+                    try
+                    {
+                        await failedConnection.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception disposalException)
+                    {
+                        // Preserve the initialization failure while retaining cleanup diagnostics.
+                        initializationException.Data["ResetConnectionDisposalException"] = disposalException;
+                    }
+
+                    throw;
+                }
             }
 
-            // Retry for PostgreSQL connection flakiness under high test load
+            // Retry transient database and transport failures under high test load.
             var retries = 3;
+            var replaceConnection = _resetConnection!.State != System.Data.ConnectionState.Open;
+
             while (retries > 0)
             {
                 try
                 {
-                    await ResetAction(_databaseReset, _resetConnection!).ConfigureAwait(false);
+                    if (replaceConnection)
+                    {
+                        await _ReplaceResetConnectionAsync(cancellationToken).ConfigureAwait(false);
+                        replaceConnection = false;
+                    }
+
+                    await ResetAction(_databaseReset, _resetConnection!, cancellationToken).ConfigureAwait(false);
                     break;
                 }
-                catch (DbException) when (retries > 1)
+                catch (Exception ex) when (_IsTransientResetException(ex) && retries > 1)
                 {
                     retries--;
+                    replaceConnection = true;
                     await Task.Delay(TimeSpan.FromMilliseconds(100), System.TimeProvider.System, cancellationToken)
                         .ConfigureAwait(false);
-
-                    // Re-open if closed or broken
-                    if (_resetConnection!.State != System.Data.ConnectionState.Open)
-                    {
-                        await _resetConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
-                    }
                 }
-                catch (DbException ex)
+                catch (Exception ex) when (_IsTransientResetException(ex))
                 {
-                    // Final attempt failed — surface retry-exhaustion context instead of a bare DbException.
+                    // Surface retry-exhaustion context instead of a provider-specific transport exception.
                     throw new InvalidOperationException("Database reset failed after 3 attempts.", ex);
                 }
             }
@@ -213,6 +251,18 @@ public sealed class HeadlessTestServer<TProgram>(
         {
             _resetGate.Release();
         }
+    }
+
+    private bool _IsTransientResetException(Exception exception) =>
+        exception is DbException or IOException or SocketException
+        || (exception.InnerException is not null && _IsTransientResetException(exception.InnerException))
+        || _additionalTransientExceptionFilter?.Invoke(exception) == true;
+
+    private async Task _ReplaceResetConnectionAsync(CancellationToken cancellationToken)
+    {
+        await _resetConnection!.DisposeAsync().ConfigureAwait(false);
+        _resetConnection = _resetConnectionProvider!(Services);
+        await _resetConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Creates a DI scope, invokes <paramref name="action"/>, and disposes the scope.</summary>

--- a/src/Headless.Testing.AspNetCore/README.md
+++ b/src/Headless.Testing.AspNetCore/README.md
@@ -17,8 +17,23 @@ this plumbing per project.
 - `DatabaseReset` - Respawner wrapper that always excludes `__EFMigrationsHistory` and resets all
   other tables; usable standalone.
 - `DatabaseResetOptions` - adapter, table exclusions, and connection provider for `DatabaseReset`.
+- Database reset APIs default to the active xUnit test's cancellation token. The server retries
+  database, I/O, socket, and broken-connection failures up to three times, replacing the reset
+  connection between attempts.
 - `TestHttpContextExtensions.SetHttpContext(...)` - wire a `ClaimsPrincipal` / remote IP / user agent
   onto `IHttpContextAccessor` from a scoped provider.
+
+## Design Notes
+
+Respawn 7 does not expose cancellation tokens for its internal database commands. Headless closes
+the active reset connection when cancellation is requested and keeps the reset gate held until
+Respawn unwinds, preventing abandoned commands from racing the next reset. A cancelled standalone
+reset therefore leaves its caller-owned connection closed. The server replaces closed connections
+and transiently failed connections through `ConnectionProvider` before the next attempt.
+
+The built-in retry set covers `DbException`, `IOException`, `SocketException`, and exceptions that
+wrap one of those types. Use `AdditionalTransientExceptionFilter` for a provider-specific transient
+shape such as a bare `InvalidOperationException`; deterministic exceptions fail immediately.
 
 ## Installation
 
@@ -77,9 +92,9 @@ await fixture.ResetDatabaseAsync(); // between tests
 ### Standalone database reset
 
 ```csharp
-await connection.OpenAsync(); // DatabaseReset requires an open connection
-var reset = await DatabaseReset.CreateAsync(connection); // after migrations have applied
-await reset.ResetAsync(connection);
+await connection.OpenAsync(TestContext.Current.CancellationToken); // requires an open connection
+var reset = await DatabaseReset.CreateAsync(connection); // after migrations; uses the xUnit token
+await reset.ResetAsync(connection); // uses the xUnit token when no token is supplied
 ```
 
 ## Configuration
@@ -89,6 +104,10 @@ await reset.ResetAsync(connection);
 - `WaitForReadiness(check, timeout)` - register post-startup readiness probes (default 30s each).
 - Constructor `initializerTimeout` - per-`IInitializer` wait budget (default 60s).
 - `DatabaseResetOptions.DbAdapter` defaults to Postgres; set it explicitly for SQL Server.
+- `DatabaseResetOptions.AdditionalTransientExceptionFilter` adds provider-specific transient
+  exception shapes to the built-in database and transport retry set.
+- `ResetDatabaseAsync`, `DatabaseReset.CreateAsync`, and `DatabaseReset.ResetAsync` accept an optional
+  cancellation token and otherwise use `TestContext.Current.CancellationToken`.
 
 ## Dependencies
 

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/DatabaseResetOptionsTests.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/DatabaseResetOptionsTests.cs
@@ -33,6 +33,14 @@ public sealed class DatabaseResetOptionsTests
     }
 
     [Fact]
+    public void should_default_to_null_additional_transient_exception_filter()
+    {
+        var options = new DatabaseResetOptions();
+
+        options.AdditionalTransientExceptionFilter.Should().BeNull();
+    }
+
+    [Fact]
     public void should_accept_custom_tables_to_ignore()
     {
         var options = new DatabaseResetOptions

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/DatabaseResetTests.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/DatabaseResetTests.cs
@@ -3,10 +3,11 @@
 using System.Data;
 using System.Data.Common;
 using Headless.Testing.AspNetCore;
+using Headless.Testing.Tests;
 
 namespace Tests;
 
-public sealed class DatabaseResetTests
+public sealed class DatabaseResetTests : TestBase
 {
     [Fact]
     public async Task should_throw_when_connection_not_open_on_create()
@@ -17,5 +18,68 @@ public sealed class DatabaseResetTests
         Func<Task> act = async () => await DatabaseReset.CreateAsync(connection);
 
         await act.Should().ThrowExactlyAsync<InvalidOperationException>().WithMessage("*open*");
+    }
+
+    [Fact]
+    public async Task should_cancel_create_when_token_is_cancelled()
+    {
+        await using var connection = await TestSqliteConnection.CreateAsync(AbortToken);
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        var act = async () => await DatabaseReset.CreateAsync(connection, cancellationToken: cancellation.Token);
+
+        await act.Should().ThrowExactlyAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task should_cancel_reset_when_token_is_cancelled()
+    {
+        await using var connection = await TestSqliteConnection.CreateAsync(AbortToken);
+        var reset = await DatabaseReset.CreateAsync(
+            connection,
+            new DatabaseResetOptions { DbAdapter = Respawn.DbAdapter.Sqlite },
+            AbortToken
+        );
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        var act = async () => await reset.ResetAsync(connection, cancellation.Token);
+
+        await act.Should().ThrowExactlyAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task should_close_connection_when_cancelling_running_operation()
+    {
+        var connection = Substitute.For<DbConnection>();
+        var operation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.When(x => x.Close()).Do(_ => operation.TrySetException(Substitute.For<DbException>()));
+        var cancellation = new CancellationTokenSource();
+
+        var task = DatabaseResetOperation.RunAsync(connection, () => operation.Task, cancellation.Token);
+        await cancellation.CancelAsync();
+
+        var act = async () => await task;
+
+        await act.Should().ThrowExactlyAsync<OperationCanceledException>();
+        cancellation.Dispose();
+        connection
+            .ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(DbConnection.Close))
+            .Should()
+            .Be(1);
+    }
+
+    [Fact]
+    public async Task should_unregister_cancellation_after_operation_completes()
+    {
+        var connection = Substitute.For<DbConnection>();
+        using var cancellation = new CancellationTokenSource();
+
+        await DatabaseResetOperation.RunAsync(connection, () => Task.CompletedTask, cancellation.Token);
+        await cancellation.CancelAsync();
+
+        connection.ReceivedCalls().Should().NotContain(call => call.GetMethodInfo().Name == nameof(DbConnection.Close));
     }
 }

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerDatabaseResetTests.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/HeadlessTestServerDatabaseResetTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Data.Common;
+using System.Net.Sockets;
 using Headless.Testing.AspNetCore;
 using Headless.Testing.Tests;
 using Microsoft.Data.Sqlite;
@@ -69,32 +70,45 @@ public sealed class HeadlessTestServerDatabaseResetTests : TestBase
         result.Should().BeSameAs(_server);
     }
 
-    [Fact]
-    public async Task should_retry_on_db_exception()
+    public static TheoryData<Func<Exception>> TransientResetExceptions =>
+        new()
+        {
+            () => Substitute.For<DbException>(),
+            () => new IOException("Transport interrupted."),
+            () => new SocketException((int)SocketError.ConnectionReset),
+            () =>
+                new InvalidOperationException(
+                    "The connection is broken.",
+                    new SocketException((int)SocketError.ConnectionReset)
+                ),
+        };
+
+    [Theory]
+    [MemberData(nameof(TransientResetExceptions))]
+    public async Task should_retry_on_transient_reset_exception(Func<Exception> exceptionFactory)
     {
         // Use a real SQLite connection for CreateAsync to succeed
-        await using var connection = new SqliteConnection("Data Source=:memory:");
-        await connection.OpenAsync(AbortToken);
+        await using var connection = await TestSqliteConnection.CreateAsync(AbortToken);
 
-        // Create a dummy table because Respawner throws if no tables are found
-        var createCommand = connection.CreateCommand();
-        createCommand.CommandText = "CREATE TABLE Dummy (Id INT PRIMARY KEY);";
-        await createCommand.ExecuteNonQueryAsync(AbortToken);
-
+        var connectionProviderCalls = 0;
         _server = new HeadlessTestServer<Program>();
         _server.ConfigureDatabaseReset(opt =>
         {
-            opt.ConnectionProvider = _ => connection;
+            opt.ConnectionProvider = _ =>
+            {
+                connectionProviderCalls++;
+                return connectionProviderCalls == 1 ? connection : new SqliteConnection("Data Source=:memory:");
+            };
             opt.DbAdapter = Respawn.DbAdapter.Sqlite;
         });
 
         var callCount = 0;
-        _server.ResetAction = (_, _) =>
+        _server.ResetAction = (_, _, _) =>
         {
             callCount++;
             if (callCount < 3)
             {
-                throw Substitute.For<DbException>();
+                throw exceptionFactory();
             }
             return Task.CompletedTask;
         };
@@ -103,5 +117,292 @@ public sealed class HeadlessTestServerDatabaseResetTests : TestBase
         await _server.ResetDatabaseAsync(AbortToken);
 
         callCount.Should().Be(3);
+        connectionProviderCalls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task should_retry_provider_specific_exception_when_configured()
+    {
+        await using var connection = await TestSqliteConnection.CreateAsync(AbortToken);
+        var connectionProviderCalls = 0;
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ =>
+            {
+                connectionProviderCalls++;
+                return connectionProviderCalls == 1 ? connection : new SqliteConnection("Data Source=:memory:");
+            };
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+            options.AdditionalTransientExceptionFilter = exception => exception is InvalidOperationException;
+        });
+
+        var callCount = 0;
+        _server.ResetAction = (_, _, _) =>
+        {
+            callCount++;
+            return callCount == 1
+                ? Task.FromException(new InvalidOperationException("Provider-specific connection failure."))
+                : Task.CompletedTask;
+        };
+
+        await _server.InitializeAsync();
+        await _server.ResetDatabaseAsync(AbortToken);
+
+        callCount.Should().Be(2);
+        connectionProviderCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task should_not_retry_non_transient_exception()
+    {
+        await using var connection = await TestSqliteConnection.CreateAsync(AbortToken);
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ => connection;
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+
+        var callCount = 0;
+        _server.ResetAction = (_, _, _) =>
+        {
+            callCount++;
+            return Task.FromException(new ArgumentException("Invalid reset configuration."));
+        };
+
+        await _server.InitializeAsync();
+        var act = async () => await _server.ResetDatabaseAsync(AbortToken);
+
+        await act.Should().ThrowExactlyAsync<ArgumentException>();
+        callCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_replace_closed_connection_through_public_reset_path()
+    {
+        var connectionString = _CreateSharedDatabaseConnectionString();
+        await using var keeper = await _CreateSharedDatabaseAsync(connectionString);
+        var connections = new List<SqliteConnection>();
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ =>
+            {
+                var connection = new SqliteConnection(connectionString);
+                connections.Add(connection);
+                return connection;
+            };
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+
+        await _server.InitializeAsync();
+        await _server.ResetDatabaseAsync(AbortToken);
+        await _InsertDummyAsync(keeper, 1);
+        await connections[0].CloseAsync();
+
+        await _server.ResetDatabaseAsync(AbortToken);
+
+        connections.Should().HaveCount(2);
+        (await _CountDummyAsync(keeper)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_wrap_final_transient_exception_after_retry_exhaustion()
+    {
+        var connectionString = _CreateSharedDatabaseConnectionString();
+        await using var keeper = await _CreateSharedDatabaseAsync(connectionString);
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ => new SqliteConnection(connectionString);
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+        var resetCalls = 0;
+        var transientException = Substitute.For<DbException>();
+        _server.ResetAction = (_, _, _) =>
+        {
+            resetCalls++;
+            return Task.FromException(transientException);
+        };
+
+        await _server.InitializeAsync();
+        var act = async () => await _server.ResetDatabaseAsync(AbortToken);
+
+        var exception = await act.Should()
+            .ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage("Database reset failed after 3 attempts.");
+        exception.Which.InnerException.Should().BeSameAs(transientException);
+        resetCalls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task should_dispose_failed_initial_connection_before_recovering()
+    {
+        var connectionString = _CreateSharedDatabaseConnectionString();
+        await using var keeper = await _CreateSharedDatabaseAsync(connectionString);
+        var failedConnection = Substitute.For<DbConnection>();
+        failedConnection
+            .OpenAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new IOException("Connection initialization failed.")));
+        var providerCalls = 0;
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ =>
+                ++providerCalls == 1 ? failedConnection : new SqliteConnection(connectionString);
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+
+        await _server.InitializeAsync();
+        var firstReset = async () => await _server.ResetDatabaseAsync(AbortToken);
+
+        await firstReset.Should().ThrowExactlyAsync<IOException>();
+        await _server.ResetDatabaseAsync(AbortToken);
+
+        providerCalls.Should().Be(2);
+        failedConnection
+            .ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(DbConnection.DisposeAsync))
+            .Should()
+            .Be(1);
+    }
+
+    [Fact]
+    public async Task should_retry_when_replacement_connection_open_fails_transiently()
+    {
+        var connectionString = _CreateSharedDatabaseConnectionString();
+        await using var keeper = await _CreateSharedDatabaseAsync(connectionString);
+        var failedReplacement = Substitute.For<DbConnection>();
+        failedReplacement
+            .OpenAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(Substitute.For<DbException>()));
+        var providerCalls = 0;
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ =>
+                ++providerCalls switch
+                {
+                    1 => new SqliteConnection(connectionString),
+                    2 => failedReplacement,
+                    _ => new SqliteConnection(connectionString),
+                };
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+        var resetCalls = 0;
+        _server.ResetAction = (_, _, _) =>
+        {
+            resetCalls++;
+            return resetCalls == 1 ? Task.FromException(Substitute.For<DbException>()) : Task.CompletedTask;
+        };
+
+        await _server.InitializeAsync();
+        await _server.ResetDatabaseAsync(AbortToken);
+
+        providerCalls.Should().Be(3);
+        resetCalls.Should().Be(2);
+        failedReplacement
+            .ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(DbConnection.DisposeAsync))
+            .Should()
+            .Be(1);
+    }
+
+    [Fact]
+    public async Task should_reset_real_database_after_transient_failure_replaces_connection()
+    {
+        var connectionString = _CreateSharedDatabaseConnectionString();
+        await using var keeper = await _CreateSharedDatabaseAsync(connectionString);
+        await _InsertDummyAsync(keeper, 1);
+        var providerCalls = 0;
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(options =>
+        {
+            options.ConnectionProvider = _ =>
+            {
+                providerCalls++;
+                return new SqliteConnection(connectionString);
+            };
+            options.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+        var resetCalls = 0;
+        _server.ResetAction = (reset, connection, cancellationToken) =>
+        {
+            resetCalls++;
+            if (resetCalls == 1)
+            {
+                return Task.FromException(new IOException("Transport interrupted."));
+            }
+
+            return reset.ResetAsync(connection, cancellationToken);
+        };
+
+        await _server.InitializeAsync();
+        await _server.ResetDatabaseAsync(AbortToken);
+
+        providerCalls.Should().Be(2);
+        resetCalls.Should().Be(2);
+        (await _CountDummyAsync(keeper)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_use_test_context_cancellation_token_by_default()
+    {
+        await using var connection = await TestSqliteConnection.CreateAsync(AbortToken);
+
+        _server = new HeadlessTestServer<Program>();
+        _server.ConfigureDatabaseReset(opt =>
+        {
+            opt.ConnectionProvider = _ => connection;
+            opt.DbAdapter = Respawn.DbAdapter.Sqlite;
+        });
+
+        var capturedToken = CancellationToken.None;
+        _server.ResetAction = (_, _, cancellationToken) =>
+        {
+            capturedToken = cancellationToken;
+            return Task.CompletedTask;
+        };
+
+        await _server.InitializeAsync();
+        await _server.ResetDatabaseAsync();
+
+        capturedToken.Should().Be(AbortToken);
+    }
+
+    private static string _CreateSharedDatabaseConnectionString() =>
+        new SqliteConnectionStringBuilder
+        {
+            DataSource = $"headless-reset-{Guid.NewGuid():N}",
+            Mode = SqliteOpenMode.Memory,
+            Cache = SqliteCacheMode.Shared,
+            DefaultTimeout = 1,
+        }.ToString();
+
+    private static async Task<SqliteConnection> _CreateSharedDatabaseAsync(string connectionString)
+    {
+        var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(AbortToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "CREATE TABLE Dummy (Id INTEGER PRIMARY KEY);";
+        await command.ExecuteNonQueryAsync(AbortToken);
+        return connection;
+    }
+
+    private static async Task _InsertDummyAsync(SqliteConnection connection, int id)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "INSERT INTO Dummy (Id) VALUES ($id);";
+        command.Parameters.AddWithValue("$id", id);
+        await command.ExecuteNonQueryAsync(AbortToken);
+    }
+
+    private static async Task<long> _CountDummyAsync(SqliteConnection connection)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM Dummy;";
+        return (long)(await command.ExecuteScalarAsync(AbortToken))!;
     }
 }

--- a/tests/Headless.Testing.AspNetCore.Tests.Unit/TestSqliteConnection.cs
+++ b/tests/Headless.Testing.AspNetCore.Tests.Unit/TestSqliteConnection.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Microsoft.Data.Sqlite;
+
+namespace Tests;
+
+internal static class TestSqliteConnection
+{
+    public static async Task<SqliteConnection> CreateAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(cancellationToken);
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "CREATE TABLE Dummy (Id INT PRIMARY KEY);";
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        return connection;
+    }
+}


### PR DESCRIPTION
## Summary

Database resets now recover from transport-level failures instead of retrying only provider database exceptions. Retries replace the failed connection, share one three-attempt budget across reset and connection-opening failures, and preserve useful exhaustion context.

Cancellation now flows through the server and standalone reset APIs, defaulting to the active xUnit test token. Because Respawn 7 has no cancellation-token overloads, cancellation closes the active connection and keeps the reset gate held until the operation unwinds; provider-specific transient shapes can be added without weakening the built-in classifier.

Fixes #493.

## Validation

- Release build of `Headless.Testing.AspNetCore.Tests.Unit`: 0 warnings, 0 errors
- Package unit suite: 54 passed
- Pre-push changed-file format check: passed
- Pre-push full Release solution build: 0 warnings, 0 errors

Cancellation interruption remains dependent on the database provider honoring `DbConnection.Close()` for an active command; this limitation is documented in the package guidance.
