### PR TITLE
refactor(domain): async-only local event bus and contract alignment

### DIFF
--- a/docs/llms/core.md
+++ b/docs/llms/core.md
@@ -387,14 +387,15 @@ Provides in-memory domain event dispatch that resolves handlers from the DI cont
 ### Key Features
 
 - `ILocalEventBus` implementation (`ServiceProviderLocalEventBus`) backed by DI
-- Generic and non-generic publish overloads (`Publish`, `PublishAsync`)
+- Generic and non-generic async publish overloads (`PublishAsync`)
 - Handler resolution per publish from the active scope
 - Handler ordering via `DomainEventHandlerOrderAttribute`
 - Handler exception aggregation and cooperative cancellation
 
 ### Design Notes
 
-- **Non-generic runtime-typed dispatch.** `Publish(IDomainEvent)` / `PublishAsync(IDomainEvent)` dispatch to handlers of the event's exact runtime type — there is no contravariant traversal to base types or implemented interfaces. The runtime type is mapped to a compiled invoker that is built once and cached, so repeated publishes of the same concrete type avoid reflection on the hot path. The generic overloads (`Publish<T>` / `PublishAsync<T>`) dispatch against the static type argument `T`.
+- **Async-only contract.** `ILocalEventBus` deliberately exposes no synchronous `Publish`: a public sync member would dispatch the async handlers sync-over-async, which can deadlock on threads that carry a synchronization context (classic ASP.NET, Blazor Server, WPF). Infrastructure that must publish from a synchronous code path (for example the EF sync `SaveChanges` pipeline) owns and contains that bridge internally.
+- **Non-generic runtime-typed dispatch.** `PublishAsync(IDomainEvent)` dispatches to handlers of the event's exact runtime type — there is no contravariant traversal to base types or implemented interfaces. The runtime type is mapped to a compiled invoker that is built once and cached, so repeated publishes of the same concrete type avoid reflection on the hot path. The generic overload (`PublishAsync<T>`) dispatches against the static type argument `T`.
 - **Scoped lifetime.** `AddHeadlessLocalEventBus()` registers `ILocalEventBus` as scoped (`TryAddScoped`). Handlers are resolved from the caller's scope, so they share the same scoped services — notably the `DbContext` — when published inside a unit of work.
 - **Exception aggregation and cancellation.** Handlers are resolved and invoked per publish. A single handler exception is rethrown as-is; multiple handler exceptions are wrapped in an `AggregateException`. Cancellation is observed between handlers; if the token is cancelled, already-accumulated handler exceptions are preserved rather than discarded.
 - **Namespace unchanged.** The package/assembly was renamed from `Headless.Domain.LocalPublisher`, but the namespace stays `Headless.Domain` — no `using` changes are needed.

--- a/src/Headless.Domain.LocalEventBus/README.md
+++ b/src/Headless.Domain.LocalEventBus/README.md
@@ -9,14 +9,15 @@ Provides in-memory domain event dispatch that resolves handlers from the DI cont
 ## Key Features
 
 - `ILocalEventBus` implementation (`ServiceProviderLocalEventBus`) backed by DI
-- Generic and non-generic publish overloads (`Publish`, `PublishAsync`)
+- Generic and non-generic async publish overloads (`PublishAsync`)
 - Handler resolution per publish from the active scope
 - Handler ordering via `DomainEventHandlerOrderAttribute`
 - Handler exception aggregation and cooperative cancellation
 
 ## Design Notes
 
-- **Non-generic runtime-typed dispatch.** `Publish(IDomainEvent)` / `PublishAsync(IDomainEvent)` dispatch to handlers of the event's exact runtime type — there is no contravariant traversal to base types or implemented interfaces. The runtime type is mapped to a compiled invoker that is built once and cached, so repeated publishes of the same concrete type avoid reflection on the hot path. The generic overloads (`Publish<T>` / `PublishAsync<T>`) dispatch against the static type argument `T`.
+- **Async-only contract.** `ILocalEventBus` deliberately exposes no synchronous `Publish`: a public sync member would dispatch the async handlers sync-over-async, which can deadlock on threads that carry a synchronization context (classic ASP.NET, Blazor Server, WPF). Infrastructure that must publish from a synchronous code path (for example the EF sync `SaveChanges` pipeline) owns and contains that bridge internally.
+- **Non-generic runtime-typed dispatch.** `PublishAsync(IDomainEvent)` dispatches to handlers of the event's exact runtime type — there is no contravariant traversal to base types or implemented interfaces. The runtime type is mapped to a compiled invoker that is built once and cached, so repeated publishes of the same concrete type avoid reflection on the hot path. The generic overload (`PublishAsync<T>`) dispatches against the static type argument `T`.
 - **Scoped lifetime.** `AddHeadlessLocalEventBus()` registers `ILocalEventBus` as scoped (`TryAddScoped`). Handlers are resolved from the caller's scope, so they share the same scoped services — notably the `DbContext` — when published inside a unit of work.
 - **Exception aggregation and cancellation.** Handlers are resolved and invoked per publish. A single handler exception is rethrown as-is; multiple handler exceptions are wrapped in an `AggregateException`. Cancellation is observed between handlers; if the token is cancelled, already-accumulated handler exceptions are preserved rather than discarded.
 

--- a/src/Headless.Domain.LocalEventBus/ServiceProviderLocalEventBus.cs
+++ b/src/Headless.Domain.LocalEventBus/ServiceProviderLocalEventBus.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Headless.Checks;
 using Microsoft.Extensions.DependencyInjection;
-using Nito.AsyncEx.Synchronous;
 
 namespace Headless.Domain;
 
@@ -20,43 +19,6 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
             var attribute = type.GetCustomAttribute<DomainEventHandlerOrderAttribute>();
             return new StrongBox<int>(attribute?.Order ?? 0);
         };
-
-    public void Publish<T>(T domainEvent)
-        where T : class, IDomainEvent
-    {
-        var handlers = services.GetServices<IDomainEventHandler<T>>();
-        List<Exception>? exceptions = null;
-
-        foreach (var handler in _OrderHandlers(handlers))
-        {
-            try
-            {
-                var pending = handler.HandleAsync(domainEvent);
-
-                // Avoid the ValueTask -> Task allocation for the common synchronously-completed handler; only
-                // fall back to AsTask() (to block / unwrap) when the handler did not finish synchronously.
-                if (!pending.IsCompletedSuccessfully)
-                {
-                    pending.AsTask().WaitAndUnwrapException();
-                }
-            }
-            catch (TargetInvocationException e)
-            {
-                // A handler that itself threw a TargetInvocationException is unwrapped to its inner
-                // exception; fall back to the wrapper when the inner is null (defensive — InnerException is nullable).
-                (exceptions ??= []).Add(e.InnerException ?? e);
-            }
-            catch (Exception e)
-            {
-                (exceptions ??= []).Add(e);
-            }
-        }
-
-        if (exceptions is { Count: > 0 })
-        {
-            _ThrowOriginalExceptions(typeof(T), exceptions);
-        }
-    }
 
     public async ValueTask PublishAsync<T>(T domainEvent, CancellationToken cancellationToken = default)
         where T : class, IDomainEvent
@@ -98,16 +60,8 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
         }
     }
 
-    // Non-generic overloads dispatch to the exact runtime type (no contravariant base-type traversal),
+    // The non-generic overload dispatches to the exact runtime type (no contravariant base-type traversal),
     // matching the generic path. A compiled per-type invoker avoids per-call reflection cost.
-    public void Publish(IDomainEvent domainEvent)
-    {
-        Argument.IsNotNull(domainEvent);
-
-        var invoker = _SyncInvokers.GetOrAdd(domainEvent.GetType(), _CreateSyncInvoker);
-        invoker(this, domainEvent);
-    }
-
     public ValueTask PublishAsync(IDomainEvent domainEvent, CancellationToken cancellationToken = default)
     {
         Argument.IsNotNull(domainEvent);
@@ -183,18 +137,9 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
         Func<ServiceProviderLocalEventBus, IDomainEvent, CancellationToken, ValueTask>
     > _AsyncInvokers = new();
 
-    private static readonly ConcurrentDictionary<
-        Type,
-        Action<ServiceProviderLocalEventBus, IDomainEvent>
-    > _SyncInvokers = new();
-
     private static readonly MethodInfo _GenericPublishAsync = typeof(ServiceProviderLocalEventBus)
         .GetMethods(BindingFlags.Public | BindingFlags.Instance)
         .Single(m => m is { Name: nameof(PublishAsync), IsGenericMethodDefinition: true });
-
-    private static readonly MethodInfo _GenericPublish = typeof(ServiceProviderLocalEventBus)
-        .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-        .Single(m => m is { Name: nameof(Publish), IsGenericMethodDefinition: true });
 
     private static Func<ServiceProviderLocalEventBus, IDomainEvent, CancellationToken, ValueTask> _CreateAsyncInvoker(
         Type eventType
@@ -220,21 +165,6 @@ internal sealed class ServiceProviderLocalEventBus(IServiceProvider services) : 
                 cancellationToken
             )
             .Compile();
-    }
-
-    private static Action<ServiceProviderLocalEventBus, IDomainEvent> _CreateSyncInvoker(Type eventType)
-    {
-        _EnsureReferenceType(eventType);
-
-        var self = Expression.Parameter(typeof(ServiceProviderLocalEventBus), "self");
-        var domainEvent = Expression.Parameter(typeof(IDomainEvent), "domainEvent");
-        var call = Expression.Call(
-            self,
-            _GenericPublish.MakeGenericMethod(eventType),
-            Expression.Convert(domainEvent, eventType)
-        );
-
-        return Expression.Lambda<Action<ServiceProviderLocalEventBus, IDomainEvent>>(call, self, domainEvent).Compile();
     }
 
     #endregion

--- a/src/Headless.Domain/Concurrency/IHasETag.cs
+++ b/src/Headless.Domain/Concurrency/IHasETag.cs
@@ -13,5 +13,11 @@ namespace Headless.Domain;
 public interface IHasETag
 {
     /// <summary>Raw version token of the entity; <see langword="null"/> until the entity has been persisted.</summary>
+    /// <remarks>
+    /// Unlike <see cref="IHasConcurrencyStamp.ConcurrencyStamp"/> (application-generated, get-only), the ETag
+    /// is written by the store: the persistence layer maps it as a database row version
+    /// (for example <c>IsRowVersion()</c> in EF Core) and materializes / refreshes the value on every load and
+    /// save. The setter exists for that store-side write path — domain code should treat the value as read-only.
+    /// </remarks>
     byte[]? ETag { get; set; }
 }

--- a/src/Headless.Domain/Domain/IAggregateRoot`T.cs
+++ b/src/Headless.Domain/Domain/IAggregateRoot`T.cs
@@ -10,7 +10,7 @@ namespace Headless.Domain;
 /// <typeparam name="TId">Type of the primary key of the entity</typeparam>
 [PublicAPI]
 public interface IAggregateRoot<out TId> : IEntity<TId>, IAggregateRoot
-    where TId : notnull;
+    where TId : notnull, IEquatable<TId>;
 
 /// <summary>Base class for aggregate roots with a single primary key.</summary>
 [PublicAPI]

--- a/src/Headless.Domain/Domain/IEntity`T.cs
+++ b/src/Headless.Domain/Domain/IEntity`T.cs
@@ -7,7 +7,7 @@ namespace Headless.Domain;
 /// <typeparam name="TId">Type of the primary key of the entity</typeparam>
 [PublicAPI]
 public interface IEntity<out TId> : IEntity
-    where TId : notnull
+    where TId : notnull, IEquatable<TId>
 {
     /// <summary>Unique identifier for this entity.</summary>
     TId Id { get; }

--- a/src/Headless.Domain/Messages/Local/ILocalEventBus.cs
+++ b/src/Headless.Domain/Messages/Local/ILocalEventBus.cs
@@ -5,26 +5,17 @@ namespace Headless.Domain;
 
 /// <summary>
 /// Publishes in-process domain events to their <see cref="IDomainEventHandler{TEvent}"/> handlers.
-/// Dispatched synchronously within the active unit of work / transaction.
+/// Dispatched inline within the active unit of work / transaction.
 /// </summary>
+/// <remarks>
+/// The contract is async-only by design: a public synchronous publish would invite sync-over-async
+/// dispatch of the async handlers, which can deadlock on threads that carry a synchronization context
+/// (classic ASP.NET, Blazor Server, WPF). Infrastructure that must publish from a synchronous code path
+/// owns and contains that bridge itself.
+/// </remarks>
 [PublicAPI]
 public interface ILocalEventBus
 {
-    /// <summary>Publishes a domain event to its handlers, blocking the calling thread until they all complete.</summary>
-    /// <param name="domainEvent">The domain event to dispatch.</param>
-    /// <remarks>
-    /// Dispatches the async handlers synchronously (sync-over-async). Do not call from a thread that carries a
-    /// synchronization context (classic ASP.NET, Blazor Server, WPF), or it may deadlock; prefer
-    /// <c>PublishAsync</c> in asynchronous code.
-    /// </remarks>
-    void Publish<T>(T domainEvent)
-        where T : class, IDomainEvent;
-
-    /// <summary>Publishes a domain event resolved by its runtime type, blocking the calling thread until all handlers complete.</summary>
-    /// <param name="domainEvent">The domain event to dispatch.</param>
-    /// <remarks>Sync-over-async; see <c>Publish</c> for the synchronization-context deadlock caveat.</remarks>
-    void Publish(IDomainEvent domainEvent);
-
     /// <summary>Publishes a domain event to its handlers asynchronously.</summary>
     /// <param name="domainEvent">The domain event to dispatch.</param>
     /// <param name="cancellationToken">Token to cancel the dispatch operation.</param>

--- a/src/Headless.EntityFramework/Contexts/Runtime/HeadlessSaveChangesPipeline.cs
+++ b/src/Headless.EntityFramework/Contexts/Runtime/HeadlessSaveChangesPipeline.cs
@@ -377,7 +377,7 @@ internal sealed partial class HeadlessSaveChangesPipeline(
                 {
                     foreach (var domainEvent in emitter.Events)
                     {
-                        bus.Publish(domainEvent);
+                        _PublishDomainEventBlocking(bus, domainEvent);
                     }
                 }
 
@@ -425,6 +425,29 @@ internal sealed partial class HeadlessSaveChangesPipeline(
             ExceptionDispatchInfo.Capture(caught).Throw();
             throw; // unreachable; satisfies analyzers
         }
+#pragma warning restore MA0045
+    }
+
+    // ILocalEventBus is async-only by contract: exposing a public sync Publish invited sync-over-async
+    // dispatch (and its synchronization-context deadlocks) in application code. The synchronous
+    // SaveChanges path still has to dispatch domain events inline, so the bridge lives HERE, contained
+    // in infrastructure. Blocking is acceptable in this frame: EF's own sync SaveChanges is already
+    // blocking database I/O on a thread without a synchronization context to deadlock against.
+    private static void _PublishDomainEventBlocking(ILocalEventBus bus, IDomainEvent domainEvent)
+    {
+#pragma warning disable MA0045 // Sync SaveChanges path intentionally blocks; see comment above.
+        var pending = bus.PublishAsync(domainEvent);
+
+        if (pending.IsCompletedSuccessfully)
+        {
+            // Observe the completed ValueTask (required for IValueTaskSource-backed implementations).
+            pending.GetAwaiter().GetResult();
+            return;
+        }
+
+        // GetResult() rethrows the original exception (no AggregateException wrapping by Task.Wait),
+        // preserving the bus's single-exception / AggregateException contract for the catch below.
+        pending.AsTask().GetAwaiter().GetResult();
 #pragma warning restore MA0045
     }
 

--- a/tests/Headless.Domain.LocalEventBus.Tests.Unit/ServiceProviderLocalEventBusTests.cs
+++ b/tests/Headless.Domain.LocalEventBus.Tests.Unit/ServiceProviderLocalEventBusTests.cs
@@ -5,7 +5,6 @@ using Headless.Domain;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 
-#pragma warning disable MA0045 // Do not use blocking calls, even when the calling method must become async
 #pragma warning disable MA0015 // Specify the parameter name in ArgumentException
 namespace Tests;
 
@@ -119,170 +118,6 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
 
     #endregion
 
-    #region Publish (Synchronous) Tests
-
-    [Fact]
-    public void should_invoke_all_handlers()
-    {
-        // given
-        var handler1 = new TrackingHandler();
-        var handler2 = new TrackingHandler();
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(handler1);
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(handler2);
-        var publisher = _CreatePublisher(services);
-        var message = new TestLocalMessage("test-value");
-
-        // when
-        publisher.Publish(message);
-
-        // then
-        handler1.ReceivedMessages.Should().ContainSingle().Which.Should().Be("test-value");
-        handler2.ReceivedMessages.Should().ContainSingle().Which.Should().Be("test-value");
-    }
-
-    [Fact]
-    public void should_invoke_handlers_in_order_attribute_order()
-    {
-        // given
-        var invocationOrder = new List<string>();
-        var services = new ServiceCollection();
-        // Register in wrong order intentionally
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerPositive10(invocationOrder));
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerNegative10(invocationOrder));
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerDefault(invocationOrder));
-        var publisher = _CreatePublisher(services);
-
-        // when
-        publisher.Publish(new TestLocalMessage("test"));
-
-        // then - should be ordered: -10, 0, 10
-        invocationOrder.Should().ContainInOrder("Negative10", "Default0", "Positive10");
-    }
-
-    [Fact]
-    public void should_invoke_handlers_with_default_order_zero()
-    {
-        // given
-        var invocationOrder = new List<string>();
-        var services = new ServiceCollection();
-        // Two handlers with default order (0) - should maintain registration order
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerDefault(invocationOrder));
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerNegative10(invocationOrder));
-        var publisher = _CreatePublisher(services);
-
-        // when
-        publisher.Publish(new TestLocalMessage("test"));
-
-        // then - Negative10 (-10) should come before Default0 (0)
-        invocationOrder.Should().ContainInOrder("Negative10", "Default0");
-    }
-
-    [Fact]
-    public void should_pass_message_to_handler()
-    {
-        // given
-        var handler = new TrackingHandler();
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(handler);
-        var publisher = _CreatePublisher(services);
-        var message = new TestLocalMessage("expected-value");
-
-        // when
-        publisher.Publish(message);
-
-        // then
-        handler.ReceivedMessages.Should().ContainSingle().Which.Should().Be("expected-value");
-    }
-
-    [Fact]
-    public void should_throw_single_exception_when_one_handler_fails()
-    {
-        // given
-        var failingHandler = new FailingHandler("Single failure");
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(failingHandler);
-        var publisher = _CreatePublisher(services);
-
-        // when
-        var act = () => publisher.Publish(new TestLocalMessage("test"));
-
-        // then - single exception should be re-thrown directly, not wrapped
-        act.Should().Throw<InvalidOperationException>().WithMessage("Single failure");
-    }
-
-    [Fact]
-    public void should_throw_aggregate_exception_when_multiple_handlers_fail()
-    {
-        // given
-        var failingHandler1 = new FailingHandler("Failure 1");
-        var failingHandler2 = new FailingHandler("Failure 2");
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(failingHandler1);
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(failingHandler2);
-        var publisher = _CreatePublisher(services);
-
-        // when
-        var act = () => publisher.Publish(new TestLocalMessage("test"));
-
-        // then
-        var exception = act.Should().Throw<AggregateException>().Which;
-        exception.InnerExceptions.Should().HaveCount(2);
-        exception.InnerExceptions.Should().AllBeOfType<InvalidOperationException>();
-        exception.InnerExceptions.Select(e => e.Message).Should().Contain("Failure 1", "Failure 2");
-    }
-
-    [Fact]
-    public void should_continue_invoking_handlers_after_failure()
-    {
-        // given
-        var failingHandler = new FailingHandler();
-        var trackingHandler = new TrackingAfterFailureHandler();
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(failingHandler);
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(trackingHandler);
-        var publisher = _CreatePublisher(services);
-
-        // when
-        var act = () => publisher.Publish(new TestLocalMessage("test"));
-
-        // then - exception thrown but both handlers were invoked
-        act.Should().Throw<Exception>();
-        failingHandler.WasInvoked.Should().BeTrue();
-        trackingHandler.WasInvoked.Should().BeTrue();
-    }
-
-    [Fact]
-    public void should_unwrap_target_invocation_exception()
-    {
-        // given
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new TargetInvocationExceptionHandler());
-        var publisher = _CreatePublisher(services);
-
-        // when
-        var act = () => publisher.Publish(new TestLocalMessage("test"));
-
-        // then - inner exception should be thrown, not TargetInvocationException
-        act.Should().Throw<ArgumentException>().WithMessage("Inner exception message");
-    }
-
-    [Fact]
-    public void should_handle_no_registered_handlers()
-    {
-        // given
-        var services = new ServiceCollection();
-        var publisher = _CreatePublisher(services);
-
-        // when
-        var act = () => publisher.Publish(new TestLocalMessage("test"));
-
-        // then - no exception
-        act.Should().NotThrow();
-    }
-
-    #endregion
-
     #region PublishAsync Tests
 
     [Fact]
@@ -321,6 +156,39 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
 
         // then
         invocationOrder.Should().ContainInOrder("Negative10", "Default0", "Positive10");
+    }
+
+    [Fact]
+    public async Task should_invoke_handlers_with_default_order_zero_async()
+    {
+        // given
+        var invocationOrder = new List<string>();
+        var services = new ServiceCollection();
+        // Two handlers where one keeps the default order (0) - explicit orders still win
+        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerDefault(invocationOrder));
+        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerNegative10(invocationOrder));
+        var publisher = _CreatePublisher(services);
+
+        // when
+        await publisher.PublishAsync(new TestLocalMessage("test"), AbortToken);
+
+        // then - Negative10 (-10) should come before Default0 (0)
+        invocationOrder.Should().ContainInOrder("Negative10", "Default0");
+    }
+
+    [Fact]
+    public async Task should_unwrap_target_invocation_exception_async()
+    {
+        // given
+        var services = new ServiceCollection();
+        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new TargetInvocationExceptionHandler());
+        var publisher = _CreatePublisher(services);
+
+        // when
+        var act = async () => await publisher.PublishAsync(new TestLocalMessage("test"), AbortToken);
+
+        // then - inner exception should be thrown, not TargetInvocationException
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("Inner exception message");
     }
 
     [Fact]
@@ -456,28 +324,11 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
     #region Non-generic runtime-typed dispatch (invoker cache)
 
     [Fact]
-    public void should_dispatch_to_runtime_type_handlers_via_non_generic_publish()
-    {
-        // given — referenced through IDomainEvent so the non-generic Publish(IDomainEvent) overload
-        // (compiled invoker) is selected. Handlers fire only if it routes by runtime type to
-        // Publish<TestLocalMessage>; a wrong IDomainEvent-typed dispatch would resolve zero handlers.
-        var handler = new TrackingHandler();
-        var services = new ServiceCollection();
-        services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(handler);
-        var publisher = _CreatePublisher(services);
-        IDomainEvent message = new TestLocalMessage("runtime-typed");
-
-        // when
-        publisher.Publish(message);
-
-        // then
-        handler.ReceivedMessages.Should().ContainSingle().Which.Should().Be("runtime-typed");
-    }
-
-    [Fact]
     public async Task should_dispatch_to_runtime_type_handlers_via_non_generic_publish_async()
     {
-        // given
+        // given — referenced through IDomainEvent so the non-generic PublishAsync(IDomainEvent) overload
+        // (compiled invoker) is selected. Handlers fire only if it routes by runtime type to
+        // PublishAsync<TestLocalMessage>; a wrong IDomainEvent-typed dispatch would resolve zero handlers.
         var handler = new TrackingHandler();
         var services = new ServiceCollection();
         services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(handler);
@@ -494,7 +345,7 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
     }
 
     [Fact]
-    public void should_cache_and_reuse_runtime_typed_invoker_across_calls()
+    public async Task should_cache_and_reuse_runtime_typed_invoker_across_calls()
     {
         // given
         var handler = new TrackingHandler();
@@ -505,15 +356,15 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
         // when — repeated non-generic dispatch of the same runtime type reuses the cached invoker
         IDomainEvent first = new TestLocalMessage("first");
         IDomainEvent second = new TestLocalMessage("second");
-        publisher.Publish(first);
-        publisher.Publish(second);
+        await publisher.PublishAsync(first, AbortToken);
+        await publisher.PublishAsync(second, AbortToken);
 
         // then
         handler.ReceivedMessages.Should().ContainInOrder("first", "second");
     }
 
     [Fact]
-    public void should_propagate_handler_failure_through_non_generic_publish()
+    public async Task should_propagate_handler_failure_through_non_generic_publish()
     {
         // given — the generic path's exception semantics must flow through the compiled invoker.
         var services = new ServiceCollection();
@@ -522,10 +373,10 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
         IDomainEvent message = new TestLocalMessage("test");
 
         // when
-        var act = () => publisher.Publish(message);
+        var act = async () => await publisher.PublishAsync(message, AbortToken);
 
         // then
-        act.Should().Throw<InvalidOperationException>().WithMessage("non-generic failure");
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("non-generic failure");
     }
 
     #endregion
@@ -533,7 +384,7 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
     #region Handler Order Caching Tests
 
     [Fact]
-    public void should_cache_handler_order()
+    public async Task should_cache_handler_order()
     {
         // given
         var invocationOrder = new List<string>();
@@ -543,9 +394,9 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
         var publisher = _CreatePublisher(services);
 
         // when - publish multiple times
-        publisher.Publish(new TestLocalMessage("test1"));
+        await publisher.PublishAsync(new TestLocalMessage("test1"), AbortToken);
         invocationOrder.Clear();
-        publisher.Publish(new TestLocalMessage("test2"));
+        await publisher.PublishAsync(new TestLocalMessage("test2"), AbortToken);
 
         // then - order should be consistent (cached)
         invocationOrder.Should().ContainInOrder("Negative10", "Positive10");
@@ -561,12 +412,10 @@ public sealed class ServiceProviderLocalEventBusTests : TestBase
         services.AddSingleton<IDomainEventHandler<TestLocalMessage>>(new OrderedHandlerDefault(invocationOrder));
         var publisher = _CreatePublisher(services);
 
-        // when - mix sync and async calls
-        // ReSharper disable once MethodHasAsyncOverload
-        publisher.Publish(new TestLocalMessage("sync1"));
-        await publisher.PublishAsync(new TestLocalMessage("async1"), AbortToken);
-        // ReSharper disable once MethodHasAsyncOverload
-        publisher.Publish(new TestLocalMessage("sync2"));
+        // when - publish repeatedly against the same cached order
+        await publisher.PublishAsync(new TestLocalMessage("first"), AbortToken);
+        await publisher.PublishAsync(new TestLocalMessage("second"), AbortToken);
+        await publisher.PublishAsync(new TestLocalMessage("third"), AbortToken);
 
         // then - all should maintain same order (cache is shared)
         // Expected: Default0, Positive10 repeated 3 times

--- a/tests/Headless.EntityFramework.Tests.Harness/Fixtures/RecordingHeadlessMessageDispatcher.cs
+++ b/tests/Headless.EntityFramework.Tests.Harness/Fixtures/RecordingHeadlessMessageDispatcher.cs
@@ -40,17 +40,6 @@ public sealed class RecordingHeadlessMessageDispatcher : ILocalEventBus, IHeadle
         _calls.Add(new DispatchCall(NextIndex(), kind, payload));
     }
 
-    public void Publish<T>(T domainEvent)
-        where T : class, IDomainEvent
-    {
-        _RecordLocal(domainEvent);
-    }
-
-    public void Publish(IDomainEvent domainEvent)
-    {
-        _RecordLocal(domainEvent);
-    }
-
     public ValueTask PublishAsync<T>(T domainEvent, CancellationToken cancellationToken = default)
         where T : class, IDomainEvent
     {

--- a/tests/Headless.EntityFramework.Tests.Integration/HeadlessDbContextRuntimeExtensibilityTests.cs
+++ b/tests/Headless.EntityFramework.Tests.Integration/HeadlessDbContextRuntimeExtensibilityTests.cs
@@ -470,17 +470,6 @@ public sealed class HeadlessDbContextRuntimeExtensibilityTests : TestBase
 
         public List<IIntegrationEvent> DistributedEmitters { get; } = [];
 
-        public void Publish<T>(T domainEvent)
-            where T : class, IDomainEvent
-        {
-            LocalEmitters.Add(domainEvent);
-        }
-
-        public void Publish(IDomainEvent domainEvent)
-        {
-            LocalEmitters.Add(domainEvent);
-        }
-
         public ValueTask PublishAsync<T>(T domainEvent, CancellationToken cancellationToken = default)
             where T : class, IDomainEvent
         {
@@ -524,17 +513,6 @@ public sealed class HeadlessDbContextRuntimeExtensibilityTests : TestBase
         private int _publishCount;
 
         public int PublishCount => _publishCount;
-
-        public void Publish<T>(T domainEvent)
-            where T : class, IDomainEvent
-        {
-            Interlocked.Increment(ref _publishCount);
-        }
-
-        public void Publish(IDomainEvent domainEvent)
-        {
-            Interlocked.Increment(ref _publishCount);
-        }
 
         public ValueTask PublishAsync<T>(T domainEvent, CancellationToken cancellationToken = default)
             where T : class, IDomainEvent


### PR DESCRIPTION
## Summary

Pre-v1 public-API hardening for the domain contracts (review findings: `src/Headless.Domain/Messages/Local/ILocalEventBus.cs:20,26`, `src/Headless.Domain/Domain/IEntity`T.cs:10`, `IAggregateRoot`T.cs:13`, `src/Headless.Domain/Events/EntityEventData.cs:11`, `src/Headless.Domain/Concurrency/IHasETag.cs:16`):

- `ILocalEventBus` was a self-documented sync-over-async deadlock hazard: it shipped two synchronous `Publish` members whose own XML docs warned "do not call from a thread that carries a synchronization context ... or it may deadlock". The public contract is now async-only; the one synchronous consumer (the EF sync `SaveChanges` pipeline) contains the bridge internally.
- `IEntity<TId>`/`IAggregateRoot<TId>` declared `where TId : notnull` while their base classes `Entity<TId>`/`AggregateRoot<TId>` require `notnull, IEquatable<TId>` — a type could implement the interface with a key type the framework's equality machinery cannot handle. The interfaces now carry the same `IEquatable<TId>` constraint.
- `IHasETag.ETag` setter asymmetry vs get-only `IHasConcurrencyStamp.ConcurrencyStamp`: kept the setter (it is the store-write path) and documented why instead (see Decisions).

## Changes

- `src/Headless.Domain/Messages/Local/ILocalEventBus.cs` — removed `Publish<T>(T)` and `Publish(IDomainEvent)`; interface remarks now document the async-only design and where a sync bridge belongs (infrastructure).
- `src/Headless.Domain.LocalEventBus/ServiceProviderLocalEventBus.cs` — removed the sync publish implementation, the sync invoker cache (`_SyncInvokers`, `_GenericPublish`, `_CreateSyncInvoker`), and the now-unused `Nito.AsyncEx.Synchronous` using.
- `src/Headless.EntityFramework/Contexts/Runtime/HeadlessSaveChangesPipeline.cs` — the sync `SaveChanges` twin now publishes domain events through a private `_PublishDomainEventBlocking` helper: a contained, commented sync-over-async bridge (`PublishAsync(...).AsTask().GetAwaiter().GetResult()` with a completed-`ValueTask` fast path). Exception semantics (single rethrow / `AggregateException`) are preserved because `GetResult()` does not re-wrap.
- `src/Headless.Domain/Domain/IEntity`T.cs`, `IAggregateRoot`T.cs` — added `IEquatable<TId>` to the interface constraints, matching `Entity<TId>`/`AggregateRoot<TId>`. All in-repo implementers (Guid/long/string/int keys) already satisfy it; the generic `FirstByIdAsync<TEntity, TKey>` helper already required it.
- `src/Headless.Domain/Concurrency/IHasETag.cs` — documented the setter as the store-side write path (EF `IsRowVersion()` materialization/refresh) and aligned the doc style with `IHasConcurrencyStamp`.
- Tests — sync `Publish` tests removed where an async twin already existed; unique coverage converted to async (`should_invoke_handlers_with_default_order_zero_async`, `should_unwrap_target_invocation_exception_async`, non-generic invoker cache/failure propagation, handler-order caching). `ILocalEventBus` test doubles in the EF harness and integration tests dropped their sync members.
- Docs — `src/Headless.Domain.LocalEventBus/README.md` and `docs/llms/core.md` updated: async-only contract design note added, `Publish` overload references removed.

## Decisions

- **EntityEventData `TEntity` constraint: intentionally NOT added (skip + record per task rule).** The EF lifecycle-event factory (`HeadlessLocalEventSaveEntryProcessor`) gates on `IDomainEventEmitter` — not `IEntity` — and instantiates `EntityCreatedEventData<T>` etc. via `MakeGenericType(entityType)` for any emitter's runtime type. `IDomainEventEmitter` does not require `IEntity`, so a downstream EF entity implementing only the emitter interface is a legitimate usage today; adding `where TEntity : IEntity` would turn that working path into a runtime `ArgumentException` inside `MakeGenericType` (invisible at compile time). The in-repo unit tests also exercise `EntityEventData<T>` with a plain record. Constraining would require also gating the EF processor on `IEntity` — a behavior change (silently dropped lifecycle events) beyond this finding's scope.
- **`IHasETag.ETag` keeps its setter; fixed with documentation.** The only writer is persistence infrastructure: `HeadlessEntityTypeBuilderExtensions.TryConfigureETag` maps the property `IsRowVersion()` and EF materializes/refreshes the value on load and save via the property setter. Removing the setter would force backing-field access mode configuration for every provider for zero consumer benefit. The XML docs now state the store-written rowversion contract and that domain code should treat the value as read-only, mirroring `IHasConcurrencyStamp`'s doc style.
- **Sync bridge placement.** The EF sync `SaveChanges` path cannot go async (EF's sync API surface is part of the pipeline contract), so the bridge lives in `HeadlessSaveChangesPipeline` as a private static helper with an explanatory comment, inside the pre-existing `MA0045` suppression pattern. It is safe there: EF's sync `SaveChanges` is already blocking database I/O on a thread without a synchronization context.
- Interface `<summary>` wording changed from "Dispatched synchronously within the active unit of work" to "Dispatched inline within the active unit of work" to stop implying a sync API.

## Testing

- `dotnet build src/Headless.Domain --no-incremental -v:minimal` — clean (0 warnings, 0 errors)
- `dotnet build src/Headless.Domain.LocalEventBus --no-incremental -v:minimal` — clean
- `dotnet build src/Headless.EntityFramework --no-incremental -v:minimal` — clean
- `dotnet build src/Headless.EntityFramework.Messaging --no-incremental -v:minimal` — clean
- `dotnet build tests/Headless.EntityFramework.Tests.Harness --no-incremental -v:minimal` — clean
- `dotnet build tests/Headless.EntityFramework.Tests.Integration --no-incremental -v:minimal` — clean (compile-gate only)
- `dotnet test --project tests/Headless.Domain.Tests.Unit` — 26/26 passed
- `dotnet test --project tests/Headless.Domain.LocalEventBus.Tests.Unit` — 16/16 passed
- Integration tests skipped: Docker unavailable on this machine (`Headless.EntityFramework.Tests.Integration`, `Headless.EntityFramework.Messaging.Tests.Integration`). They were compiled but not executed.
- Changed files formatted with CSharpier.

## Docs

- `src/Headless.Domain.LocalEventBus/README.md` — Key Features + Design Notes updated for the async-only surface (new "Async-only contract" note).
- `docs/llms/core.md` — mirrored the same Key Features / Design Notes update.
- EF docs (`docs/llms/orm.md`, `src/Headless.EntityFramework*/README.md`) reference `ILocalEventBus` only by name, never the sync members — no change needed.
