### PR TITLE
ci: run CodeQL on main and gate package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,8 @@ jobs:
     name: "Push GitHub Packages"
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    # Publishing a GitHub Release is the explicit package-release gate.
+    if: github.event_name == 'release'
 
     permissions:
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,10 @@
 name: "CodeQL"
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
   schedule:
-    # Weekly full scan covers everything outside the pull request gate.
+    # Weekly rescan picks up improvements to CodeQL queries even without a push.
     - cron: "0 8 * * 4"
   workflow_dispatch:
 
@@ -23,6 +23,8 @@ env:
 jobs:
   analyze:
     name: Analyze
+    # GitHub allows manual dispatch from any ref; keep every analysis on main.
+    if: github.ref == 'refs/heads/main'
     permissions:
       actions: read
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ After creating the project, attach it to [headless-framework.slnx](headless-fram
 
 ## Learnings
 
+- Workflow trigger changes must stay synchronized with `main` branch protection: removing the CodeQL `pull_request` trigger while `Analyze (csharp)` remains required leaves PRs permanently waiting. Package publication is gated by a published GitHub Release; Release Drafter updates drafts but does not publish them. (2026-07-16)
 - Messaging retry ceilings require an atomic durable attempt reservation before transport or consumer invocation; persisting progress only after failure lets a crash reset an inline burst. Recovery of a consumed reservation advances Messaging-owned persisted state without applying domain exception classification. (2026-07-10)
 - Jobs retry recovery depends on carrying `RetryCount` through every EF and in-memory pickup projection and persisting it before Polly waits; omitting it from a projection silently restores a fresh retry budget after process restart. (2026-07-10)
 - `[JsonExtensionData]` properties must be `{ get; set; }` (never `init`) and every source-gen `JsonSerializerContext` whose models carry extension data needs `[JsonSerializable(typeof(object))]` + `[JsonSerializable(typeof(JsonElement))]`. `init` binding throws on EVERY deserialization; missing object metadata throws on any unknown response field — both at runtime only, build stays green. Found via Paymob CashOut/CashIn unit tests. (2026-07-07)


### PR DESCRIPTION
## Summary

Pull requests no longer spend CI time on CodeQL; analysis runs after changes reach `main`, on the weekly schedule, or through a manual dispatch that targets `main`.

Merging to `main` still builds and packs the repository, but it no longer publishes packages. Publishing a GitHub Release is now the explicit gate for both GitHub Packages and nuget.org; Release Drafter continues preparing an unpublished draft.

Main branch protection was updated alongside the workflow so PRs no longer wait for the removed `Analyze (csharp)` check.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- Pre-push solution build: succeeded with 0 warnings and 0 errors
- Live branch-protection check: `Build and pack` plus both dashboard builds remain required; `Analyze (csharp)` is removed
- No live release was published during validation, so package-publish routing remains deploy-time verification

## Post-Deploy Monitoring & Validation

- After merge, verify the push-triggered CodeQL `Analyze` job succeeds on `main`.
- Confirm the merge-triggered CI run skips both package-publish jobs.
- On the next intentionally published GitHub Release, confirm GitHub Packages and nuget.org publication both succeed.
- Failure signals: a PR waits for CodeQL, a normal `main` push publishes a package, or a published release skips either package destination.
- Mitigation: cancel the unexpected run and revert the workflow gate before another merge or release.
- Validation window/owner: repository maintainer through the first post-merge CodeQL run and next intentional release.
