### PR TITLE
test(jobs): verify coordinated write isolation

### DIFF
--- a/docs/plans/2026-07-14-001-test-coordinated-write-isolation-plan.md
+++ b/docs/plans/2026-07-14-001-test-coordinated-write-isolation-plan.md
@@ -1,0 +1,177 @@
+---
+title: Coordinated Write Change Tracker Isolation - Plan
+type: test
+date: 2026-07-14
+artifact_contract: x-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: x-plan-bootstrap
+execution: code
+---
+
+# Coordinated Write Change Tracker Isolation - Plan
+
+## Goal Capsule
+
+- **Objective:** Add provider-conformance regression coverage proving Jobs coordinated writes preserve consumer EF Core hooks while isolating each `SaveChangesAsync` pipeline to its own `DbContext` change tracker.
+- **Authority:** GitHub issue [#460](https://github.com/xshaheen/headless-framework/issues/460) body and comments, then this plan, then repository conventions in `CLAUDE.md`.
+- **Execution profile:** Prefer a test-only change on a branch created from `origin/main`; make a production correction only if the new cross-provider test exposes a real defect.
+- **Stop condition:** PostgreSQL and SQL Server conformance suites prove the same isolation contract, or a genuine production defect requires the smallest correction backed by those tests.
+- **Tail ownership:** Open an independent PR, babysit its checks to green, and do not merge it.
+
+---
+
+## Product Contract
+
+### Summary
+
+Extend the existing Jobs EF coordinated-enqueue conformance harness with one real-transaction scenario that distinguishes the caller context from the short-lived coordinated context and verifies both `SaveChangesAsync` overrides and interceptors process only their own tracked entries exactly once.
+
+### Problem Frame
+
+The coordinated Jobs writer clones the registered `DbContextOptions<TDbContext>`, rebinds a short-lived non-pooled context to the caller-owned connection and transaction, tracks only Jobs rows, and saves them before the caller later saves its own pending application row. The missing regression contract is change-tracker isolation: EF hooks execute once per `SaveChangesAsync`, not once per ambient transaction, and each invocation must observe only entries owned by that context.
+
+### Requirements
+
+#### Context and transaction topology
+
+- R1. Run the scenario through the existing shared Jobs EF conformance harness on PostgreSQL and SQL Server.
+- R2. Use one ambient coordinated transaction containing one pending caller-side probe, one coordinated time-job enqueue, and exactly one explicit caller `SaveChangesAsync` before commit.
+- R3. Identify exactly two concrete context instances by stable EF context identity while preserving the caller-owned connection and live transaction.
+
+#### Hook isolation and multiplicity
+
+- R4. A test `JobsDbContext` override and a registered `SaveChangesInterceptor` must observe Added or Modified entries as stable entity type/key snapshots at `SavingChangesAsync` time.
+- R5. The coordinated context observations must contain only the intended time-job entry and exclude the caller probe.
+- R6. The caller context observations must contain only the probe entry and exclude the coordinated time-job entry.
+- R7. Idempotence-sensitive markers keyed by hook kind, context role, entity type, and entity key must exist exactly once for each expected entry with no unexpected markers.
+
+#### Durable outcome and documentation
+
+- R8. After commit, an independent connection must observe exactly one probe row and one time-job row, and the test must document that hooks execute per save while isolation is by context/change tracker rather than ambient transaction.
+
+### Scope Boundaries
+
+- Keep the change independent of the Jobs API stack and any work related to issues #304 or #305.
+- Preserve non-pooled coordinated context construction, consumer interceptors, concrete context overrides, transaction ownership, and configured model behavior.
+- Do not assert that interceptors or overrides run once per transaction.
+- Do not broaden into messaging atomicity, claim behavior, general commit/rollback coverage, pooling changes, or transaction ownership changes.
+- Omit the rollback twin by default because existing coordinated-enqueue tests already prove rollback atomicity; add it only if the final fixture makes it a negligible extension.
+
+### Source
+
+- GitHub issue [#460: test(jobs): verify coordinated writes isolate EF side effects](https://github.com/xshaheen/headless-framework/issues/460).
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Extend `JobsEnqueueAtomicityConformanceTests<TFixture>` and its existing provider leaves rather than creating a new suite, keeping one behavioral contract for both relational providers.
+- KTD2. Add a generic/custom-context path behind `BuildCoordinatedEnqueueHost` while preserving its current non-generic wrapper so existing atomicity tests remain unchanged.
+- KTD3. Register the interceptor through the same Jobs context options action that production clones for coordinated writes; this proves option cloning preserves consumer hooks.
+- KTD4. Inside the fixture's live transaction callback, bind the caller test context to the supplied connection without taking ownership, enlist the supplied transaction, and then perform the pending probe, coordinated enqueue, and caller save.
+- KTD5. Use `DbContext.ContextId.InstanceId` for instance identity. Register the resolved caller ID before enqueue, attribute the other target-save ID as coordinated, and reset or freeze observations immediately before the transaction to exclude schema/bootstrap noise.
+- KTD6. Treat observer markers as in-memory test side effects, separate from durable database assertions. Record every override and interceptor invocation with an ordinal and its Added or Modified entry snapshot, including empty snapshots; require one invocation per hook/context role plus the exact four hook/role/entity combinations once each.
+- KTD7. Make probe schema lifecycle explicit. The custom model owns the mapped probe table for this scenario, while provider reset logic prevents collisions with the existing raw probe helper.
+
+### High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Test as Conformance test
+  participant Caller as Caller test DbContext
+  participant Manager as Time-job manager
+  participant Writer as Coordinated Jobs writer
+  participant Short as Short-lived Jobs DbContext
+  participant DB as Provider database
+
+  Test->>Caller: Bind caller connection and transaction
+  Test->>Caller: Track one unsaved probe
+  Test->>Manager: Enqueue one time job
+  Manager->>Writer: Flush coordinated work
+  Writer->>Short: Clone options and enlist transaction
+  Short->>DB: Save only the time-job entry
+  Test->>Caller: Save exactly once
+  Caller->>DB: Save only the probe entry
+  Test->>DB: Commit and verify exact row counts
+```
+
+### Assumptions
+
+- The production implementation already satisfies the contract, so the expected result is a test-only PR.
+- The custom test context can retain the required public options-only constructor and use test-scoped observer state without adding a production DI surface.
+- Existing harness project references are sufficient for EF interceptors and the mapped probe entity.
+
+### Patterns and Evidence
+
+- `tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsCoordinationFixtureBase.cs` owns shared host construction, transaction callbacks, schema setup, reset, and independent row counts.
+- `tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsEnqueueAtomicityConformanceTests.cs` owns the cross-provider coordinated-enqueue scenarios.
+- `tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlEnqueueAtomicityTests.cs` and `tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerEnqueueAtomicityTests.cs` expose inherited conformance methods as provider-discovered facts.
+- `src/Headless.Jobs.EntityFramework/Infrastructure/JobsEFCorePersistenceProvider.cs` is the production seam to characterize; its options cloning, connection rebinding, `UseTransaction`, concrete context construction, and hook execution must remain intact unless the test proves a defect.
+- `docs/solutions/logic-errors/asynclocal-ambient-scope-stranded-across-await.md` reinforces that final row counts alone do not distinguish correct and escaped execution paths; direct per-context observations provide the required proof.
+
+---
+
+## Implementation Units
+
+### U1. Enable an observable caller and coordinated context topology
+
+- **Goal:** Let the shared harness run coordinated enqueue with a custom Jobs context, mapped probe entity, interceptor, and explicit caller enlistment without changing existing tests.
+- **Requirements:** R2, R3, R4, R8.
+- **Dependencies:** None.
+- **Files:**
+  - `tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsCoordinationFixtureBase.cs`
+  - `tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlJobsCoordinationFixture.cs`
+  - `tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerJobsCoordinationFixture.cs`
+- **Approach:** Preserve the existing host helper as a wrapper around a generic path, compose provider options with the test interceptor, map the probe in the custom test context, and ensure provider reset/bootstrap keeps the probe schema deterministic. The scenario should bind the caller context to the callback's connection and transaction without transferring connection ownership.
+- **Patterns to follow:** Generic mapped-context host construction in `JobsCoordinationFixtureBase.cs`; provider-owned reset SQL in each leaf fixture; options-only Jobs context constructors used elsewhere in the harness.
+- **Test scenarios:**
+  1. Existing atomicity conformance scenarios still build and run through the unchanged non-generic helper.
+  2. A custom Jobs context can create its mapped Jobs and probe schema, bind to the live provider connection, and enlist the helper's transaction without owning or closing that connection.
+- **Verification:** Both provider integration projects compile and their existing coordinated-enqueue suites remain green.
+
+### U2. Prove hook isolation and exact per-entry side effects across providers
+
+- **Goal:** Add the issue-locked regression scenario once in the harness and expose it from both provider leaves.
+- **Requirements:** R1, R2, R3, R4, R5, R6, R7, R8.
+- **Dependencies:** U1.
+- **Files:**
+  - `tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsEnqueueAtomicityConformanceTests.cs`
+  - `tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlEnqueueAtomicityTests.cs`
+  - `tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerEnqueueAtomicityTests.cs`
+- **Approach:** Add a custom context override, interceptor, and thread-safe recorder close to the conformance scenario. Reset observations after schema startup, record the caller context ID before enqueue, and capture every hook invocation with its ordinal and Added or Modified entity type/key snapshot, including empty snapshots. Assert one override and one interceptor invocation per context role, the exact caller/coordinated entry matrix, and exact committed row counts.
+- **Execution note:** Establish the provider-conformance assertion before considering any production edit. If it fails, diagnose whether the failure is test setup or real option/change-tracker leakage, then make only the smallest production correction supported by both providers.
+- **Patterns to follow:** Virtual shared test methods with `[Fact]` forwarding overrides in each provider leaf; `TestBase.AbortToken`; AwesomeAssertions; far-future time-job data used by the current atomicity suite.
+- **Test scenarios:**
+  1. PostgreSQL: the coordinated override and interceptor observe only the time job, the caller override and interceptor observe only the probe, the two context IDs differ, each hook/context role has exactly one invocation, every expected marker count is one, no extra marker or empty duplicate invocation exists, and final counts are one probe and one job.
+  2. SQL Server: the same invocation, observation, and durable-state contract holds through the SQL Server fixture.
+  3. The test comment states that EF hooks run per `SaveChangesAsync` and isolation is by context/change tracker rather than ambient transaction.
+- **Verification:** The targeted regression fact and the full coordinated-enqueue conformance class pass on PostgreSQL and SQL Server.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Proves |
+|---|---|---|
+| PostgreSQL targeted regression | `make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj TEST_FILTER='--filter-method "*coordinated*isolate*"'` | The new contract passes on PostgreSQL. |
+| SQL Server targeted regression | `make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj TEST_FILTER='--filter-method "*coordinated*isolate*"'` | The new contract passes on SQL Server. |
+| PostgreSQL provider suite | `make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj` | Existing and new PostgreSQL Jobs EF integration behavior remains green. |
+| SQL Server provider suite | `make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj` | Existing and new SQL Server Jobs EF integration behavior remains green. |
+| Formatting | `make format-check` | Changed C# files satisfy repository formatting. |
+| Analyzer/build quality | `make quality-analyzers-project PROJECT=tests/Headless.Jobs.EntityFramework.Tests.Harness/Headless.Jobs.EntityFramework.Tests.Harness.csproj` | Harness changes build cleanly under repository analyzers. |
+
+If a production file changes, also run its focused build/analyzer gate and document why the test-only expectation was insufficient.
+
+---
+
+## Definition of Done
+
+- U1 and U2 satisfy every linked requirement without inheriting Jobs API stack work.
+- The shared conformance scenario is discovered and passes in both provider leaves.
+- Exactly two context identities, one override and interceptor invocation per context role, and exactly four expected hook/role/entity markers are observed, each once, with no empty duplicate invocation or cross-context entry leakage.
+- Independent database counts are exactly one probe row and one time-job row after commit.
+- Existing coordinated-enqueue tests remain green and no abandoned test scaffolding or experimental production code remains.
+- The final diff is test-only unless a failing provider-conformance test proves a production defect; any production correction is minimal and covered by both providers.
+- The branch is pushed as `xshaheen/*`, the PR links issue #460, CI is green, review feedback is resolved or durably surfaced, and the PR remains unmerged.

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlEnqueueAtomicityTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlEnqueueAtomicityTests.cs
@@ -8,6 +8,10 @@ public sealed class PostgreSqlEnqueueAtomicityTests(PostgreSqlJobsCoordinationFi
     : JobsEnqueueAtomicityConformanceTests<PostgreSqlJobsCoordinationFixture>(fixture)
 {
     [Fact]
+    public override Task coordinated_save_hooks_isolate_tracked_entries_per_context() =>
+        base.coordinated_save_hooks_isolate_tracked_entries_per_context();
+
+    [Fact]
     public override Task domain_message_and_job_commit_atomically() => base.domain_message_and_job_commit_atomically();
 
     [Fact]

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlJobsCoordinationFixture.cs
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlJobsCoordinationFixture.cs
@@ -40,6 +40,7 @@ public sealed class PostgreSqlJobsCoordinationFixture
     public string ResetSql =>
         "DROP SCHEMA IF EXISTS jobs CASCADE;"
         + "DROP SCHEMA IF EXISTS messaging CASCADE;"
+        + "DROP TABLE IF EXISTS jobs_probe;"
         + "DROP TABLE IF EXISTS coordination_liveness, coordination_descriptor, coordination_node_generation CASCADE;";
 
     protected override PostgreSqlBuilder Configure()

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerEnqueueAtomicityTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerEnqueueAtomicityTests.cs
@@ -8,6 +8,10 @@ public sealed class SqlServerEnqueueAtomicityTests(SqlServerJobsCoordinationFixt
     : JobsEnqueueAtomicityConformanceTests<SqlServerJobsCoordinationFixture>(fixture)
 {
     [Fact]
+    public override Task coordinated_save_hooks_isolate_tracked_entries_per_context() =>
+        base.coordinated_save_hooks_isolate_tracked_entries_per_context();
+
+    [Fact]
     public override Task domain_message_and_job_commit_atomically() => base.domain_message_and_job_commit_atomically();
 
     [Fact]

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerJobsCoordinationFixture.cs
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerJobsCoordinationFixture.cs
@@ -47,6 +47,7 @@ public sealed class SqlServerJobsCoordinationFixture
         + "IF TYPE_ID(N'messaging.HeadlessMessagingOwnerList') IS NOT NULL DROP TYPE [messaging].[HeadlessMessagingOwnerList];"
         + "IF TYPE_ID(N'messaging.HeadlessMessagingPoisonMessageList') IS NOT NULL DROP TYPE [messaging].[HeadlessMessagingPoisonMessageList];"
         + "IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'messaging') DROP SCHEMA [messaging];"
+        + "DROP TABLE IF EXISTS [jobs_probe];"
         + "DROP TABLE IF EXISTS [coordination_liveness];"
         + "DROP TABLE IF EXISTS [coordination_descriptor];"
         + "DROP TABLE IF EXISTS [coordination_node_generation];";

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsCoordinationFixtureBase.cs
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsCoordinationFixtureBase.cs
@@ -189,7 +189,18 @@ public static class JobsCoordinationFixtureExtensions
         this IJobsCoordinationFixture fixture,
         string nodeId,
         bool includeMessaging = false
+    ) => fixture.BuildCoordinatedEnqueueHost<JobsDbContext>(nodeId, includeMessaging: includeMessaging);
+
+    /// <summary>
+    /// Builds the coordinated-enqueue host with a custom Jobs context and optional options instrumentation.
+    /// </summary>
+    public static IHost BuildCoordinatedEnqueueHost<TDbContext>(
+        this IJobsCoordinationFixture fixture,
+        string nodeId,
+        Action<DbContextOptionsBuilder>? configureOptions = null,
+        bool includeMessaging = false
     )
+        where TDbContext : JobsDbContext<TimeJobEntity, CronJobEntity>
     {
         JobFunctionProvider.RegisterFunctions(
             new Dictionary<string, JobFunctionRegistration>(StringComparer.Ordinal)
@@ -225,7 +236,14 @@ public static class JobsCoordinationFixtureExtensions
         {
             options.DisableBackgroundServices();
             options.UseEntityFramework(ef =>
-                ef.UseJobsDbContext<JobsDbContext>(fixture.ConfigureStore, schema: "jobs")
+                ef.UseJobsDbContext<TDbContext>(
+                    db =>
+                    {
+                        fixture.ConfigureStore(db);
+                        configureOptions?.Invoke(db);
+                    },
+                    schema: "jobs"
+                )
             );
         });
 

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsEnqueueAtomicityConformanceTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsEnqueueAtomicityConformanceTests.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Jobs.DbContextFactory;
 using Headless.Jobs.Entities;
 using Headless.Jobs.Interfaces.Managers;
 using Headless.Messaging;
 using Headless.Messaging.Persistence;
 using Headless.Testing.Tests;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -41,6 +44,106 @@ public abstract class JobsEnqueueAtomicityConformanceTests<TFixture>(TFixture fi
     where TFixture : class, IJobsCoordinationFixture
 {
     private sealed record CapstoneMessage(Guid JobId);
+
+    public virtual async Task coordinated_save_hooks_isolate_tracked_entries_per_context()
+    {
+        var ct = AbortToken;
+        var observer = new SavePipelineObserver();
+
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildCoordinatedEnqueueHost<ObservableJobsDbContext>(
+            "node-a",
+            options => options.AddInterceptors(new SavePipelineInterceptor(observer))
+        );
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync<ObservableJobsDbContext>(host, ct);
+        await host.StartAsync(ct);
+        ObservableJobsDbContext.Observer = observer;
+
+        try
+        {
+            var manager = host.Services.GetRequiredService<ITimeJobManager<TimeJobEntity>>();
+            var probe = new SaveHookProbe { Id = Guid.NewGuid() };
+            var job = _TimeJob();
+
+            await fixture.RunCoordinatedTransactionAsync(
+                host.Services,
+                async (connection, transaction, innerCt) =>
+                {
+                    await using var scope = host.Services.CreateAsyncScope();
+                    var caller = scope.ServiceProvider.GetRequiredService<ObservableJobsDbContext>();
+                    caller.Database.SetDbConnection(connection, contextOwnsConnection: false);
+#pragma warning disable MA0045 // Enlisting the existing transaction is an in-memory operation.
+                    caller.Database.UseTransaction(transaction);
+#pragma warning restore MA0045
+
+                    observer.Reset();
+                    observer.RegisterCaller(caller.ContextId.InstanceId);
+                    caller.Add(probe);
+
+                    (await manager.AddAsync(job, innerCt)).Should().NotBeNull();
+                    await caller.SaveChangesAsync(innerCt);
+                },
+                ct
+            );
+
+            // EF hooks execute once per SaveChangesAsync call. The contract is tracker isolation between the
+            // caller and coordinated contexts, not one global hook invocation per ambient transaction.
+            var invocations = observer.Invocations;
+            invocations.Should().HaveCount(4);
+            invocations.Select(x => x.ContextId).Distinct().Should().HaveCount(2);
+
+            var expectedMarkers = new[]
+            {
+                new SavePipelineMarker(SaveHookKind.Override, SaveContextRole.Caller, nameof(SaveHookProbe), probe.Id),
+                new SavePipelineMarker(
+                    SaveHookKind.Interceptor,
+                    SaveContextRole.Caller,
+                    nameof(SaveHookProbe),
+                    probe.Id
+                ),
+                new SavePipelineMarker(
+                    SaveHookKind.Override,
+                    SaveContextRole.Coordinated,
+                    nameof(TimeJobEntity),
+                    job.Id
+                ),
+                new SavePipelineMarker(
+                    SaveHookKind.Interceptor,
+                    SaveContextRole.Coordinated,
+                    nameof(TimeJobEntity),
+                    job.Id
+                ),
+            };
+
+            var markers = invocations
+                .SelectMany(invocation =>
+                    invocation.Entries.Select(entry => new SavePipelineMarker(
+                        invocation.Hook,
+                        invocation.Role,
+                        entry.EntityType,
+                        entry.EntityId
+                    ))
+                )
+                .CountBy(marker => marker)
+                .ToDictionary();
+
+            markers.Should().HaveCount(expectedMarkers.Length);
+            foreach (var marker in expectedMarkers)
+            {
+                _AssertInvocation(invocations, marker);
+                markers.TryGetValue(marker, out var count).Should().BeTrue();
+                count.Should().Be(1);
+            }
+
+            (await fixture.CountProbeRowsAsync(ct)).Should().Be(1);
+            (await fixture.CountTimeJobsAsync(ct)).Should().Be(1);
+        }
+        finally
+        {
+            ObservableJobsDbContext.Observer = null;
+            await host.StopAsync(ct);
+        }
+    }
 
     public virtual async Task domain_message_and_job_commit_atomically()
     {
@@ -417,4 +520,156 @@ public abstract class JobsEnqueueAtomicityConformanceTests<TFixture>(TFixture fi
             Expression = "0 0 0 * * *",
             Request = [],
         };
+
+    private static void _AssertInvocation(
+        IReadOnlyCollection<SavePipelineInvocation> invocations,
+        SavePipelineMarker marker
+    )
+    {
+        var invocation = invocations.Should().ContainSingle(x => x.Hook == marker.Hook && x.Role == marker.Role).Which;
+        invocation.Ordinal.Should().Be(1);
+        invocation
+            .Entries.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(new TrackedEntry(marker.EntityType, marker.EntityId));
+    }
+
+    private sealed class ObservableJobsDbContext : JobsDbContext<TimeJobEntity, CronJobEntity>
+    {
+        public ObservableJobsDbContext(DbContextOptions<ObservableJobsDbContext> options)
+            : base(options) { }
+
+        public static SavePipelineObserver? Observer { get; set; }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            Observer?.Record(SaveHookKind.Override, this);
+            return base.SaveChangesAsync(cancellationToken);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<SaveHookProbe>(builder =>
+            {
+                builder.ToTable("jobs_probe");
+                builder.HasKey(x => x.Id);
+            });
+        }
+    }
+
+    private sealed class SavePipelineInterceptor(SavePipelineObserver observer) : SaveChangesInterceptor
+    {
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (eventData.Context is not null)
+            {
+                observer.Record(SaveHookKind.Interceptor, eventData.Context);
+            }
+
+            return ValueTask.FromResult(result);
+        }
+    }
+
+    private sealed class SavePipelineObserver
+    {
+        private readonly Lock _lock = new();
+        private readonly List<SavePipelineInvocation> _invocations = [];
+        private Guid? _callerContextId;
+
+        public IReadOnlyCollection<SavePipelineInvocation> Invocations
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return [.. _invocations];
+                }
+            }
+        }
+
+        public void Reset()
+        {
+            lock (_lock)
+            {
+                _callerContextId = null;
+                _invocations.Clear();
+            }
+        }
+
+        public void RegisterCaller(Guid contextId)
+        {
+            lock (_lock)
+            {
+                _callerContextId = contextId;
+            }
+        }
+
+        public void Record(SaveHookKind hook, DbContext context)
+        {
+            lock (_lock)
+            {
+                if (_callerContextId is null)
+                {
+                    return;
+                }
+            }
+
+            var contextId = context.ContextId.InstanceId;
+            var entries = context
+                .ChangeTracker.Entries()
+                .Where(x => x.State is EntityState.Added or EntityState.Modified)
+                .Select(x => new TrackedEntry(x.Metadata.ClrType.Name, (Guid)x.Property("Id").CurrentValue!))
+                .OrderBy(x => x.EntityType, StringComparer.Ordinal)
+                .ThenBy(x => x.EntityId)
+                .ToArray();
+
+            lock (_lock)
+            {
+                var callerContextId = _callerContextId;
+                if (callerContextId is null)
+                {
+                    return;
+                }
+
+                var role = contextId == callerContextId ? SaveContextRole.Caller : SaveContextRole.Coordinated;
+                var ordinal = _invocations.Count(x => x.Hook == hook && x.ContextId == contextId) + 1;
+                _invocations.Add(new SavePipelineInvocation(hook, role, contextId, ordinal, entries));
+            }
+        }
+    }
+
+    private sealed class SaveHookProbe
+    {
+        public Guid Id { get; set; }
+    }
+
+    private sealed record TrackedEntry(string EntityType, Guid EntityId);
+
+    private sealed record SavePipelineInvocation(
+        SaveHookKind Hook,
+        SaveContextRole Role,
+        Guid ContextId,
+        int Ordinal,
+        IReadOnlyCollection<TrackedEntry> Entries
+    );
+
+    private sealed record SavePipelineMarker(SaveHookKind Hook, SaveContextRole Role, string EntityType, Guid EntityId);
+
+    private enum SaveHookKind
+    {
+        Override,
+        Interceptor,
+    }
+
+    private enum SaveContextRole
+    {
+        Caller,
+        Coordinated,
+    }
 }


### PR DESCRIPTION
## Summary

Coordinated Jobs writes now have provider-level regression proof that the application's save pipeline and the short-lived Jobs save pipeline remain isolated while sharing one transaction. A custom Jobs `DbContext` override and interceptor each observe only their own pending entity, and idempotence-sensitive markers fail on duplicate processing.

The shared scenario runs unchanged on PostgreSQL and SQL Server. Production code remains untouched; the existing coordinated writer already satisfies the contract.

## Affected Packages

- `Headless.Jobs.EntityFramework` integration-test harness and PostgreSQL/SQL Server conformance suites
- No runtime package behavior or public API changes

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [x] Test only

## Validation

- [ ] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [x] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [x] Added or updated tests for behavior changes
- [ ] Updated XML docs for public API changes
- [ ] Updated package `README.md` files for public behavior/setup changes
- [ ] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj
# 50 passed

make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj
# 54 passed

make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration.csproj TEST_FILTER='--filter-method "*coordinated_save_hooks_isolate_tracked_entries_per_context*"'
# 1 passed after simplify/review

make test-project TEST_PROJECT=tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration.csproj TEST_FILTER='--filter-method "*coordinated_save_hooks_isolate_tracked_entries_per_context*"'
# 1 passed after simplify/review

make quality-analyzers-project PROJECT=tests/Headless.Jobs.EntityFramework.Tests.Harness/Headless.Jobs.EntityFramework.Tests.Harness.csproj
# passed

make format-check
# passed

make hook-build MSBUILD_ARGS='-p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false'
# full solution build passed with 0 warnings/errors; SourceLink metadata queries were disabled only to avoid Microsoft.Build.Tasks.Git failing to resolve this linked worktree
```

No XML/package/LLM documentation updates are required because this changes test coverage only.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
N/A
```

## Release Notes

None; test-only regression coverage.

Fixes #460
