### PR TITLE
refactor(core): seal accessor, checks polish, slug options

### DIFF
--- a/docs/llms/index.md
+++ b/docs/llms/index.md
@@ -20,7 +20,7 @@ This project uses the [Headless .NET Framework](https://github.com/xshaheen/head
 
 ### Argument validation and guard clauses
 
-- Use `Argument.*` (e.g., `Argument.IsNotNull(value)`, `Argument.IsNotNullOrWhiteSpace(value)`, `Argument.IsPositive(value)`) and `Ensure.*` (e.g., `Ensure.True(condition)`, `Ensure.NotDisposed(this, _disposed)`) from `Headless.Checks`.
+- Use `Argument.*` (e.g., `Argument.IsNotNull(value)`, `Argument.IsNotNullOrWhiteSpace(value)`, `Argument.IsPositive(value)`) and `Ensure.*` (e.g., `Ensure.True(condition)`, `Ensure.NotDisposed(_disposed, this)`) from `Headless.Checks`.
 - Do not use `ArgumentNullException.ThrowIfNull`, `ArgumentOutOfRangeException.ThrowIfGreaterThan`, or other `*.ThrowIf*` static helpers.
 - For request payloads, use FluentValidation rules rather than manual `if` guards.
 

--- a/docs/llms/utilities.md
+++ b/docs/llms/utilities.md
@@ -796,10 +796,13 @@ var slug = Slug.Create("Long Title That Needs Truncation", options);
 
 #### Character Replacements
 
+`Replacements` accepts any `IReadOnlyDictionary<string, string>` and replaces the default set entirely;
+the assigned dictionary is frozen internally (ordinal comparison) for lookup performance.
+
 ```csharp
 var options = new SlugOptions
 {
-    Replacements =
+    Replacements = new Dictionary<string, string>(StringComparer.Ordinal)
     {
         ["&"] = "and",
         ["@"] = "at",

--- a/src/Headless.Checks/Argument.cs
+++ b/src/Headless.Checks/Argument.cs
@@ -14,6 +14,9 @@ namespace Headless.Checks;
 ///   <item><description><see cref="ArgumentOutOfRangeException"/> — numeric / comparable range checks (<c>IsPositive</c>, <c>IsNegative</c>, <c>IsInclusiveBetween</c>, etc.).</description></item>
 /// </list>
 /// Use <see cref="Ensure"/> for runtime state assertions that are not about caller arguments.
+/// The auto-captured <c>paramName</c> parameter is the caller's argument expression and becomes the thrown
+/// exception's <see cref="ArgumentException.ParamName"/>; unlike <see cref="Ensure"/>'s <c>expression</c>, it names
+/// the offending parameter rather than describing a checked condition.
 /// </remarks>
 [PublicAPI]
 public static partial class Argument;

--- a/src/Headless.Checks/Ensure.cs
+++ b/src/Headless.Checks/Ensure.cs
@@ -7,6 +7,11 @@ using Headless.Checks.Internals;
 namespace Headless.Checks;
 
 /// <summary>Common runtime checks that throw exceptions upon failure.</summary>
+/// <remarks>
+/// The auto-captured <c>expression</c> parameter is the source text of the checked condition or value and is
+/// embedded in the exception <em>message</em>; unlike <see cref="Argument"/>'s <c>paramName</c>, it is not an
+/// <see cref="ArgumentException.ParamName"/> (state checks throw exceptions that carry no parameter name).
+/// </remarks>
 [PublicAPI]
 public static class Ensure
 {
@@ -97,13 +102,20 @@ public static class Ensure
     /// <param name="disposed">Whether the object has already been disposed.</param>
     /// <param name="disposedValue">The disposed instance; its runtime type name is used as the object name in the exception.</param>
     /// <param name="message">(Optional) Custom error message.</param>
+    /// <param name="expression">The captured text of <paramref name="disposed"/> (auto generated, no need to pass it); used as the object name when <paramref name="disposedValue"/> is null.</param>
     /// <exception cref="ObjectDisposedException">if <paramref name="disposed"/> is <see langword="true"/>.</exception>
     [DebuggerStepThrough]
-    public static void NotDisposed([DoesNotReturnIf(true)] bool disposed, object? disposedValue, string? message = null)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotDisposed(
+        [DoesNotReturnIf(true)] bool disposed,
+        object? disposedValue,
+        string? message = null,
+        [CallerArgumentExpression(nameof(disposed))] string? expression = null
+    )
     {
         if (disposed)
         {
-            _ThrowObjectDisposed(disposedValue, message);
+            _ThrowObjectDisposed(disposedValue, message, expression);
         }
     }
 
@@ -126,9 +138,9 @@ public static class Ensure
     }
 
     [DoesNotReturn]
-    private static void _ThrowObjectDisposed(object? disposedValue, string? message)
+    private static void _ThrowObjectDisposed(object? disposedValue, string? message, string? expression)
     {
-        var objectName = disposedValue != null ? (disposedValue.GetType().FullName ?? string.Empty) : string.Empty;
+        var objectName = disposedValue?.GetType().FullName ?? expression ?? string.Empty;
         if (message != null)
         {
             throw new ObjectDisposedException(objectName, message);

--- a/src/Headless.Slugs/README.md
+++ b/src/Headless.Slugs/README.md
@@ -51,10 +51,13 @@ var slug = Slug.Create("Long Title That Needs Truncation", options);
 
 ### Character Replacements
 
+`Replacements` accepts any `IReadOnlyDictionary<string, string>` and replaces the default set entirely;
+the assigned dictionary is frozen internally (ordinal comparison) for lookup performance.
+
 ```csharp
 var options = new SlugOptions
 {
-    Replacements =
+    Replacements = new Dictionary<string, string>(StringComparer.Ordinal)
     {
         ["&"] = "and",
         ["@"] = "at",

--- a/src/Headless.Slugs/SlugOptions.cs
+++ b/src/Headless.Slugs/SlugOptions.cs
@@ -71,20 +71,29 @@ public sealed class SlugOptions
         UnicodeRange.Create('ؠ', 'ي'),
     ];
 
+    private static readonly FrozenDictionary<string, string> _DefaultReplacements = new Dictionary<string, string>(
+        StringComparer.Ordinal
+    )
+    {
+        { "&", " and " },
+        { "+", " plus " },
+        { ".", " dot " },
+        { "%", " percent " },
+    }.ToFrozenDictionary(StringComparer.Ordinal);
+
     /// <summary>
     /// Verbatim string substitutions applied before slug processing. Each key is replaced with its
-    /// corresponding value using ordinal comparison. Defaults to a small set of common symbol expansions:
+    /// corresponding value using ordinal comparison. Accepts any <see cref="IReadOnlyDictionary{TKey,TValue}"/>;
+    /// the assigned dictionary is frozen internally (ordinal key comparison) for lookup performance.
+    /// Defaults to a small set of common symbol expansions:
     /// <c>&amp;</c> to <c> and </c>, <c>+</c> to <c> plus </c>, <c>.</c> to <c> dot </c>, and
     /// <c>%</c> to <c> percent </c>.
     /// </summary>
-    public FrozenDictionary<string, string> Replacements { get; init; } =
-        new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            { "&", " and " },
-            { "+", " plus " },
-            { ".", " dot " },
-            { "%", " percent " },
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> Replacements
+    {
+        get;
+        init => field = value as FrozenDictionary<string, string> ?? value.ToFrozenDictionary(StringComparer.Ordinal);
+    } = _DefaultReplacements;
 
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="character"/> falls within at least one of the

--- a/tests/Headless.Checks.Tests.Unit/EnsureTests.cs
+++ b/tests/Headless.Checks.Tests.Unit/EnsureTests.cs
@@ -87,6 +87,19 @@ public sealed class EnsureTests
     }
 
     [Fact]
+    public void should_use_captured_expression_as_object_name_when_not_disposed_with_null_value()
+    {
+        // given
+        var isShutDown = true;
+
+        // when
+        var action = () => Ensure.NotDisposed(isShutDown, disposedValue: null);
+
+        // then - the captured condition text stands in for the missing instance
+        action.Should().ThrowExactly<ObjectDisposedException>().Which.ObjectName.Should().Be("isShutDown");
+    }
+
+    [Fact]
     public void should_throw_when_not_disposed_disposed_with_object()
     {
         // given

--- a/tests/Headless.Slugs.Tests.Unit/SlugTests.cs
+++ b/tests/Headless.Slugs.Tests.Unit/SlugTests.cs
@@ -291,14 +291,25 @@ public sealed class SlugTests
     {
         var options = new SlugOptions
         {
-            Replacements = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                { "@", " at " },
-            }.ToFrozenDictionary(),
+            Replacements = new Dictionary<string, string>(StringComparer.Ordinal) { { "@", " at " } },
             MaximumLength = 0,
         };
 
         Slug.Create("user@domain", options).Should().Be("user-at-domain");
+    }
+
+    [Fact]
+    public void should_freeze_replacements_internally()
+    {
+        // given - a plain dictionary assigned to the read-only surface
+        var options = new SlugOptions
+        {
+            Replacements = new Dictionary<string, string>(StringComparer.Ordinal) { { "@", " at " } },
+        };
+
+        // then - the stored representation is frozen for lookup performance
+        options.Replacements.Should().BeAssignableTo<FrozenDictionary<string, string>>();
+        new SlugOptions().Replacements.Should().BeAssignableTo<FrozenDictionary<string, string>>();
     }
 
     [Fact]
@@ -316,10 +327,7 @@ public sealed class SlugTests
         // Replacements happen first, then filtering by AllowedRanges
         var options = new SlugOptions
         {
-            Replacements = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                { "&", "AND" },
-            }.ToFrozenDictionary(),
+            Replacements = new Dictionary<string, string>(StringComparer.Ordinal) { { "&", "AND" } },
             MaximumLength = 0,
         };
 


### PR DESCRIPTION
## Summary

Pre-v1 public-API hardening nits across the foundation packages (`Headless.Checks`, `Headless.Slugs`), per the pre-v1 API review findings. The `ThreadCurrentPrincipalAccessor` sealing task was verified and intentionally skipped (see Decisions).

## Changes

- `Ensure.NotDisposed` (finding at `src/Headless.Checks/Ensure.cs:102`): aligned with its siblings (`True`/`False`/`NotNull`) — added `[MethodImpl(MethodImplOptions.AggressiveInlining)]` and a `[CallerArgumentExpression(nameof(disposed))] string? expression = null` parameter. The captured condition text is used as the `ObjectDisposedException.ObjectName` fallback when `disposedValue` is null (previously an empty name); the common `Ensure.NotDisposed(_disposed, this)` shape is unchanged.
- `Ensure` vs `Argument` captured-parameter naming: inspected — they capture **different** things, so both names are kept and each class-level doc now carries a clarifying note. `Argument.*`'s `paramName` is the caller's argument expression fed into the thrown exception's `ArgumentException.ParamName`; `Ensure.*`'s `expression` is condition/value source text embedded in the `InvalidOperationException` message (state-check exceptions carry no parameter name).
- `SlugOptions.Replacements` (finding at `src/Headless.Slugs/SlugOptions.cs:80`): public surface widened from `FrozenDictionary<string, string>` to `IReadOnlyDictionary<string, string>`; the init accessor freezes the assigned dictionary internally (`ToFrozenDictionary(StringComparer.Ordinal)`, pass-through when already frozen), so consumers pass a plain `Dictionary<string, string>` while the stored representation stays `FrozenDictionary` for lookup performance.
- Tests: `SlugTests` custom-replacement cases now pass plain dictionaries (no `.ToFrozenDictionary()`); added `should_freeze_replacements_internally`; added `EnsureTests.should_use_captured_expression_as_object_name_when_not_disposed_with_null_value`.

## Decisions

- **Skipped sealing `ThreadCurrentPrincipalAccessor`** (finding at `src/Headless.Core/Abstractions/ICurrentPrincipalAccessor.cs:85`): `rg` found a derived type — `HttpContextCurrentPrincipalAccessor` in `src/Headless.Api.Core/Security/Claims/HttpContextCurrentPrincipalAccessor.cs:14` extends it to add HTTP-context fallback resolution. Sealing would break it, so per the task's decision rule the sub-task was skipped and `Headless.Core` is untouched in this PR.
- **Kept both `expression` and `paramName` names** (decision rule above): they are semantically different captures — parameter identity vs. condition text — documented via one `<remarks>` note on each holder class rather than repeating a note on every method of the large `Argument` partial surface.
- `NotDisposed` uses the captured expression only as the object-name fallback for the degenerate `disposedValue: null` case; it does not change the default message shape, keeping existing call sites and tests intact.
- `Replacements` keeps a caller-supplied `FrozenDictionary` as-is (no re-freeze); its comparer is irrelevant to replacement semantics because `Slug.Create` applies replacements with `StringComparison.Ordinal` on the text, not via dictionary lookup.
- Fixed a reversed-argument doc example in `docs/llms/index.md` (`Ensure.NotDisposed(this, _disposed)` → `Ensure.NotDisposed(_disposed, this)`), and replaced the Slugs docs' `Replacements = { ... }` collection-initializer examples, which never compiled against a get/init dictionary property, with the real construction shape.

## Testing

- `dotnet build src/Headless.Checks -c Release --no-incremental -v:minimal -nologo` — 0 warnings, 0 errors.
- `dotnet build src/Headless.Slugs -c Release --no-incremental -v:minimal -nologo` — clean.
- `dotnet build src/Headless.Core -c Release --no-incremental -v:minimal -nologo` — clean (untouched; verified anyway).
- `dotnet test --project tests/Headless.Checks.Tests.Unit -c Release` — 393 passed.
- `dotnet test --project tests/Headless.Slugs.Tests.Unit -c Release` — 73 passed.
- `make quality-analyzers-project` for `Headless.Checks` and `Headless.Slugs` — clean.
- Integration tests skipped: Docker unavailable on this machine (no integration project covers these packages directly).

## Docs

- `src/Headless.Slugs/README.md` + `docs/llms/utilities.md`: fixed the non-compiling `Replacements` example and documented the new `IReadOnlyDictionary` surface with internal freezing.
- `docs/llms/index.md`: corrected the `Ensure.NotDisposed` argument order.
- `docs/llms/core.md` and `src/Headless.Checks/README.md` examples (`Ensure.NotDisposed(_disposed, this)`) remain valid unchanged — the new parameters are optional/auto-captured.
