### PR TITLE
fix(messaging-asb): share pooled client with consumer clients

### DIFF
--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -1171,7 +1171,7 @@ Provides Azure Service Bus topic and queue transports.
 - Session-aware processing.
 - Producer hatch: `UseAzureServiceBus(asb => asb.PartitionKey(message => ...))`.
 - Consumer startup honors host cancellation through client, topology, and processor setup.
-- Shared publish connection: bus and queue publishing share one `ServiceBusClient` (one AMQP connection) per namespace with per-destination cached senders; senders are drained before the client on shutdown.
+- Shared connection: bus and queue publishing and consumer processors share one `ServiceBusClient` (one AMQP connection) per namespace with per-destination cached senders and a shared administration client; senders are drained before the client on shutdown, and consumers stop their processors without touching the shared client.
 
 ### Design Notes
 
@@ -1205,7 +1205,7 @@ Azure.Messaging.ServiceBus, `Headless.Messaging.Core`.
 
 ### Side Effects
 
-Registers a shared publish client pool (one `ServiceBusClient` per namespace, shared by the bus and queue transports), transports, consumer client factory, and producer descriptor services. Consumer clients maintain their own receive-side connection.
+Registers a shared client pool (one `ServiceBusClient` per namespace, shared by the bus and queue transports and every consumer client, plus a shared administration client), transports, consumer client factory, and producer descriptor services.
 
 ## Headless.Messaging.InMemory
 

--- a/docs/solutions/architecture-patterns/shared-broker-client-sender-pool.md
+++ b/docs/solutions/architecture-patterns/shared-broker-client-sender-pool.md
@@ -94,7 +94,7 @@ private int _disposed;
 - Adding or reworking any broker/provider whose SDK exposes a connection-owning client plus per-destination senders/producers/channels.
 - Two-plus DI singletons need the same broker connection (publish transports, dispatchers) — hand them one pool, never per-consumer clients.
 - Reviewing code where a shared field is guarded by `??=` inside per-key lazy factories — the per-key guard does not protect the shared root; that is this pattern's trigger bug.
-- NOT for receive-side clients that own processor lifecycles with different disposal choreography — the ASB consumer client intentionally keeps its own connection today (consolidation tracked in issue #687).
+- Receive-side sharing works through the same pool but with inverted disposal ownership: consumers obtain the shared client (`GetClient()`) to create processors, dispose only their processors, and never the client — the container-owned pool disposes it after the bootstrapper has stopped all consumers (issue #687).
 
 ## Examples
 

--- a/src/Headless.Messaging.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/Headless.Messaging.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -16,6 +16,7 @@ internal sealed class AzureServiceBusConsumerClient(
     byte groupConcurrent,
     IOptions<AzureServiceBusMessagingOptions> options,
     IServiceProvider serviceProvider,
+    IAzureServiceBusClientPool clientPool,
     IntentType intentType = IntentType.Bus
 ) : IConsumerClient
 {
@@ -31,7 +32,10 @@ internal sealed class AzureServiceBusConsumerClient(
     private int _disposed;
     private int _hasStartedProcessing;
     private ServiceBusAdministrationClient? _administrationClient;
+
+#pragma warning disable CA2213 // Justification: shared client owned and disposed by AzureServiceBusClientPool
     private ServiceBusClient? _serviceBusClient;
+#pragma warning restore CA2213
     private ServiceBusProcessorFacade? _serviceBusProcessor;
     private readonly List<ServiceBusProcessorFacade> _queueProcessors = [];
 
@@ -247,10 +251,8 @@ internal sealed class AzureServiceBusConsumerClient(
             await processor.DisposeAsync().ConfigureAwait(false);
         }
 
-        if (_serviceBusClient is not null)
-        {
-            await _serviceBusClient.DisposeAsync().ConfigureAwait(false);
-        }
+        // The ServiceBusClient is shared and pool-owned; other consumers and the publish
+        // transports keep using it after this consumer stops. Only processors are ours.
 
         _connectionLock.Dispose();
         _semaphore.Dispose();
@@ -333,13 +335,13 @@ internal sealed class AzureServiceBusConsumerClient(
             if (_serviceBusProcessor == null && (intentType != IntentType.Queue || _serviceBusClient == null))
 #pragma warning restore CA1508
             {
-                _serviceBusClient = ServiceBusHelpers.CreateClient(_asbOptions);
+                // Shared, pool-owned resources: processors created from this client multiplex the
+                // same AMQP connection as the publish senders. This client is never disposed here.
+                _serviceBusClient = clientPool.GetClient();
 
                 if (_asbOptions.AutoProvision)
                 {
-                    _administrationClient = _asbOptions.TokenCredential is not null
-                        ? new ServiceBusAdministrationClient(_asbOptions.Namespace, _asbOptions.TokenCredential)
-                        : new ServiceBusAdministrationClient(_asbOptions.ConnectionString);
+                    _administrationClient = clientPool.GetAdministrationClient();
                 }
 
                 if (intentType == IntentType.Bus && _asbOptions.AutoProvision)

--- a/src/Headless.Messaging.AzureServiceBus/AzureServiceBusConsumerClientFactory.cs
+++ b/src/Headless.Messaging.AzureServiceBus/AzureServiceBusConsumerClientFactory.cs
@@ -10,7 +10,8 @@ namespace Headless.Messaging.AzureServiceBus;
 internal sealed class AzureServiceBusConsumerClientFactory(
     ILoggerFactory loggerFactory,
     IOptions<AzureServiceBusMessagingOptions> asbOptions,
-    IServiceProvider serviceProvider
+    IServiceProvider serviceProvider,
+    IAzureServiceBusClientPool clientPool
 ) : IIntentAwareConsumerClientFactory
 {
     public Task<IConsumerClient> CreateAsync(
@@ -46,6 +47,7 @@ internal sealed class AzureServiceBusConsumerClientFactory(
                 groupConcurrent,
                 asbOptions,
                 serviceProvider,
+                clientPool,
                 intentType
             );
 

--- a/src/Headless.Messaging.AzureServiceBus/Helpers/ServiceBusHelpers.cs
+++ b/src/Headless.Messaging.AzureServiceBus/Helpers/ServiceBusHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 
 namespace Headless.Messaging.AzureServiceBus.Helpers;
 
@@ -18,6 +19,18 @@ internal static class ServiceBusHelpers
         return options.TokenCredential is null
             ? new ServiceBusClient(options.ConnectionString)
             : new ServiceBusClient(options.Namespace, options.TokenCredential);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ServiceBusAdministrationClient"/> from the configured authentication
+    /// mode, mirroring the credential selection of <see cref="CreateClient"/>.
+    /// </summary>
+    /// <param name="options">The messaging options carrying the authentication configuration.</param>
+    public static ServiceBusAdministrationClient CreateAdministrationClient(AzureServiceBusMessagingOptions options)
+    {
+        return options.TokenCredential is null
+            ? new ServiceBusAdministrationClient(options.ConnectionString)
+            : new ServiceBusAdministrationClient(options.Namespace, options.TokenCredential);
     }
 
     /// <summary>

--- a/src/Headless.Messaging.AzureServiceBus/IAzureServiceBusClientPool.cs
+++ b/src/Headless.Messaging.AzureServiceBus/IAzureServiceBusClientPool.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Concurrent;
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Headless.Messaging.AzureServiceBus.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,10 +14,12 @@ namespace Headless.Messaging.AzureServiceBus;
 /// <see cref="ServiceBusSender"/> instances keyed by entity path (topic or queue name).
 /// </summary>
 /// <remarks>
-/// One <see cref="ServiceBusClient"/> equals one multiplexed AMQP connection; senders created from it
-/// share that connection. The pool is registered as a singleton and shared by the bus and queue
-/// transports so co-registering both uses a single connection and a single sender per destination.
-/// Disposal drains every materialized sender before disposing the client.
+/// One <see cref="ServiceBusClient"/> equals one multiplexed AMQP connection; senders, processors,
+/// and receivers created from it share that connection. The pool is registered as a singleton and
+/// shared by the bus and queue transports and the consumer clients, so co-registering all of them
+/// uses a single connection. Disposal drains every materialized sender before disposing the client;
+/// consumers must stop their processors before the container disposes the pool (the bootstrapper
+/// stops consumers first, so this holds under normal host shutdown).
 /// </remarks>
 internal interface IAzureServiceBusClientPool : IAsyncDisposable
 {
@@ -28,6 +31,22 @@ internal interface IAzureServiceBusClientPool : IAsyncDisposable
     /// <param name="entityPath">The topic or queue name the sender publishes to.</param>
     /// <exception cref="ObjectDisposedException">The pool has been disposed.</exception>
     ServiceBusSender GetSender(string entityPath);
+
+    /// <summary>
+    /// Gets the shared namespace <see cref="ServiceBusClient"/>, creating it on first use.
+    /// Used by consumer clients to create processors that multiplex the same AMQP connection as
+    /// the publish senders. The returned client is shared and pool-owned; do not dispose it.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">The pool has been disposed.</exception>
+    ServiceBusClient GetClient();
+
+    /// <summary>
+    /// Gets the shared <see cref="ServiceBusAdministrationClient"/> for topology provisioning,
+    /// creating it on first use. The administration client is HTTP-based and holds no connection;
+    /// it is shared for the same single-instance-per-namespace reason as the messaging client.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">The pool has been disposed.</exception>
+    ServiceBusAdministrationClient GetAdministrationClient();
 }
 
 /// <summary>Default implementation of <see cref="IAzureServiceBusClientPool"/>.</summary>
@@ -40,9 +59,11 @@ internal sealed class AzureServiceBusClientPool : IAzureServiceBusClientPool
     private readonly ILogger _logger;
     private readonly IOptions<AzureServiceBusMessagingOptions> _options;
     private readonly Func<AzureServiceBusMessagingOptions, ServiceBusClient> _clientFactory;
+    private readonly Func<AzureServiceBusMessagingOptions, ServiceBusAdministrationClient> _adminClientFactory;
     private readonly ConcurrentDictionary<string, Lazy<ServiceBusSender>> _senders = new(StringComparer.Ordinal);
     private readonly Lock _clientLock = new();
     private ServiceBusClient? _client;
+    private ServiceBusAdministrationClient? _administrationClient;
     private int _disposed;
 
     public AzureServiceBusClientPool(
@@ -51,16 +72,44 @@ internal sealed class AzureServiceBusClientPool : IAzureServiceBusClientPool
     )
         : this(logger, options, ServiceBusHelpers.CreateClient) { }
 
-    /// <summary>Test seam: lets unit tests substitute the client and count creations.</summary>
+    /// <summary>Test seam: lets unit tests substitute the clients and count creations.</summary>
     internal AzureServiceBusClientPool(
         ILogger<AzureServiceBusClientPool> logger,
         IOptions<AzureServiceBusMessagingOptions> options,
-        Func<AzureServiceBusMessagingOptions, ServiceBusClient> clientFactory
+        Func<AzureServiceBusMessagingOptions, ServiceBusClient> clientFactory,
+        Func<AzureServiceBusMessagingOptions, ServiceBusAdministrationClient>? adminClientFactory = null
     )
     {
         _logger = logger;
         _options = options;
         _clientFactory = clientFactory;
+        _adminClientFactory = adminClientFactory ?? ServiceBusHelpers.CreateAdministrationClient;
+    }
+
+    public ServiceBusClient GetClient()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        return _GetOrCreateClient();
+    }
+
+    public ServiceBusAdministrationClient GetAdministrationClient()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        var adminClient = Volatile.Read(ref _administrationClient);
+
+        if (adminClient is not null)
+        {
+            return adminClient;
+        }
+
+        lock (_clientLock)
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+            return _administrationClient ??= _adminClientFactory(_options.Value);
+        }
     }
 
     public ServiceBusSender GetSender(string entityPath)

--- a/src/Headless.Messaging.AzureServiceBus/README.md
+++ b/src/Headless.Messaging.AzureServiceBus/README.md
@@ -14,7 +14,7 @@ Enables enterprise messaging using Azure Service Bus with topics, subscriptions,
 - **Advanced Routing**: Message routing rules and filters
 - **Enterprise Features**: Transactions, duplicate detection, dead-lettering
 - **Host-Cancellable Startup**: Client, topology, and processor setup honor host shutdown.
-- **Shared Publish Connection**: Bus and queue publishing share one `ServiceBusClient` (one AMQP connection) per namespace with per-destination cached senders; senders are drained before the client on shutdown.
+- **Shared Connection**: Bus and queue publishing and consumer processors all share one `ServiceBusClient` (one AMQP connection) per namespace, with per-destination cached senders and a shared administration client for topology provisioning; senders are drained before the client on shutdown, and consumers stop their processors without touching the shared client.
 
 ## Installation
 
@@ -128,5 +128,5 @@ options.EnableSubscriberParallelExecute = false;
 ## Side Effects
 
 - Creates Service Bus topics and subscriptions if they don't exist
-- Establishes a persistent connection to Azure Service Bus (publishing shares a single client per namespace)
+- Establishes a persistent connection to Azure Service Bus (one shared client per namespace across publishing and consuming)
 - Configures message routing rules and filters

--- a/tests/Headless.Messaging.AzureServiceBus.Tests.Unit/AzureServiceBusClientPoolTests.cs
+++ b/tests/Headless.Messaging.AzureServiceBus.Tests.Unit/AzureServiceBusClientPoolTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Headless.Messaging.AzureServiceBus;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -342,6 +343,65 @@ public sealed class AzureServiceBusClientPoolTests : TestBase
         await disposeTask;
         await warmupSender.Received(1).DisposeAsync();
         await client.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task should_share_one_client_between_get_client_and_senders()
+    {
+        // given
+        var creations = 0;
+        var client = _CreateClientSubstitute();
+        await using var pool = _CreatePool(client, () => Interlocked.Increment(ref creations));
+
+        // when: receive-side (GetClient) and publish-side (GetSender) both use the pool
+        var direct = pool.GetClient();
+        _ = pool.GetSender("orders");
+
+        // then: one client serves both paths
+        direct.Should().BeSameAs(client);
+        creations.Should().Be(1);
+        client.Received(1).CreateSender("orders");
+    }
+
+    [Fact]
+    public async Task should_share_single_administration_client()
+    {
+        // given
+        var adminCreations = 0;
+        var adminClient = Substitute.For<ServiceBusAdministrationClient>();
+        await using var pool = new AzureServiceBusClientPool(
+            NullLogger<AzureServiceBusClientPool>.Instance,
+            _Options,
+            _ => _CreateClientSubstitute(),
+            _ =>
+            {
+                Interlocked.Increment(ref adminCreations);
+                return adminClient;
+            }
+        );
+
+        // when
+        var first = pool.GetAdministrationClient();
+        var second = pool.GetAdministrationClient();
+
+        // then
+        first.Should().BeSameAs(adminClient);
+        second.Should().BeSameAs(adminClient);
+        adminCreations.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_throw_from_get_client_and_administration_client_after_dispose()
+    {
+        // given
+        var pool = _CreatePool(_CreateClientSubstitute(), () => 0);
+        await pool.DisposeAsync();
+
+        // when / then
+        var getClient = () => pool.GetClient();
+        var getAdmin = () => pool.GetAdministrationClient();
+        getClient.Should().Throw<ObjectDisposedException>();
+        getAdmin.Should().Throw<ObjectDisposedException>();
     }
 
     [Fact]

--- a/tests/Headless.Messaging.AzureServiceBus.Tests.Unit/AzureServiceBusConsumerClientFactoryTests.cs
+++ b/tests/Headless.Messaging.AzureServiceBus.Tests.Unit/AzureServiceBusConsumerClientFactoryTests.cs
@@ -5,6 +5,7 @@ using Headless.Messaging.AzureServiceBus;
 using Headless.Messaging.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Tests;
@@ -24,7 +25,8 @@ public sealed class AzureServiceBusConsumerClientFactoryTests
                     ConnectionString = "Endpoint=sb://localhost/;SharedAccessKeyName=name;SharedAccessKey=key",
                 }
             ),
-            new ServiceCollection().BuildServiceProvider()
+            new ServiceCollection().BuildServiceProvider(),
+            Substitute.For<IAzureServiceBusClientPool>()
         );
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
@@ -51,7 +53,12 @@ public sealed class AzureServiceBusConsumerClientFactoryTests
         );
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
-        var factory = new AzureServiceBusConsumerClientFactory(loggerFactory, options, serviceProvider);
+        var factory = new AzureServiceBusConsumerClientFactory(
+            loggerFactory,
+            options,
+            serviceProvider,
+            Substitute.For<IAzureServiceBusClientPool>()
+        );
 
         // when
         var act = async () => await factory.CreateAsync("test-group", 5);
@@ -76,7 +83,12 @@ public sealed class AzureServiceBusConsumerClientFactoryTests
         );
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
 
-        var factory = new AzureServiceBusConsumerClientFactory(loggerFactory, options, serviceProvider);
+        var factory = new AzureServiceBusConsumerClientFactory(
+            loggerFactory,
+            options,
+            serviceProvider,
+            Substitute.For<IAzureServiceBusClientPool>()
+        );
 
         // when
         var act = async () => await factory.CreateAsync("test-group", 5);
@@ -96,7 +108,10 @@ public sealed class AzureServiceBusConsumerClientFactoryTests
             new AzureServiceBusMessagingOptions { ConnectionString = "InvalidConnectionString" }
         );
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
-        var factory = new AzureServiceBusConsumerClientFactory(loggerFactory, options, serviceProvider);
+
+        // Real pool: the invalid connection string must fail through the actual client creation path.
+        await using var pool = new AzureServiceBusClientPool(NullLogger<AzureServiceBusClientPool>.Instance, options);
+        var factory = new AzureServiceBusConsumerClientFactory(loggerFactory, options, serviceProvider, pool);
         var groupName = new string('a', 80);
 
         // when

--- a/tests/Headless.Messaging.AzureServiceBus.Tests.Unit/AzureServiceBusConsumerClientTests.cs
+++ b/tests/Headless.Messaging.AzureServiceBus.Tests.Unit/AzureServiceBusConsumerClientTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Reflection;
+using Azure.Messaging.ServiceBus;
 using Headless.Messaging;
 using Headless.Messaging.AzureServiceBus;
 using Headless.Messaging.Transport;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Tests;
@@ -22,6 +24,7 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
         }
     );
     private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
+    private readonly IAzureServiceBusClientPool _clientPool = Substitute.For<IAzureServiceBusClientPool>();
 
     [Fact]
     public void should_throw_when_options_value_is_null()
@@ -30,7 +33,8 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
         var nullOptions = Options.Create<AzureServiceBusMessagingOptions>(null!);
 
         // when
-        var act = () => new AzureServiceBusConsumerClient(_logger, "test-sub", 1, nullOptions, _serviceProvider);
+        var act = () =>
+            new AzureServiceBusConsumerClient(_logger, "test-sub", 1, nullOptions, _serviceProvider, _clientPool);
 
         // then
         act.Should().ThrowExactly<ArgumentNullException>();
@@ -40,7 +44,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_have_correct_broker_address_from_connection_string()
     {
         // given, when
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // then
         client.BrokerAddress.Name.Should().Be("servicebus");
@@ -56,7 +67,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
         );
 
         // when
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // then
         client.BrokerAddress.Endpoint.Should().Be("sb://custom.servicebus.windows.net/");
@@ -66,7 +84,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_initialize_callbacks_as_null()
     {
         // given, when
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // then
         client.OnMessageCallback.Should().BeNull();
@@ -77,7 +102,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_allow_setting_on_message_callback()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
         Func<TransportMessage, object?, Task> callback = (_, _) => Task.CompletedTask;
 
         // when
@@ -91,7 +123,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_allow_setting_on_log_callback()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
         Action<LogMessageEventArgs> callback = _ => { };
 
         // when
@@ -105,7 +144,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_throw_when_subscribing_with_null_topics()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         var act = async () => await client.SubscribeAsync(null!);
@@ -144,7 +190,16 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
                 Namespace = null!,
             }
         );
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, options, _serviceProvider);
+        // Real pool: connection validation must come from the actual SDK client creation path.
+        await using var pool = new AzureServiceBusClientPool(NullLogger<AzureServiceBusClientPool>.Instance, options);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            options,
+            _serviceProvider,
+            pool
+        );
 
         // when
         var act = async () => await client.ConnectAsync();
@@ -154,10 +209,44 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     }
 
     [Fact]
+    public async Task should_not_dispose_shared_client_on_consumer_dispose()
+    {
+        // given: a queue-intent consumer connected through the shared pool
+        var sharedClient = Substitute.For<ServiceBusClient>();
+        var pool = Substitute.For<IAzureServiceBusClientPool>();
+        pool.GetClient().Returns(sharedClient);
+
+        var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            pool,
+            IntentType.Queue
+        );
+        await client.ConnectAsync(AbortToken);
+
+        // when
+        await client.DisposeAsync();
+
+        // then: the pool-owned client stays usable for other consumers and the transports
+        await sharedClient.DidNotReceive().DisposeAsync();
+        await pool.DidNotReceive().DisposeAsync();
+    }
+
+    [Fact]
     public async Task should_dispose_without_error_when_not_connected()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         var act = async () => await client.DisposeAsync();
@@ -174,7 +263,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task pause_async_is_noop_when_processor_is_null()
     {
         // given — no ConnectAsync called, processor is null
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         await client.PauseAsync(AbortToken);
@@ -186,7 +282,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task pause_async_is_idempotent_when_called_twice()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         await client.PauseAsync(AbortToken);
@@ -199,7 +302,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task resume_async_is_noop_when_not_paused()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         await client.ResumeAsync(AbortToken);
@@ -211,7 +321,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task pause_async_then_resume_async_completes_full_cycle()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         await client.PauseAsync(AbortToken);
@@ -224,7 +341,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task resume_async_is_idempotent_after_resume()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
 
         // when
         await client.PauseAsync(AbortToken);
@@ -238,7 +362,7 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task pause_async_is_noop_after_disposal()
     {
         // given
-        var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider, _clientPool);
         await client.DisposeAsync();
 
         // when — should not throw
@@ -249,7 +373,7 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task resume_async_is_noop_after_disposal()
     {
         // given
-        var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider, _clientPool);
         await client.DisposeAsync();
 
         // when — should not throw
@@ -260,7 +384,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_toggle_the_startup_gate_before_processing_starts_when_pause_async_and_resume_async()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
         var gateField = typeof(AzureServiceBusConsumerClient).GetField(
             "_pauseGate",
             BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly
@@ -295,7 +426,14 @@ public sealed class AzureServiceBusConsumerClientTests : TestBase
     public async Task should_not_mark_processing_as_started_before_listening_runs_when_resume_async()
     {
         // given
-        await using var client = new AzureServiceBusConsumerClient(_logger, "test-sub", 1, _options, _serviceProvider);
+        await using var client = new AzureServiceBusConsumerClient(
+            _logger,
+            "test-sub",
+            1,
+            _options,
+            _serviceProvider,
+            _clientPool
+        );
         var startedField = typeof(AzureServiceBusConsumerClient).GetField(
             "_hasStartedProcessing",
             BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly


### PR DESCRIPTION
Closes #687. Stacked on #688 (base auto-retargets to `main` when #688 merges).

## Problem

After #688, publishing shared one `ServiceBusClient` per namespace — but each consumer client still constructed its own client and administration client in `ConnectAsync`. An app with bus + queue + N consumer groups opened **1 + N** AMQP connections to one namespace.

## Change

- `IAzureServiceBusClientPool` gains `GetClient()` and `GetAdministrationClient()` — the same disposed-check discipline, lock protocol, and no-leak guarantees as the sender path (admin client is HTTP-based, nothing to dispose).
- `AzureServiceBusConsumerClient` obtains both from the injected pool; its `DisposeAsync` now stops/disposes only its processors — the shared client is pool-owned and stays usable by other consumers and the transports.
- `ServiceBusHelpers.CreateAdministrationClient` mirrors `CreateClient` so credential selection stays single-sourced (resolves the ride-along note on #687).
- Ordering safety: the bootstrapper stops consumers (processors) before the container disposes the pool (senders → client) — MassTransit's receive-before-send-before-connection shutdown shape.

## Acceptance criteria → evidence

| Criterion | Test |
|---|---|
| Bus + Queue + consumers → exactly one client per namespace | `should_share_one_client_between_get_client_and_senders` |
| Consumer disposal leaves the shared client usable | `should_not_dispose_shared_client_on_consumer_dispose` |
| Pool disposal ordering unchanged | existing dispose-ordering suite (unchanged, green) |
| Shared admin client, single instance | `should_share_single_administration_client` |
| Use-after-dispose fails loudly on all pool surfaces | `should_throw_from_get_client_and_administration_client_after_dispose` |

Connection-validation tests (`should_throw_when_connecting_without_connection_info`, queue-group-name test) now use a **real pool** so genuine SDK validation still fires through the new path.

## Verification

- 102/102 unit tests pass
- `make quality-analyzers-project` clean (one CA2213 suppression with justification: the consumer's client field is intentionally pool-owned)
- README + docs/llms/messaging.md + the pool solution doc updated in lockstep