### PR TITLE
refactor(ef): disambiguate extension holders

### DIFF
--- a/src/Headless.AuditLog.Storage.EntityFramework/HeadlessAuditLogModelBuilderExtensions.cs
+++ b/src/Headless.AuditLog.Storage.EntityFramework/HeadlessAuditLogModelBuilderExtensions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.AuditLog;
 using Microsoft.EntityFrameworkCore;
 
-namespace Headless.AuditLog;
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>ModelBuilder extensions for configuring the audit log schema.</summary>
 [PublicAPI]
-public static class AuditLogModelBuilderExtensions
+public static class HeadlessAuditLogModelBuilderExtensions
 {
     /// <summary>
     /// Registers and configures the <see cref="AuditLogEntry"/> entity type.

--- a/src/Headless.AuditLog.Storage.EntityFramework/README.md
+++ b/src/Headless.AuditLog.Storage.EntityFramework/README.md
@@ -12,7 +12,7 @@ Persists audit entries through the application's EF Core `DbContext` so they com
 - `EfAuditLog<TContext>` — implements `IAuditLog<TContext>` for explicit event logging; resolves `ICurrentUser`, `ICurrentTenant`, `ICorrelationIdProvider`, and `TimeProvider` from DI.
 - `EfReadAuditLog<TContext>` — implements `IReadAuditLog<TContext>` using `IDbContextFactory<TContext>` (no-tracking queries).
 - `AuditLogEntry` — EF entity excluded from automatic capture through EF model metadata, preventing recursion when `AuditByDefault` is enabled.
-- `AuditLogModelBuilderExtensions.AddHeadlessAuditLog(modelBuilder, options)` — registers and configures the `AuditLogEntry` entity type; idempotent.
+- `HeadlessAuditLogModelBuilderExtensions.AddHeadlessAuditLog(modelBuilder, options)` — registers and configures the `AuditLogEntry` entity type; idempotent.
 - Composite primary key `(CreatedAt, Id)` for partition-readiness; index set covers tenant+time, tenant+action+time, tenant+entity+time, tenant+actor+time, and correlation ID.
 - Startup gate validates that `AuditLogEntry` was fully configured through `modelBuilder.AddHeadlessAuditLog` and throws with a clear message if the call was omitted, even when the entity was pre-registered.
 

--- a/src/Headless.AuditLog.Storage.EntityFramework/Setup.cs
+++ b/src/Headless.AuditLog.Storage.EntityFramework/Setup.cs
@@ -22,7 +22,7 @@ public static class SetupAuditLogEntityFramework
         /// </summary>
         /// <typeparam name="TContext">
         /// The <c>DbContext</c> subclass that owns the audit log table. The context must call
-        /// <see cref="AuditLogModelBuilderExtensions.AddHeadlessAuditLog"/> inside
+        /// <see cref="Microsoft.EntityFrameworkCore.HeadlessAuditLogModelBuilderExtensions.AddHeadlessAuditLog"/> inside
         /// <c>OnModelCreating</c>, which is validated at application startup.
         /// </typeparam>
         /// <remarks>

--- a/src/Headless.EntityFramework/Extensions/HeadlessDataGridExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessDataGridExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>Extension method for materializing a data-grid query result.</summary>
 [PublicAPI]
-public static class DataGridExtensions
+public static class HeadlessDataGridExtensions
 {
     /// <summary>
     /// Applies the ordering and paging from <paramref name="request"/> to the query and materializes the

--- a/src/Headless.EntityFramework/Extensions/HeadlessDbContextExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessDbContextExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>Extension methods for <see cref="DbContext"/>.</summary>
 [PublicAPI]
-public static class DbContextExtensions
+public static class HeadlessDbContextExtensions
 {
     /// <summary>
     /// Resolves <typeparamref name="T"/> from the EF Core internal service provider, returning

--- a/src/Headless.EntityFramework/Extensions/HeadlessDbContextOptionsBuilderExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessDbContextOptionsBuilderExtensions.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.EntityFrameworkCore;
 
 [PublicAPI]
-public static class DbContextOptionsBuilderExtensions
+public static class HeadlessDbContextOptionsBuilderExtensions
 {
     /// <summary>
     /// Replaces EF Core's default string primary-key value generation (a hyphenated <c>Guid.ToString()</c>) with a

--- a/src/Headless.EntityFramework/Extensions/HeadlessDbContextTransactionExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessDbContextTransactionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// Extension methods for executing operations within a resilient transaction that is
 /// coordinated with the <see cref="DbContext"/>'s execution strategy.
 /// </summary>
-public static class DbContextTransactionExtensions
+public static class HeadlessDbContextTransactionExtensions
 {
     /// <summary>
     /// Executes <paramref name="operation"/> inside a resilient transaction. The entire block is

--- a/src/Headless.EntityFramework/Extensions/HeadlessEntityTypeBuilderExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessEntityTypeBuilderExtensions.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore;
 
-public static class EntityTypeBuilderExtensions
+public static class HeadlessEntityTypeBuilderExtensions
 {
     /// <summary>
     /// It allows you to add a query filter to an entity type, combining it with

--- a/src/Headless.EntityFramework/Extensions/HeadlessIndexPageExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessIndexPageExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// <c>size</c> are <see langword="null"/> the full result set is returned as a single page.
 /// </remarks>
 [PublicAPI]
-public static class IndexPageExtensions
+public static class HeadlessIndexPageExtensions
 {
     extension<T>(IQueryable<T> source)
     {

--- a/src/Headless.EntityFramework/Extensions/HeadlessMigrateDbContextExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessMigrateDbContextExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// the context is not registered in DI or the factory lifetime differs.
 /// </remarks>
 [PublicAPI]
-public static class MigrateDbContextExtensions
+public static class HeadlessMigrateDbContextExtensions
 {
     extension(IServiceProvider services)
     {

--- a/src/Headless.EntityFramework/Extensions/HeadlessModelBuilderExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessModelBuilderExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.EntityFrameworkCore;
 
 [PublicAPI]
-public static class ModelBuilderExtensions
+public static class HeadlessModelBuilderExtensions
 {
     /// <summary>
     /// Applies configuration from all <see cref="IEntityTypeConfiguration{T}" />

--- a/src/Headless.EntityFramework/Extensions/HeadlessModelConfigurationBuilderExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessModelConfigurationBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// Extension methods for registering Headless building-block primitive type converter mappings on a
 /// <see cref="ModelConfigurationBuilder"/>.
 /// </summary>
-public static class ModelConfigurationBuilderExtensions
+public static class HeadlessModelConfigurationBuilderExtensions
 {
     /// <summary>
     /// Registers default column precision rules and value converters for the Headless primitive types

--- a/src/Headless.EntityFramework/Extensions/HeadlessMutableEntityTypeExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessMutableEntityTypeExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 namespace Microsoft.EntityFrameworkCore;
 
 [PublicAPI]
-public static class MutableEntityTypeExtensions
+public static class HeadlessMutableEntityTypeExtensions
 {
     /// <summary>
     /// Makes the application-side generator the single source of an <see cref="IEntity{TId}.Id"/> of type

--- a/src/Headless.EntityFramework/Extensions/HeadlessOrderExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessOrderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// Extension members for applying dynamic, string-based or <c>OrderBy</c>-descriptor ordering to an
 /// <see cref="IQueryable{T}"/>.
 /// </summary>
-public static class OrderExtensions
+public static class HeadlessOrderExtensions
 {
     extension<T>(IQueryable<T> source)
     {

--- a/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.DateOnly.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.DateOnly.cs
@@ -9,7 +9,7 @@ using Headless.Linq;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore;
 
-public static partial class QueryableExtensions
+public static partial class HeadlessQueryableExtensions
 {
     /// <summary>
     /// Count number of entities per each month in the interval from <paramref name="start"/>

--- a/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.DateTimeOffset.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.DateTimeOffset.cs
@@ -9,7 +9,7 @@ using Headless.Linq;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore;
 
-public static partial class QueryableExtensions
+public static partial class HeadlessQueryableExtensions
 {
     /// <summary>
     /// Count number of entities per each month in the interval from <paramref name="start"/>

--- a/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.IEntity.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.IEntity.cs
@@ -6,7 +6,7 @@ using Headless.Exceptions;
 #pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore;
 
-public static partial class QueryableExtensions
+public static partial class HeadlessQueryableExtensions
 {
     /// <summary>
     /// Returns the first entity with the specified <paramref name="id"/>, or throws

--- a/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.ToLookup.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessQueryableExtensions.ToLookup.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore;
 
 [PublicAPI]
-public static partial class QueryableExtensions
+public static partial class HeadlessQueryableExtensions
 {
     /// <summary>
     /// Asynchronously materializes the query and groups the results into an <see cref="ILookup{TKey,TElement}"/>.

--- a/src/Headless.EntityFramework/Extensions/HeadlessValueConvertersExtensions.cs
+++ b/src/Headless.EntityFramework/Extensions/HeadlessValueConvertersExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>A static class providing methods to configure EF value converts for Primitive types.</summary>
 [PublicAPI]
-public static class ValueConvertersExtensions
+public static class HeadlessValueConvertersExtensions
 {
     private const string _TypeName = "AddPrimitivesValueConvertersExtensions";
     private const string _MethodName = "AddPrimitivePropertyConversions";

--- a/src/Headless.EntityFramework/README.md
+++ b/src/Headless.EntityFramework/README.md
@@ -23,7 +23,7 @@ Provides a framework-aware base `DbContext` with conventions for audit fields, E
 - Runtime guard that fails the save with a remediation message when an entity emits events but the matching tier is not registered
 - Resilient transaction helpers: `ExecuteTransactionAsync(...)` (EF execution strategy), `ExecuteCoordinatedTransactionAsync(...)` (also enlists commit coordination)
 - Value converters: `MoneyAmountValueConverter`, `MonthValueConverter`, `AccountIdValueConverter`, `UserIdValueConverter`, `LocaleValueConverter`, `NormalizeDateTimeValueConverter`, `JsonValueConverter`, `ExtraPropertiesValueConverter`
-- `DataGridExtensions` for pagination and ordering on `IQueryable<T>`
+- `HeadlessDataGridExtensions` for pagination and ordering on `IQueryable<T>`
 - `IDbContextFactory<TDbContext>` auto-registered as singleton via `HeadlessDbContextFactory<TDbContext>`
 
 ## Design Notes

--- a/src/Headless.Features.Storage.EntityFramework/HeadlessFeaturesModelBuilderExtensions.cs
+++ b/src/Headless.Features.Storage.EntityFramework/HeadlessFeaturesModelBuilderExtensions.cs
@@ -1,15 +1,17 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Checks;
+using Headless.Features;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
 
-namespace Headless.Features;
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>Extension members on <see cref="ModelBuilder"/> for registering Headless feature entity configurations.</summary>
 [PublicAPI]
-public static class FeaturesModelBuilderExtensions
+public static class HeadlessFeaturesModelBuilderExtensions
 {
     extension(ModelBuilder modelBuilder)
     {

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/HeadlessJobsPaginationExtensions.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/HeadlessJobsPaginationExtensions.cs
@@ -3,9 +3,10 @@
 using Headless.Jobs.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace Headless.Jobs.Infrastructure;
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
 
-public static class PaginationExtensions
+public static class HeadlessJobsPaginationExtensions
 {
     /// <summary>
     /// Converts an IQueryable to a paginated list

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/HeadlessJobsQueryExtensions.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/HeadlessJobsQueryExtensions.cs
@@ -3,9 +3,10 @@
 using Headless.Jobs.Entities;
 using Headless.Jobs.Enums;
 
-namespace Headless.Jobs.Infrastructure;
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
 
-public static class JobsQueryExtensions
+public static class HeadlessJobsQueryExtensions
 {
     /// <summary>
     /// Selects acquirable non-terminal rows using the caller-supplied clock. EF runtime claim paths use the internal

--- a/src/Headless.Permissions.Storage.EntityFramework/HeadlessPermissionsModelBuilderExtensions.cs
+++ b/src/Headless.Permissions.Storage.EntityFramework/HeadlessPermissionsModelBuilderExtensions.cs
@@ -1,14 +1,16 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Checks;
+using Headless.Permissions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
 
-namespace Headless.Permissions;
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
 
 [PublicAPI]
-public static class PermissionsModelBuilderExtensions
+public static class HeadlessPermissionsModelBuilderExtensions
 {
     extension(ModelBuilder modelBuilder)
     {

--- a/src/Headless.Settings.Storage.EntityFramework/HeadlessSettingsModelBuilderExtensions.cs
+++ b/src/Headless.Settings.Storage.EntityFramework/HeadlessSettingsModelBuilderExtensions.cs
@@ -1,15 +1,17 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using Headless.Checks;
+using Headless.Settings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
 
-namespace Headless.Settings;
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>Extension methods on <see cref="ModelBuilder"/> for registering Headless settings entities.</summary>
 [PublicAPI]
-public static class SettingsModelBuilderExtensions
+public static class HeadlessSettingsModelBuilderExtensions
 {
     extension(ModelBuilder modelBuilder)
     {

--- a/tests/Headless.AuditLog.Tests.Unit/AuditLogModelBuilderExtensionsTests.cs
+++ b/tests/Headless.AuditLog.Tests.Unit/AuditLogModelBuilderExtensionsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Tests;
 
-public sealed class AuditLogModelBuilderExtensionsTests : TestBase
+public sealed class HeadlessAuditLogModelBuilderExtensionsTests : TestBase
 {
     [Fact]
     public void should_configure_and_exclude_audit_log_entry()

--- a/tests/Headless.Jobs.Tests.Unit/Infrastructure/JobsQueryPredicateTests.cs
+++ b/tests/Headless.Jobs.Tests.Unit/Infrastructure/JobsQueryPredicateTests.cs
@@ -3,6 +3,7 @@
 using Headless.Jobs.Entities;
 using Headless.Jobs.Enums;
 using Headless.Jobs.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 
 namespace Tests.Infrastructure;
 


### PR DESCRIPTION
## Summary

Framework-owned Entity Framework extension holders now identify themselves as Headless APIs instead of competing with generic names such as `DbContextExtensions` and `ModelBuilderExtensions`. EF feature extensions live in the conventional `Microsoft.EntityFrameworkCore` namespace so consumers discover them with the rest of the EF surface.

This is a source-level naming and namespace cleanup; affected consumers may need updated imports or static holder names.

Split from #708.

## Validation

- Full solution build: passed with 0 warnings and 0 errors
- Audit log unit tests: 62 passed
- Jobs unit tests: 325 passed
- Diff review: no actionable findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this changes compile-time API discovery and naming only.
