### PR TITLE
refactor(settings): depend on security abstractions

### DIFF
--- a/demo/Headless.EntityFramework.Migrations.Startup/packages.lock.json
+++ b/demo/Headless.EntityFramework.Migrations.Startup/packages.lock.json
@@ -763,7 +763,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/src/Headless.Settings.Core/Headless.Settings.Core.csproj
+++ b/src/Headless.Settings.Core/Headless.Settings.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Headless.Core\Headless.Core.csproj" />
-    <ProjectReference Include="..\Headless.Security\Headless.Security.csproj" />
+    <ProjectReference Include="..\Headless.Security.Abstractions\Headless.Security.Abstractions.csproj" />
     <ProjectReference Include="..\Headless.Domain\Headless.Domain.csproj" />
     <ProjectReference Include="..\Headless.Caching.Abstractions\Headless.Caching.Abstractions.csproj" />
     <ProjectReference Include="..\Headless.Hosting\Headless.Hosting.csproj" />

--- a/src/Headless.Settings.Storage.EntityFramework/packages.lock.json
+++ b/src/Headless.Settings.Storage.EntityFramework/packages.lock.json
@@ -491,15 +491,6 @@
           "libphonenumber-csharp": "[9.0.34, )"
         }
       },
-      "headless.security": {
-        "type": "Project",
-        "dependencies": {
-          "FluentValidation": "[12.1.1, )",
-          "Headless.Checks": "[1.0.0, )",
-          "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security.Abstractions": "[1.0.0, )"
-        }
-      },
       "headless.security.abstractions": {
         "type": "Project"
       },
@@ -527,7 +518,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/src/Headless.Settings.Storage.PostgreSql/packages.lock.json
+++ b/src/Headless.Settings.Storage.PostgreSql/packages.lock.json
@@ -429,15 +429,6 @@
           "libphonenumber-csharp": "[9.0.34, )"
         }
       },
-      "headless.security": {
-        "type": "Project",
-        "dependencies": {
-          "FluentValidation": "[12.1.1, )",
-          "Headless.Checks": "[1.0.0, )",
-          "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security.Abstractions": "[1.0.0, )"
-        }
-      },
       "headless.security.abstractions": {
         "type": "Project"
       },
@@ -465,7 +456,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/src/Headless.Settings.Storage.SqlServer/packages.lock.json
+++ b/src/Headless.Settings.Storage.SqlServer/packages.lock.json
@@ -534,15 +534,6 @@
           "libphonenumber-csharp": "[9.0.34, )"
         }
       },
-      "headless.security": {
-        "type": "Project",
-        "dependencies": {
-          "FluentValidation": "[12.1.1, )",
-          "Headless.Checks": "[1.0.0, )",
-          "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security.Abstractions": "[1.0.0, )"
-        }
-      },
       "headless.security.abstractions": {
         "type": "Project"
       },
@@ -570,7 +561,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/tests/Headless.Settings.Storage.PostgreSql.Tests.Integration/Headless.Settings.Storage.PostgreSql.Tests.Integration.csproj
+++ b/tests/Headless.Settings.Storage.PostgreSql.Tests.Integration/Headless.Settings.Storage.PostgreSql.Tests.Integration.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Headless.Settings.Storage.PostgreSql\Headless.Settings.Storage.PostgreSql.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Security\Headless.Security.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Headless.Settings.Storage.PostgreSql.Tests.Integration/packages.lock.json
+++ b/tests/Headless.Settings.Storage.PostgreSql.Tests.Integration/packages.lock.json
@@ -838,7 +838,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/Headless.Settings.Storage.SqlServer.Tests.Integration.csproj
+++ b/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/Headless.Settings.Storage.SqlServer.Tests.Integration.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Headless.Settings.Storage.SqlServer\Headless.Settings.Storage.SqlServer.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Security\Headless.Security.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Headless.Settings.Storage.SqlServer.Tests.Integration/packages.lock.json
@@ -838,7 +838,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/tests/Headless.Settings.Tests.Integration/Headless.Settings.Tests.Integration.csproj
+++ b/tests/Headless.Settings.Tests.Integration/Headless.Settings.Tests.Integration.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Headless.Messaging.InMemoryStorage\Headless.Messaging.InMemoryStorage.csproj" />
     <ProjectReference Include="..\..\src\Headless.DistributedLocks.Redis\Headless.DistributedLocks.Redis.csproj" />
     <ProjectReference Include="..\..\src\Headless.Settings.Storage.EntityFramework\Headless.Settings.Storage.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Security\Headless.Security.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing.Testcontainers\Headless.Testing.Testcontainers.csproj" />
   </ItemGroup>

--- a/tests/Headless.Settings.Tests.Integration/packages.lock.json
+++ b/tests/Headless.Settings.Tests.Integration/packages.lock.json
@@ -1068,7 +1068,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },

--- a/tests/Headless.Settings.Tests.Unit/Headless.Settings.Tests.Unit.csproj
+++ b/tests/Headless.Settings.Tests.Unit/Headless.Settings.Tests.Unit.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\src\Headless.Settings.Abstractions\Headless.Settings.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Headless.Settings.Core\Headless.Settings.Core.csproj" />
     <ProjectReference Include="..\..\src\Headless.Settings.Storage.EntityFramework\Headless.Settings.Storage.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\src\Headless.Security\Headless.Security.csproj" />
     <ProjectReference Include="..\..\src\Headless.Testing\Headless.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Headless.Settings.Tests.Unit/packages.lock.json
+++ b/tests/Headless.Settings.Tests.Unit/packages.lock.json
@@ -798,7 +798,7 @@
           "Headless.DistributedLocks.Abstractions": "[1.0.0, )",
           "Headless.Domain": "[1.0.0, )",
           "Headless.Hosting": "[1.0.0, )",
-          "Headless.Security": "[1.0.0, )",
+          "Headless.Security.Abstractions": "[1.0.0, )",
           "Headless.Settings.Abstractions": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
## Summary

Settings can now consume string encryption through the security abstraction package without taking a transitive dependency on the concrete security implementation. Application composition remains responsible for choosing the implementation.

Split from #708.

## Validation

- Full solution build: passed with 0 warnings and 0 errors
- Settings unit tests: 195 passed
- Diff review: no actionable findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this changes package dependency direction without changing runtime behavior.
