### PR TITLE
fix(dashboards): keep host tokens out of URLs

### DIFF
--- a/demo/Headless.Jobs.Dashboard.Jwt.Demo/Program.cs
+++ b/demo/Headless.Jobs.Dashboard.Jwt.Demo/Program.cs
@@ -35,18 +35,6 @@ builder
             RequireExpirationTime = true,
             ClockSkew = TimeSpan.Zero,
         };
-        options.Events = new JwtBearerEvents
-        {
-            OnMessageReceived = context =>
-            {
-                if (context.Request.Query.ContainsKey("access_token"))
-                {
-                    context.Token = context.Request.Query["access_token"];
-                }
-
-                return Task.CompletedTask;
-            },
-        };
     });
 
 const string dashboardPolicy = "DashboardPolicy";

--- a/demo/Headless.Jobs.Dashboard.Jwt.Demo/wwwroot/js/site.js
+++ b/demo/Headless.Jobs.Dashboard.Jwt.Demo/wwwroot/js/site.js
@@ -22,7 +22,7 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
     }
 
     const token = await res.json();
-    window.open(`/jobs/dashboard/login?access_token=Bearer ${token}`, '_blank');
+    window.open(`/jobs/dashboard/login#access_token=${encodeURIComponent(token)}`, '_blank');
   } catch {
     error.textContent = 'Request failed';
     error.style.display = 'block';

--- a/demo/Headless.Messaging.Dashboard.Jwt.Demo/Program.cs
+++ b/demo/Headless.Messaging.Dashboard.Jwt.Demo/Program.cs
@@ -37,18 +37,6 @@ builder
             RequireExpirationTime = true,
             ClockSkew = TimeSpan.Zero,
         };
-        options.Events = new JwtBearerEvents
-        {
-            OnMessageReceived = context =>
-            {
-                if (context.Request.Query.ContainsKey("access_token"))
-                {
-                    context.Token = context.Request.Query["access_token"];
-                }
-
-                return Task.CompletedTask;
-            },
-        };
     });
 
 const string dashboardPolicy = "DashboardPolicy";

--- a/demo/Headless.Messaging.Dashboard.Jwt.Demo/README.md
+++ b/demo/Headless.Messaging.Dashboard.Jwt.Demo/README.md
@@ -16,8 +16,8 @@ ASP.NET Core demo for protecting the Messaging Dashboard with JWT bearer authent
 dotnet run --project demo/Headless.Messaging.Dashboard.Jwt.Demo
 ```
 
-Create a token by posting user `bob` with password `bob` to `/security/createToken`, then use it when opening dashboard endpoints.
+Submit user `bob` with password `bob` on the demo login page. The demo opens the dashboard with the token in a URL fragment, which the Host-auth login consumes and removes before navigating.
 
 ## Production Note
 
-The JWT setup disables issuer and audience validation and allows query-string tokens for the demo. Validate issuer, audience, HTTPS, signing keys, and token transport before using this pattern in production.
+The JWT setup disables issuer and audience validation for the demo. Validate issuer, audience, HTTPS, signing keys, and token transport before using this pattern in production.

--- a/demo/Headless.Messaging.Dashboard.Jwt.Demo/wwwroot/js/site.js
+++ b/demo/Headless.Messaging.Dashboard.Jwt.Demo/wwwroot/js/site.js
@@ -22,7 +22,7 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
     }
 
     const token = await res.json();
-    window.open(`/messaging/login?access_token=Bearer ${token}`, '_blank');
+    window.open(`/messaging/login#access_token=${encodeURIComponent(token)}`, '_blank');
   } catch {
     error.textContent = 'Request failed';
     error.style.display = 'block';

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
+  consumeHostAccessTokenFromFragment,
   getApiBaseUrl,
   getAuthMode,
   getBackendUrl,
@@ -15,6 +16,38 @@ const baseConfig = {
 
 afterEach(() => {
   delete window.JobsConfig
+  window.history.replaceState(null, '', '/')
+})
+
+describe('host access token fragments', () => {
+  it('normalizes and removes an encoded token fragment in Host mode', () => {
+    window.history.replaceState(null, '', '/jobs/dashboard/login?redirect=%2F#access_token=demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('host')).toBe('Bearer demo.jwt')
+    expect(window.location.pathname).toBe('/jobs/dashboard/login')
+    expect(window.location.search).toBe('?redirect=%2F')
+    expect(window.location.hash).toBe('')
+  })
+
+  it('does not add a second Bearer prefix', () => {
+    window.history.replaceState(null, '', '/jobs/dashboard/login#access_token=Bearer%20demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('host')).toBe('Bearer demo.jwt')
+    expect(window.location.hash).toBe('')
+  })
+
+  it('removes but does not consume a token fragment outside Host mode', () => {
+    window.history.replaceState(null, '', '/jobs/dashboard/login#access_token=demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('apikey')).toBeNull()
+    expect(window.location.hash).toBe('')
+  })
+
+  it('ignores query-string tokens', () => {
+    window.history.replaceState(null, '', '/jobs/dashboard/login?access_token=demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('host')).toBeNull()
+  })
 })
 
 describe('with basePath only (no backend domain)', () => {

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/pathResolver.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/utilities/pathResolver.ts
@@ -137,6 +137,33 @@ export function getAuthMode(): 'basic' | 'apikey' | 'host' | 'none' {
 }
 
 /**
+ * Consume a fragment-delivered access token for Host authentication.
+ * The fragment is removed before the token is returned so it does not remain in browser history.
+ */
+export function consumeHostAccessTokenFromFragment(
+  authMode: 'basic' | 'apikey' | 'host' | 'none' = getAuthMode(),
+): string | null {
+  const fragment = new URLSearchParams(window.location.hash.slice(1));
+
+  if (!fragment.has('access_token')) {
+    return null;
+  }
+
+  const token = fragment.get('access_token')?.trim();
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${window.location.pathname}${window.location.search}`,
+  );
+
+  if (authMode !== 'host' || !token) {
+    return null;
+  }
+
+  return token.startsWith('Bearer ') ? token : `Bearer ${token}`;
+}
+
+/**
  * Get protocol from domain based on prefix
  * @param domain - The domain with optional protocol prefix
  * @returns The protocol (https:// or http://)

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/Login.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/Login.vue
@@ -183,7 +183,7 @@ defineOptions({ name: 'LoginView' })
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
-import { getAuthMode } from '@/utilities/pathResolver'
+import { consumeHostAccessTokenFromFragment, getAuthMode } from '@/utilities/pathResolver'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -248,19 +248,23 @@ const clearError = () => {
 }
 
 onMounted(async () => {
+  const token = consumeHostAccessTokenFromFragment(authMode.value)
+
   if (authStore.isLoggedIn) {
     router.push('/')
     return
   }
 
-  // Auto-fill from ?access_token= query param (useful for host auth with JWT)
-  const token = router.currentRoute.value.query.access_token as string
-  if (token && authMode.value === 'host') {
-    authStore.credentials.hostAccessKey = token.startsWith('Bearer ') ? token : `Bearer ${token}`
-    const success = await authStore.login()
-    if (success) {
-      router.push('/')
-    }
+  if (!token) {
+    return
+  }
+
+  authStore.credentials.hostAccessKey = token
+  const success = await authStore.login()
+  authStore.credentials.hostAccessKey = ''
+
+  if (success) {
+    router.push('/')
   }
 })
 </script>

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/__tests__/pathResolver.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
+  consumeHostAccessTokenFromFragment,
   getApiBaseUrl,
   getAuthMode,
   getBasePath,
@@ -15,6 +16,38 @@ const baseConfig = {
 
 afterEach(() => {
   delete window.MessagingConfig
+  window.history.replaceState(null, '', '/')
+})
+
+describe('host access token fragments', () => {
+  it('normalizes and removes an encoded token fragment in Host mode', () => {
+    window.history.replaceState(null, '', '/messaging/login?redirect=%2F#access_token=demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('host')).toBe('Bearer demo.jwt')
+    expect(window.location.pathname).toBe('/messaging/login')
+    expect(window.location.search).toBe('?redirect=%2F')
+    expect(window.location.hash).toBe('')
+  })
+
+  it('does not add a second Bearer prefix', () => {
+    window.history.replaceState(null, '', '/messaging/login#access_token=Bearer%20demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('host')).toBe('Bearer demo.jwt')
+    expect(window.location.hash).toBe('')
+  })
+
+  it('removes but does not consume a token fragment outside Host mode', () => {
+    window.history.replaceState(null, '', '/messaging/login#access_token=demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('apikey')).toBeNull()
+    expect(window.location.hash).toBe('')
+  })
+
+  it('ignores query-string tokens', () => {
+    window.history.replaceState(null, '', '/messaging/login?access_token=demo.jwt')
+
+    expect(consumeHostAccessTokenFromFragment('host')).toBeNull()
+  })
 })
 
 describe('with basePath only (no backend domain)', () => {

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/pathResolver.ts
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/utilities/pathResolver.ts
@@ -84,6 +84,33 @@ export function getAuthMode(): 'basic' | 'apikey' | 'host' | 'none' {
   return config.auth.mode as 'basic' | 'apikey' | 'host' | 'none'
 }
 
+/**
+ * Consume a fragment-delivered access token for Host authentication.
+ * The fragment is removed before the token is returned so it does not remain in browser history.
+ */
+export function consumeHostAccessTokenFromFragment(
+  authMode: 'basic' | 'apikey' | 'host' | 'none' = getAuthMode(),
+): string | null {
+  const fragment = new URLSearchParams(window.location.hash.slice(1))
+
+  if (!fragment.has('access_token')) {
+    return null
+  }
+
+  const token = fragment.get('access_token')?.trim()
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${window.location.pathname}${window.location.search}`,
+  )
+
+  if (authMode !== 'host' || !token) {
+    return null
+  }
+
+  return token.startsWith('Bearer ') ? token : `Bearer ${token}`
+}
+
 export function getStatsPollingInterval(): number {
   const config = window.MessagingConfig
   return config?.statsPollingInterval || 5000

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Login.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Login.vue
@@ -176,7 +176,7 @@ defineOptions({ name: 'LoginView' })
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
-import { getAuthMode } from '@/utilities/pathResolver'
+import { consumeHostAccessTokenFromFragment, getAuthMode } from '@/utilities/pathResolver'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -233,19 +233,23 @@ const clearError = () => {
 }
 
 onMounted(async () => {
+  const token = consumeHostAccessTokenFromFragment(authMode.value)
+
   if (authStore.isLoggedIn) {
     router.push('/')
     return
   }
 
-  // Auto-fill from ?access_token= query param (useful for host auth with JWT)
-  const token = router.currentRoute.value.query.access_token as string
-  if (token && authMode.value === 'host') {
-    authStore.credentials.hostAccessKey = token.startsWith('Bearer ') ? token : `Bearer ${token}`
-    const success = await authStore.login()
-    if (success) {
-      router.push('/')
-    }
+  if (!token) {
+    return
+  }
+
+  authStore.credentials.hostAccessKey = token
+  const success = await authStore.login()
+  authStore.credentials.hostAccessKey = ''
+
+  if (success) {
+    router.push('/')
   }
 })
 </script>


### PR DESCRIPTION
## Summary

- deliver dashboard host-auth tokens through the URL fragment instead of the query string
- consume and immediately remove the fragment before storing the bearer token
- remove demo server support for query-string bearer tokens
- cover fragment consumption, cleanup, auth-mode rejection, and bearer normalization in both dashboards

This is the dashboard token-handling slice split from #707. Debug/development request-response logging remains intentionally unchanged.

## Testing

- Jobs dashboard: `npm run test:unit` — 34 passed
- Jobs dashboard: `npm run lint:check`
- Jobs dashboard: `npm run build`
- Messaging dashboard: `npm run test:unit` — 24 passed
- Messaging dashboard: `npm run lint:check`
- Messaging dashboard: `npm run build`
- `make build-project PROJECT=demo/Headless.Jobs.Dashboard.Jwt.Demo/Headless.Jobs.Dashboard.Jwt.Demo.csproj`
- `make build-project PROJECT=demo/Headless.Messaging.Dashboard.Jwt.Demo/Headless.Messaging.Dashboard.Jwt.Demo.csproj`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- **Responsible:** dashboard/demo maintainer
- **Window:** first deployment or demo run using host authentication
- **Healthy:** login redirect uses `#access_token=...`; the fragment is removed immediately; authenticated API calls use the Authorization header; server access logs contain no token query parameter
- **Failure:** token remains in the address bar/history, appears in request URLs, or host-auth login no longer succeeds
- **Action:** disable the affected host-auth entry point and inspect redirect generation plus browser history replacement before redeploying
- **Rollback:** revert this PR only if the authentication flow is unusable; do not restore query-string token acceptance without a security review

## Checklist

- [x] Tokens are not sent in query strings
- [x] URL fragments are cleared before continued navigation
- [x] Both dashboard implementations have equivalent tests
- [x] Debug/development logging is out of scope

