### PR TITLE
fix(workers): bound queues and initialization retries

### DIFF
--- a/docs/llms/features.md
+++ b/docs/llms/features.md
@@ -120,7 +120,7 @@ The *static store* (`IStaticFeatureDefinitionStore`) builds the feature catalog 
 
 ### Startup Initialization
 
-`FeaturesInitializationBackgroundService` runs after the application starts. It saves static feature definitions to the database (idempotent, guarded by a distributed lock; retries up to 10 times with exponential back-off), then pre-caches the dynamic feature definitions if `IsDynamicFeatureStoreEnabled` is true. Dependents can await `WaitForInitializationAsync()` to block until initialization completes. Both tasks are skipped when their governing option flags are disabled — in that case the service signals completion immediately.
+`FeaturesInitializationBackgroundService` runs after the application starts. It saves static feature definitions to the database (idempotent and guarded by a distributed lock), with up to 10 jittered exponential-back-off retries capped at 30 seconds, then pre-caches the dynamic feature definitions if `IsDynamicFeatureStoreEnabled` is true. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other terminal failures surface through `WaitForInitializationAsync()`. Both tasks are skipped when their governing option flags are disabled — in that case the service signals completion immediately.
 
 ## Choosing a Provider
 
@@ -248,7 +248,7 @@ Provides the full feature management implementation including hierarchical value
 - Built-in value providers: `DefaultValueFeatureValueProvider`, `EditionFeatureValueProvider`, `TenantFeatureValueProvider`
 - `IStaticFeatureDefinitionStore` — builds the feature catalog lazily and thread-safely from all registered `IFeatureDefinitionProvider` implementations
 - `IDynamicFeatureDefinitionStore` — database-backed definition store with in-process caching and distributed-stamp cross-instance coordination
-- `FeaturesInitializationBackgroundService` — seeds static definitions to the database at startup with exponential-back-off retry; pre-caches dynamic definitions when enabled
+- `FeaturesInitializationBackgroundService` — seeds static definitions with up to 10 jittered exponential-back-off retries capped at 30 seconds; pre-caches dynamic definitions when enabled
 - `FeatureManagementOptions` — tuning options for lock keys, cache expiries, dynamic store toggle, and named cache routing
 - `FeaturesStorageOptions` — schema and table name configuration shared across all storage providers
 - `HeadlessFeaturesSetupBuilder` — fluent builder returned to `AddHeadlessFeatures`; exposes `ConfigureManagement`, `ConfigureStorage`, and `RegisterExtension`
@@ -259,7 +259,7 @@ Provides the full feature management implementation including hierarchical value
 
 - Value providers are registered with the last-added provider having the highest resolution priority. The built-in order is `DefaultValue` → `Edition` → `Tenant` (Tenant wins). Custom providers added via `AddFeatureValueProvider<T>()` are appended after `Tenant` and therefore have the highest priority. This matters when writing custom providers that must override built-in resolution.
 - `AddHeadlessFeatures` is guarded on `IFeatureManager` so it is safe to call more than once (only the first call registers the core; the storage extension always applies). However, only one storage provider extension may be registered — a second call with a different provider throws at startup.
-- `FeaturesInitializationBackgroundService` implements `IInitializer` so anything that awaits `WaitForInitializationAsync()` blocks until the seed and pre-cache steps complete. If the host is stopped before initialization finishes, the background task is cancelled and the `TaskCompletionSource` is faulted with `OperationCanceledException`.
+- `FeaturesInitializationBackgroundService` implements `IInitializer` so anything that awaits `WaitForInitializationAsync()` blocks until the seed and pre-cache steps complete. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other failures retain 10 retries, and the terminal exception is surfaced to every waiter. If the host is stopped before initialization finishes, the background task and waiters are cancelled.
 - `FeatureValueRecord` implements `ICreateAudit` / `IUpdateAudit`, carrying `DateCreated` (stamped on insert) and `DateUpdated` (stamped on update). On the EF path these are populated by the Headless audit save-processor; the raw-SQL PostgreSQL / SQL Server providers stamp them from the registered `TimeProvider`. Features scope tenancy through `ProviderName`/`ProviderKey` (e.g. `ProviderName == "Tenant"` with the tenant id in `ProviderKey`) — there is deliberately no first-class `TenantId` column nor `IMultiTenant`; a scoping value provider expresses tenant, edition, and other scopes uniformly. This is an intentional divergence from `PermissionGrantRecord`, not drift.
 
 ### Installation

--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -481,7 +481,8 @@ services.AddHeadlessMessaging(setup =>
 ### Configuration
 
 - `MessagingOptions.DefaultGroupName`, `GroupNamePrefix`, `MessageNamePrefix`, and `Version` control naming and isolation. `Version` is validated non-empty and at most 20 characters — the SQL storage providers persist it as a literal into a `VARCHAR(20)`/`nvarchar(20)` column, so an over-long value is rejected at startup instead of failing every outbox insert.
-- Retry configuration lives under `RetryPolicy`, publish/receive retry processors, and storage cleanup options. `RetryBatchSize` (default 200, `> 0`) caps the retry-pickup batch and `SchedulerBatchSize` (default 1,000, `> 0`) caps the delayed/queued scheduler batch.
+- `ConsumerThreadCount`, `SubscriberParallelExecuteThreadCount`, and `SubscriberParallelExecuteBufferFactor` accept 1 through 1,024; the subscriber thread-count × buffer-factor product must not exceed 100,000.
+- Retry configuration lives under `RetryPolicy`, publish/receive retry processors, and storage cleanup options. `RetryBatchSize` (default 200) and `SchedulerBatchSize` (default 1,000) accept 1 through 100,000. `SchedulerBatchSize` also bounds the in-memory near-term scheduler queue; overflow remains durable as `Delayed` work.
 - `UseStorageLock` coordinates retry processors through a messaging-keyed distributed lock provider.
 - `DeadNodeReconcileInterval` (default 1 minute, `> 0`) sets the always-on dead-owner recovery reconcile cadence (see [Dead-owner recovery](#dead-owner-recovery)). Independent of `UseStorageLock`.
 - `ShutdownTimeout` (default 30 seconds, `> 0`, `<= 5m`) is one end-to-end messaging shutdown bound shared by the consumer-register listener drain, concurrent consumer-client disposal, provider-specific in-flight drains, and the dispatcher loop drain. Cleanup still running when the deadline expires continues fault-observed in the background.

--- a/docs/llms/permissions.md
+++ b/docs/llms/permissions.md
@@ -170,10 +170,10 @@ The *dynamic store* (`IDynamicPermissionDefinitionStore`) reads definitions from
 
 `PermissionsInitializationBackgroundService` runs after the application starts. It:
 
-1. Persists static permission definitions to the database (guarded by a distributed lock; retries up to 10 times with exponential back-off), when `SaveStaticPermissionsToDatabase = true`.
+1. Persists static permission definitions to the database (guarded by a distributed lock; up to 10 jittered exponential-back-off retries capped at 30 seconds), when `SaveStaticPermissionsToDatabase = true`.
 2. Pre-caches dynamic definitions from the database into the in-process cache, when `IsDynamicPermissionStoreEnabled = true`.
 
-Dependents can await `WaitForInitializationAsync()` on the `IInitializer` interface to block until both tasks complete. When both options are `false`, initialization is a no-op and `IsInitialized` is set to `true` immediately.
+Dependents can await `WaitForInitializationAsync()` on the `IInitializer` interface to block until both tasks complete. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other terminal failures surface to every waiter. When both options are `false`, initialization is a no-op and `IsInitialized` is set to `true` immediately.
 
 ## Choosing a Provider
 
@@ -292,7 +292,7 @@ Provides the full permission management runtime: AWS IAM-style grant resolution 
 - `IPermissionGrantProvider` / built-in providers: `UserPermissionGrantProvider` (`"User"`) and `RolePermissionGrantProvider` (`"Role"`)
 - `IStaticPermissionDefinitionStore` — builds the permission catalog lazily and thread-safely from all registered `IPermissionDefinitionProvider` instances
 - `IDynamicPermissionDefinitionStore` — database-backed definition store with in-process caching and distributed-stamp cross-instance coordination; disabled by default
-- `PermissionsInitializationBackgroundService` — seeds static definitions to the database at startup with exponential-back-off retry; pre-caches dynamic definitions when enabled; implements `IInitializer`
+- `PermissionsInitializationBackgroundService` — seeds static definitions with up to 10 jittered exponential-back-off retries capped at 30 seconds; pre-caches dynamic definitions when enabled; implements `IInitializer`
 - `PermissionManagementOptions` — all tuning options for lock keys/timeouts, cache expiry, dynamic store toggle
 - `PermissionsStorageOptions` — schema and table name configuration shared across all storage providers
 - `HeadlessPermissionsSetupBuilder` — fluent builder returned inside `AddHeadlessPermissions`; exposes `ConfigureManagement`, `ConfigureStorage`, `RegisterExtension`
@@ -310,7 +310,7 @@ The always-allow test doubles (`AlwaysAllowPermissionManager` / `AlwaysAllowAuth
 - Grant providers are stored in registration order with last-registered = highest priority. The built-in registration is `Role` first, then `User`, making User the highest-priority built-in provider. Custom providers added via `AddPermissionGrantProvider<T>()` are appended after `User` and override both built-ins.
 - `AddHeadlessPermissions` is guarded on `IPermissionGrantStore` so calling it more than once is safe — the management core registers once. However, registering a second storage provider extension throws at host startup.
 - The grant cache is tenant-scoped (`ScopedCache<PermissionGrantCacheItem>` keyed on `ICurrentTenant.Id`). A permission check for tenant A never returns a cached result for tenant B.
-- `PermissionsInitializationBackgroundService` implements `IInitializer`: anything awaiting `WaitForInitializationAsync()` blocks until both the save and pre-cache steps complete. If the host stops before initialization finishes, the `TaskCompletionSource` is cancelled.
+- `PermissionsInitializationBackgroundService` implements `IInitializer`: anything awaiting `WaitForInitializationAsync()` blocks until both the save and pre-cache steps complete. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other failures retain 10 retries, and the terminal exception is surfaced to every waiter. If the host stops before initialization finishes, the background task and waiters are cancelled.
 - `PermissionGrantRecord` implements `ICreateAudit` / `IUpdateAudit` and carries `DateCreated` (non-null) and `DateUpdated` (nullable) audit timestamps. Grants are insert-only — a revoke deletes the row and inserts a replacement rather than updating — so `DateUpdated` is normally null. The EF provider stamps `DateCreated` through the audit save-processor; the raw-SQL providers stamp it from the injected `TimeProvider`. Hydrate from storage with the `PermissionGrantRecord.FromStorage(...)` factory, which sets the audit fields.
 - **Tenancy divergence (intentional).** `PermissionGrantRecord` keeps a first-class `TenantId` column and implements `IMultiTenant`, unlike `SettingValueRecord` / `FeatureValueRecord`, which scope tenancy through `ProviderName`/`ProviderKey` and have no tenant column. Grants need tenant-scoped uniqueness expressed directly in the `(Name, ProviderName, ProviderKey, TenantId)` unique index so the same grant can coexist per tenant and for the host. This is a deliberate design decision, not drift.
 

--- a/docs/llms/settings.md
+++ b/docs/llms/settings.md
@@ -127,7 +127,7 @@ The *static store* (`IStaticSettingDefinitionStore`) builds the setting catalog 
 
 ### Startup Initialization
 
-`SettingsInitializationBackgroundService` runs after the application starts. It saves static setting definitions to the database (idempotent, guarded by a distributed lock; retries up to 10 times with exponential back-off), then pre-caches dynamic setting definitions when `IsDynamicSettingStoreEnabled` is true. Dependents can await `WaitForInitializationAsync()` to block until initialization completes. Both tasks are skipped when their governing option flags are disabled — in that case the service signals completion immediately. If the host is stopped before initialization finishes, the background task is cancelled and the `TaskCompletionSource` is faulted with `OperationCanceledException`.
+`SettingsInitializationBackgroundService` runs after the application starts. It saves static setting definitions to the database (idempotent and guarded by a distributed lock), with up to 10 jittered exponential-back-off retries capped at 30 seconds, then pre-caches dynamic setting definitions when `IsDynamicSettingStoreEnabled` is true. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other terminal failures surface through `WaitForInitializationAsync()`. Both tasks are skipped when their governing option flags are disabled — in that case the service signals completion immediately. If the host is stopped before initialization finishes, the background task and waiters are cancelled.
 
 ## Choosing a Provider
 
@@ -251,7 +251,7 @@ Provides the full settings management implementation including hierarchical valu
 - Built-in value providers (lowest to highest priority): `DefaultValueSettingValueProvider`, `ConfigurationSettingValueProvider`, `GlobalSettingValueProvider`, `TenantSettingValueProvider`, `UserSettingValueProvider`
 - `IStaticSettingDefinitionStore` — builds the setting catalog lazily from all registered `ISettingDefinitionProvider` implementations
 - `IDynamicSettingDefinitionStore` — database-backed definition store with in-process caching and distributed-stamp cross-instance coordination
-- `SettingsInitializationBackgroundService` — seeds static definitions to the database at startup with exponential-back-off retry; pre-caches dynamic definitions when enabled
+- `SettingsInitializationBackgroundService` — seeds static definitions with up to 10 jittered exponential-back-off retries capped at 30 seconds; pre-caches dynamic definitions when enabled
 - `SettingManagementOptions` — tuning options for lock keys, cache expiries, dynamic store toggle
 - `SettingsStorageOptions` — schema and table name configuration shared across all storage providers
 - `HeadlessSettingsSetupBuilder` — fluent builder returned to `AddHeadlessSettings`; exposes `ConfigureManagement`, `ConfigureStorage`, and `RegisterExtension`
@@ -264,7 +264,7 @@ Value providers are registered with the last-added provider having the highest r
 
 `AddHeadlessSettings` is guarded on `ISettingManager` so it is safe to call more than once (only the first call registers the core). However, only one storage provider extension may be registered — a second call with a different provider throws at startup.
 
-`SettingsInitializationBackgroundService` implements `IInitializer` so anything that awaits `WaitForInitializationAsync()` blocks until the seed and pre-cache steps complete. If the host is stopped before initialization finishes, the background task is cancelled and the `TaskCompletionSource` is faulted with `OperationCanceledException`.
+`SettingsInitializationBackgroundService` implements `IInitializer` so anything that awaits `WaitForInitializationAsync()` blocks until the seed and pre-cache steps complete. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other failures retain 10 retries, and the terminal exception is surfaced to every waiter. If the host is stopped before initialization finishes, the background task and waiters are cancelled.
 
 ### Installation
 

--- a/src/Headless.Features.Core/README.md
+++ b/src/Headless.Features.Core/README.md
@@ -13,7 +13,7 @@ Provides the full feature management implementation including hierarchical value
 - Built-in value providers: `DefaultValueFeatureValueProvider`, `EditionFeatureValueProvider`, `TenantFeatureValueProvider`
 - `IStaticFeatureDefinitionStore` — builds the feature catalog lazily and thread-safely from all registered `IFeatureDefinitionProvider` implementations
 - `IDynamicFeatureDefinitionStore` — database-backed definition store with in-process caching and distributed-stamp cross-instance coordination
-- `FeaturesInitializationBackgroundService` — seeds static definitions to the database at startup with exponential-back-off retry; pre-caches dynamic definitions when enabled
+- `FeaturesInitializationBackgroundService` — seeds static definitions with up to 10 jittered exponential-back-off retries capped at 30 seconds; pre-caches dynamic definitions when enabled
 - `FeatureManagementOptions` — tuning options for lock keys, cache expiries, dynamic store toggle, and named cache routing
 - `FeaturesStorageOptions` — schema and table name configuration shared across all storage providers
 - `HeadlessFeaturesSetupBuilder` — fluent builder returned to `AddHeadlessFeatures`; exposes `ConfigureManagement`, `ConfigureStorage`, and `RegisterExtension`
@@ -24,7 +24,7 @@ Provides the full feature management implementation including hierarchical value
 
 - Value providers are registered with the last-added provider having the highest resolution priority. The built-in order is `DefaultValue` → `Edition` → `Tenant` (Tenant wins). Custom providers added via `AddFeatureValueProvider<T>()` are appended after `Tenant` and therefore have the highest priority. This matters when writing custom providers that must override built-in resolution.
 - `AddHeadlessFeatures` is guarded on `IFeatureManager` so it is safe to call more than once (only the first call registers the core; the storage extension always applies). However, only one storage provider extension may be registered — a second call with a different provider throws at startup.
-- `FeaturesInitializationBackgroundService` implements `IInitializer` so anything that awaits `WaitForInitializationAsync()` blocks until the seed and pre-cache steps complete. If the host is stopped before initialization finishes, the background task is cancelled and the `TaskCompletionSource` is faulted with `OperationCanceledException`.
+- `FeaturesInitializationBackgroundService` implements `IInitializer` so anything that awaits `WaitForInitializationAsync()` blocks until the seed and pre-cache steps complete. Cancellation, `ArgumentException`, and `NotSupportedException` fail immediately without retry; other failures retain 10 retries, and the terminal exception is surfaced to every waiter. If the host is stopped before initialization finishes, the background task and waiters are cancelled.
 - `FeatureValueRecord` implements `ICreateAudit` / `IUpdateAudit`, carrying `DateCreated` (stamped on insert) and `DateUpdated` (stamped on update). On the EF path these are populated by the Headless audit save-processor; the raw-SQL PostgreSQL / SQL Server providers stamp them from the registered `TimeProvider`. Features scope tenancy through `ProviderName`/`ProviderKey` (e.g. `ProviderName == "Tenant"` with the tenant id in `ProviderKey`) — there is deliberately no first-class `TenantId` column nor `IMultiTenant`. This is an intentional divergence from `PermissionGrantRecord`, not drift.
 
 ## Installation

--- a/src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs
+++ b/src/Headless.Features.Core/Seeders/FeaturesInitializationBackgroundService.cs
@@ -19,7 +19,7 @@ namespace Headless.Features.Seeders;
 /// <remarks>
 /// On startup, this service:
 /// <list type="number">
-///   <item><description>Saves static definitions to the database (retried up to 10 times with exponential back-off when <see cref="FeatureManagementOptions.SaveStaticFeaturesToDatabase"/> is <see langword="true"/>).</description></item>
+///   <item><description>Saves static definitions to the database (retried up to 10 times with jittered exponential back-off capped at 30 seconds when <see cref="FeatureManagementOptions.SaveStaticFeaturesToDatabase"/> is <see langword="true"/>). Cancellation, invalid arguments, and unsupported operations are not retried.</description></item>
 ///   <item><description>Pre-caches the dynamic feature catalog so the first request does not incur a cold-cache database round-trip (when <see cref="FeatureManagementOptions.IsDynamicFeatureStoreEnabled"/> is <see langword="true"/>).</description></item>
 /// </list>
 /// Both steps are skipped (and the initializer signals completion immediately) when both options are disabled.
@@ -92,19 +92,13 @@ internal sealed class FeaturesInitializationBackgroundService(
     {
         try
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await using var scope = serviceScopeFactory.CreateAsyncScope();
 
             await _SaveStaticFeaturesToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await _PreCacheDynamicFeaturesAsync(scope, cancellationToken).ConfigureAwait(false);
 
@@ -131,10 +125,13 @@ internal sealed class FeaturesInitializationBackgroundService(
         {
             Name = "SaveStaticFeatureToDatabaseRetry",
             Delay = TimeSpan.FromSeconds(2),
+            MaxDelay = TimeSpan.FromSeconds(30),
             MaxRetryAttempts = 10,
             BackoffType = DelayBackoffType.Exponential,
-            UseJitter = false,
-            ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+            UseJitter = true,
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(static exception =>
+                exception is not OperationCanceledException and not ArgumentException and not NotSupportedException
+            ),
         };
 
         var builder = new ResiliencePipelineBuilder { TimeProvider = timeProvider };
@@ -152,7 +149,7 @@ internal sealed class FeaturesInitializationBackgroundService(
                     {
                         await store.SaveAsync(cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (e is not OperationCanceledException)
                     {
                         logger.LogFailedToSaveStaticFeatures(e);
 

--- a/src/Headless.Messaging.Core/Configuration/MessagingOptions.cs
+++ b/src/Headless.Messaging.Core/Configuration/MessagingOptions.cs
@@ -304,6 +304,7 @@ public sealed class MessagingOptions
         target.PublishBatchSize = PublishBatchSize;
         target.CollectorCleaningInterval = CollectorCleaningInterval;
         target.SchedulerBatchSize = SchedulerBatchSize;
+        target.RetryBatchSize = RetryBatchSize;
         target.UseStorageLock = UseStorageLock;
         target.TenantContextRequired = TenantContextRequired;
         target.TransportPublishTimeout = TransportPublishTimeout;
@@ -511,8 +512,28 @@ internal sealed class MessagingOptionsValidator : AbstractValidator<MessagingOpt
             .WithMessage("Version must not be empty.")
             .MaximumLength(20)
             .WithMessage("Version must not exceed 20 characters (it is stored in a VARCHAR(20) column).");
-        RuleFor(x => x.SchedulerBatchSize).GreaterThan(0).WithMessage("SchedulerBatchSize must be greater than zero.");
-        RuleFor(x => x.RetryBatchSize).GreaterThan(0).WithMessage("RetryBatchSize must be greater than zero.");
+        RuleFor(x => x.ConsumerThreadCount)
+            .InclusiveBetween(1, 1024)
+            .WithMessage("ConsumerThreadCount must be between 1 and 1024.");
+        RuleFor(x => x.SubscriberParallelExecuteThreadCount)
+            .InclusiveBetween(1, 1024)
+            .WithMessage("SubscriberParallelExecuteThreadCount must be between 1 and 1024.");
+        RuleFor(x => x.SubscriberParallelExecuteBufferFactor)
+            .InclusiveBetween(1, 1024)
+            .WithMessage("SubscriberParallelExecuteBufferFactor must be between 1 and 1024.");
+        RuleFor(x => x)
+            .Must(options =>
+                (long)options.SubscriberParallelExecuteThreadCount * options.SubscriberParallelExecuteBufferFactor
+                <= 100_000
+            )
+            .WithName(nameof(MessagingOptions.SubscriberParallelExecuteBufferFactor))
+            .WithMessage("Subscriber parallel buffer capacity must not exceed 100,000.");
+        RuleFor(x => x.SchedulerBatchSize)
+            .InclusiveBetween(1, 100_000)
+            .WithMessage("SchedulerBatchSize must be between 1 and 100,000.");
+        RuleFor(x => x.RetryBatchSize)
+            .InclusiveBetween(1, 100_000)
+            .WithMessage("RetryBatchSize must be between 1 and 100,000.");
         RuleFor(x => x).Custom((_, _) => _ValidateMiddlewareDescriptors(middlewareDescriptorRegistry));
     }
 

--- a/src/Headless.Messaging.Core/Internal/ScheduledMediumMessageQueue.cs
+++ b/src/Headless.Messaging.Core/Internal/ScheduledMediumMessageQueue.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Runtime.CompilerServices;
+using Headless.Checks;
 using Headless.Messaging.Messages;
 
 namespace Headless.Messaging.Internal;
 
-internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider) : IDisposable
+internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider, int capacity = 1000) : IDisposable
 {
+    private readonly int _capacity = Argument.IsPositive(capacity);
     private readonly SortedSet<(long, MediumMessage)> _queue = new(
         Comparer<(long, MediumMessage)>.Create(
             (a, b) =>
@@ -21,24 +23,38 @@ internal sealed class ScheduledMediumMessageQueue(TimeProvider timeProvider) : I
     private readonly Lock _lock = new();
     private bool _isDisposed;
 
-    public void Enqueue(MediumMessage message, long sendTime)
+    public bool TryEnqueue(MediumMessage message, long sendTime)
     {
         var shouldSignal = false;
 
         lock (_lock)
         {
+            if (_queue.Contains((sendTime, message)))
+            {
+                return true;
+            }
+
+            if (_queue.Count >= _capacity)
+            {
+                return false;
+            }
+
             var previousEarliest = _queue.Count > 0 ? _queue.Min.Item1 : (long?)null;
 
-            if (_queue.Add((sendTime, message)))
+            if (!_queue.Add((sendTime, message)))
             {
-                shouldSignal = previousEarliest is null || sendTime < previousEarliest.Value;
+                return false;
             }
+
+            shouldSignal = previousEarliest is null || sendTime < previousEarliest.Value;
         }
 
         if (shouldSignal)
         {
             _changedSignal.Release();
         }
+
+        return true;
     }
 
     public int Count

--- a/src/Headless.Messaging.Core/Processor/Dispatcher.cs
+++ b/src/Headless.Messaging.Core/Processor/Dispatcher.cs
@@ -85,7 +85,7 @@ internal sealed class Dispatcher : IDispatcher, ICommittedDelayedMessageDispatch
         _timeProvider = timeProvider;
         _scopeFactory = scopeFactory;
         _hostApplicationLifetime = hostApplicationLifetime;
-        _schedulerQueue = new ScheduledMediumMessageQueue(timeProvider);
+        _schedulerQueue = new ScheduledMediumMessageQueue(timeProvider, _options.SchedulerBatchSize);
         _enableParallelExecute = _options.EnableSubscriberParallelExecute;
         _enableParallelSend = _options.EnablePublishParallelSend;
         _publishChannelSize = Environment.ProcessorCount * 500;
@@ -176,7 +176,17 @@ internal sealed class Dispatcher : IDispatcher, ICommittedDelayedMessageDispatch
 
         if (statusName == StatusName.Queued)
         {
-            _schedulerQueue.Enqueue(message, publishTime.Ticks);
+            if (!_schedulerQueue.TryEnqueue(message, publishTime.Ticks))
+            {
+                await _storage
+                    .ChangePublishStateAsync(
+                        message,
+                        StatusName.Delayed,
+                        transaction,
+                        cancellationToken: CancellationToken.None
+                    )
+                    .ConfigureAwait(false);
+            }
         }
     }
 
@@ -187,7 +197,8 @@ internal sealed class Dispatcher : IDispatcher, ICommittedDelayedMessageDispatch
             throw new InvalidOperationException("A committed delayed message must have an expiration time.");
         }
 
-        _schedulerQueue.Enqueue(message, publishTime.Ticks);
+        // A full in-memory queue is safe here: the committed message remains durable as Delayed work.
+        _ = _schedulerQueue.TryEnqueue(message, publishTime.Ticks);
     }
 
     public async ValueTask EnqueueToPublish(MediumMessage message, CancellationToken cancellationToken = default)
@@ -481,7 +492,9 @@ internal sealed class Dispatcher : IDispatcher, ICommittedDelayedMessageDispatch
 
     private void _InitializeReceivedChannel()
     {
-        var bufferSize = _options.SubscriberParallelExecuteThreadCount * _options.SubscriberParallelExecuteBufferFactor;
+        var bufferSize = checked(
+            _options.SubscriberParallelExecuteThreadCount * _options.SubscriberParallelExecuteBufferFactor
+        );
         var isSingleReader = _options.SubscriberParallelExecuteThreadCount == 1;
 
         ReceivedChannel = Channel.CreateBounded<(MediumMessage, ConsumerExecutorDescriptor?)>(

--- a/src/Headless.Messaging.Core/README.md
+++ b/src/Headless.Messaging.Core/README.md
@@ -254,7 +254,8 @@ builder.Services.AddHeadlessMessaging(setup =>
 ```
 
 - `Version` is validated non-empty and at most 20 characters: the SQL storage providers persist it as a literal into a `VARCHAR(20)`/`nvarchar(20)` column, so an over-long value is rejected at startup instead of failing every outbox insert.
-- `RetryBatchSize` (default 200, `> 0`) caps the retry-pickup batch; `SchedulerBatchSize` (default 1,000, `> 0`) caps the delayed/queued scheduler batch.
+- `ConsumerThreadCount`, `SubscriberParallelExecuteThreadCount`, and `SubscriberParallelExecuteBufferFactor` accept 1 through 1,024; the subscriber thread-count × buffer-factor product must not exceed 100,000.
+- `RetryBatchSize` (default 200) and `SchedulerBatchSize` (default 1,000) accept 1 through 100,000. `SchedulerBatchSize` also bounds the in-memory near-term scheduler queue; overflow remains durable as `Delayed` work.
 
 ## Middleware
 

--- a/src/Headless.Permissions.Core/README.md
+++ b/src/Headless.Permissions.Core/README.md
@@ -12,7 +12,7 @@ Provides the full permission management runtime: AWS IAM-style grant resolution 
 - `IPermissionGrantProvider` / built-in providers: `UserPermissionGrantProvider` (`"User"`) and `RolePermissionGrantProvider` (`"Role"`)
 - `IStaticPermissionDefinitionStore` — builds the permission catalog lazily and thread-safely from all registered `IPermissionDefinitionProvider` instances
 - `IDynamicPermissionDefinitionStore` — database-backed definition store with in-process caching and distributed-stamp cross-instance coordination; disabled by default
-- `PermissionsInitializationBackgroundService` — seeds static definitions to the database at startup with exponential-back-off retry; pre-caches dynamic definitions when enabled; implements `IInitializer`
+- `PermissionsInitializationBackgroundService` — seeds static definitions with up to 10 jittered exponential-back-off retries capped at 30 seconds; pre-caches dynamic definitions when enabled; implements `IInitializer`
 - `PermissionManagementOptions` — all tuning options for lock keys/timeouts, cache expiry, dynamic store toggle
 - `PermissionsStorageOptions` — schema and table name configuration shared across all storage providers
 - `HeadlessPermissionsSetupBuilder` — fluent builder returned inside `AddHeadlessPermissions`; exposes `ConfigureManagement`, `ConfigureStorage`, `RegisterExtension`
@@ -29,6 +29,7 @@ The always-allow test doubles (`AlwaysAllowPermissionManager` / `AlwaysAllowAuth
 
 - Grant providers are stored in registration order with last-registered = highest priority. Built-in registration is `Role` first, then `User`, making User the highest-priority built-in provider. Custom providers added via `AddPermissionGrantProvider<T>()` are appended after `User` and override both built-ins.
 - `AddHeadlessPermissions` is guarded on `IPermissionGrantStore` so calling it more than once is safe — the management core registers once. Registering a second storage provider extension throws at host startup.
+- `PermissionsInitializationBackgroundService` does not retry cancellation, `ArgumentException`, or `NotSupportedException`; other failures retain 10 retries, and the terminal exception is surfaced to every `IInitializer` waiter.
 - The grant cache is tenant-scoped (`ScopedCache<PermissionGrantCacheItem>` keyed on `ICurrentTenant.Id`). A permission check for tenant A never returns a cached result for tenant B.
 - `PermissionGrantRecord` implements `ICreateAudit` / `IUpdateAudit` and carries `DateCreated` (non-null) and `DateUpdated` (nullable). Grants are insert-only — a revoke deletes and re-inserts rather than updating — so `DateUpdated` is normally null. The EF provider stamps `DateCreated` via the audit save-processor; the raw-SQL providers stamp it from the injected `TimeProvider`. Use `PermissionGrantRecord.FromStorage(...)` to hydrate with audit fields.
 - **Tenancy divergence (intentional).** `PermissionGrantRecord` keeps a first-class `TenantId` column and implements `IMultiTenant`, unlike `SettingValueRecord` / `FeatureValueRecord` (which scope tenancy through `ProviderName`/`ProviderKey`). Grants need tenant-scoped uniqueness in the `(Name, ProviderName, ProviderKey, TenantId)` unique index so the same grant can coexist per tenant and for the host. This is a deliberate decision, not drift.

--- a/src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs
+++ b/src/Headless.Permissions.Core/Seeders/PermissionsInitializationBackgroundService.cs
@@ -21,6 +21,8 @@ namespace Headless.Permissions.Seeders;
 /// <para>
 /// On failure the <see cref="IInitializer.WaitForInitializationAsync"/> task surfaces the exception so
 /// dependents receive it rather than hanging indefinitely.
+/// Static-definition persistence retries other failures up to 10 times with jittered exponential back-off capped at
+/// 30 seconds. Cancellation, invalid arguments, and unsupported operations are not retried.
 /// </para>
 /// </summary>
 internal sealed class PermissionsInitializationBackgroundService(
@@ -93,19 +95,13 @@ internal sealed class PermissionsInitializationBackgroundService(
     {
         try
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await using var scope = serviceScopeFactory.CreateAsyncScope();
 
             await _SaveStaticPermissionsToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await _PreCacheDynamicPermissionsAsync(scope, cancellationToken).ConfigureAwait(false);
 
@@ -135,10 +131,13 @@ internal sealed class PermissionsInitializationBackgroundService(
         {
             Name = "SaveStaticPermissionToDatabaseRetry",
             Delay = TimeSpan.FromSeconds(2),
+            MaxDelay = TimeSpan.FromSeconds(30),
             MaxRetryAttempts = 10,
             BackoffType = DelayBackoffType.Exponential,
-            UseJitter = false,
-            ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+            UseJitter = true,
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(static exception =>
+                exception is not OperationCanceledException and not ArgumentException and not NotSupportedException
+            ),
         };
 
         var builder = new ResiliencePipelineBuilder { TimeProvider = timeProvider };
@@ -156,7 +155,7 @@ internal sealed class PermissionsInitializationBackgroundService(
                     {
                         await store.SaveAsync(cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (e is not OperationCanceledException)
                     {
                         logger.LogFailedToSaveStaticPermissions(e);
 

--- a/src/Headless.Settings.Core/README.md
+++ b/src/Headless.Settings.Core/README.md
@@ -13,7 +13,7 @@ Provides the full settings management implementation including hierarchical valu
 - Built-in value providers (lowest to highest priority): `DefaultValueSettingValueProvider`, `ConfigurationSettingValueProvider`, `GlobalSettingValueProvider`, `TenantSettingValueProvider`, `UserSettingValueProvider`
 - `IStaticSettingDefinitionStore` — builds the setting catalog lazily from all registered `ISettingDefinitionProvider` implementations
 - `IDynamicSettingDefinitionStore` — database-backed definition store with in-process caching and distributed-stamp cross-instance coordination
-- `SettingsInitializationBackgroundService` — seeds static definitions to the database at startup with exponential-back-off retry; pre-caches dynamic definitions when enabled
+- `SettingsInitializationBackgroundService` — seeds static definitions with up to 10 jittered exponential-back-off retries capped at 30 seconds; pre-caches dynamic definitions when enabled
 - `SettingManagementOptions` — tuning options for lock keys, cache expiries, dynamic store toggle
 - `SettingsStorageOptions` — schema and table name configuration shared across all storage providers
 - `HeadlessSettingsSetupBuilder` — fluent builder returned to `AddHeadlessSettings`; exposes `ConfigureManagement`, `ConfigureStorage`, and `RegisterExtension`
@@ -25,6 +25,8 @@ Provides the full settings management implementation including hierarchical valu
 Value providers are registered with the last-added provider having the highest resolution priority. The built-in order (from setup) is `DefaultValue → Configuration → Global → Tenant → User` — User wins. Custom providers added via `AddSettingValueProvider<T>()` are appended after `User` and therefore have the highest priority of all.
 
 `AddHeadlessSettings` is guarded on `ISettingManager` so it is safe to call more than once (only the first call registers the core). However, only one storage provider extension may be registered — a second call with a different provider throws at startup.
+
+`SettingsInitializationBackgroundService` does not retry cancellation, `ArgumentException`, or `NotSupportedException`; other failures retain 10 retries, and the terminal exception is surfaced to every `IInitializer` waiter.
 
 ## Installation
 

--- a/src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs
+++ b/src/Headless.Settings.Core/Seeders/SettingsInitializationBackgroundService.cs
@@ -17,6 +17,10 @@ namespace Headless.Settings.Seeders;
 /// on application startup. Implements <see cref="IInitializer"/> so dependents can await
 /// <see cref="WaitForInitializationAsync"/> before serving requests.
 /// </summary>
+/// <remarks>
+/// Static-definition persistence retries other failures up to 10 times with jittered exponential back-off capped at
+/// 30 seconds. Cancellation, invalid arguments, and unsupported operations are not retried.
+/// </remarks>
 internal sealed class SettingsInitializationBackgroundService(
     TimeProvider timeProvider,
     IServiceScopeFactory serviceScopeFactory,
@@ -87,19 +91,13 @@ internal sealed class SettingsInitializationBackgroundService(
     {
         try
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await using var scope = serviceScopeFactory.CreateAsyncScope();
 
             await _SaveStaticSettingsToDatabaseAsync(scope, cancellationToken).ConfigureAwait(false);
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await _PreCacheDynamicSettingsAsync(scope, cancellationToken).ConfigureAwait(false);
 
@@ -126,10 +124,13 @@ internal sealed class SettingsInitializationBackgroundService(
         {
             Name = "SaveStaticSettingsToDatabaseRetry",
             Delay = TimeSpan.FromSeconds(2),
+            MaxDelay = TimeSpan.FromSeconds(30),
             MaxRetryAttempts = 10,
             BackoffType = DelayBackoffType.Exponential,
-            UseJitter = false,
-            ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+            UseJitter = true,
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(static exception =>
+                exception is not OperationCanceledException and not ArgumentException and not NotSupportedException
+            ),
         };
 
         var builder = new ResiliencePipelineBuilder { TimeProvider = timeProvider };
@@ -147,7 +148,7 @@ internal sealed class SettingsInitializationBackgroundService(
                     {
                         await store.SaveAsync(cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (e is not OperationCanceledException)
                     {
                         logger.LogFailedToSaveStaticSettings(e);
 

--- a/tests/Headless.Features.Tests.Unit/Seeders/FeaturesInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Features.Tests.Unit/Seeders/FeaturesInitializationBackgroundServiceTests.cs
@@ -300,7 +300,7 @@ public sealed class FeaturesInitializationBackgroundServiceTests : TestBase
         // when
         await sut.StartAsync(AbortToken);
 
-        // Advance time to allow retries to proceed (2s, 4s base delays with exponential backoff)
+        // Advance time to allow jittered retries to proceed.
         for (var i = 0; i < 5 && !completionSource.Task.IsCompleted; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(10));
@@ -311,9 +311,91 @@ public sealed class FeaturesInitializationBackgroundServiceTests : TestBase
         callCount.Should().BeGreaterThanOrEqualTo(3);
     }
 
+    [Fact]
+    public async Task should_cap_retry_delays_and_surface_terminal_unknown_failure()
+    {
+        var options = new FeatureManagementOptions
+        {
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
+        };
+
+        var callCount = 0;
+        _store
+            .SaveAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                throw new InvalidOperationException("Always fails");
+            });
+
+        using var sut = _CreateSut(options);
+        await sut.StartAsync(CancellationToken.None);
+
+        await _AdvancePastCappedRetriesAsync();
+
+        var act = () => sut.WaitForInitializationAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("Always fails");
+        callCount.Should().Be(11);
+    }
+
+    [Theory]
+    [InlineData("argument")]
+    [InlineData("not-supported")]
+    [InlineData("operation-cancelled")]
+    public async Task should_not_retry_terminal_save_failure(string failure)
+    {
+        var options = new FeatureManagementOptions
+        {
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
+        };
+
+        var callCount = 0;
+        var expected = _CreateTerminalException(failure);
+        _store
+            .SaveAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                throw expected;
+            });
+
+        using var sut = _CreateSut(options);
+        await sut.StartAsync(CancellationToken.None);
+
+        var thrown = await Record.ExceptionAsync(() =>
+            sut.WaitForInitializationAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken)
+        );
+
+        thrown.Should().NotBeNull();
+        expected.GetType().IsAssignableFrom(thrown!.GetType()).Should().BeTrue();
+        callCount.Should().Be(1);
+    }
+
     #endregion
 
     #region Cancellation
+
+    [Fact]
+    public async Task should_complete_waiter_as_cancelled_when_start_token_is_already_cancelled()
+    {
+        var options = new FeatureManagementOptions
+        {
+            SaveStaticFeaturesToDatabase = true,
+            IsDynamicFeatureStoreEnabled = false,
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        using var sut = _CreateSut(options);
+
+        await sut.StartAsync(cts.Token);
+
+        var act = () => sut.WaitForInitializationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await _store.DidNotReceive().SaveAsync(Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task should_cancel_on_start_token_cancellation()
@@ -394,6 +476,27 @@ public sealed class FeaturesInitializationBackgroundServiceTests : TestBase
     #endregion
 
     #region Helpers
+
+    private async Task _AdvancePastCappedRetriesAsync()
+    {
+        // Each advance exceeds the 30-second cap, while remaining far below the old unbounded exponential tail.
+        for (var i = 0; i < 15; i++)
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(31));
+            await Task.Delay(10, AbortToken);
+        }
+    }
+
+    private static Exception _CreateTerminalException(string failure)
+    {
+        return failure switch
+        {
+            "argument" => new ArgumentException("Invalid configuration"),
+            "not-supported" => new NotSupportedException("Unsupported configuration"),
+            "operation-cancelled" => new OperationCanceledException("Initialization cancelled"),
+            _ => throw new ArgumentOutOfRangeException(nameof(failure), failure, message: null),
+        };
+    }
 
     private FeaturesInitializationBackgroundService _CreateSut(FeatureManagementOptions options)
     {

--- a/tests/Headless.Messaging.Core.Tests.Unit/Configuration/MessagingOptionsCopyToTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Configuration/MessagingOptionsCopyToTests.cs
@@ -162,6 +162,7 @@ public sealed class MessagingOptionsCopyToTests : TestBase
         options.PublishBatchSize = 42;
         options.CollectorCleaningInterval = 6;
         options.SchedulerBatchSize = 7;
+        options.RetryBatchSize = 8;
         options.UseStorageLock = true;
         options.TenantContextRequired = true;
         options.TransportPublishTimeout = TimeSpan.FromSeconds(17);

--- a/tests/Headless.Messaging.Core.Tests.Unit/Configuration/MessagingOptionsValidationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Configuration/MessagingOptionsValidationTests.cs
@@ -328,6 +328,46 @@ public sealed class MessagingOptionsValidationTests : TestBase
         result.Errors.Should().Contain(x => x.PropertyName == nameof(MessagingOptions.SchedulerBatchSize));
     }
 
+    [Theory]
+    [InlineData(0, 1, 1)]
+    [InlineData(1025, 1, 1)]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 1025, 1)]
+    [InlineData(1, 1, 0)]
+    [InlineData(1, 1, 1025)]
+    [InlineData(1, 1000, 101)]
+    public void should_reject_unbounded_messaging_concurrency(
+        int consumerThreads,
+        int subscriberThreads,
+        int bufferFactor
+    )
+    {
+        var result = new MessagingOptionsValidator().Validate(
+            new MessagingOptions
+            {
+                ConsumerThreadCount = consumerThreads,
+                SubscriberParallelExecuteThreadCount = subscriberThreads,
+                SubscriberParallelExecuteBufferFactor = bufferFactor,
+            }
+        );
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(0, 200)]
+    [InlineData(100001, 200)]
+    [InlineData(1000, 0)]
+    [InlineData(1000, 100001)]
+    public void should_reject_unbounded_scheduler_and_retry_batches(int schedulerBatchSize, int retryBatchSize)
+    {
+        var result = new MessagingOptionsValidator().Validate(
+            new MessagingOptions { SchedulerBatchSize = schedulerBatchSize, RetryBatchSize = retryBatchSize }
+        );
+
+        result.IsValid.Should().BeFalse();
+    }
+
     [Fact]
     public void should_reject_retry_policy_with_non_positive_on_exhausted_timeout()
     {

--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -116,6 +116,7 @@ public sealed class DispatcherTests : TestBase
                 EnablePublishParallelSend = false,
                 SubscriberParallelExecuteThreadCount = 2,
                 SubscriberParallelExecuteBufferFactor = 2,
+                SchedulerBatchSize = 10000,
             }
         );
 
@@ -161,6 +162,80 @@ public sealed class DispatcherTests : TestBase
         var receivedMessages = sender.ReceivedMessages.Select(m => m.StorageId).Order().ToList();
         var expected = messages.Select(m => m.StorageId).Order().ToList();
         expected.Should().Equal(receivedMessages);
+    }
+
+    [Fact]
+    public async Task should_keep_scheduler_overflow_durable_as_delayed()
+    {
+        var options = Options.Create(new MessagingOptions { SchedulerBatchSize = 1 });
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            new TestThreadSafeMessageSender(),
+            options,
+            _executor,
+            _storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        var first = _CreateTestMessage(1);
+        var second = _CreateTestMessage(2);
+        var publishTime = DateTimeOffset.UtcNow.AddSeconds(30);
+        _storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTimeOffset?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new ValueTask<bool>(true));
+
+        await dispatcher.EnqueueToScheduler(first, publishTime, cancellationToken: AbortToken);
+        await dispatcher.EnqueueToScheduler(second, publishTime, cancellationToken: AbortToken);
+
+        await _storage
+            .Received(1)
+            .ChangePublishStateAsync(second, StatusName.Delayed, null, null, cancellationToken: CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task should_not_mark_an_identical_scheduled_entry_as_delayed()
+    {
+        var options = Options.Create(new MessagingOptions { SchedulerBatchSize = 1 });
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            new TestThreadSafeMessageSender(),
+            options,
+            _executor,
+            _storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        var message = _CreateTestMessage(1);
+        var duplicate = _CreateTestMessage(1);
+        var publishTime = DateTimeOffset.UtcNow.AddSeconds(30);
+        _storage
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<StatusName>(),
+                Arg.Any<object?>(),
+                Arg.Any<DateTimeOffset?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new ValueTask<bool>(true));
+
+        await dispatcher.EnqueueToScheduler(message, publishTime, cancellationToken: AbortToken);
+        await dispatcher.EnqueueToScheduler(duplicate, publishTime, cancellationToken: AbortToken);
+
+        await _storage
+            .DidNotReceive()
+            .ChangePublishStateAsync(
+                Arg.Any<MediumMessage>(),
+                StatusName.Delayed,
+                Arg.Any<object?>(),
+                Arg.Any<DateTimeOffset?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -250,6 +325,7 @@ public sealed class DispatcherTests : TestBase
                 EnablePublishParallelSend = true,
                 SubscriberParallelExecuteThreadCount = 2,
                 SubscriberParallelExecuteBufferFactor = 2,
+                SchedulerBatchSize = 10000,
             }
         );
 

--- a/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Internal/ScheduledMediumMessageQueueTests.cs
@@ -11,6 +11,38 @@ namespace Tests.Internal;
 public sealed class ScheduledMediumMessageQueueTests : TestBase
 {
     [Fact]
+    public async Task should_reject_overflow_until_a_due_item_is_consumed()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        using var queue = new ScheduledMediumMessageQueue(timeProvider, capacity: 1);
+        var first = _CreateMediumMessage(1);
+        var second = _CreateMediumMessage(2);
+
+        queue.TryEnqueue(first, timeProvider.GetUtcNow().Ticks).Should().BeTrue();
+        queue.TryEnqueue(second, timeProvider.GetUtcNow().Ticks).Should().BeFalse();
+
+        await using var enumerator = queue.GetConsumingEnumerable(AbortToken).GetAsyncEnumerator(AbortToken);
+        (await enumerator.MoveNextAsync()).Should().BeTrue();
+        enumerator.Current.Should().BeSameAs(first);
+
+        queue.TryEnqueue(second, timeProvider.GetUtcNow().Ticks).Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_treat_an_identical_entry_as_already_enqueued_when_at_capacity()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        using var queue = new ScheduledMediumMessageQueue(timeProvider, capacity: 1);
+        var message = _CreateMediumMessage(1);
+        var sendTime = timeProvider.GetUtcNow().Ticks;
+
+        queue.TryEnqueue(message, sendTime).Should().BeTrue();
+        queue.TryEnqueue(_CreateMediumMessage(1), sendTime).Should().BeTrue();
+
+        queue.Count.Should().Be(1);
+    }
+
+    [Fact]
     public void should_reflect_all_enqueued_messages_without_removing_them_when_unordered_items()
     {
         // given
@@ -20,8 +52,8 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         var second = _CreateMediumMessage(2);
 
         // when
-        queue.Enqueue(first, timeProvider.GetUtcNow().Ticks);
-        queue.Enqueue(second, timeProvider.GetUtcNow().Ticks + TimeSpan.FromSeconds(1).Ticks);
+        queue.TryEnqueue(first, timeProvider.GetUtcNow().Ticks).Should().BeTrue();
+        queue.TryEnqueue(second, timeProvider.GetUtcNow().Ticks + TimeSpan.FromSeconds(1).Ticks).Should().BeTrue();
 
         // then
         queue.Count.Should().Be(2);
@@ -40,9 +72,9 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         var third = _CreateMediumMessage(3);
         var dueAt = timeProvider.GetUtcNow().Ticks;
 
-        queue.Enqueue(second, dueAt);
-        queue.Enqueue(first, dueAt);
-        queue.Enqueue(third, dueAt + TimeSpan.FromMilliseconds(10).Ticks);
+        queue.TryEnqueue(second, dueAt).Should().BeTrue();
+        queue.TryEnqueue(first, dueAt).Should().BeTrue();
+        queue.TryEnqueue(third, dueAt + TimeSpan.FromMilliseconds(10).Ticks).Should().BeTrue();
 
         var enumerator = queue.GetConsumingEnumerable(AbortToken).GetAsyncEnumerator(AbortToken);
 
@@ -72,7 +104,10 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
         using var queue = new ScheduledMediumMessageQueue(timeProvider);
         var message = _CreateMediumMessage(7);
-        queue.Enqueue(message, timeProvider.GetUtcNow().Ticks + TimeSpan.FromMilliseconds(200).Ticks);
+        queue
+            .TryEnqueue(message, timeProvider.GetUtcNow().Ticks + TimeSpan.FromMilliseconds(200).Ticks)
+            .Should()
+            .BeTrue();
 
         var enumerator = queue.GetConsumingEnumerable(AbortToken).GetAsyncEnumerator(AbortToken);
 
@@ -105,7 +140,7 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         var early = _CreateMediumMessage(9);
         var now = timeProvider.GetUtcNow().Ticks;
 
-        queue.Enqueue(late, now + TimeSpan.FromSeconds(10).Ticks);
+        queue.TryEnqueue(late, now + TimeSpan.FromSeconds(10).Ticks).Should().BeTrue();
         var enumerator = queue.GetConsumingEnumerable(AbortToken).GetAsyncEnumerator(AbortToken);
 
         // when
@@ -114,7 +149,7 @@ public sealed class ScheduledMediumMessageQueueTests : TestBase
         timeProvider.Advance(TimeSpan.FromSeconds(1));
         moveNextTask.IsCompleted.Should().BeFalse();
 
-        queue.Enqueue(early, now + TimeSpan.FromSeconds(2).Ticks);
+        queue.TryEnqueue(early, now + TimeSpan.FromSeconds(2).Ticks).Should().BeTrue();
         await Task.Delay(25, AbortToken);
         timeProvider.Advance(TimeSpan.FromSeconds(1));
         await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);

--- a/tests/Headless.Permissions.Tests.Unit/Services/PermissionsInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Permissions.Tests.Unit/Services/PermissionsInitializationBackgroundServiceTests.cs
@@ -309,7 +309,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         // when
         await sut.StartAsync(AbortToken);
 
-        // Advance time to allow retries to proceed (2s, 4s base delays with exponential backoff)
+        // Advance time to allow jittered retries to proceed.
         for (var i = 0; i < 5 && !completionSource.Task.IsCompleted; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(10));
@@ -321,7 +321,7 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     }
 
     [Fact]
-    public async Task should_use_10_retries_max()
+    public async Task should_cap_retry_delays_and_use_10_retries_max()
     {
         // given
         var options = new PermissionManagementOptions
@@ -346,21 +346,70 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
         // when
         await sut.StartAsync(CancellationToken.None);
 
-        // Advance time significantly to allow all retries
-        // Total delay for 10 retries: 2+4+8+16+32+64+128+256+512+1024 = 2046 seconds ~= 34 minutes
-        for (var i = 0; i < 20; i++)
-        {
-            _timeProvider.Advance(TimeSpan.FromMinutes(5));
-            await Task.Delay(50, AbortToken);
-        }
+        await _AdvancePastCappedRetriesAsync();
 
-        // then - should have exactly 11 attempts (1 initial + 10 retries)
+        var act = () => sut.WaitForInitializationAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("Always fails");
         callCount.Should().Be(11);
+    }
+
+    [Theory]
+    [InlineData("argument")]
+    [InlineData("not-supported")]
+    [InlineData("operation-cancelled")]
+    public async Task should_not_retry_terminal_save_failure(string failure)
+    {
+        var options = new PermissionManagementOptions
+        {
+            SaveStaticPermissionsToDatabase = true,
+            IsDynamicPermissionStoreEnabled = false,
+        };
+
+        var callCount = 0;
+        var expected = _CreateTerminalException(failure);
+        _store
+            .SaveAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                throw expected;
+            });
+
+        using var sut = _CreateSut(options);
+        await sut.StartAsync(CancellationToken.None);
+
+        var thrown = await Record.ExceptionAsync(() =>
+            sut.WaitForInitializationAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken)
+        );
+
+        thrown.Should().NotBeNull();
+        expected.GetType().IsAssignableFrom(thrown!.GetType()).Should().BeTrue();
+        callCount.Should().Be(1);
     }
 
     #endregion
 
     #region Cancellation
+
+    [Fact]
+    public async Task should_complete_waiter_as_cancelled_when_start_token_is_already_cancelled()
+    {
+        var options = new PermissionManagementOptions
+        {
+            SaveStaticPermissionsToDatabase = true,
+            IsDynamicPermissionStoreEnabled = false,
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        using var sut = _CreateSut(options);
+
+        await sut.StartAsync(cts.Token);
+
+        var act = () => sut.WaitForInitializationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await _store.DidNotReceive().SaveAsync(Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task should_cancel_on_start_token_cancellation()
@@ -481,6 +530,27 @@ public sealed class PermissionsInitializationBackgroundServiceTests : TestBase
     #endregion
 
     #region Helpers
+
+    private async Task _AdvancePastCappedRetriesAsync()
+    {
+        // Each advance exceeds the 30-second cap, while remaining far below the old unbounded exponential tail.
+        for (var i = 0; i < 15; i++)
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(31));
+            await Task.Delay(10, AbortToken);
+        }
+    }
+
+    private static Exception _CreateTerminalException(string failure)
+    {
+        return failure switch
+        {
+            "argument" => new ArgumentException("Invalid configuration"),
+            "not-supported" => new NotSupportedException("Unsupported configuration"),
+            "operation-cancelled" => new OperationCanceledException("Initialization cancelled"),
+            _ => throw new ArgumentOutOfRangeException(nameof(failure), failure, message: null),
+        };
+    }
 
     private PermissionsInitializationBackgroundService _CreateSut(PermissionManagementOptions options)
     {

--- a/tests/Headless.Settings.Tests.Unit/Seeders/SettingsInitializationBackgroundServiceTests.cs
+++ b/tests/Headless.Settings.Tests.Unit/Seeders/SettingsInitializationBackgroundServiceTests.cs
@@ -301,7 +301,7 @@ public sealed class SettingsInitializationBackgroundServiceTests : TestBase
         // when
         await sut.StartAsync(AbortToken);
 
-        // Advance time to allow retries to proceed (2s, 4s base delays with exponential backoff)
+        // Advance time to allow jittered retries to proceed.
         for (var i = 0; i < 5 && !completionSource.Task.IsCompleted; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(10));
@@ -312,9 +312,91 @@ public sealed class SettingsInitializationBackgroundServiceTests : TestBase
         callCount.Should().BeGreaterThanOrEqualTo(3);
     }
 
+    [Fact]
+    public async Task should_cap_retry_delays_and_surface_terminal_unknown_failure()
+    {
+        var options = new SettingManagementOptions
+        {
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
+        };
+
+        var callCount = 0;
+        _store
+            .SaveAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                throw new InvalidOperationException("Always fails");
+            });
+
+        using var sut = _CreateSut(options);
+        await sut.StartAsync(CancellationToken.None);
+
+        await _AdvancePastCappedRetriesAsync();
+
+        var act = () => sut.WaitForInitializationAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("Always fails");
+        callCount.Should().Be(11);
+    }
+
+    [Theory]
+    [InlineData("argument")]
+    [InlineData("not-supported")]
+    [InlineData("operation-cancelled")]
+    public async Task should_not_retry_terminal_save_failure(string failure)
+    {
+        var options = new SettingManagementOptions
+        {
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
+        };
+
+        var callCount = 0;
+        var expected = _CreateTerminalException(failure);
+        _store
+            .SaveAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                throw expected;
+            });
+
+        using var sut = _CreateSut(options);
+        await sut.StartAsync(CancellationToken.None);
+
+        var thrown = await Record.ExceptionAsync(() =>
+            sut.WaitForInitializationAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken)
+        );
+
+        thrown.Should().NotBeNull();
+        expected.GetType().IsAssignableFrom(thrown!.GetType()).Should().BeTrue();
+        callCount.Should().Be(1);
+    }
+
     #endregion
 
     #region Cancellation
+
+    [Fact]
+    public async Task should_complete_waiter_as_cancelled_when_start_token_is_already_cancelled()
+    {
+        var options = new SettingManagementOptions
+        {
+            SaveStaticSettingsToDatabase = true,
+            IsDynamicSettingStoreEnabled = false,
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        using var sut = _CreateSut(options);
+
+        await sut.StartAsync(cts.Token);
+
+        var act = () => sut.WaitForInitializationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await _store.DidNotReceive().SaveAsync(Arg.Any<CancellationToken>());
+    }
 
     [Fact]
     public async Task should_cancel_on_start_token_cancellation()
@@ -395,6 +477,27 @@ public sealed class SettingsInitializationBackgroundServiceTests : TestBase
     #endregion
 
     #region Helpers
+
+    private async Task _AdvancePastCappedRetriesAsync()
+    {
+        // Each advance exceeds the 30-second cap, while remaining far below the old unbounded exponential tail.
+        for (var i = 0; i < 15; i++)
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(31));
+            await Task.Delay(10, AbortToken);
+        }
+    }
+
+    private static Exception _CreateTerminalException(string failure)
+    {
+        return failure switch
+        {
+            "argument" => new ArgumentException("Invalid configuration"),
+            "not-supported" => new NotSupportedException("Unsupported configuration"),
+            "operation-cancelled" => new OperationCanceledException("Initialization cancelled"),
+            _ => throw new ArgumentOutOfRangeException(nameof(failure), failure, message: null),
+        };
+    }
 
     private SettingsInitializationBackgroundService _CreateSut(SettingManagementOptions options)
     {


### PR DESCRIPTION
## Summary

- cap and jitter feature, permission, and setting initialization retries while excluding terminal/cancellation failures
- bound messaging thread/buffer configuration and retry/scheduler batch sizes
- cap the in-memory near-term scheduler queue; overflow remains durable as delayed work
- preserve current startup initialization and committed-message behavior while applying the limits

This is the background-worker and messaging bounds slice split from #707.

## Testing

- `make test-project TEST_PROJECT=tests/Headless.Messaging.Core.Tests.Unit/Headless.Messaging.Core.Tests.Unit.csproj` — 946 passed
- `make test-project TEST_PROJECT=tests/Headless.Features.Tests.Unit/Headless.Features.Tests.Unit.csproj` — 39 passed
- `make test-project TEST_PROJECT=tests/Headless.Permissions.Tests.Unit/Headless.Permissions.Tests.Unit.csproj` — 156 passed
- `make test-project TEST_PROJECT=tests/Headless.Settings.Tests.Unit/Headless.Settings.Tests.Unit.csproj` — 200 passed
- `git diff --check`

## Post-Deploy Monitoring & Validation

- **Responsible:** messaging and application-startup operator
- **Window:** first startup plus one delayed-message scheduling cycle after deployment
- **Healthy:** initialization retries stop after the documented budget; terminal failures surface immediately; scheduler memory stays within `SchedulerBatchSize`; overflowed messages remain durable and are later processed
- **Failure:** startup retry storms, cancelled initialization hanging, memory growth beyond configured bounds, or delayed messages becoming stuck/lost
- **Action:** inspect initialization exception types, retry counts, delayed-message status transitions, and configured capacities; stop scaling the failing worker until the cause is known
- **Rollback:** revert this PR only with external queue/memory/retry controls in place; durable delayed rows allow safe recovery after capacity tuning

## Checklist

- [x] Retries are bounded, jittered, cancellation-aware, and terminal-error aware
- [x] Messaging thread, buffer, retry, and scheduler values are validated
- [x] Queue overflow preserves durable work
- [x] Current `main` initialization and committed-message contracts are preserved

