### PR TITLE
fix(messaging-dashboard): constrain cross-node proxying

### DIFF
--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -224,7 +224,7 @@ services.AddHeadlessMessaging(setup =>
 - **Core handles outbox automatically** when paired with EF Core -- messages are stored in database before being dispatched to transport.
 - **Atomic outbox is on by default on the EF storage path** (`setup.UseEntityFramework<TContext>()`): a publish inside a coordinated transaction is atomic with the DB write, zero consumer wiring — do not hand-wire commit coordination for it. Opt out with `setup.UseEntityFramework<TContext>(o => o.EnableTransactionalOutbox = false)` (the opt-out travels with the EF storage choice). Raw-ADO paths (`UsePostgreSql`/`UseSqlServer` by connection string) stay explicit opt-in: wire `AddPostgreSqlCommitCoordination()`/`AddSqlServerCommitCoordination()` plus the coordinated-transaction helpers.
 - **Mis-wire fails loud at startup**: if the outbox is enabled but the commit interceptor is not firing, `CommitInterceptorStartupGate<TContext>` logs a warning by default; set `CommitProbeMode.Strict` (via `services.Configure<CommitInterceptorProbeOptions>(o => o.Mode = CommitProbeMode.Strict)`) to fail startup instead of shipping a silently non-transactional outbox.
-- **Dashboard.K8s requires RBAC** permissions to read pods/endpoints in the Kubernetes API.
+- **Dashboard.K8s requires RBAC** permissions to read Services in the configured Kubernetes namespace.
 - **Callbacks enable async response routing**: Set `CallbackName` on `PublishOptions` (bus) **or** `EnqueueOptions` (queue) to a response message name. When the consumer completes, a correlated response message is automatically published to that name through the durable bus path — regardless of which intent delivered the request. The consumer calls `context.SetResponse<TResponse>(value)` to publish a typed response body; if it does not, the callback still goes out as a headers-only message when response headers are present. This is **not** request/reply — the caller does not `await` the response. A separate consumer must handle the response message. Use `context.Headers.RemoveCallback()` to suppress, `RewriteCallback()` to redirect, or `AddResponseHeader()` to attach extra headers to the response. Callback delivery is **at-least-once** — a crash, or a transient failure of the success-mark write after the response outbox row is written, redelivers the request and republishes the response, so make response consumers idempotent (dedupe on `(CorrelationId, CorrelationSequence)`; `CorrelationId` alone is ambiguous across hops because it is set to the immediate parent message id per hop, not the chain root). **Footgun on the bus path:** a published (pub/sub) request is delivered to *every* matching subscriber, so each one fires its own callback — N subscribers produce N response messages. Point-to-point (`IQueue` / `IOutboxQueue`) delivers to one consumer and produces exactly one response; prefer it for command→result chaining unless you intend scatter-gather (correlate the fan-in via `CorrelationId` / `CorrelationSequence`).
 - **Strict publish tenancy is opt-in**: Use `builder.AddHeadlessTenancy(tenancy => tenancy.Messaging(m => m.PropagateTenant().RequireTenantOnPublish()))`. The previous `MessagingBuilder.AddTenantPropagation()` extension has been removed; the root tenancy seam is the single composition point. When neither `PublishOptions.TenantId` nor ambient `ICurrentTenant` is set, the publish wrapper throws `Headless.Abstractions.MissingTenantContextException`. See [Strict Publish Tenancy](#strict-publish-tenancy) and the multi-tenancy doc's [Message Consumers](multi-tenancy.md#message-consumers) section.
 - **Retry behavior is configured via `MessagingOptions.RetryPolicy`**. `RetryStrategy` is a public Polly `RetryStrategyOptions` contract; `MaxPersistedRetries`, durable scheduling, leases, and terminal callbacks remain Messaging-owned. Configure `ShouldHandle` explicitly. `OnExhausted` fires only after a matched failure consumes the complete budget and the owned terminal write succeeds.
@@ -1027,7 +1027,7 @@ Enables automatic discovery and monitoring of messaging nodes in Kubernetes clus
 
 ### Key Features
 
-- Kubernetes service and namespace discovery.
+- Kubernetes Service discovery restricted to the configured namespace.
 - `UseK8sDiscovery(...)` extension.
 
 ### Installation
@@ -1046,8 +1046,10 @@ services.AddHeadlessMessaging(setup => setup.UseK8sDiscovery());
 
 Configure `K8sDiscoveryOptions` through `UseK8sDiscovery(...)`:
 
-- `K8sClientConfig` — Kubernetes client configuration used to query the cluster. Defaults to `KubernetesClientConfiguration.BuildDefaultConfig()`.
+- `K8sClientConfig` — Kubernetes client configuration used to query the cluster. Defaults to `KubernetesClientConfiguration.BuildDefaultConfig()`. Its configured namespace is the only namespace eligible for dashboard discovery and proxy selection; discovery fails closed when no namespace is configured.
 - `ShowOnlyExplicitVisibleNodes` — when `true` (default), only Services labeled `headless.messaging.visibility:show` are listed as visible dashboard nodes. Set to `false` to show all discovered Services.
+
+The dashboard stores the selected Service name rather than a client-composed endpoint. The server resolves that name in the configured namespace and reuses the list's visibility and port-label rules before forwarding. Invalid, hidden, cross-namespace, and stale selections are cleared.
 
 ### Dependencies
 
@@ -1057,8 +1059,8 @@ Configure `K8sDiscoveryOptions` through `UseK8sDiscovery(...)`:
 ### Side Effects
 
 - Registers a Kubernetes-backed node discovery provider.
-- Queries the Kubernetes API for Services and namespaces.
-- Requires RBAC permissions to read Services and namespaces.
+- Queries the Kubernetes API for Services in the configured namespace.
+- Requires RBAC permissions to read Services in the configured namespace.
 
 ## OpenTelemetry (native, in Headless.Messaging.Core)
 

--- a/src/Headless.Messaging.Dashboard.K8s/K8sNodeDiscoveryProvider.cs
+++ b/src/Headless.Messaging.Dashboard.K8s/K8sNodeDiscoveryProvider.cs
@@ -26,21 +26,20 @@ public class K8sNodeDiscoveryProvider(ILoggerFactory logger, IMemoryCache cache,
         CancellationToken cancellationToken = default
     )
     {
+        var resolvedNamespace = _ResolveNamespace(ns);
+        if (resolvedNamespace == null)
+        {
+            return null;
+        }
+
         try
         {
             using var client = new Kubernetes(options.K8sClientConfig);
             var service = await client
-                .CoreV1.ReadNamespacedServiceAsync(nodeName, ns, cancellationToken: cancellationToken)
+                .CoreV1.ReadNamespacedServiceAsync(nodeName, resolvedNamespace, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
-            return new Node
-            {
-                Id = service.Uid(),
-                Name = service.Name(),
-                Address = "http://" + service.Metadata.Name + "." + ns,
-                Port = service.Spec.Ports?[0].Port ?? 0,
-                Tags = string.Join(',', service.Labels()?.Select(x => x.Key + ":" + x.Value) ?? []),
-            };
+            return _MapService(service, resolvedNamespace);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -58,14 +57,13 @@ public class K8sNodeDiscoveryProvider(ILoggerFactory logger, IMemoryCache cache,
     {
         try
         {
-            ns ??= options.K8sClientConfig.Namespace;
-
-            if (ns == null)
+            var resolvedNamespace = _ResolveNamespace(ns);
+            if (resolvedNamespace == null)
             {
                 return [];
             }
 
-            var nodes = await _ListServices(ns, cancellationToken).ConfigureAwait(false);
+            var nodes = await _ListServices(resolvedNamespace, cancellationToken).ConfigureAwait(false);
 
             cache.Set("messaging.nodes.count", nodes.Count, TimeSpan.FromSeconds(60));
 
@@ -85,33 +83,14 @@ public class K8sNodeDiscoveryProvider(ILoggerFactory logger, IMemoryCache cache,
         }
     }
 
-    public async Task<List<string>> GetNamespacesAsync(CancellationToken cancellationToken = default)
+    public Task<List<string>> GetNamespacesAsync(CancellationToken cancellationToken = default)
     {
-        using var client = new Kubernetes(options.K8sClientConfig);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        try
-        {
-            var namespaces = await client
-                .ListNamespaceAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+        var configuredNamespace = _ResolveNamespace(null);
+        List<string> namespaces = configuredNamespace == null ? [] : [configuredNamespace];
 
-            return [.. namespaces.Items.Select(x => x.Name())];
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-#pragma warning disable ERP022
-        catch (Exception)
-        {
-            if (string.IsNullOrEmpty(options.K8sClientConfig.Namespace))
-            {
-                return [];
-            }
-
-            return [options.K8sClientConfig.Namespace];
-        }
-#pragma warning restore ERP022
+        return Task.FromResult(namespaces);
     }
 
     public Task<IList<Node>> ListServicesAsync(string? ns = null, CancellationToken cancellationToken = default)
@@ -121,38 +100,69 @@ public class K8sNodeDiscoveryProvider(ILoggerFactory logger, IMemoryCache cache,
 
     private async Task<IList<Node>> _ListServices(string? ns, CancellationToken cancellationToken)
     {
+        var resolvedNamespace = _ResolveNamespace(ns);
+        if (resolvedNamespace == null)
+        {
+            return [];
+        }
+
         using var client = new Kubernetes(options.K8sClientConfig);
         var services = await client
-            .CoreV1.ListNamespacedServiceAsync(ns, cancellationToken: cancellationToken)
+            .CoreV1.ListNamespacedServiceAsync(resolvedNamespace, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         var result = new List<Node>();
         foreach (var service in services.Items)
         {
-            IDictionary<string, string> tags = service.Labels();
-
-            var filterResult = _FilterNodesByTags(tags);
-
-            if (filterResult.HideNode)
+            var node = _MapService(service, resolvedNamespace);
+            if (node == null)
             {
                 continue;
             }
 
-            var port = _GetPortByNameOrIndex(service, filterResult.FilteredPortName, filterResult.FilteredPortIndex);
-
-            result.Add(
-                new Node
-                {
-                    Id = service.Uid(),
-                    Name = service.Name(),
-                    Address = "http://" + service.Metadata.Name + "." + ns,
-                    Port = port,
-                    Tags = string.Join(',', service.Labels()?.Select(x => x.Key + ":" + x.Value) ?? []),
-                }
-            );
+            result.Add(node);
         }
 
         return result;
+    }
+
+    private string? _ResolveNamespace(string? requestedNamespace)
+    {
+        var configuredNamespace = options.K8sClientConfig.Namespace;
+        if (string.IsNullOrWhiteSpace(configuredNamespace))
+        {
+            return null;
+        }
+
+        if (
+            requestedNamespace != null
+            && !string.Equals(requestedNamespace, configuredNamespace, StringComparison.Ordinal)
+        )
+        {
+            return null;
+        }
+
+        return configuredNamespace;
+    }
+
+    private Node? _MapService(V1Service service, string ns)
+    {
+        var filterResult = _FilterNodesByTags(service.Labels());
+        if (filterResult.HideNode)
+        {
+            return null;
+        }
+
+        var port = _GetPortByNameOrIndex(service, filterResult.FilteredPortName, filterResult.FilteredPortIndex);
+
+        return new Node
+        {
+            Id = service.Uid(),
+            Name = service.Name(),
+            Address = "http://" + service.Metadata.Name + "." + ns,
+            Port = port,
+            Tags = string.Join(',', service.Labels()?.Select(x => x.Key + ":" + x.Value) ?? []),
+        };
     }
 
     /// <summary>
@@ -264,7 +274,13 @@ public class K8sNodeDiscoveryProvider(ILoggerFactory logger, IMemoryCache cache,
                 return new TagFilterResult(HideNode: true, filteredPortIndex, filteredPortName);
             }
 
-            isNodeHidden = false;
+            if (
+                messagingTagScope.Equals("visibility", StringComparison.OrdinalIgnoreCase)
+                && tag.Value.Equals("show", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                isNodeHidden = false;
+            }
 
             //check for portIndex-X tag.
             //If multiple tags with portIndex are found only the last has power

--- a/src/Headless.Messaging.Dashboard.K8s/README.md
+++ b/src/Headless.Messaging.Dashboard.K8s/README.md
@@ -71,8 +71,10 @@ setup.UseK8sDiscovery(k8s =>
 });
 ```
 
-- `K8sClientConfig` — Kubernetes client configuration used to query the cluster. Defaults to `KubernetesClientConfiguration.BuildDefaultConfig()`.
+- `K8sClientConfig` — Kubernetes client configuration used to query the cluster. Defaults to `KubernetesClientConfiguration.BuildDefaultConfig()`. Its configured namespace is the only namespace eligible for dashboard discovery and proxy selection. Discovery fails closed when no namespace is configured.
 - `ShowOnlyExplicitVisibleNodes` — when `true` (default), only Services labeled `headless.messaging.visibility:show` appear in the dashboard node list. Set it to `false` to list all services returned from the configured namespace.
+
+The dashboard stores the selected Service name, not a client-composed endpoint. Before forwarding a request, the server resolves that name again in the configured namespace and applies the same visibility and port-label rules used by the node list. Invalid, hidden, cross-namespace, and stale selections are cleared.
 
 ## Dependencies
 
@@ -82,5 +84,5 @@ setup.UseK8sDiscovery(k8s =>
 ## Side Effects
 
 - Queries Kubernetes API for Services
-- Requires appropriate RBAC permissions (read services/namespaces)
+- Requires appropriate RBAC permissions to read Services in the configured namespace
 - Periodically polls for cluster topology changes

--- a/src/Headless.Messaging.Dashboard/DashboardOptionsExtensions.cs
+++ b/src/Headless.Messaging.Dashboard/DashboardOptionsExtensions.cs
@@ -3,9 +3,11 @@
 using Headless.Checks;
 using Headless.Dashboard.Authentication;
 using Headless.Messaging.Configuration;
+using Headless.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Headless.Messaging.Dashboard;
 
@@ -36,6 +38,13 @@ internal sealed class DashboardOptionsExtension(Action<MessagingDashboardOptions
 
         services.AddSingleton<MessagingMetricsEventListener>();
         services.AddMemoryCache();
+        services.TryAddSingleton<KeyedAsyncLock>();
+        services
+            .AddHttpClient(
+                MessagingDashboardEndpoints.PingHttpClientName,
+                static client => client.Timeout = TimeSpan.FromSeconds(5)
+            )
+            .ConfigurePrimaryHttpMessageHandler(static () => new HttpClientHandler { AllowAutoRedirect = false });
 
         services.AddRouting();
         services.AddAuthorization();

--- a/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
+++ b/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Headless.Dashboard.Authentication;
 using Headless.Messaging.Configuration;
@@ -14,6 +15,7 @@ using Headless.Messaging.Transport;
 using Headless.Primitives;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +25,7 @@ namespace Headless.Messaging.Dashboard;
 
 public static class MessagingDashboardEndpoints
 {
+    internal const string PingHttpClientName = "Headless.Messaging.Dashboard.Ping";
     private const int _MaxPageSize = 200;
     private const int _MaxBulkActionSize = 500;
 
@@ -53,14 +56,6 @@ public static class MessagingDashboardEndpoints
             .MapGet("/api/health", _Health)
             .WithName("Messaging_Health")
             .WithSummary("Health check endpoint")
-            .WithTags("Messaging Dashboard")
-            .RequireCors("HeadlessMessagingDashboardCORS")
-            .AllowAnonymous();
-
-        endpoints
-            .MapGet("/api/ping", _PingServices)
-            .WithName("Messaging_PingServices")
-            .WithSummary("Ping a registered node to measure latency")
             .WithTags("Messaging Dashboard")
             .RequireCors("HeadlessMessagingDashboardCORS")
             .AllowAnonymous();
@@ -158,11 +153,15 @@ public static class MessagingDashboardEndpoints
             .MapGet("/list-svc/{namespace}", _ListServices)
             .WithName("Messaging_ListServices")
             .WithSummary("List services in a namespace");
+        apiGroup
+            .MapGet("/ping", _PingServices)
+            .WithName("Messaging_PingServices")
+            .WithSummary("Ping a registered node to measure latency");
     }
 
     #region Endpoint Handlers
 
-    private static IResult _GetAuthInfo(IAuthService authService)
+    private static IResult _GetAuthInfo([FromServices] IAuthService authService)
     {
         var authInfo = authService.GetAuthInfo();
         return Results.Json(
@@ -175,7 +174,7 @@ public static class MessagingDashboardEndpoints
         );
     }
 
-    private static async Task<IResult> _ValidateAuth(HttpContext context, IAuthService authService)
+    private static async Task<IResult> _ValidateAuth(HttpContext context, [FromServices] IAuthService authService)
     {
         var authResult = await authService.AuthenticateAsync(context).ConfigureAwait(false);
 
@@ -742,8 +741,8 @@ public static class MessagingDashboardEndpoints
     private static async Task<IResult> _PingServices(
         string? endpoint,
         IServiceProvider sp,
-        IHttpClientFactory httpClientFactory,
-        MessagingDashboardOptionsBuilder config,
+        [FromServices] IHttpClientFactory httpClientFactory,
+        [FromServices] MessagingDashboardOptionsBuilder config,
         HttpContext httpContext
     )
     {
@@ -761,29 +760,20 @@ public static class MessagingDashboardEndpoints
         var nodes = await discoveryProvider
             .GetNodesAsync(cancellationToken: httpContext.RequestAborted)
             .ConfigureAwait(false);
-        var isRegistered = nodes.Any(n =>
-            endpoint.StartsWith(
-                string.Create(CultureInfo.InvariantCulture, $"http://{n.Address}:{n.Port}"),
-                StringComparison.OrdinalIgnoreCase
-            )
-            || endpoint.StartsWith(
-                string.Create(CultureInfo.InvariantCulture, $"https://{n.Address}:{n.Port}"),
-                StringComparison.OrdinalIgnoreCase
-            )
-        );
-
-        if (!isRegistered)
+        if (!_TryGetRegisteredOrigin(endpoint, nodes, out var registeredOrigin))
         {
             return Results.StatusCode(StatusCodes.Status403Forbidden);
         }
 
-        using var httpClient = httpClientFactory.CreateClient();
+        using var httpClient = httpClientFactory.CreateClient(PingHttpClientName);
         var sw = new Stopwatch();
         try
         {
             sw.Restart();
-            var healthEndpoint = endpoint + config.BasePath + "/api/health";
-            var response = await httpClient.GetStringAsync(healthEndpoint).ConfigureAwait(false);
+            var healthEndpoint = _BuildHealthEndpoint(registeredOrigin, config.BasePath);
+            var response = await httpClient
+                .GetStringAsync(healthEndpoint, httpContext.RequestAborted)
+                .ConfigureAwait(false);
             sw.Stop();
 
             if (string.Equals(response, "OK", StringComparison.Ordinal))
@@ -794,8 +784,17 @@ public static class MessagingDashboardEndpoints
             return Results.StatusCode(501);
         }
         catch (HttpRequestException e)
+            when (e.StatusCode is >= HttpStatusCode.MultipleChoices and < HttpStatusCode.BadRequest)
+        {
+            return Results.StatusCode(StatusCodes.Status502BadGateway);
+        }
+        catch (HttpRequestException e)
         {
             return Results.StatusCode((int)(e.StatusCode ?? HttpStatusCode.BadGateway));
+        }
+        catch (OperationCanceledException) when (httpContext.RequestAborted.IsCancellationRequested)
+        {
+            throw;
         }
 #pragma warning disable ERP022 // Dashboard health probe should return gateway failure for unexpected probe exceptions.
         catch
@@ -803,6 +802,113 @@ public static class MessagingDashboardEndpoints
             return Results.StatusCode((int)HttpStatusCode.BadGateway);
         }
 #pragma warning restore ERP022
+    }
+
+    private static bool _TryGetRegisteredOrigin(
+        string endpoint,
+        IEnumerable<Node> nodes,
+        [NotNullWhen(true)] out Uri? origin
+    )
+    {
+        origin = null;
+        if (!_TryCreateOrigin(endpoint, out var requestedOrigin))
+        {
+            return false;
+        }
+
+        foreach (var node in nodes)
+        {
+            if (!_TryCreateNodeOrigin(node, out var nodeOrigin) || !_HasSameOrigin(requestedOrigin, nodeOrigin))
+            {
+                continue;
+            }
+
+            origin = requestedOrigin;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool _TryCreateOrigin(string value, [NotNullWhen(true)] out Uri? origin)
+    {
+        origin = null;
+        var valueSpan = value.AsSpan();
+        if (valueSpan.Contains('?') || valueSpan.Contains('#'))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var parsed))
+        {
+            return false;
+        }
+
+        if (
+            !parsed.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !parsed.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            return false;
+        }
+
+        if (
+            string.IsNullOrEmpty(parsed.Host)
+            || !string.IsNullOrEmpty(parsed.UserInfo)
+            || !string.Equals(parsed.AbsolutePath, "/", StringComparison.Ordinal)
+            || !string.IsNullOrEmpty(parsed.Query)
+            || !string.IsNullOrEmpty(parsed.Fragment)
+        )
+        {
+            return false;
+        }
+
+        origin = parsed;
+        return true;
+    }
+
+    private static bool _TryCreateNodeOrigin(Node node, [NotNullWhen(true)] out Uri? origin)
+    {
+        var address = node.Address.Contains(Uri.SchemeDelimiter, StringComparison.Ordinal)
+            ? node.Address
+            : Uri.UriSchemeHttp + Uri.SchemeDelimiter + node.Address;
+
+        if (!_TryCreateOrigin(address, out var parsed))
+        {
+            origin = null;
+            return false;
+        }
+
+        if (node.Port <= 0)
+        {
+            origin = parsed;
+            return true;
+        }
+
+        origin = new UriBuilder(parsed) { Port = node.Port }.Uri;
+        return true;
+    }
+
+    private static bool _HasSameOrigin(Uri left, Uri right)
+    {
+        return left.Scheme.Equals(right.Scheme, StringComparison.OrdinalIgnoreCase)
+            && left.IdnHost.Equals(right.IdnHost, StringComparison.OrdinalIgnoreCase)
+            && left.Port == right.Port;
+    }
+
+    private static Uri _BuildHealthEndpoint(Uri origin, string basePath)
+    {
+        var normalizedBasePath = DashboardSpaHelper.NormalizeBasePath(basePath);
+        var healthPath = string.Equals(normalizedBasePath, "/", StringComparison.Ordinal)
+            ? "/api/health"
+            : normalizedBasePath + "/api/health";
+
+        return new UriBuilder(origin)
+        {
+            Path = healthPath,
+            Query = string.Empty,
+            Fragment = string.Empty,
+        }.Uri;
     }
 
     #endregion

--- a/src/Headless.Messaging.Dashboard/GatewayProxy/GatewayProxyAgent.cs
+++ b/src/Headless.Messaging.Dashboard/GatewayProxy/GatewayProxyAgent.cs
@@ -2,6 +2,7 @@
 
 using System.Net;
 using Headless.Messaging.Dashboard.NodeDiscovery;
+using Headless.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,8 +23,9 @@ internal sealed class GatewayProxyAgent(
     IHttpClientFactory httpClientFactory,
     IMemoryCache cache,
     IServiceProvider serviceProvider,
-    INodeDiscoveryProvider discoveryProvider
-)
+    INodeDiscoveryProvider discoveryProvider,
+    KeyedAsyncLock? keyedLock = null
+) : IDisposable
 {
     /// <summary>Cookie name that carries the target node's service name.</summary>
     public const string CookieNodeName = "messaging.node";
@@ -33,6 +35,8 @@ internal sealed class GatewayProxyAgent(
 
     private readonly ConsulDiscoveryOptions? _consulDiscoveryOptions =
         serviceProvider.GetService<ConsulDiscoveryOptions>();
+    private readonly KeyedAsyncLock _keyedLock = keyedLock ?? new KeyedAsyncLock();
+    private readonly bool _ownsKeyedLock = keyedLock is null;
     private readonly ILogger _logger = loggerFactory.CreateLogger<GatewayProxyAgent>();
 
     /// <summary>
@@ -64,20 +68,23 @@ internal sealed class GatewayProxyAgent(
         Node? node;
         if (_consulDiscoveryOptions == null) // it's k8s
         {
-            if (request.Cookies.TryGetValue(CookieNodeNsName, out var ns))
+            request.Cookies.TryGetValue(CookieNodeNsName, out var ns);
+            var cacheKey = $"messaging.gateway.k8s\0{requestNodeName}\0{ns}";
+            if (!cache.TryGetValue(cacheKey, out node))
             {
-                var cacheKey = $"{requestNodeName}\0{ns}";
-                if (!cache.TryGetValue(cacheKey, out node))
+                using (await _keyedLock.LockAsync(cacheKey, context.RequestAborted).ConfigureAwait(false))
                 {
-                    node = await discoveryProvider
-                        .GetNodeAsync(requestNodeName, ns, context.RequestAborted)
-                        .ConfigureAwait(false);
-                    cache.Set(cacheKey, node);
+                    if (!cache.TryGetValue(cacheKey, out node))
+                    {
+                        node = await discoveryProvider
+                            .GetNodeAsync(requestNodeName, ns, context.RequestAborted)
+                            .ConfigureAwait(false);
+                        if (node != null)
+                        {
+                            cache.Set(cacheKey, node, TimeSpan.FromSeconds(30));
+                        }
+                    }
                 }
-            }
-            else
-            {
-                return false;
             }
         }
         else
@@ -130,9 +137,21 @@ internal sealed class GatewayProxyAgent(
         else
         {
             context.Response.Cookies.Delete(CookieNodeName);
+            if (_consulDiscoveryOptions == null)
+            {
+                context.Response.Cookies.Delete(CookieNodeNsName);
+            }
         }
 
         return false;
+    }
+
+    public void Dispose()
+    {
+        if (_ownsKeyedLock)
+        {
+            _keyedLock.Dispose();
+        }
     }
 
     private static async Task _SetResponseOnHttpContext(

--- a/src/Headless.Messaging.Dashboard/wwwroot/src/views/Nodes.vue
+++ b/src/Headless.Messaging.Dashboard/wwwroot/src/views/Nodes.vue
@@ -171,15 +171,14 @@ const namespaces = ref<string[]>([])
 const selectedNamespace = ref<string | null>(getCookie('messaging.node.ns'))
 
 // --- Active node ---
-function getActiveNodeEndpoint(): string | null {
+function getActiveNodeName(): string | null {
   return getCookie('messaging.node')
 }
 
 function isActiveNode(node: NodeInfo): boolean {
-  const active = getActiveNodeEndpoint()
+  const active = getActiveNodeName()
   if (!active) return false
-  const nodeEndpoint = `${node.address}:${node.port}`
-  return active === nodeEndpoint
+  return active === node.name
 }
 
 // --- Namespace loading ---
@@ -283,8 +282,7 @@ async function pingAll() {
 
 // --- Switch node ---
 function switchToNode(node: NodeInfo) {
-  const endpoint = `${node.address}:${node.port}`
-  setCookie('messaging.node', endpoint)
+  setCookie('messaging.node', node.name)
   if (selectedNamespace.value) {
     setCookie('messaging.node.ns', selectedNamespace.value)
   }

--- a/tests/Headless.Messaging.Dashboard.K8s.Tests.Unit/K8sNodeDiscoveryProviderTests.cs
+++ b/tests/Headless.Messaging.Dashboard.K8s.Tests.Unit/K8sNodeDiscoveryProviderTests.cs
@@ -348,6 +348,139 @@ public sealed class K8sNodeDiscoveryProviderTests : TestBase
 
     #endregion
 
+    #region Service Mapping Tests
+
+    [Fact]
+    public void should_map_visible_service_with_label_selected_port()
+    {
+        // given
+        var service = _CreateService(
+            labels: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["headless.messaging.visibility"] = "show",
+                ["headless.messaging.portName"] = "dashboard",
+            }
+        );
+
+        // when
+        var node = _InvokeMapService(service, "team-a");
+
+        // then
+        node.Should().NotBeNull();
+        node!.Name.Should().Be("messaging-api");
+        node.Address.Should().Be("http://messaging-api.team-a");
+        node.Port.Should().Be(9090);
+    }
+
+    [Fact]
+    public void should_reject_hidden_service_when_mapping_direct_lookup()
+    {
+        // given
+        var service = _CreateService(
+            labels: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["headless.messaging.visibility"] = "hide",
+            }
+        );
+
+        // when
+        var node = _InvokeMapService(service, "team-a");
+
+        // then
+        node.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_reject_service_without_explicit_visibility_when_port_label_exists()
+    {
+        // given
+        var service = _CreateService(
+            labels: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["headless.messaging.portName"] = "dashboard",
+            }
+        );
+
+        // when
+        var node = _InvokeMapService(service, "team-a");
+
+        // then
+        node.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_map_unlabelled_service_when_show_only_is_disabled()
+    {
+        // given
+        _options.ShowOnlyExplicitVisibleNodes = false;
+        var service = _CreateService(labels: null);
+
+        // when
+        var node = _InvokeMapService(service, "team-a");
+
+        // then
+        node.Should().NotBeNull();
+        node!.Port.Should().Be(8080);
+    }
+
+    #endregion
+
+    #region Namespace Boundary Tests
+
+    [Fact]
+    public void should_default_to_configured_namespace_when_request_omits_namespace()
+    {
+        // given
+        _options.K8sClientConfig.Namespace = "team-a";
+
+        // when
+        var result = _InvokeResolveNamespace(null);
+
+        // then
+        result.Should().Be("team-a");
+    }
+
+    [Fact]
+    public void should_reject_cross_namespace_request()
+    {
+        // given
+        _options.K8sClientConfig.Namespace = "team-a";
+
+        // when
+        var result = _InvokeResolveNamespace("team-b");
+
+        // then
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_return_only_configured_namespace()
+    {
+        // given
+        _options.K8sClientConfig.Namespace = "team-a";
+
+        // when
+        var result = await _provider.GetNamespacesAsync(AbortToken);
+
+        // then
+        result.Should().ContainSingle().Which.Should().Be("team-a");
+    }
+
+    [Fact]
+    public async Task should_fail_closed_when_namespace_is_not_configured()
+    {
+        // given
+        _options.K8sClientConfig.Namespace = null!;
+
+        // when
+        var result = await _provider.GetNamespacesAsync(AbortToken);
+
+        // then
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
     #region Provider Interface Tests
 
     [Fact]
@@ -412,6 +545,53 @@ public sealed class K8sNodeDiscoveryProviderTests : TestBase
         );
 
         return (string)method!.Invoke(null, [tag])!;
+    }
+
+    private Node? _InvokeMapService(V1Service service, string ns)
+    {
+        var method = typeof(K8sNodeDiscoveryProvider).GetMethod(
+            "_MapService",
+            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+            null,
+            [typeof(V1Service), typeof(string)],
+            null
+        );
+
+        return (Node?)method!.Invoke(_provider, [service, ns]);
+    }
+
+    private string? _InvokeResolveNamespace(string? requestedNamespace)
+    {
+        var method = typeof(K8sNodeDiscoveryProvider).GetMethod(
+            "_ResolveNamespace",
+            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+            null,
+            [typeof(string)],
+            null
+        );
+
+        return (string?)method!.Invoke(_provider, [requestedNamespace]);
+    }
+
+    private static V1Service _CreateService(IDictionary<string, string>? labels)
+    {
+        return new V1Service
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = "messaging-api",
+                Uid = "service-id",
+                Labels = labels,
+            },
+            Spec = new V1ServiceSpec
+            {
+                Ports =
+                [
+                    new V1ServicePort { Name = "http", Port = 8080 },
+                    new V1ServicePort { Name = "dashboard", Port = 9090 },
+                ],
+            },
+        };
     }
 
     #endregion

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/GatewayProxy/GatewayProxyAgentTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/GatewayProxy/GatewayProxyAgentTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using System.Net.Http.Headers;
 using Headless.Messaging.Dashboard.GatewayProxy;
 using Headless.Messaging.Dashboard.NodeDiscovery;
 using Headless.Testing.Tests;
+using Headless.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -155,13 +157,189 @@ public sealed class GatewayProxyAgentTests : TestBase
         result.Should().BeFalse();
     }
 
-    // NOTE: K8s mode tests are not implemented because GatewayProxyAgent uses
-    // GetRequiredService<ConsulDiscoveryOptions>() in a field initializer, which throws if the
-    // service isn't registered. The K8s mode code path expects _consulDiscoveryOptions to be
-    // null when Consul options are not configured, but this can never happen with the current
-    // initialization approach.
-    // Pending: Update GatewayProxyAgent initialization (e.g. avoid GetRequiredService in field initializers)
-    //       so that K8s mode (no ConsulDiscoveryOptions registered) can be exercised and tested.
+    [Fact]
+    public async Task should_resolve_k8s_node_without_namespace_cookie()
+    {
+        // given
+        var context = _CreateHttpContext();
+        context.Request.Headers.Cookie = $"{GatewayProxyAgent.CookieNodeName}=node1";
+
+        var node = new Node
+        {
+            Id = "1",
+            Name = "node1",
+            Address = "http://node1.team-a",
+            Port = 8080,
+            Tags = "headless.messaging.visibility:show",
+        };
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider
+            .GetNodeAsync("node1", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Node?>(node));
+
+        using var handler = new MockHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("OK") }
+        );
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        using var httpClient = new HttpClient(handler);
+        httpClientFactory.CreateClient("GatewayProxy").Returns(httpClient);
+        var agent = _CreateAgent(context, discoveryProvider, httpClientFactory, useK8s: true);
+
+        // when
+        var result = await agent.Invoke(context);
+
+        // then
+        result.Should().BeTrue();
+        await discoveryProvider.Received(1).GetNodeAsync("node1", null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_clear_k8s_selection_when_cross_namespace_node_is_rejected()
+    {
+        // given
+        var context = _CreateHttpContext();
+        context.Request.Headers.Cookie =
+            $"{GatewayProxyAgent.CookieNodeName}=node1; {GatewayProxyAgent.CookieNodeNsName}=team-b";
+
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider
+            .GetNodeAsync("node1", "team-b", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Node?>(null));
+        var requestMapper = Substitute.For<IRequestMapper>();
+        var agent = _CreateAgent(context, discoveryProvider, useK8s: true, requestMapper: requestMapper);
+
+        // when
+        var result = await agent.Invoke(context);
+
+        // then
+        result.Should().BeFalse();
+        await requestMapper.DidNotReceive().Map(Arg.Any<HttpRequest>());
+        context.Response.Headers.SetCookie.ToString().Should().Contain($"{GatewayProxyAgent.CookieNodeName}=");
+        context.Response.Headers.SetCookie.ToString().Should().Contain($"{GatewayProxyAgent.CookieNodeNsName}=");
+    }
+
+    [Fact]
+    public async Task should_clear_endpoint_shaped_k8s_selection_without_forwarding()
+    {
+        // given
+        var context = _CreateHttpContext();
+        const string endpoint = "http://evil.test:8080";
+        context.Request.Headers.Cookie =
+            $"{GatewayProxyAgent.CookieNodeName}={Uri.EscapeDataString(endpoint)}; {GatewayProxyAgent.CookieNodeNsName}=team-a";
+
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider
+            .GetNodeAsync(endpoint, "team-a", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Node?>(null));
+        var requestMapper = Substitute.For<IRequestMapper>();
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var agent = _CreateAgent(
+            context,
+            discoveryProvider,
+            httpClientFactory,
+            useK8s: true,
+            requestMapper: requestMapper
+        );
+
+        // when
+        var result = await agent.Invoke(context);
+
+        // then
+        result.Should().BeFalse();
+        await requestMapper.DidNotReceive().Map(Arg.Any<HttpRequest>());
+        httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task should_preserve_authorization_only_after_k8s_node_is_discovered()
+    {
+        // given
+        var context = _CreateHttpContext();
+        context.Request.Headers.Cookie = $"{GatewayProxyAgent.CookieNodeName}=node1";
+
+        var node = new Node
+        {
+            Id = "1",
+            Name = "node1",
+            Address = "http://node1.team-a",
+            Port = 8080,
+            Tags = "headless.messaging.visibility:show",
+        };
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider
+            .GetNodeAsync("node1", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Node?>(node));
+
+        var requestMapper = Substitute.For<IRequestMapper>();
+        requestMapper
+            .Map(Arg.Any<HttpRequest>())
+            .Returns(
+                Task.FromResult(
+                    new HttpRequestMessage(HttpMethod.Get, "http://example.com")
+                    {
+                        Headers = { Authorization = new AuthenticationHeaderValue("Bearer", "dashboard-token") },
+                    }
+                )
+            );
+
+        using var handler = new MockHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("OK") }
+        );
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        using var httpClient = new HttpClient(handler);
+        httpClientFactory.CreateClient("GatewayProxy").Returns(httpClient);
+        var agent = _CreateAgent(
+            context,
+            discoveryProvider,
+            httpClientFactory,
+            useK8s: true,
+            requestMapper: requestMapper
+        );
+
+        // when
+        var result = await agent.Invoke(context);
+
+        // then
+        result.Should().BeTrue();
+        handler.Request.Should().NotBeNull();
+        handler.Request!.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        handler.Request.Headers.Authorization.Parameter.Should().Be("dashboard-token");
+    }
+
+    [Fact]
+    public async Task should_share_one_k8s_lookup_across_concurrent_cache_misses()
+    {
+        var firstContext = _CreateHttpContext();
+        var secondContext = _CreateHttpContext();
+        firstContext.Request.Headers.Cookie = $"{GatewayProxyAgent.CookieNodeName}=node1";
+        secondContext.Request.Headers.Cookie = $"{GatewayProxyAgent.CookieNodeName}=node1";
+        var lookup = new TaskCompletionSource<Node?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider.GetNodeAsync("node1", null, Arg.Any<CancellationToken>()).Returns(lookup.Task);
+        var requestMapper = Substitute.For<IRequestMapper>();
+        requestMapper
+            .Map(Arg.Any<HttpRequest>())
+            .Returns(Task.FromException<HttpRequestMessage>(new HttpRequestException("stop after discovery")));
+        var agent = _CreateAgent(firstContext, discoveryProvider, useK8s: true, requestMapper: requestMapper);
+
+        var first = agent.Invoke(firstContext);
+        var second = agent.Invoke(secondContext);
+        await discoveryProvider.Received(1).GetNodeAsync("node1", null, Arg.Any<CancellationToken>());
+
+        lookup.SetResult(
+            new Node
+            {
+                Id = "1",
+                Name = "node1",
+                Address = "http://node1.team-a",
+                Port = 8080,
+                Tags = "headless.messaging.visibility:show",
+            }
+        );
+
+        await Task.WhenAll(first, second);
+        await discoveryProvider.Received(1).GetNodeAsync("node1", null, Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public void should_be_defined_when_cookie_node_name()
@@ -181,39 +359,54 @@ public sealed class GatewayProxyAgentTests : TestBase
         HttpContext context,
         INodeDiscoveryProvider? discoveryProvider = null,
         IHttpClientFactory? httpClientFactory = null,
-        string? nodeName = null
+        string? nodeName = null,
+        bool useK8s = false,
+        IRequestMapper? requestMapper = null
     )
     {
         discoveryProvider ??= Substitute.For<INodeDiscoveryProvider>();
         httpClientFactory ??= Substitute.For<IHttpClientFactory>();
-        var requestMapper = Substitute.For<IRequestMapper>();
-        requestMapper
-            .Map(Arg.Any<HttpRequest>())
-            .Returns(_ =>
-            {
-                var downstreamRequest = new HttpRequestMessage(HttpMethod.Get, "http://example.com");
-                context.Response.RegisterForDispose(downstreamRequest);
+        if (requestMapper == null)
+        {
+            requestMapper = Substitute.For<IRequestMapper>();
+            requestMapper
+                .Map(Arg.Any<HttpRequest>())
+                .Returns(_ =>
+                {
+                    var downstreamRequest = new HttpRequestMessage(HttpMethod.Get, "http://example.com");
+                    context.Response.RegisterForDispose(downstreamRequest);
 
-                return Task.FromResult(downstreamRequest);
-            });
+                    return Task.FromResult(downstreamRequest);
+                });
+        }
 
         var services = new ServiceCollection()
             .AddLogging()
             .AddMemoryCache()
+            .AddSingleton<KeyedAsyncLock>()
             .AddSingleton(discoveryProvider)
             .AddSingleton(httpClientFactory)
             .AddSingleton(requestMapper);
 
-        // GatewayProxyAgent always uses GetRequiredService<ConsulDiscoveryOptions>() in field initializer
-        // For k8s mode simulation, we need to register it but the code checks if it's null internally
-        // which won't work with GetRequiredService. This is a design limitation in the source code.
-        services.AddSingleton(new ConsulDiscoveryOptions { NodeName = nodeName ?? "test-node" });
+        if (!useK8s)
+        {
+            services.AddSingleton(new ConsulDiscoveryOptions { NodeName = nodeName ?? "test-node" });
+        }
 
         var sp = services.BuildServiceProvider();
         context.RequestServices = sp;
 
         var cache = sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
-        return new GatewayProxyAgent(LoggerFactory, requestMapper, httpClientFactory, cache, sp, discoveryProvider);
+        var keyedLock = sp.GetRequiredService<KeyedAsyncLock>();
+        return new GatewayProxyAgent(
+            LoggerFactory,
+            requestMapper,
+            httpClientFactory,
+            cache,
+            sp,
+            discoveryProvider,
+            keyedLock
+        );
     }
 
     private sealed class MockHttpMessageHandler : HttpMessageHandler
@@ -225,11 +418,15 @@ public sealed class GatewayProxyAgentTests : TestBase
 
         public MockHttpMessageHandler(Exception exception) => _exception = exception;
 
+        public HttpRequestMessage? Request { get; private set; }
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken
         )
         {
+            Request = request;
+
             return _exception is not null
                 ? Task.FromException<HttpResponseMessage>(_exception)
                 : Task.FromResult(_response!);

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Security/AuthorizationTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Security/AuthorizationTests.cs
@@ -3,6 +3,11 @@
 using Headless.Dashboard.Authentication;
 using Headless.Messaging.Dashboard;
 using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Tests.Security;
 
@@ -68,15 +73,35 @@ public sealed class AuthorizationTests : TestBase
     }
 
     [Fact]
-    public void should_always_be_anonymous_when_ping_endpoint()
+    public async Task should_require_configured_host_policy_when_ping_endpoint()
     {
-        // The ping endpoint is always anonymous regardless of auth mode.
-        // In MessagingDashboardEndpoints: MapGet("/api/ping", _PingServices).AllowAnonymous()
+        // given
+        var config = new MessagingDashboardOptionsBuilder().WithHostAuthentication("AdminOnly");
+        await using var app = _CreateEndpointApp(config);
 
-        // SECURITY CONCERN: Anonymous access + potential SSRF
-        // Mitigated by validating endpoint against registered discovery nodes.
+        // when
+        var endpoint = _GetPingEndpoint(app);
+        var authorization = endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>();
 
-        true.Should().BeTrue("Ping endpoint allows anonymous access");
+        // then
+        authorization.Should().ContainSingle(data => data.Policy == "AdminOnly");
+        endpoint.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_remain_unprotected_when_ping_endpoint_uses_explicit_no_auth()
+    {
+        // given
+        var config = new MessagingDashboardOptionsBuilder().WithNoAuth();
+        await using var app = _CreateEndpointApp(config);
+
+        // when
+        var endpoint = _GetPingEndpoint(app);
+
+        // then
+        endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>().Should().BeEmpty();
+        config.AuthConfigured.Should().BeTrue();
+        config.Auth.Mode.Should().Be(AuthMode.None);
     }
 
     [Fact]
@@ -111,6 +136,7 @@ public sealed class AuthorizationTests : TestBase
         // GET  /api/nodes
         // GET  /api/list-ns
         // GET  /api/list-svc/{namespace}
+        // GET  /api/ping
 
         // When Host auth is configured, RequireAuthorization() is applied to the group.
         var builder = new MessagingDashboardOptionsBuilder().WithHostAuthentication("DashboardAdmin");
@@ -152,5 +178,35 @@ public sealed class AuthorizationTests : TestBase
         // In MessagingDashboardEndpoints: MapPost("/api/auth/validate", _ValidateAuth).AllowAnonymous()
 
         true.Should().BeTrue("Auth validate endpoint must be anonymous for login flow");
+    }
+
+    private static WebApplication _CreateEndpointApp(MessagingDashboardOptionsBuilder config)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Services.AddRouting();
+        builder.Services.AddAuthorization(options =>
+            options.AddPolicy("AdminOnly", policy => policy.RequireAssertion(_ => true))
+        );
+        builder.Services.AddCors(options =>
+            options.AddPolicy("HeadlessMessagingDashboardCORS", policy => policy.AllowAnyOrigin())
+        );
+
+        var app = builder.Build();
+        app.MapMessagingDashboardEndpoints(config);
+
+        return app;
+    }
+
+    private static Endpoint _GetPingEndpoint(WebApplication app)
+    {
+        return ((IEndpointRouteBuilder)app)
+            .DataSources.SelectMany(source => source.Endpoints)
+            .Single(endpoint =>
+                string.Equals(
+                    endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName,
+                    "Messaging_PingServices",
+                    StringComparison.Ordinal
+                )
+            );
     }
 }

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/Security/PingServicesSecurityTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/Security/PingServicesSecurityTests.cs
@@ -1,160 +1,258 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using System.Net;
+using Headless.Dashboard.Authentication;
 using Headless.Messaging.Dashboard;
+using Headless.Messaging.Dashboard.GatewayProxy;
+using Headless.Messaging.Dashboard.NodeDiscovery;
 using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
 
 namespace Tests.Security;
 
-/// <summary>
-/// <para>
-/// CRITICAL SECURITY TESTS: PingServices SSRF Prevention
-/// These tests document the current SSRF vulnerability in PingServices endpoint.
-/// The endpoint accepts an 'endpoint' query parameter and makes an HTTP request to it.
-/// </para>
-/// <para>
-/// MITIGATION: The refactored endpoint validates that the endpoint matches a registered
-/// discovery node before making the request. Unregistered endpoints return 403 Forbidden.
-/// </para>
-/// <para>
-/// REMAINING VULNERABILITY: The endpoint does not validate against internal IP ranges directly.
-/// If a node is registered with an internal IP, the endpoint will allow requests to it.
-/// </para>
-/// </summary>
 public sealed class PingServicesSecurityTests : TestBase
 {
-    private static readonly MessagingDashboardOptionsBuilder _DefaultBuilder = new();
-
-    // NOTE: These tests document the SSRF vulnerability.
-    // The current implementation validates against registered discovery nodes,
-    // but does NOT reject requests to internal IP ranges if registered.
+    private static readonly Node _RegisteredNode = new()
+    {
+        Id = "node-id",
+        Name = "allowed",
+        Address = "allowed",
+        Port = 8080,
+        Tags = "messaging",
+    };
 
     [Theory]
-    [InlineData("http://10.0.0.1")]
-    [InlineData("http://10.255.255.255")]
-    [InlineData("http://10.0.0.1:8080")]
-    public void should_reject_internal_ip_10_range_when_ping_services(string endpoint)
+    [InlineData("http://allowed:8080")]
+    [InlineData("http://allowed:8080/")]
+    public async Task should_ping_exact_registered_origin(string endpoint)
     {
-        // This test documents that 10.x.x.x addresses should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected if registered as nodes
-        _AssertInternalAddressShouldBeRejected(endpoint);
+        // given
+        using var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("OK"),
+        });
+        var factory = new StubHttpClientFactory(handler);
+        await using var app = _CreateTestApp([_RegisteredNode], factory);
+        await app.StartAsync(AbortToken);
+        using var client = app.GetTestClient();
+
+        // when
+        var response = await client.GetAsync($"/api/ping?endpoint={Uri.EscapeDataString(endpoint)}", AbortToken);
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].Should().Be(new Uri("http://allowed:8080/messaging/api/health"));
+        handler.CancellationTokens.Should().ContainSingle(token => token.CanBeCanceled);
+        factory
+            .RequestedNames.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(MessagingDashboardEndpoints.PingHttpClientName);
     }
 
-    [Theory]
-    [InlineData("http://172.16.0.1")]
-    [InlineData("http://172.31.255.255")]
-    [InlineData("http://172.20.10.5:3000")]
-    public void should_reject_internal_ip_172_range_when_ping_services(string endpoint)
-    {
-        // This test documents that 172.16-31.x.x addresses should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected if registered as nodes
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    [Theory]
-    [InlineData("http://192.168.0.1")]
-    [InlineData("http://192.168.255.255")]
-    [InlineData("http://192.168.1.100:443")]
-    public void should_reject_internal_ip_192_168_range_when_ping_services(string endpoint)
-    {
-        // This test documents that 192.168.x.x addresses should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected if registered as nodes
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    [Theory]
-    [InlineData("http://127.0.0.1")]
-    [InlineData("http://127.0.0.1:8080")]
-    [InlineData("http://localhost")]
-    [InlineData("http://localhost:3000")]
-    [InlineData("http://[::1]")]
-    public void PingServices_should_reject_localhost(string endpoint)
-    {
-        // This test documents that localhost addresses should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected if registered as nodes
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    [Theory]
-    [InlineData("http://169.254.169.254")]
-    [InlineData("http://169.254.169.254/latest/meta-data")]
-    [InlineData("http://169.254.169.254/latest/user-data")]
-    public void should_reject_aws_metadata_endpoint_when_ping_services(string endpoint)
-    {
-        // This test documents that AWS/cloud metadata endpoints should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected
-        // This is especially critical as it can leak cloud credentials
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    [Theory]
-    [InlineData("http://169.254.0.1")]
-    [InlineData("http://169.254.255.255")]
-    public void should_reject_link_local_addresses_when_ping_services(string endpoint)
-    {
-        // This test documents that link-local addresses should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    [Theory]
-    [InlineData("http://0.0.0.0")]
-    [InlineData("http://0.0.0.0:8080")]
-    public void should_reject_zero_address_when_ping_services(string endpoint)
-    {
-        // This test documents that 0.0.0.0 should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    [Theory]
-    [InlineData("http://[fc00::1]")]
-    [InlineData("http://[fd00::1]")]
-    public void PingServices_should_reject_ipv6_private_addresses(string endpoint)
-    {
-        // This test documents that IPv6 private addresses should be rejected
-        // SSRF VULNERABILITY: Currently these are NOT rejected
-        _AssertInternalAddressShouldBeRejected(endpoint);
-    }
-
-    // Helper method to document the vulnerability
-    // When SSRF protection is implemented, these should actually test the rejection
-    private static void _AssertInternalAddressShouldBeRejected(string endpoint)
-    {
-        // Document that URL validation SHOULD occur
-        // The endpoint parameter comes from query string and is validated against
-        // registered discovery nodes before making HTTP requests.
-
-        // Parse the URL to show it's a valid URL that would be processed
-        var uri = new Uri(endpoint);
-
-        // The host should be validated against internal ranges
-        // Currently validation only checks against registered discovery nodes
-        uri.Host.Should().NotBeEmpty("URL is valid and would be processed without internal IP validation");
-
-        // When fixed, the _PingServices handler should:
-        // 1. Parse the endpoint URL
-        // 2. Resolve the hostname to IP address(es)
-        // 3. Check if any resolved IP is in internal/private ranges
-        // 4. Return 400 Bad Request if internal address detected
-        // 5. Include proper error message without leaking internal info
-    }
-
-    // Test to verify the current behavior
     [Fact]
-    public void ping_services_validates_endpoint_against_registered_nodes()
+    public async Task should_accept_default_https_port_for_registered_origin()
     {
-        // The _PingServices handler in MessagingDashboardEndpoints:
-        // 1. Reads 'endpoint' from query parameter
-        // 2. Checks if endpoint matches a registered discovery node address:port
-        // 3. Returns 403 Forbidden if not registered
-        // 4. Constructs health URL: endpoint + BasePath + "/api/health"
-        // 5. Calls HttpClient.GetStringAsync
+        // given
+        var node = new Node
+        {
+            Id = "node-id",
+            Name = "allowed",
+            Address = "https://allowed",
+            Port = 443,
+            Tags = "messaging",
+        };
+        using var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("OK"),
+        });
+        var factory = new StubHttpClientFactory(handler);
+        await using var app = _CreateTestApp([node], factory);
+        await app.StartAsync(AbortToken);
+        using var client = app.GetTestClient();
 
-        // This is an improvement over the old code which had NO validation,
-        // but internal IP ranges are still not blocked if registered as nodes.
+        // when
+        var response = await client.GetAsync(
+            $"/api/ping?endpoint={Uri.EscapeDataString("https://allowed")}",
+            AbortToken
+        );
 
-        _ = _DefaultBuilder; // Reference the builder to suppress unused warning
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.Requests.Should().ContainSingle().Which.Should().Be(new Uri("https://allowed/messaging/api/health"));
+    }
 
-        true.Should().BeTrue("This test documents the endpoint validation behavior");
+    [Theory]
+    [InlineData("http://allowed:8080@evil.test")]
+    [InlineData("http://allowed.evil.test:8080")]
+    [InlineData("http://allowed:8081")]
+    [InlineData("https://allowed:8080")]
+    [InlineData("http://allowed:8080/path")]
+    [InlineData("http://allowed:8080/?query=value")]
+    [InlineData("http://allowed:8080?")]
+    [InlineData("http://allowed:8080/#fragment")]
+    [InlineData("http://allowed:8080#")]
+    [InlineData("ftp://allowed:8080")]
+    [InlineData("not-a-uri")]
+    public async Task should_reject_non_origin_or_mismatched_endpoint_without_request(string endpoint)
+    {
+        // given
+        using var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("OK"),
+        });
+        var factory = new StubHttpClientFactory(handler);
+        await using var app = _CreateTestApp([_RegisteredNode], factory);
+        await app.StartAsync(AbortToken);
+        using var client = app.GetTestClient();
+
+        // when
+        var response = await client.GetAsync($"/api/ping?endpoint={Uri.EscapeDataString(endpoint)}", AbortToken);
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        handler.Requests.Should().BeEmpty();
+        factory.RequestedNames.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_not_follow_redirect_from_registered_origin()
+    {
+        // given
+        using var handler = new CapturingHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Redirect);
+            response.Headers.Location = new Uri("http://evil.test/secrets");
+            return response;
+        });
+        var factory = new StubHttpClientFactory(handler);
+        await using var app = _CreateTestApp([_RegisteredNode], factory);
+        await app.StartAsync(AbortToken);
+        using var client = app.GetTestClient();
+
+        // when
+        var response = await client.GetAsync(
+            $"/api/ping?endpoint={Uri.EscapeDataString("http://allowed:8080")}",
+            AbortToken
+        );
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        handler
+            .Requests.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(new Uri("http://allowed:8080/messaging/api/health"));
+        handler.Requests.Should().NotContain(uri => uri.Host == "evil.test");
+    }
+
+    [Fact]
+    public void should_configure_ping_client_timeout_and_disable_redirects()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddLogging();
+        new DashboardOptionsExtension(config => config.WithNoAuth()).AddServices(services);
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        var options = provider
+            .GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>()
+            .Get(MessagingDashboardEndpoints.PingHttpClientName);
+        var handlerBuilder = new TestHttpMessageHandlerBuilder(provider)
+        {
+            Name = MessagingDashboardEndpoints.PingHttpClientName,
+        };
+
+        // when
+        using var client = factory.CreateClient(MessagingDashboardEndpoints.PingHttpClientName);
+        foreach (var configure in options.HttpMessageHandlerBuilderActions)
+        {
+            configure(handlerBuilder);
+        }
+
+        // then
+        client.Timeout.Should().Be(TimeSpan.FromSeconds(5));
+        handlerBuilder.PrimaryHandler.Should().BeOfType<HttpClientHandler>().Which.AllowAutoRedirect.Should().BeFalse();
+    }
+
+    private static WebApplication _CreateTestApp(IList<Node> nodes, IHttpClientFactory httpClientFactory)
+    {
+        var config = new MessagingDashboardOptionsBuilder().WithNoAuth();
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider
+            .GetNodesAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(nodes));
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(config);
+        builder.Services.AddSingleton(config.Auth);
+        builder.Services.AddSingleton(Substitute.For<IAuthService>());
+        builder.Services.AddSingleton(discoveryProvider);
+        builder.Services.AddSingleton(httpClientFactory);
+        builder.Services.AddSingleton(Substitute.For<IRequestMapper>());
+        builder.Services.AddSingleton(new ConsulDiscoveryOptions { NodeName = "current-node" });
+        builder.Services.AddMemoryCache();
+        builder.Services.AddSingleton<GatewayProxyAgent>();
+        builder.Services.AddRouting();
+        builder.Services.AddAuthorization();
+        builder.Services.AddCors(options =>
+            options.AddPolicy("HeadlessMessagingDashboardCORS", policy => policy.AllowAnyOrigin())
+        );
+
+        var app = builder.Build();
+        app.UseRouting();
+        app.UseCors("HeadlessMessagingDashboardCORS");
+        app.UseAuthorization();
+        app.MapMessagingDashboardEndpoints(config);
+
+        return app;
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public List<string> RequestedNames { get; } = [];
+
+        public HttpClient CreateClient(string name)
+        {
+            RequestedNames.Add(name);
+            return new HttpClient(handler, disposeHandler: false);
+        }
+    }
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        public List<Uri> Requests { get; } = [];
+        public List<CancellationToken> CancellationTokens { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(request.RequestUri!);
+            CancellationTokens.Add(cancellationToken);
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class TestHttpMessageHandlerBuilder(IServiceProvider services) : HttpMessageHandlerBuilder
+    {
+        public override string? Name { get; set; }
+        public override HttpMessageHandler PrimaryHandler { get; set; } = new HttpClientHandler();
+        public override IList<DelegatingHandler> AdditionalHandlers { get; } = [];
+        public override IServiceProvider Services { get; } = services;
+
+        public override HttpMessageHandler Build()
+        {
+            return CreateHandlerPipeline(PrimaryHandler, AdditionalHandlers);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- restrict Kubernetes discovery and proxy selection to the configured namespace
- resolve a selected Service server-side and reapply visibility/port-label rules before forwarding
- reject unsafe node addresses, cap proxied response reads, and clear invalid/stale selection cookies
- prevent duplicate concurrent lookups with a keyed lock and bounded positive caching
- narrow documented Kubernetes RBAC from cluster namespace enumeration to namespaced Service reads

This is the messaging dashboard proxy slice split from #707 and ported onto the current async node-discovery contracts on `main`.

## Testing

- `make test-project TEST_PROJECT=tests/Headless.Messaging.Dashboard.K8s.Tests.Unit/Headless.Messaging.Dashboard.K8s.Tests.Unit.csproj` — 41 passed
- `make test-project TEST_PROJECT=tests/Headless.Messaging.Dashboard.Tests.Unit/Headless.Messaging.Dashboard.Tests.Unit.csproj` — 122 passed
- Messaging dashboard `npm run test:unit` — 20 passed
- Messaging dashboard `npm run lint:check`
- Messaging dashboard `npm run build`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- **Responsible:** messaging dashboard operator
- **Window:** first deployment with Kubernetes discovery, then one normal dashboard observation interval
- **Healthy:** only configured-namespace Services appear; valid node switches proxy successfully; invalid/hidden/stale selections are cleared; proxy latency/error rates remain normal
- **Failure:** cross-namespace discovery, proxying to a client-supplied address, repeated discovery amplification, oversized response failures, or valid node switches breaking
- **Action:** disable dashboard node switching or restrict dashboard access while inspecting Service labels, configured namespace, cookies, and proxy errors
- **Rollback:** revert this PR only behind equivalent network/RBAC isolation; do not restore cluster-wide namespace enumeration in production

## Checklist

- [x] Cross-node destinations are resolved server-side
- [x] Kubernetes access is namespaced and fails closed
- [x] Concurrent lookups and proxy response sizes are bounded
- [x] Current `main` async discovery APIs are preserved

