### PR TITLE
chore: update Headless SDK to 0.0.129

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Headless.NET.Sdk": "0.0.128",
-    "Headless.NET.Sdk.Web": "0.0.128",
-    "Headless.NET.Sdk.Test": "0.0.128",
-    "Headless.NET.Sdk.Razor": "0.0.128",
-    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.128",
-    "Headless.NET.Sdk.WindowsDesktop": "0.0.128"
+    "Headless.NET.Sdk": "0.0.129",
+    "Headless.NET.Sdk.Web": "0.0.129",
+    "Headless.NET.Sdk.Test": "0.0.129",
+    "Headless.NET.Sdk.Razor": "0.0.129",
+    "Headless.NET.Sdk.BlazorWebAssembly": "0.0.129",
+    "Headless.NET.Sdk.WindowsDesktop": "0.0.129"
   }
 }


### PR DESCRIPTION
Framework projects now consume Headless SDK 0.0.129 across every supported project SDK variant. Restore and the repository pre-push Release build both succeed with the new SDK packages.
