### PR TITLE
test: thread-safe telemetry collectors and name-scoped metric assertions

### DIFF
--- a/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheRequestMetricsTests.cs
+++ b/tests/Headless.Caching.InMemory.Tests.Unit/InMemoryCacheRequestMetricsTests.cs
@@ -129,8 +129,17 @@ public sealed class InMemoryCacheRequestMetricsTests : TestBase
         missCount.Should().Be(1);
         (hitCount + missCount).Should().Be(3);
 
-        // Exactly two adds per call (skip an add when its count is 0) — never per-key "get" records.
-        metrics.Measurements("headless.cache.requests").Should().HaveCount(2);
+        // Exactly two adds per call (skip an add when its count is 0) — never per-key "get" records. Scoped to
+        // THIS cache name: the meter is process-global and parallel tests' requests land in the same collector.
+        metrics
+            .Measurements("headless.cache.requests")
+            .Where(m =>
+                m.Tags.Any(t =>
+                    string.Equals(t.Key, "headless.cache.name", StringComparison.Ordinal) && Equals(t.Value, cacheName)
+                )
+            )
+            .Should()
+            .HaveCount(2);
     }
 
     [Fact]
@@ -147,8 +156,16 @@ public sealed class InMemoryCacheRequestMetricsTests : TestBase
         // when
         await cache.GetAllAsync<string>([key], AbortToken);
 
-        // then — only the hit add fired.
-        metrics.Measurements("headless.cache.requests").Should().ContainSingle();
+        // then — only the hit add fired (scoped to THIS cache name; the meter is process-global).
+        metrics
+            .Measurements("headless.cache.requests")
+            .Where(m =>
+                m.Tags.Any(t =>
+                    string.Equals(t.Key, "headless.cache.name", StringComparison.Ordinal) && Equals(t.Value, cacheName)
+                )
+            )
+            .Should()
+            .ContainSingle();
 
         metrics
             .Count(
@@ -262,7 +279,10 @@ public sealed class InMemoryCacheRequestMetricsTests : TestBase
 
         // then
         removed.Should().BeFalse();
-        metrics.Measurements("headless.cache.writes").Should().BeEmpty();
+
+        // Scope to THIS test's cache name: the meter is process-global, so parallel tests' writes (e.g. an
+        // upsert on the "default" instance) land in the same collector and must not fail this assertion.
+        metrics.Count("headless.cache.writes", ("headless.cache.name", cacheName)).Should().Be(0);
     }
 
     [Fact]

--- a/tests/Headless.Messaging.Core.Tests.Unit/Diagnostics/ConsumeTelemetryPipelineTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Diagnostics/ConsumeTelemetryPipelineTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
@@ -103,7 +104,7 @@ public sealed class ConsumeTelemetryPipelineTests : TestBase
         var message = _CreateMediumMessage();
         var descriptor = _CreateDescriptor();
 
-        var spans = new List<Activity>();
+        var spans = new ConcurrentBag<Activity>();
         using var activityListener = _StartActivityListener(spans);
         var measurements = new List<string>();
         using var meterListener = _StartMeterListener(measurements);
@@ -165,7 +166,8 @@ public sealed class ConsumeTelemetryPipelineTests : TestBase
         };
     }
 
-    private static ActivityListener _StartActivityListener(List<Activity> captured)
+    // Process-global callback: parallel tests' activities all land here — the collection must be thread-safe.
+    private static ActivityListener _StartActivityListener(ConcurrentBag<Activity> captured)
     {
         var listener = new ActivityListener
         {

--- a/tests/Headless.Messaging.Core.Tests.Unit/Diagnostics/MessagingTelemetryCancellationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Diagnostics/MessagingTelemetryCancellationTests.cs
@@ -167,7 +167,7 @@ public sealed class MessagingTelemetryCancellationTests : TestBase
             );
 
         using var stopped = new PublishActivityCollector();
-        var metrics = new List<(string Name, long Value)>();
+        var metrics = new ConcurrentBag<(string Name, long Value)>();
         using var meters = _StartMeterListener(metrics);
         var sender = _CreateSender(storage, serializer, busTransport, new MessagingOptions());
 
@@ -222,7 +222,7 @@ public sealed class MessagingTelemetryCancellationTests : TestBase
             );
 
         using var stopped = new PublishActivityCollector();
-        var metrics = new List<(string Name, long Value)>();
+        var metrics = new ConcurrentBag<(string Name, long Value)>();
         using var meters = _StartMeterListener(metrics);
         var sender = _CreateSender(
             storage,
@@ -307,7 +307,7 @@ public sealed class MessagingTelemetryCancellationTests : TestBase
         return new TransportMessage(headers, new byte[] { 1, 2, 3 });
     }
 
-    private static MeterListener _StartMeterListener(List<(string Name, long Value)> captured)
+    private static MeterListener _StartMeterListener(ConcurrentBag<(string Name, long Value)> captured)
     {
         var listener = new MeterListener
         {

--- a/tests/Headless.Messaging.Core.Tests.Unit/Diagnostics/MessagingTelemetryTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Diagnostics/MessagingTelemetryTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
@@ -95,7 +96,7 @@ public sealed class MessagingTelemetryTests : TestBase
     [Fact]
     public void should_record_expected_instrument_names_when_full_flow()
     {
-        var measurements = new List<(string Name, string[] TagKeys)>();
+        var measurements = new ConcurrentBag<(string Name, string[] TagKeys)>();
         using var listener = _StartMeterListener(measurements);
         var telemetry = MessagingTelemetry.Default;
 
@@ -251,7 +252,8 @@ public sealed class MessagingTelemetryTests : TestBase
 
     private static void _SampleHandler() { }
 
-    private static ActivityListener _StartActivityListener(List<Activity> captured)
+    // Process-global callback: parallel tests' activities all land here — the collection must be thread-safe.
+    private static ActivityListener _StartActivityListener(ConcurrentBag<Activity> captured)
     {
         var listener = new ActivityListener
         {
@@ -266,7 +268,7 @@ public sealed class MessagingTelemetryTests : TestBase
         return listener;
     }
 
-    private static MeterListener _StartMeterListener(List<(string Name, string[] TagKeys)> captured)
+    private static MeterListener _StartMeterListener(ConcurrentBag<(string Name, string[] TagKeys)> captured)
     {
         var listener = new MeterListener
         {

--- a/tests/Headless.Messaging.Core.Tests.Unit/MessagingIntentSplitTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/MessagingIntentSplitTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using Headless.Abstractions;
@@ -299,7 +300,7 @@ public sealed class MessagingIntentSplitTests : TestBase
             .Returns(_CreatePreparedPublishMessage("events.prepared", IntentType.Bus));
 
         await using var transport = new CapturingBusTransport();
-        var activities = new List<Activity>();
+        var activities = new ConcurrentBag<Activity>();
         using var listener = _CreatePublishActivityListener(activities);
         var bus = _CreateBus(transport, publishRequestFactory);
 
@@ -349,7 +350,7 @@ public sealed class MessagingIntentSplitTests : TestBase
             .Returns(_CreatePreparedPublishMessage("jobs.prepared", IntentType.Queue));
 
         await using var transport = new CapturingQueueTransport();
-        var activities = new List<Activity>();
+        var activities = new ConcurrentBag<Activity>();
         using var listener = _CreatePublishActivityListener(activities);
         var queue = _CreateQueue(transport, publishRequestFactory);
 
@@ -617,7 +618,9 @@ public sealed class MessagingIntentSplitTests : TestBase
         }
     }
 
-    private static ActivityListener _CreatePublishActivityListener(List<Activity> captured)
+    // The listener is process-global and parallel tests' activities all land in `captured`, so the collection
+    // must be thread-safe — a plain List.Add here races and can drop this test's own activity.
+    private static ActivityListener _CreatePublishActivityListener(ConcurrentBag<Activity> captured)
     {
         var listener = new ActivityListener
         {


### PR DESCRIPTION
## Summary

Fixes the two CI flakes from PR #692's head run (`Build and pack` / non-UTC-timezone leg) — both test-isolation bugs, no product code touched.

**Root cause:** process-global `ActivityListener`/`MeterListener` callbacks receive every parallel test's emissions:
- Plain `List.Add` collectors race under concurrent callbacks and can drop the owning test's own activity — `MessagingIntentSplitTests.should_request_bus_intent_from_factory_and_trace_prepared_intent_when_bus_publish` failed with zero matches even though its publish happened (the earlier predicate-scoping fix addressed duplicates, not the lossy collection).
- Unscoped count/empty assertions see other tests' measurements — `InMemoryCacheRequestMetricsTests.should_not_record_write_counter_on_remove_async_when_key_absent` failed on a parallel test's `default`-cache upsert landing in its collector.

**Fix:**
- All six `List`-backed collector callbacks across four messaging test files -> `ConcurrentBag` (`MessagingIntentSplitTests`, `MessagingTelemetryTests`, `MessagingTelemetryCancellationTests`, `ConsumeTelemetryPipelineTests`).
- Three unscoped assertions in `InMemoryCacheRequestMetricsTests` now filter by the test's own unique cache name.

## Validation

Fresh Release binaries, `TZ=Australia/Sydney`: caching InMemory suite 4/4 runs green (251 tests), messaging Core suite 4/4 runs green (921 tests). Pre-push format-check + incremental build gate passed.

Residual (noted, not fixed): `MessagingInstrumentationTests` feeds the OTel SDK `InMemoryExporter` a plain `List` — same theoretical race via the export pipeline, unproven in CI; left as-is to keep this change minimal.