### PR TITLE
fix(generator): standardize primitive diagnostic IDs

### DIFF
--- a/docs/llms/utilities.md
+++ b/docs/llms/utilities.md
@@ -22,6 +22,7 @@ packages: FluentValidation, Generator.Primitives, Generator.Primitives.Abstracti
 - [Headless.Generator.Primitives](#headlessgeneratorprimitives)
     - [Problem Solved](#problem-solved-1)
     - [Key Features](#key-features-1)
+    - [Design Notes](#design-notes)
     - [Installation](#installation-1)
     - [Quick Start](#quick-start-2)
     - [Configuration](#configuration-1)
@@ -223,6 +224,7 @@ Automatically generates boilerplate code for domain primitives including constru
 ### Key Features
 
 - Roslyn incremental source generator
+- Emits unique `HF1000`-series diagnostics for invalid primitive declarations; legacy `AL` diagnostic IDs are no longer emitted.
 - Generates for types implementing `IPrimitive<T>`
 - Auto-generated code:
   - Constructors and factory methods
@@ -232,6 +234,23 @@ Automatically generates boilerplate code for domain primitives including constru
   - TypeConverter for model binding
   - Dapper type handlers
   - NSwag/Swashbuckle schema mappings
+
+### Design Notes
+
+Primitive generator diagnostics use the framework-wide `HF` prefix. Existing suppressions for legacy `AL` IDs must move to the corresponding `HF` ID. The former duplicate `AL1012` is split: date-format validation uses `HF1012`, while numeric-operation validation uses `HF1013`.
+
+| ID | Severity | Meaning |
+| --- | --- | --- |
+| `HF1000` | Error | The generator failed with an exception. |
+| `HF1001` | Error | The primitive has an unsupported base type. |
+| `HF1002` | Error | The primitive must be partial. |
+| `HF1003` | Error | The primitive has a non-obsolete default constructor. |
+| `HF1011` | Error | The primitive has a parameterized constructor. |
+| `HF1012` | Error | `SerializationFormatAttribute` requires a date primitive. |
+| `HF1013` | Error | `SupportedOperationsAttribute` requires an operational numeric primitive. |
+| `HF1015` | Warning | A primitive wrapping a value type should be a value type. |
+| `HF1016` | Warning | A primitive wrapping a reference type should be a reference type. |
+| `HF1021` | Warning | Primitive validation throws an incompatible exception type. |
 
 ### Installation
 

--- a/src/Headless.Generator.Primitives/Emitter.cs
+++ b/src/Headless.Generator.Primitives/Emitter.cs
@@ -221,7 +221,7 @@ internal static class Emitter
             builder.AppendNullableDisable();
         }
 
-        builder.AppendLine("#pragma warning disable AL1003 // Should not have non obsolete empty constructors.");
+        builder.AppendLine("#pragma warning disable HF1003 // Should not have non obsolete empty constructors.");
 
         builder
             .AppendLine("[Obsolete(\"Primitive cannot be created using empty Constructor\", true)]")
@@ -229,7 +229,7 @@ internal static class Emitter
             .Append(data.ClassName)
             .AppendLine("() { }");
 
-        builder.AppendLine("#pragma warning restore AL1003");
+        builder.AppendLine("#pragma warning restore HF1003");
 
         if (!primitiveTypeIsValueType)
         {

--- a/src/Headless.Generator.Primitives/Helpers/DiagnosticHelper.cs
+++ b/src/Headless.Generator.Primitives/Helpers/DiagnosticHelper.cs
@@ -18,7 +18,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1000",
+                "HF1000",
                 "An exception was thrown by the PrimitiveGenerator generator",
                 "An exception was thrown by the PrimitiveGenerator generator: `{0}`{1}{2}",
                 _Category,
@@ -39,7 +39,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1021",
+                "HF1021",
                 "InvalidPrimitiveValueException should be thrown in order to be converted to bad request and work Correctly",
                 "InvalidPrimitiveValueException should be thrown in order to be converted to bad request and work Correctly",
                 _Category,
@@ -57,7 +57,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1001",
+                "HF1001",
                 "Primitive type must be a Numeric type, Date type or string type to use PrimitivesGenerator",
                 "Primitive type must be a Numeric type, Date type or string type to use PrimitivesGenerator",
                 _Category,
@@ -76,7 +76,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1012",
+                "HF1012",
                 $"{AbstractionConstants.SerializationFormatAttribute} can only be used with  Date types",
                 "Type {0} cannot have SerializationFormatAttribute as it's not a date type",
                 _Category,
@@ -96,7 +96,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1012",
+                "HF1013",
                 $"{AbstractionConstants.SupportedOperationsAttribute} can only be used with Operational Numeric types",
                 "Type {0} cannot have SupportedOperationsAttribute as it's not an operational numeric type",
                 _Category,
@@ -115,7 +115,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1002",
+                "HF1002",
                 "Class must be partial to generate Empty constructor",
                 "Class must be partial to generate Empty constructor",
                 _Category,
@@ -135,7 +135,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1016",
+                "HF1016",
                 "Type should be a reference type",
                 "Type `{0}` should be a reference type as it's wrapping a reference type of `{1}`",
                 _Category,
@@ -157,7 +157,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1015",
+                "HF1015",
                 "Type should be a value type",
                 "Type `{0}` should be a value type as it's wrapping a value type of `{1}`",
                 _Category,
@@ -178,7 +178,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1011",
+                "HF1011",
                 "Primitives must not have a parameterized constructor to successfully generate members",
                 "Type `{0}` must not have a parameterized constructor to successfully generate members",
                 _Category,
@@ -198,7 +198,7 @@ internal static class DiagnosticHelper
     {
         return Diagnostic.Create(
             new DiagnosticDescriptor(
-                "AL1003",
+                "HF1003",
                 "Primitives Should not have non obsolete empty constructors, either delete or add an obsolete attribute with Error=true",
                 "Type `{0}` Should not have non obsolete empty constructors, either delete or add an obsolete attribute with Error=true",
                 _Category,

--- a/src/Headless.Generator.Primitives/README.md
+++ b/src/Headless.Generator.Primitives/README.md
@@ -9,6 +9,7 @@ Automatically generates boilerplate code for domain primitives including constru
 ## Key Features
 
 - Roslyn incremental source generator
+- Emits unique `HF1000`-series diagnostics for invalid primitive declarations; legacy `AL` diagnostic IDs are no longer emitted.
 - Generates for types implementing `IPrimitive<T>`
 - Auto-generated code:
   - Constructors and factory methods
@@ -18,6 +19,23 @@ Automatically generates boilerplate code for domain primitives including constru
   - TypeConverter for model binding
   - Dapper type handlers
   - NSwag/Swashbuckle schema mappings
+
+## Design Notes
+
+Primitive generator diagnostics use the framework-wide `HF` prefix. Existing suppressions for legacy `AL` IDs must move to the corresponding `HF` ID. The former duplicate `AL1012` is split: date-format validation uses `HF1012`, while numeric-operation validation uses `HF1013`.
+
+| ID | Severity | Meaning |
+| --- | --- | --- |
+| `HF1000` | Error | The generator failed with an exception. |
+| `HF1001` | Error | The primitive has an unsupported base type. |
+| `HF1002` | Error | The primitive must be partial. |
+| `HF1003` | Error | The primitive has a non-obsolete default constructor. |
+| `HF1011` | Error | The primitive has a parameterized constructor. |
+| `HF1012` | Error | `SerializationFormatAttribute` requires a date primitive. |
+| `HF1013` | Error | `SupportedOperationsAttribute` requires an operational numeric primitive. |
+| `HF1015` | Warning | A primitive wrapping a value type should be a value type. |
+| `HF1016` | Warning | A primitive wrapping a reference type should be a reference type. |
+| `HF1021` | Warning | Primitive validation throws an incompatible exception type. |
 
 ## Installation
 

--- a/tests/Headless.Generator.Primitives.Tests.Unit/PrimitiveGeneratorTests.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/PrimitiveGeneratorTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Reflection;
 using Headless.Generator.Primitives;
 using Headless.Generator.Primitives.Models;
 using Microsoft.CodeAnalysis;
@@ -21,6 +22,51 @@ public sealed class PrimitiveGeneratorTests
         GenerateEntityFrameworkValueConverters = true, // generate 2 files
         GenerateDapperConverters = true, // generate 2 files
     };
+
+    [Fact]
+    public void should_use_unique_headless_framework_diagnostic_ids()
+    {
+        var diagnosticHelperType = typeof(PrimitiveGenerator).Assembly.GetType(
+            "Headless.Generator.Primitives.Helpers.DiagnosticHelper"
+        );
+
+        diagnosticHelperType.Should().NotBeNull();
+        var diagnostics = diagnosticHelperType!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(method => method.ReturnType == typeof(Diagnostic))
+            .Select(method =>
+            {
+                var arguments = method
+                    .GetParameters()
+                    .Select<ParameterInfo, object?>(parameter =>
+                        parameter.ParameterType == typeof(Exception)
+                            ? new InvalidOperationException("diagnostic contract test")
+                        : parameter.ParameterType == typeof(string) ? "Primitive"
+                        : null
+                    )
+                    .ToArray();
+
+                return (Diagnostic)method.Invoke(null, arguments)!;
+            })
+            .Select(diagnostic => diagnostic.Id)
+            .ToArray();
+
+        diagnostics.Should().OnlyHaveUniqueItems();
+        diagnostics
+            .Should()
+            .BeEquivalentTo(
+                "HF1000",
+                "HF1001",
+                "HF1002",
+                "HF1003",
+                "HF1011",
+                "HF1012",
+                "HF1013",
+                "HF1015",
+                "HF1016",
+                "HF1021"
+            );
+    }
 
     [Fact]
     public Task should_generate_all_converters_when_string_primitive()
@@ -694,7 +740,7 @@ public sealed class PrimitiveGeneratorTests
             }
             """;
 
-        return TestHelper.VerifyDiagnostic(source, "AL1002");
+        return TestHelper.VerifyDiagnostic(source, "HF1002");
     }
 
     [Fact]

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_DateOnly_primitive#DateOnlyPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_DateOnly_primitive#DateOnlyPrimitive.g.verified.cs
@@ -67,10 +67,10 @@ public readonly partial struct DateOnlyPrimitive : global::System.IEquatable<Dat
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public DateOnlyPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create DateOnlyPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_DateTimeOffset_primitive#DateTimeOffsetPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_DateTimeOffset_primitive#DateTimeOffsetPrimitive.g.verified.cs
@@ -67,10 +67,10 @@ public readonly partial struct DateTimeOffsetPrimitive : global::System.IEquatab
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public DateTimeOffsetPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create DateTimeOffsetPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_DateTime_primitive#DateTimePrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_DateTime_primitive#DateTimePrimitive.g.verified.cs
@@ -67,10 +67,10 @@ public readonly partial struct DateTimePrimitive : global::System.IEquatable<Dat
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public DateTimePrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create DateTimePrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_TimeOnly_primitive#TimeOnlyPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_TimeOnly_primitive#TimeOnlyPrimitive.g.verified.cs
@@ -67,10 +67,10 @@ public readonly partial struct TimeOnlyPrimitive : global::System.IEquatable<Tim
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public TimeOnlyPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create TimeOnlyPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_TimeSpan_primitive#TimeSpanPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_TimeSpan_primitive#TimeSpanPrimitive.g.verified.cs
@@ -67,10 +67,10 @@ public readonly partial struct TimeSpanPrimitive : global::System.IEquatable<Tim
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public TimeSpanPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create TimeSpanPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_bool_primitive#BoolPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_bool_primitive#BoolPrimitive.g.verified.cs
@@ -62,10 +62,10 @@ public readonly partial struct BoolPrimitive : global::System.IEquatable<BoolPri
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public BoolPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create BoolPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_byte_primitive#BytePrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_byte_primitive#BytePrimitive.g.verified.cs
@@ -66,10 +66,10 @@ public readonly partial struct BytePrimitive : global::System.IEquatable<BytePri
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public BytePrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create BytePrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_char_primitive#CharPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_char_primitive#CharPrimitive.g.verified.cs
@@ -66,10 +66,10 @@ public readonly partial struct CharPrimitive : global::System.IEquatable<CharPri
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public CharPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create CharPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_decimal_primitive#DecimalPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_decimal_primitive#DecimalPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct DecimalPrimitive : global::System.IEquatable<Deci
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public DecimalPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create DecimalPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_double_primitive#DoublePrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_double_primitive#DoublePrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct DoublePrimitive : global::System.IEquatable<Doubl
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public DoublePrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create DoublePrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_float_primitive#FloatPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_float_primitive#FloatPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct FloatPrimitive : global::System.IEquatable<FloatP
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public FloatPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create FloatPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_guid_primitive#GuidPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_guid_primitive#GuidPrimitive.g.verified.cs
@@ -65,10 +65,10 @@ public readonly partial struct GuidPrimitive : global::System.IEquatable<GuidPri
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public GuidPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create GuidPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_int_of_int_primitive#IntOfIntPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_int_of_int_primitive#IntOfIntPrimitive.g.verified.cs
@@ -69,10 +69,10 @@ public readonly partial struct IntOfIntPrimitive : IEquatable<IntOfIntPrimitive>
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public IntOfIntPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create IntOfIntPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_int_of_int_primitive#IntPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_int_of_int_primitive#IntPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct IntPrimitive : IEquatable<IntPrimitive>
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public IntPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create IntPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_int_primitive#IntPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_int_primitive#IntPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct IntPrimitive : global::System.IEquatable<IntPrimi
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public IntPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create IntPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_long_primitive#LongPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_long_primitive#LongPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct LongPrimitive : global::System.IEquatable<LongPri
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public LongPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create LongPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_nested_namespace_primitive#IntPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_nested_namespace_primitive#IntPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct IntPrimitive : global::System.IEquatable<IntPrimi
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public IntPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create IntPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_sbyte_primitive#SBytePrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_sbyte_primitive#SBytePrimitive.g.verified.cs
@@ -66,10 +66,10 @@ public readonly partial struct SBytePrimitive : global::System.IEquatable<SByteP
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public SBytePrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create SBytePrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_short_primitive#ShortPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_short_primitive#ShortPrimitive.g.verified.cs
@@ -66,10 +66,10 @@ public readonly partial struct ShortPrimitive : global::System.IEquatable<ShortP
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public ShortPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create ShortPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_string_of_string_primitive#StringOfStringPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_string_of_string_primitive#StringOfStringPrimitive.g.verified.cs
@@ -64,10 +64,10 @@ public sealed partial class StringOfStringPrimitive : IEquatable<StringOfStringP
     }
 
 #nullable disable
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public StringOfStringPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 #nullable enable
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_string_of_string_primitive#StringPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_string_of_string_primitive#StringPrimitive.g.verified.cs
@@ -63,10 +63,10 @@ public sealed partial class StringPrimitive : IEquatable<StringPrimitive>
     }
 
 #nullable disable
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public StringPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 #nullable enable
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_string_primitive#StringPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_string_primitive#StringPrimitive.g.verified.cs
@@ -63,10 +63,10 @@ public sealed partial class StringPrimitive : global::System.IEquatable<StringPr
     }
 
 #nullable disable
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public StringPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 #nullable enable
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_uint_primitive#IntPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_uint_primitive#IntPrimitive.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct IntPrimitive : global::System.IEquatable<IntPrimi
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public IntPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create IntPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_ulong_primitive#LongValue.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_ulong_primitive#LongValue.g.verified.cs
@@ -71,10 +71,10 @@ public readonly partial struct LongValue : global::System.IEquatable<LongValue>
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public LongValue() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create LongValue from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_ushort_primitive#UShortPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_generate_all_converters_when_ushort_primitive#UShortPrimitive.g.verified.cs
@@ -66,10 +66,10 @@ public readonly partial struct UShortPrimitive : global::System.IEquatable<UShor
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public UShortPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create UShortPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_report_diagnostic_for_non_partial_class#NonPartialPrimitive.g.verified.cs
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_report_diagnostic_for_non_partial_class#NonPartialPrimitive.g.verified.cs
@@ -67,10 +67,10 @@ public struct NonPartialPrimitive : global::System.IEquatable<NonPartialPrimitiv
         _isInitialized = true;
     }
 
-#pragma warning disable AL1003 // Should not have non obsolete empty constructors.
+#pragma warning disable HF1003 // Should not have non obsolete empty constructors.
     [Obsolete("Primitive cannot be created using empty Constructor", true)]
     public NonPartialPrimitive() { }
-#pragma warning restore AL1003
+#pragma warning restore HF1003
 
     /// <summary>Tries to create an instance of AsciiString from the specified value.</summary>
     /// <param name="value">The value to create NonPartialPrimitive from</param>

--- a/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_report_diagnostic_for_non_partial_class.verified.txt
+++ b/tests/Headless.Generator.Primitives.Tests.Unit/Snapshots/PrimitiveGeneratorTests.should_report_diagnostic_for_non_partial_class.verified.txt
@@ -4,7 +4,7 @@
       Message: Class must be partial to generate Empty constructor,
       Severity: Error,
       Descriptor: {
-        Id: AL1002,
+        Id: HF1002,
         Title: Class must be partial to generate Empty constructor,
         MessageFormat: Class must be partial to generate Empty constructor,
         Category: Headless.Generator.Primitives,


### PR DESCRIPTION
## Summary

- migrate every Primitives source-generator diagnostic from the legacy AL prefix to the framework HF prefix
- split the duplicated AL1012 contract into HF1012 for date-format validation and HF1013 for numeric-operation validation
- update generated warning suppressions, snapshots, package docs, and the utilities guide
- add an exhaustive contract test that keeps every emitted diagnostic ID unique

## Validation

- Primitives generator tests: 27 passed, 2 intentionally skipped
- Primitives generator analyzer gate: clean
- changed-file formatting: clean
- diff check: clean
- pre-push solution build: clean

Note: the test-project locked analyzer target is blocked on current main by pre-existing packages.lock.json drift (Microsoft.Testing.Extensions.CrashDump 2.2.3 -> 2.3.1); unrelated dependency lock churn is intentionally excluded.