### PR TITLE
build: pin dependency and container inputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,15 @@ updates:
       timezone: "Africa/Cairo"
 
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "/demo/Headless.Messaging.Dashboard.Jwt.Demo"
+      - "/demo/Headless.Messaging.Redis.SqlServer.Demo"
+      - "/tests/Headless.Blobs.Aws.Tests.Integration"
+      - "/tests/Headless.Blobs.Azure.Tests.Integration"
+      - "/tests/Headless.Blobs.Redis.Tests.Integration"
+      - "/tests/Headless.Blobs.SshNet.Tests.Integration"
+      - "/tests/Headless.DistributedLocks.Redis.Tests.Integration"
+      - "/tests/Headless.Tus.Azure.Tests.Integration/TestSetup"
     target-branch: "main"
     labels:
       - "maintenance"
@@ -98,6 +106,7 @@ updates:
     directories:
       - "/src/Headless.Jobs.Dashboard/wwwroot"
       - "/src/Headless.Messaging.Dashboard/wwwroot"
+      - "/demo/Headless.Tus.Demo/frontend"
     labels:
       - "maintenance"
     commit-message:

--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -12,6 +12,7 @@ on:
       - 'eng/**'
       - 'src/Headless.Jobs.Dashboard/wwwroot/**'
       - 'src/Headless.Messaging.Dashboard/wwwroot/**'
+      - 'demo/Headless.Tus.Demo/frontend/**'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -19,6 +20,7 @@ on:
       - 'eng/**'
       - 'src/Headless.Jobs.Dashboard/wwwroot/**'
       - 'src/Headless.Messaging.Dashboard/wwwroot/**'
+      - 'demo/Headless.Tus.Demo/frontend/**'
   workflow_dispatch:
 
 concurrency:
@@ -67,3 +69,28 @@ jobs:
       - name: "Lint (eslint)"
         working-directory: ${{ matrix.dashboard }}
         run: npm run lint:check
+
+  tus:
+    name: "Build Tus demo"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: false
+          persist-credentials: false
+
+      - name: "Setup Node"
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: demo/Headless.Tus.Demo/frontend/package-lock.json
+
+      - name: "Install dependencies"
+        working-directory: demo/Headless.Tus.Demo/frontend
+        run: npm ci
+
+      - name: "Build frontend"
+        working-directory: demo/Headless.Tus.Demo/frontend
+        run: npm run build

--- a/demo/Headless.Messaging.Dashboard.Jwt.Demo/Dockerfile
+++ b/demo/Headless.Messaging.Dashboard.Jwt.Demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:1fa23fc4872d95fd71c2833ebe65d7e84a43b2d51a31d119516852f13d9505a7
 WORKDIR /app
 COPY . ./
 ENTRYPOINT ["dotnet", "Headless.Messaging.Dashboard.Jwt.Demo.dll"]

--- a/demo/Headless.Messaging.Redis.SqlServer.Demo/Dockerfile
+++ b/demo/Headless.Messaging.Redis.SqlServer.Demo/Dockerfile
@@ -1,13 +1,13 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:1fa23fc4872d95fd71c2833ebe65d7e84a43b2d51a31d119516852f13d9505a7 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 80
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/Directory.Build.props", "src/"]

--- a/demo/Headless.Messaging.Redis.SqlServer.Demo/docker-compose.yml
+++ b/demo/Headless.Messaging.Redis.SqlServer.Demo/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis-node-0:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0.15@sha256:84f3c451737aeef420ba00d2320f53bb1757863190d6d42693cc341c29809398
     volumes:
       - redis-cluster_data-0:/bitnami/redis/data
     environment:
@@ -8,7 +8,7 @@ services:
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
   redis-node-1:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0.15@sha256:84f3c451737aeef420ba00d2320f53bb1757863190d6d42693cc341c29809398
     volumes:
       - redis-cluster_data-1:/bitnami/redis/data
     environment:
@@ -16,7 +16,7 @@ services:
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
   redis-node-2:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0.15@sha256:84f3c451737aeef420ba00d2320f53bb1757863190d6d42693cc341c29809398
     volumes:
       - redis-cluster_data-2:/bitnami/redis/data
     environment:
@@ -24,7 +24,7 @@ services:
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
   redis-node-3:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0.15@sha256:84f3c451737aeef420ba00d2320f53bb1757863190d6d42693cc341c29809398
     volumes:
       - redis-cluster_data-3:/bitnami/redis/data
     environment:
@@ -32,7 +32,7 @@ services:
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
   redis-node-4:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0.15@sha256:84f3c451737aeef420ba00d2320f53bb1757863190d6d42693cc341c29809398
     volumes:
       - redis-cluster_data-4:/bitnami/redis/data
     environment:
@@ -40,7 +40,7 @@ services:
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
   redis-node-5:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0.15@sha256:84f3c451737aeef420ba00d2320f53bb1757863190d6d42693cc341c29809398
     ports:
      - 6379:6379
     volumes:
@@ -59,7 +59,7 @@ services:
       - 'REDIS_CLUSTER_CREATOR=yes'
 
   db:
-     image: "mcr.microsoft.com/mssql/server:2022-latest"
+     image: "mcr.microsoft.com/mssql/server:2022-latest@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89"
      ports:
         - 1433:1433
      environment:

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <!-- https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file -->
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="github.com" value="https://nuget.pkg.github.com/xshaheen/index.json" />
   </packageSources>
@@ -19,6 +20,7 @@
   </packageManagement>
   <!-- Define mappings by adding package patterns beneath the target source. -->
   <packageSourceMapping>
+    <clear />
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
@@ -26,6 +28,10 @@
       <package pattern="Headless.*" />
     </packageSource>
   </packageSourceMapping>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
   <!-- Add credentials for private feeds here. -->
   <packageSourceCredentials>
     <github.com>

--- a/src/Headless.Testing.Testcontainers/TestImages.cs
+++ b/src/Headless.Testing.Testcontainers/TestImages.cs
@@ -3,27 +3,30 @@
 namespace Headless.Testing.Testcontainers;
 
 /// <summary>
-/// Single source of truth for container image tags used across integration tests.
-/// Pinning to specific tags (rather than <c>:latest</c>) keeps Docker pulls reproducible
-/// and avoids repeated registry round-trips that occur with unpinned tags.
+/// Single source of truth for container images used across integration tests.
+/// Every reference includes a reviewed manifest digest so a mutable registry tag cannot change test inputs.
 /// </summary>
 [PublicAPI]
 public static class TestImages
 {
     /// <summary>PostgreSQL image tag.</summary>
-    public const string PostgreSql = "postgres:18.1-alpine3.23";
+    public const string PostgreSql =
+        "postgres:18.1-alpine3.23@sha256:aa6eb304ddb6dd26df23d05db4e5cb05af8951cda3e0dc57731b771e0ef4ab29";
 
     /// <summary>Redis image tag.</summary>
-    public const string Redis = "redis:7-alpine";
+    public const string Redis =
+        "redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99";
 
     /// <summary>NATS image tag.</summary>
-    public const string Nats = "nats:2-alpine";
+    public const string Nats = "nats:2-alpine@sha256:c11af972c99ae542de8925e6a7d9c533aa1eb039660420d2074beed6089b3bf0";
 
     /// <summary>RabbitMQ image tag.</summary>
-    public const string RabbitMq = "rabbitmq:3-alpine";
+    public const string RabbitMq =
+        "rabbitmq:3-alpine@sha256:d7af1c87c5f1eda13fcfca06db452bf3aeab6619fc3358b68535c0c02c4e52bc";
 
     /// <summary>Azurite (Azure Storage emulator) image tag.</summary>
-    public const string Azurite = "mcr.microsoft.com/azure-storage/azurite:3.35.0";
+    public const string Azurite =
+        "mcr.microsoft.com/azure-storage/azurite:3.35.0@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37";
 
     /// <summary>
     /// LocalStack (AWS emulator) image tag.
@@ -33,19 +36,22 @@ public static class TestImages
     /// either acquiring a free Hobby-plan token or swapping to an alternative
     /// emulator (e.g., adobe/S3Mock for S3-only workloads).
     /// </summary>
-    public const string LocalStack = "localstack/localstack:4.4.0";
+    public const string LocalStack =
+        "localstack/localstack:4.4.0@sha256:b52c16663c70b7234f217cb993a339b46686e30a1a5d9279cb5feeb2202f837c";
 
     /// <summary>
     /// SQL Server 2022 image tag (used on x86_64 hosts).
     /// Pinned to an immutable CU tag rather than the rolling <c>2022-latest</c> so Docker does not
     /// re-check the registry on every run and so a fresh pull cannot silently change the SQL Server build.
     /// </summary>
-    public const string MsSqlServer = "mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04";
+    public const string MsSqlServer =
+        "mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04@sha256:147ee765ff1db3b86ce6ec05908e51fd0dab2feda5dd85b2721f28c77ca305eb";
 
     /// <summary>
     /// Azure SQL Edge image tag (used on ARM64 hosts; SQL Server doesn't ship ARM images).
     /// Pinned to <c>1.0.7</c> (SQL engine 15.0.2000.x) rather than the rolling <c>latest</c>: the
     /// <c>latest</c> tag moved on to the 2.0.x line, so an unpinned pull would change engine behavior on ARM.
     /// </summary>
-    public const string AzureSqlEdge = "mcr.microsoft.com/azure-sql-edge:1.0.7";
+    public const string AzureSqlEdge =
+        "mcr.microsoft.com/azure-sql-edge:1.0.7@sha256:1dcc88d2d9e555d0addb0636648d0da033206978d7c5c4da044c904a0f06f58b";
 }

--- a/tests/Headless.Blobs.Aws.Tests.Integration/docker-compose.yml
+++ b/tests/Headless.Blobs.Aws.Tests.Integration/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   localstack:
-    image: localstack/localstack:4.4.0
+    image: localstack/localstack:4.4.0@sha256:b52c16663c70b7234f217cb993a339b46686e30a1a5d9279cb5feeb2202f837c
     ports:
       - 4563-4599:4563-4599
       - 8055:8080
@@ -14,7 +14,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   ready:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     command: localstack:4566
     depends_on:
       - localstack

--- a/tests/Headless.Blobs.Azure.Tests.Integration/docker-compose.yml
+++ b/tests/Headless.Blobs.Azure.Tests.Integration/docker-compose.yml
@@ -2,14 +2,14 @@ version: '2.1'
 
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:3.35.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.35.0@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37
     ports:
       - 10000:10000
       - 10001:10001
       - 10002:10002
 
   ready:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     command: azurite:10000
     depends_on:
       - azurite

--- a/tests/Headless.Blobs.Redis.Tests.Integration/docker-compose.yml
+++ b/tests/Headless.Blobs.Redis.Tests.Integration/docker-compose.yml
@@ -1,6 +1,6 @@
 ﻿services:
   redis:
-    image: grokzen/redis-cluster:7.0.10
+    image: grokzen/redis-cluster:7.0.10@sha256:f130dd8a322fc4dc595380ec94907539c341d5841de7d31e679223aec04d30f6
     environment:
       IP: '0.0.0.0'
       STANDALONE: 'true'
@@ -11,7 +11,7 @@
       - 5000-5002:5000-5002 # sentinel
 
   ready:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     command: redis:7000
     depends_on:
       - redis

--- a/tests/Headless.Blobs.SshNet.Tests.Integration/SshBlobStorageFixture.cs
+++ b/tests/Headless.Blobs.SshNet.Tests.Integration/SshBlobStorageFixture.cs
@@ -12,7 +12,9 @@ namespace Tests;
 [CollectionDefinition(DisableParallelization = true)]
 public sealed class SshBlobStorageFixture : ICollectionFixture<SshBlobStorageFixture>, IAsyncLifetime
 {
-    private readonly IContainer _sftpContainer = new ContainerBuilder("atmoz/sftp:latest")
+    private readonly IContainer _sftpContainer = new ContainerBuilder(
+        "atmoz/sftp:latest@sha256:0960390462a4441dbb63698d7c185b76a41ffcee7b78ff4adf275f3e66f9c475"
+    )
         .WithLabel("type", "ssh-blob-sftp")
         .WithPortBinding(22, true)
         .WithCommand("headless:password:::storage")

--- a/tests/Headless.Blobs.SshNet.Tests.Integration/docker-compose.yml
+++ b/tests/Headless.Blobs.SshNet.Tests.Integration/docker-compose.yml
@@ -2,13 +2,13 @@ version: '2.1'
 
 services:
   sftp:
-    image: atmoz/sftp:latest
+    image: atmoz/sftp:latest@sha256:0960390462a4441dbb63698d7c185b76a41ffcee7b78ff4adf275f3e66f9c475
     ports:
         - "2222:22"
     command: framework:password:::storage
 
   ready:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     command: sftp:22
     depends_on:
       - sftp

--- a/tests/Headless.DistributedLocks.Redis.Tests.Integration/docker-compose.yml
+++ b/tests/Headless.DistributedLocks.Redis.Tests.Integration/docker-compose.yml
@@ -1,6 +1,6 @@
 ﻿services:
   redis:
-    image: grokzen/redis-cluster:7.0.10
+    image: grokzen/redis-cluster:7.0.10@sha256:f130dd8a322fc4dc595380ec94907539c341d5841de7d31e679223aec04d30f6
     environment:
       IP: '0.0.0.0'
       STANDALONE: 'true'
@@ -11,7 +11,7 @@
       - 5000-5002:5000-5002 # sentinel
 
   ready:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     command: redis:7000
     depends_on:
       - redis

--- a/tests/Headless.Tus.Azure.Tests.Integration/TestSetup/docker-compose.yml
+++ b/tests/Headless.Tus.Azure.Tests.Integration/TestSetup/docker-compose.yml
@@ -2,14 +2,14 @@ version: '2.1'
 
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:3.35.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.35.0@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37
     ports:
       - 10000:10000
       - 10001:10001
       - 10002:10002
 
   ready:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     command: azurite:10000
     depends_on:
       - azurite


### PR DESCRIPTION
## Summary

Dependency automation now covers every maintained Docker and frontend surface, NuGet source resolution no longer inherits machine-level feeds, and maintained container inputs resolve to reviewed immutable digests. This separates registry-input integrity from the larger remediation in #707.

Related: #707

## Affected Packages

- `Headless.Testing.Testcontainers`
- Repository dependency automation, demo containers, and integration-test infrastructure

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Test only

## Validation

- [ ] `make build`
- [ ] `make format-check`
- [ ] `make test-unit`
- [x] `make test-integration` or Docker-dependent tests not required for this change
- [x] Scoped validation listed below when full validation was not necessary
- [ ] Added or updated tests for behavior changes
- [ ] Updated XML docs for public API changes
- [ ] Updated package `README.md` files for public behavior/setup changes
- [ ] Updated `docs/llms/` guidance for public behavior/setup changes
- [x] No package versions were added directly to `.csproj` files

Validation details:

```text
make build-project PROJECT=src/Headless.Testing.Testcontainers/Headless.Testing.Testcontainers.csproj
git push pre-push hook: changed-file format check + full Release solution build
Ruby YAML parsing for Dependabot and dashboard workflows
docker compose config --quiet for every changed Compose file
Digest-completeness scan for every changed FROM/image reference
git diff --check
```

Compose emitted only the existing warning that the legacy `version` key is obsolete.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change described below

Describe any breaking changes, migration steps, or downstream package impact:

```text
N/A
```

## Release Notes

No package release note required. Maintainers should expect Dependabot to open updates for the newly covered Docker and Tus frontend inputs.

## Post-Deploy Monitoring & Validation

No additional production monitoring required: this changes build, dependency-update, and test inputs only. The maintainer should confirm the next scheduled Dependabot run discovers the added directories and treat any digest-resolution failure in CI as the rollback trigger.
