### PR TITLE
test: cover cancellation retry and buffer contracts

### DIFF
--- a/tests/Headless.Jobs.Tests.Unit/JobsCancellationTokenManagerTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/JobsCancellationTokenManagerTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs;
+using Headless.Jobs.Models;
+
+namespace Tests;
+
+public sealed class JobsCancellationTokenManagerTests
+{
+    [Fact]
+    public void should_cancel_registered_job_and_remove_parent_state_when_requested_by_id()
+    {
+        // given
+        var parentId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+        using var source = new CancellationTokenSource();
+        var token = source.Token;
+        var callbackInvoked = false;
+        using var registration = token.Register(() => callbackInvoked = true);
+
+        JobsCancellationTokenManager.AddTickerCancellationToken(source, _Job(jobId, parentId), isDue: false);
+
+        try
+        {
+            // when
+            var result = JobsCancellationTokenManager.RequestTickerCancellationById(jobId);
+
+            // then
+            result.Should().BeTrue();
+            token.IsCancellationRequested.Should().BeTrue();
+            callbackInvoked.Should().BeTrue();
+            JobsCancellationTokenManager.IsParentRunning(parentId).Should().BeFalse();
+            JobsCancellationTokenManager.RequestTickerCancellationById(jobId).Should().BeFalse();
+        }
+        finally
+        {
+            JobsCancellationTokenManager.RemoveTickerCancellationToken(jobId);
+        }
+    }
+
+    [Fact]
+    public void should_report_other_running_siblings_when_excluding_current_job()
+    {
+        // given
+        var parentId = Guid.NewGuid();
+        var firstJobId = Guid.NewGuid();
+        var secondJobId = Guid.NewGuid();
+        using var firstSource = new CancellationTokenSource();
+        using var secondSource = new CancellationTokenSource();
+
+        JobsCancellationTokenManager.AddTickerCancellationToken(firstSource, _Job(firstJobId, parentId), isDue: false);
+        JobsCancellationTokenManager.AddTickerCancellationToken(
+            secondSource,
+            _Job(secondJobId, parentId),
+            isDue: false
+        );
+
+        try
+        {
+            // when / then
+            JobsCancellationTokenManager.IsParentRunningExcludingSelf(parentId, firstJobId).Should().BeTrue();
+
+            JobsCancellationTokenManager.RemoveTickerCancellationToken(secondJobId).Should().BeTrue();
+
+            JobsCancellationTokenManager.IsParentRunningExcludingSelf(parentId, firstJobId).Should().BeFalse();
+            JobsCancellationTokenManager.IsParentRunning(parentId).Should().BeTrue();
+        }
+        finally
+        {
+            JobsCancellationTokenManager.RemoveTickerCancellationToken(firstJobId);
+            JobsCancellationTokenManager.RemoveTickerCancellationToken(secondJobId);
+        }
+
+        JobsCancellationTokenManager.IsParentRunning(parentId).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_retain_all_siblings_when_jobs_register_concurrently()
+    {
+        const int registrationCount = 32;
+
+        for (var survivorIndex = 0; survivorIndex < registrationCount; survivorIndex++)
+        {
+            // given
+            var parentId = Guid.NewGuid();
+            var registrations = Enumerable
+                .Range(0, registrationCount)
+                .Select(static _ => (JobId: Guid.NewGuid(), Source: new CancellationTokenSource()))
+                .ToArray();
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            try
+            {
+                var registrationTasks = registrations
+                    .Select(async registration =>
+                    {
+                        await start.Task;
+                        JobsCancellationTokenManager.AddTickerCancellationToken(
+                            registration.Source,
+                            _Job(registration.JobId, parentId),
+                            isDue: false
+                        );
+                    })
+                    .ToArray();
+
+                // when
+                start.SetResult();
+                await Task.WhenAll(registrationTasks);
+
+                foreach (var (jobId, _) in registrations.Where((_, index) => index != survivorIndex))
+                {
+                    JobsCancellationTokenManager.RemoveTickerCancellationToken(jobId).Should().BeTrue();
+                }
+
+                // then
+                JobsCancellationTokenManager.IsParentRunning(parentId).Should().BeTrue();
+                JobsCancellationTokenManager
+                    .RemoveTickerCancellationToken(registrations[survivorIndex].JobId)
+                    .Should()
+                    .BeTrue();
+                JobsCancellationTokenManager.IsParentRunning(parentId).Should().BeFalse();
+            }
+            finally
+            {
+                foreach (var (jobId, source) in registrations)
+                {
+                    JobsCancellationTokenManager.RemoveTickerCancellationToken(jobId);
+                    source.Dispose();
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void should_return_false_when_cancellation_is_requested_for_unknown_job()
+    {
+        JobsCancellationTokenManager.RequestTickerCancellationById(Guid.NewGuid()).Should().BeFalse();
+    }
+
+    private static JobExecutionState _Job(Guid jobId, Guid parentId)
+    {
+        return new JobExecutionState
+        {
+            JobId = jobId,
+            ParentId = parentId,
+            FunctionName = "test-function",
+        };
+    }
+}

--- a/tests/Headless.Serializer.Tests.Unit/PooledByteBufferWriterTests.cs
+++ b/tests/Headless.Serializer.Tests.Unit/PooledByteBufferWriterTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Buffers;
+using Headless.Serializer;
+
+namespace Tests;
+
+public sealed class PooledByteBufferWriterTests
+{
+    [Fact]
+    public void should_preserve_written_bytes_when_buffer_grows()
+    {
+        // given
+        using var writer = new PooledByteBufferWriter();
+        var first = Enumerable.Range(0, 256).Select(static value => (byte)value).ToArray();
+        var second = Enumerable.Range(0, 300).Select(static value => (byte)(value % 251)).ToArray();
+
+        writer.Write(first);
+
+        // when
+        writer.Write(second);
+
+        // then
+        writer.WrittenSpan.ToArray().Should().Equal([.. first, .. second]);
+        writer.WrittenMemory.ToArray().Should().Equal([.. first, .. second]);
+    }
+
+    [Fact]
+    public void should_reject_negative_advance_without_changing_written_length()
+    {
+        // given
+        using var writer = new PooledByteBufferWriter();
+
+        // when
+        var act = () => writer.Advance(-1);
+
+        // then
+        act.Should().Throw<InvalidOperationException>().WithMessage("Cannot advance past the end of the buffer.");
+        writer.WrittenSpan.ToArray().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void should_reject_advance_beyond_granted_buffer_without_changing_written_length()
+    {
+        // given
+        using var writer = new PooledByteBufferWriter();
+        var grantedLength = writer.GetSpan().Length;
+
+        // when
+        var act = () => writer.Advance(grantedLength + 1);
+
+        // then
+        act.Should().Throw<InvalidOperationException>().WithMessage("Cannot advance past the end of the buffer.");
+        writer.WrittenSpan.ToArray().Should().BeEmpty();
+    }
+}

--- a/tests/Headless.Testing.Tests.Unit/RetryAttributeTests.cs
+++ b/tests/Headless.Testing.Tests.Unit/RetryAttributeTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Collections.Concurrent;
+using Headless.Testing.Retry;
+
+namespace Tests;
+
+public sealed class RetryAttributeTests
+{
+    private static readonly ConcurrentDictionary<string, int> _Attempts = new(StringComparer.Ordinal);
+
+    [RetryFact(MaxRetries = 2)]
+    public void should_retry_fact_until_it_succeeds()
+    {
+        _AssertAttempt("fact", expectedSuccessfulAttempt: 2);
+    }
+
+    [RetryFact(MaxRetries = 0)]
+    public void should_use_three_attempts_when_max_retries_is_less_than_one()
+    {
+        _AssertAttempt("fallback", expectedSuccessfulAttempt: 3);
+    }
+
+    [RetryTheory(MaxRetries = 2)]
+    [InlineData("first-row")]
+    [InlineData("second-row")]
+    public void should_retry_each_theory_row_independently(string row)
+    {
+        _AssertAttempt(row, expectedSuccessfulAttempt: 2);
+    }
+
+    private static void _AssertAttempt(string key, int expectedSuccessfulAttempt)
+    {
+        var attempt = _Attempts.AddOrUpdate(key, 1, static (_, current) => current + 1);
+
+        if (attempt == expectedSuccessfulAttempt)
+        {
+            _Attempts.TryRemove(key, out _);
+        }
+
+        attempt.Should().Be(expectedSuccessfulAttempt);
+    }
+}


### PR DESCRIPTION
## Summary

Add focused regression coverage for three public behavior surfaces that previously lacked direct tests:

- pooled byte-buffer growth and invalid `Advance` bounds
- Jobs cancellation, sibling tracking, and concurrent registration
- xUnit retry facts, fallback attempt counts, and independent theory rows

This is a test-only change with no production behavior or public API modifications.

## Affected Packages

- `Headless.Jobs.Core`
- `Headless.Serializer.Abstractions`
- `Headless.Testing`

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [x] Test only

## Validation

- [ ] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [x] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [x] Added or updated tests for behavior changes
- [ ] Updated XML docs for public API changes
- [ ] Updated package `README.md` files for public behavior/setup changes
- [ ] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
make restore
make format-check
make quality-analyzers-project PROJECT=tests/Headless.Jobs.Tests.Unit/Headless.Jobs.Tests.Unit.csproj
make quality-analyzers-project PROJECT=tests/Headless.Serializer.Tests.Unit/Headless.Serializer.Tests.Unit.csproj
make quality-analyzers-project PROJECT=tests/Headless.Testing.Tests.Unit/Headless.Testing.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Jobs.Tests.Unit/Headless.Jobs.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Serializer.Tests.Unit/Headless.Serializer.Tests.Unit.csproj
make test-project TEST_PROJECT=tests/Headless.Testing.Tests.Unit/Headless.Testing.Tests.Unit.csproj

Targeted results:
- Jobs: 241 passed
- Serializer: 152 passed
- Testing: 9 passed

Pre-push validation after rebasing onto current main:
- changed-file format check passed
- dotnet build headless-framework.slnx --configuration Release --no-restore passed with 0 warnings and 0 errors

Full make test result:
- 11,500 passed, 2 failed, 54 skipped (11,556 total)
- RedisMembershipLuaTests.should_retain_generation_mirror_when_a_newer_incarnation_is_still_active_during_cleanup reproduced when isolated and is unrelated to this test-only diff
- DataStorageTestsBase.should_handle_concurrent_redelivery_storm_on_same_message_id passed when isolated and appears contention-sensitive
```

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
N/A
```

## Release Notes

Test coverage only; no changelog entry required.
