### PR TITLE
refactor(hosting): options wrapper placement and dashboard auth polish

### DIFF
--- a/src/Headless.Blobs.SshNet/Setup.cs
+++ b/src/Headless.Blobs.SshNet/Setup.cs
@@ -2,6 +2,7 @@
 
 using Headless.Blobs.SshNet;
 using Headless.Checks;
+using Headless.Hosting.Options;
 using Headless.Serializer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Headless.Dashboard.Authentication/AuthConfig.cs
+++ b/src/Headless.Dashboard.Authentication/AuthConfig.cs
@@ -7,6 +7,12 @@ namespace Headless.Dashboard.Authentication;
 /// <summary>
 /// Authentication configuration for dashboards.
 /// </summary>
+/// <remarks>
+/// Credential completeness for the selected <see cref="Mode"/> is enforced by the internal
+/// FluentValidation validator wired into the options pipeline (validate-on-start) by every
+/// <c>AddDashboardAuthentication</c> overload — there is no imperative validation entry point.
+/// </remarks>
+[PublicAPI]
 public sealed class AuthConfig
 {
     /// <summary>
@@ -44,36 +50,13 @@ public sealed class AuthConfig
     /// Whether authentication is enabled.
     /// </summary>
     public bool IsEnabled => Mode != AuthMode.None;
-
-    /// <summary>
-    /// Validates the configuration and throws when a required credential is missing for the
-    /// selected <see cref="Mode"/>.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when <see cref="Mode"/> is <see cref="AuthMode.Basic"/> and <see cref="BasicCredentials"/>
-    /// is null or empty, when <see cref="Mode"/> is <see cref="AuthMode.ApiKey"/> and <see cref="ApiKey"/>
-    /// is null or empty, or when <see cref="Mode"/> is <see cref="AuthMode.Custom"/> and
-    /// <see cref="CustomValidator"/> is null.
-    /// </exception>
-    public void Validate()
-    {
-        switch (Mode)
-        {
-            case AuthMode.Basic when string.IsNullOrEmpty(BasicCredentials):
-                throw new InvalidOperationException("BasicCredentials is required for Basic authentication mode");
-            case AuthMode.ApiKey when string.IsNullOrEmpty(ApiKey):
-                throw new InvalidOperationException("ApiKey is required for ApiKey authentication mode");
-            case AuthMode.Custom when CustomValidator == null:
-                throw new InvalidOperationException("CustomValidator is required for Custom authentication mode");
-        }
-    }
 }
 
 /// <summary>
 /// FluentValidation validator for <see cref="AuthConfig"/>. Enforces that the credential required by
 /// the selected <see cref="AuthMode"/> is present. Wired into the options pipeline (with validation on
-/// start) by <see cref="SetupDashboardAuthentication"/>; the equivalent imperative check is also exposed
-/// via <see cref="AuthConfig.Validate"/> for callers that construct <see cref="AuthConfig"/> directly.
+/// start) by <see cref="SetupDashboardAuthentication"/> — the single validation point every
+/// <see cref="AuthConfig"/> construction path traverses.
 /// </summary>
 internal sealed class AuthConfigValidator : AbstractValidator<AuthConfig>
 {

--- a/src/Headless.Dashboard.Authentication/AuthMiddleware.cs
+++ b/src/Headless.Dashboard.Authentication/AuthMiddleware.cs
@@ -13,6 +13,7 @@ namespace Headless.Dashboard.Authentication;
 /// <remarks>Initializes a new instance of <see cref="AuthMiddleware"/>.</remarks>
 /// <param name="next">The next middleware delegate in the ASP.NET Core pipeline.</param>
 /// <param name="logger">The logger used to record authentication failures.</param>
+[PublicAPI]
 public sealed class AuthMiddleware(RequestDelegate next, ILogger<AuthMiddleware> logger)
 {
     /// <summary>Key used to store the authenticated username in <see cref="HttpContext.Items"/>.</summary>

--- a/src/Headless.Dashboard.Authentication/AuthMode.cs
+++ b/src/Headless.Dashboard.Authentication/AuthMode.cs
@@ -5,6 +5,7 @@ namespace Headless.Dashboard.Authentication;
 /// <summary>
 /// Authentication modes supported by dashboards.
 /// </summary>
+[PublicAPI]
 public enum AuthMode
 {
     /// <summary>

--- a/src/Headless.Dashboard.Authentication/AuthService.cs
+++ b/src/Headless.Dashboard.Authentication/AuthService.cs
@@ -9,27 +9,18 @@ namespace Headless.Dashboard.Authentication;
 /// <summary>
 /// Authentication service supporting 5 modes: None, Basic, ApiKey, Host, Custom.
 /// </summary>
-public sealed class AuthService : IAuthService
+/// <remarks>
+/// The service does not re-validate <paramref name="config"/>: credential completeness is enforced
+/// once, by the FluentValidation validator wired into the options pipeline (validate-on-start) in
+/// <see cref="SetupDashboardAuthentication"/>, which every DI-resolved <see cref="AuthConfig"/> traverses.
+/// </remarks>
+/// <param name="config">The authentication configuration, including mode and credentials.</param>
+/// <param name="logger">The logger used to record authentication errors.</param>
+[PublicAPI]
+public sealed class AuthService(AuthConfig config, ILogger<AuthService> logger) : IAuthService
 {
-    private readonly AuthConfig _config;
-    private readonly ILogger<AuthService> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AuthService"/> and validates <paramref name="config"/>
-    /// immediately so misconfiguration is caught at startup rather than on the first request.
-    /// </summary>
-    /// <param name="config">The authentication configuration, including mode and credentials.</param>
-    /// <param name="logger">The logger used to record authentication errors.</param>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown by <see cref="AuthConfig.Validate"/> when the configuration is incomplete for the
-    /// selected <see cref="AuthMode"/>.
-    /// </exception>
-    public AuthService(AuthConfig config, ILogger<AuthService> logger)
-    {
-        _config = config;
-        _logger = logger;
-        _config.Validate();
-    }
+    private readonly AuthConfig _config = config;
+    private readonly ILogger<AuthService> _logger = logger;
 
     /// <inheritdoc/>
     public async Task<AuthResult> AuthenticateAsync(HttpContext context, CancellationToken cancellationToken = default)

--- a/src/Headless.Dashboard.Authentication/IAuthService.cs
+++ b/src/Headless.Dashboard.Authentication/IAuthService.cs
@@ -11,6 +11,7 @@ namespace Headless.Dashboard.Authentication;
 /// Consumed by <see cref="AuthMiddleware"/> on every protected API request. Implementations
 /// are resolved from the request service scope so they may use scoped dependencies.
 /// </remarks>
+[PublicAPI]
 public interface IAuthService
 {
     /// <summary>
@@ -36,6 +37,7 @@ public interface IAuthService
 /// <summary>
 /// Represents the outcome of an authentication attempt.
 /// </summary>
+[PublicAPI]
 public sealed class AuthResult
 {
     /// <summary>
@@ -85,6 +87,7 @@ public sealed class AuthResult
 /// A read-only snapshot of the current authentication configuration, returned by
 /// <see cref="IAuthService.GetAuthInfo"/> for consumption by the dashboard frontend.
 /// </summary>
+[PublicAPI]
 public sealed class AuthInfo
 {
     /// <summary>

--- a/src/Headless.Dashboard.Authentication/README.md
+++ b/src/Headless.Dashboard.Authentication/README.md
@@ -81,7 +81,7 @@ builder.Services.AddDashboardAuthentication(cfg =>
 });
 ```
 
-`AuthConfig` controls credentials, API key, custom validation, host authorization policy, and `SessionTimeoutMinutes`. `AuthConfig.Validate()` throws when the selected mode requires a credential or validator that has not been configured.
+`AuthConfig` controls credentials, API key, custom validation, host authorization policy, and `SessionTimeoutMinutes`. Credential completeness for the selected mode is enforced by an internal FluentValidation validator wired into the options pipeline (validate-on-start) by every `AddDashboardAuthentication` overload; a missing credential surfaces as an `OptionsValidationException` at startup.
 
 Add the middleware to protect `/api/*` paths:
 
@@ -92,7 +92,7 @@ app.UseMiddleware<AuthMiddleware>();
 ## Types
 
 - `AuthMode` — enum of supported modes
-- `AuthConfig` — configuration (credentials, API key, validator, session timeout); its imperative `Validate()` is mirrored by an internal FluentValidation validator wired into the options pipeline
+- `AuthConfig` — configuration (credentials, API key, validator, session timeout); validated by an internal FluentValidation validator wired into the options pipeline (the single validation point)
 - `IAuthService` / `AuthService` — authenticate requests, return `AuthResult`; `AuthenticateAsync(HttpContext, CancellationToken)` accepts an optional cancellation token
 - `AuthMiddleware` — protects `/api/*` paths, skips static files; passes `HttpContext.RequestAborted` to `AuthenticateAsync`
 - `AuthResult` — success/failure with username

--- a/src/Headless.Hosting/Options/OptionsMonitorWrapper.cs
+++ b/src/Headless.Hosting/Options/OptionsMonitorWrapper.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Microsoft.Extensions.Options;
 using Nito.Disposables;
 
-#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
-namespace Microsoft.Extensions.Options;
+namespace Headless.Hosting.Options;
 
 /// <summary>An <see cref="IOptionsMonitor{TOptions}"/> that always returns a single fixed value.</summary>
 /// <remarks>

--- a/src/Headless.Hosting/Options/OptionsSnapshotWrapper.cs
+++ b/src/Headless.Hosting/Options/OptionsSnapshotWrapper.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
-namespace Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
+
+namespace Headless.Hosting.Options;
 
 /// <summary>An <see cref="IOptionsSnapshot{TOptions}"/> that always returns a single fixed value.</summary>
 /// <remarks>

--- a/src/Headless.Jobs.Dashboard/DashboardOptionsBuilder.cs
+++ b/src/Headless.Jobs.Dashboard/DashboardOptionsBuilder.cs
@@ -193,6 +193,8 @@ public sealed class DashboardOptionsBuilder
             );
         }
 
-        Auth.Validate();
+        // Credential completeness for the selected mode is validated once, by the FluentValidation
+        // validator wired into the options pipeline (validate-on-start) when these values are copied
+        // into AddDashboardAuthentication — not re-checked here.
     }
 }

--- a/src/Headless.Messaging.Dashboard/MessagingDashboardOptionsBuilder.cs
+++ b/src/Headless.Messaging.Dashboard/MessagingDashboardOptionsBuilder.cs
@@ -157,6 +157,8 @@ public sealed class MessagingDashboardOptionsBuilder
             );
         }
 
-        Auth.Validate();
+        // Credential completeness for the selected mode is validated once, by the FluentValidation
+        // validator wired into the options pipeline (validate-on-start) when these values are copied
+        // into AddDashboardAuthentication — not re-checked here.
     }
 }

--- a/src/Headless.MultiTenancy/HeadlessTenancyBuilder.cs
+++ b/src/Headless.MultiTenancy/HeadlessTenancyBuilder.cs
@@ -45,7 +45,7 @@ public sealed class HeadlessTenancyBuilder
     /// <paramref name="seam"/> or <paramref name="capabilities"/> is <see langword="null"/>.
     /// </exception>
     /// <exception cref="ArgumentException"><paramref name="seam"/> is empty or white space.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
+    /// <exception cref="System.ComponentModel.InvalidEnumArgumentException">
     /// <paramref name="status"/> is not a defined <see cref="TenantPostureStatus"/> value (validated when
     /// the seam already has a recorded posture and the two are merged).
     /// </exception>

--- a/tests/Headless.Blobs.SshNet.Tests.Integration/SshBlobStorageFixture.cs
+++ b/tests/Headless.Blobs.SshNet.Tests.Integration/SshBlobStorageFixture.cs
@@ -4,6 +4,7 @@ using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using Headless.Blobs;
 using Headless.Blobs.SshNet;
+using Headless.Hosting.Options;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 

--- a/tests/Headless.Blobs.SshNet.Tests.Integration/SshBlobStorageTests.cs
+++ b/tests/Headless.Blobs.SshNet.Tests.Integration/SshBlobStorageTests.cs
@@ -2,9 +2,9 @@
 
 using Headless.Blobs;
 using Headless.Blobs.SshNet;
+using Headless.Hosting.Options;
 using Headless.Serializer;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Renci.SshNet.Common;
 
 namespace Tests;

--- a/tests/Headless.Dashboard.Authentication.Tests.Unit/AuthConfigTests.cs
+++ b/tests/Headless.Dashboard.Authentication.Tests.Unit/AuthConfigTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
 using Headless.Dashboard.Authentication;
 using Headless.Testing.Tests;
 
@@ -26,89 +28,5 @@ public sealed class AuthConfigTests : TestBase
     {
         var config = new AuthConfig();
         config.SessionTimeoutMinutes.Should().Be(60);
-    }
-
-    [Fact]
-    public void validate_throws_for_basic_without_credentials()
-    {
-        var config = new AuthConfig { Mode = AuthMode.Basic };
-
-        var act = () => config.Validate();
-
-        act.Should().Throw<InvalidOperationException>().WithMessage("*BasicCredentials*");
-    }
-
-    [Fact]
-    public void validate_throws_for_apikey_without_key()
-    {
-        var config = new AuthConfig { Mode = AuthMode.ApiKey };
-
-        var act = () => config.Validate();
-
-        act.Should().Throw<InvalidOperationException>().WithMessage("*ApiKey*");
-    }
-
-    [Fact]
-    public void validate_throws_for_custom_without_validator()
-    {
-        var config = new AuthConfig { Mode = AuthMode.Custom };
-
-        var act = () => config.Validate();
-
-        act.Should().Throw<InvalidOperationException>().WithMessage("*CustomValidator*");
-    }
-
-    [Fact]
-    public void validate_passes_for_none()
-    {
-        var config = new AuthConfig { Mode = AuthMode.None };
-
-        var act = () => config.Validate();
-
-        act.Should().NotThrow();
-    }
-
-    [Fact]
-    public void validate_passes_for_host()
-    {
-        var config = new AuthConfig { Mode = AuthMode.Host };
-
-        var act = () => config.Validate();
-
-        act.Should().NotThrow();
-    }
-
-    [Fact]
-    public void validate_passes_for_basic_with_credentials()
-    {
-        var config = new AuthConfig
-        {
-            Mode = AuthMode.Basic,
-            BasicCredentials = Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:pass")),
-        };
-
-        var act = () => config.Validate();
-
-        act.Should().NotThrow();
-    }
-
-    [Fact]
-    public void validate_passes_for_apikey_with_key()
-    {
-        var config = new AuthConfig { Mode = AuthMode.ApiKey, ApiKey = "test-api-key" };
-
-        var act = () => config.Validate();
-
-        act.Should().NotThrow();
-    }
-
-    [Fact]
-    public void validate_passes_for_custom_with_validator()
-    {
-        var config = new AuthConfig { Mode = AuthMode.Custom, CustomValidator = (_, _) => true };
-
-        var act = () => config.Validate();
-
-        act.Should().NotThrow();
     }
 }

--- a/tests/Headless.Dashboard.Authentication.Tests.Unit/SetupDashboardAuthenticationTests.cs
+++ b/tests/Headless.Dashboard.Authentication.Tests.Unit/SetupDashboardAuthenticationTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
 using Headless.Dashboard.Authentication;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,5 +45,70 @@ public sealed class SetupDashboardAuthenticationTests : TestBase
         var act = () => provider.GetRequiredService<AuthConfig>();
 
         act.Should().Throw<OptionsValidationException>();
+    }
+
+    [Fact]
+    public void add_dashboard_authentication_throws_for_api_key_mode_without_key()
+    {
+        var act = () => _ResolveConfig(cfg => cfg.Mode = AuthMode.ApiKey);
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*ApiKey*");
+    }
+
+    [Fact]
+    public void add_dashboard_authentication_throws_for_custom_mode_without_validator()
+    {
+        var act = () => _ResolveConfig(cfg => cfg.Mode = AuthMode.Custom);
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*CustomValidator*");
+    }
+
+    [Theory]
+    [InlineData(AuthMode.None)]
+    [InlineData(AuthMode.Host)]
+    public void add_dashboard_authentication_passes_for_credentialless_modes(AuthMode mode)
+    {
+        var act = () => _ResolveConfig(cfg => cfg.Mode = mode);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void add_dashboard_authentication_passes_for_basic_with_credentials()
+    {
+        var act = () =>
+            _ResolveConfig(cfg =>
+            {
+                cfg.Mode = AuthMode.Basic;
+                cfg.BasicCredentials = Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:pass"));
+            });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void add_dashboard_authentication_passes_for_custom_with_validator()
+    {
+        var act = () =>
+            _ResolveConfig(cfg =>
+            {
+                cfg.Mode = AuthMode.Custom;
+                cfg.CustomValidator = (_, _) => true;
+            });
+
+        act.Should().NotThrow();
+    }
+
+    private static void _ResolveConfig(Action<AuthConfig> setupAction)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDashboardAuthentication(setupAction);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Resolving the AuthConfig value runs the FluentValidation options pipeline —
+        // the single validation point for every construction path.
+        provider.GetRequiredService<AuthConfig>();
     }
 }

--- a/tests/Headless.Hosting.Tests.Unit/Options/OptionsMonitorWrapperTests.cs
+++ b/tests/Headless.Hosting.Tests.Unit/Options/OptionsMonitorWrapperTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Microsoft.Extensions.Options;
+using Headless.Hosting.Options;
 
 namespace Tests.Options;
 

--- a/tests/Headless.Hosting.Tests.Unit/Options/OptionsSnapshotWrapperTests.cs
+++ b/tests/Headless.Hosting.Tests.Unit/Options/OptionsSnapshotWrapperTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using Microsoft.Extensions.Options;
+using Headless.Hosting.Options;
 
 namespace Tests.Options;
 

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/DashboardOptionsTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/DashboardOptionsTests.cs
@@ -158,48 +158,6 @@ public sealed class DashboardOptionsTests : TestBase
     }
 
     [Fact]
-    public void should_throw_for_basic_without_credentials_when_validate()
-    {
-        // given
-        var builder = new MessagingDashboardOptionsBuilder().WithBasicAuth("admin", "password");
-        builder.Auth.BasicCredentials = null;
-
-        // when
-        var act = () => builder.Validate();
-
-        // then
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void should_throw_for_api_key_without_key_when_validate()
-    {
-        // given
-        var builder = new MessagingDashboardOptionsBuilder().WithApiKey("temp-key");
-        builder.Auth.ApiKey = null;
-
-        // when
-        var act = () => builder.Validate();
-
-        // then
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void should_throw_for_custom_without_validator_when_validate()
-    {
-        // given
-        var builder = new MessagingDashboardOptionsBuilder().WithCustomAuth((_, _) => true);
-        builder.Auth.CustomValidator = null;
-
-        // when
-        var act = () => builder.Validate();
-
-        // then
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
     public void should_throw_when_validate_no_auth_mode_configured()
     {
         // given — a builder where no WithXxx auth method (not even WithNoAuth) was ever called

--- a/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsConformanceTests.cs
@@ -3,10 +3,10 @@
 using System.Net;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Aws;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute.ExceptionExtensions;
 
 namespace Tests;

--- a/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsSenderTests.cs
+++ b/tests/Headless.Sms.Aws.Tests.Unit/AwsSnsSmsSenderTests.cs
@@ -3,11 +3,11 @@
 using System.Net;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Aws;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute.ExceptionExtensions;
 
 namespace Tests;

--- a/tests/Headless.Sms.Cequens.Tests.Unit/CequensBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Cequens.Tests.Unit/CequensBulkSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Cequens;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/tests/Headless.Sms.Cequens.Tests.Unit/CequensSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Cequens.Tests.Unit/CequensSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Cequens;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/tests/Headless.Sms.Cequens.Tests.Unit/CequensSmsSenderTests.cs
+++ b/tests/Headless.Sms.Cequens.Tests.Unit/CequensSmsSenderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Cequens;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Polly.CircuitBreaker;
 using Polly.RateLimiting;

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioBulkSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Connekio;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Connekio;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsSenderTests.cs
+++ b/tests/Headless.Sms.Connekio.Tests.Unit/ConnekioSmsSenderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Connekio;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Polly.CircuitBreaker;
 using Polly.RateLimiting;
 using Polly.Timeout;

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipBulkSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Infobip;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Infobip;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
+++ b/tests/Headless.Sms.Infobip.Tests.Unit/InfobipSmsSenderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Infobip;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Polly.CircuitBreaker;
 using Polly.RateLimiting;
 using Polly.Timeout;

--- a/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Twilio;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute.ExceptionExtensions;
 using Twilio.Clients;
 using Twilio.Http;

--- a/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsSenderTests.cs
+++ b/tests/Headless.Sms.Twilio.Tests.Unit/TwilioSmsSenderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Twilio;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute.ExceptionExtensions;
 using Polly.CircuitBreaker;
 using Polly.RateLimiting;

--- a/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkBulkSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.VictoryLink;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.VictoryLink;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkSmsSenderTests.cs
+++ b/tests/Headless.Sms.VictoryLink.Tests.Unit/VictoryLinkSmsSenderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.VictoryLink;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Polly.CircuitBreaker;
 using Polly.RateLimiting;
 using Polly.Timeout;

--- a/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneBulkSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneBulkSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Vodafone;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneSmsConformanceTests.cs
+++ b/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneSmsConformanceTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Vodafone;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneSmsSenderTests.cs
+++ b/tests/Headless.Sms.Vodafone.Tests.Unit/VodafoneSmsSenderTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
 using System.Net;
+using Headless.Hosting.Options;
 using Headless.Sms;
 using Headless.Sms.Vodafone;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Polly.CircuitBreaker;
 using Polly.RateLimiting;
 using Polly.Timeout;


### PR DESCRIPTION
## Summary

Pre-v1 public-API hardening across Hosting, MultiTenancy, and Dashboard.Authentication (review findings: `src/Headless.Hosting/Options/OptionsMonitorWrapper.cs` + `OptionsSnapshotWrapper.cs` — concrete public types declared in the foreign `Microsoft.Extensions.Options` namespace; `src/Headless.MultiTenancy/HeadlessTenancyBuilder.cs` — `RecordSeam` XML doc promises `ArgumentOutOfRangeException` but the implementation throws `InvalidEnumArgumentException`; `src/Headless.Dashboard.Authentication` — public types missing `[PublicAPI]` and triple validation surfaces around `AuthConfig`).

## Changes

- **Wrapper namespace move (tier-1 policy: types never live in foreign namespaces).** `OptionsMonitorWrapper<T>` and `OptionsSnapshotWrapper<T>` moved from `Microsoft.Extensions.Options` to `Headless.Hosting.Options`; the `IDE0130` pragmas are gone and `using Microsoft.Extensions.Options;` added for the implemented interfaces. All 24 consumer files (Blobs.SshNet `Setup.cs`, SMS test suites, SshNet integration tests, Hosting unit tests) gained `using Headless.Hosting.Options;`; the now-unneeded `using Microsoft.Extensions.Options;` was dropped wherever nothing else required it.
- **MultiTenancy doc fix.** `HeadlessTenancyBuilder.RecordSeam`'s `<exception>` cref corrected to `System.ComponentModel.InvalidEnumArgumentException`, matching what `Argument.IsInEnum` (via `TenantPostureManifest._MaxStatus`) actually throws and matching `TenantPostureManifest.RecordSeam`'s already-correct doc.
- **`[PublicAPI]` annotations.** Added to `AuthMode`, `AuthConfig`, `IAuthService`, `AuthService`, `AuthResult`, `AuthInfo`, and `AuthMiddleware`, matching sibling package style (`SetupDashboardAuthentication` already carried it). `DashboardSpaHelper` is `internal` and needs none.
- **Validation consolidation to the DI FluentValidation pipeline.** Removed the imperative `AuthConfig.Validate()` and the `AuthService` constructor re-validation; removed the `Auth.Validate()` calls from the two dashboard builders (`MessagingDashboardOptionsBuilder.Validate`, Jobs `DashboardOptionsBuilder.Validate` — the not-configured guard stays). The single validation point is now `AuthConfigValidator` wired by every `AddDashboardAuthentication` overload via `Configure<AuthConfig, AuthConfigValidator>` (validate-on-start + on-first-resolve).
- **Tests.** `AuthConfigTests` trimmed to config-shape tests; the mode-specific missing-credential and passing cases moved to `SetupDashboardAuthenticationTests` as DI-pipeline tests asserting `OptionsValidationException` on `AuthConfig` resolution (added the missing copyright headers to both files while editing them). The three Messaging dashboard builder tests that mutated `builder.Auth.*` to `null` via internals were removed — that scenario is unreachable through the public fluent API and its detection now lives at the consolidated DI point.
- **Docs.** `src/Headless.Dashboard.Authentication/README.md` updated: validation is described as the options-pipeline validator (single point, `OptionsValidationException` at startup) instead of `AuthConfig.Validate()`.

## Decisions

- **Wrapper target namespace is `Headless.Hosting.Options`, not bare `Headless.Hosting`.** The task suggested the package root namespace, but `Headless.Hosting` consistently uses folder-matching namespaces for its types (`Headless.Hosting.Initialization`, `Headless.Hosting.Seeders`). `Headless.Hosting.Options` is package-owned (tier-1 satisfied), folder-consistent, and needs no `IDE0130` pragma. The extension-holder files in the same folder (`OptionsBuilderFluentValidationExtensions`, `HeadlessOptionsServiceCollectionExtensions`) intentionally stay in their foreign namespaces — they are registration/helper extension surfaces, which the namespace policy explicitly allows.
- **Validation consolidated to the DI pipeline (repo convention).** Every production construction path of `AuthConfig` flows through `AddDashboardAuthentication` (the Jobs and Messaging dashboards copy their fluent-builder values into it), so the FluentValidation options pipeline covers all routes; resolving the `AuthConfig` singleton (`AddSingletonOptionValue`) triggers it even before validate-on-start. The dashboard builders' eager `Auth.Validate()` calls and the `AuthService` ctor check duplicated that with a different exception type (`InvalidOperationException` vs `OptionsValidationException`). Consequence: an incomplete credential now surfaces at host start / first options resolution instead of inside `AddServices` — both are startup-time failures, and misconfiguration now throws one consistent exception type. Direct `new AuthService(config, …)` construction (test-only route) is no longer validated; DI is the supported production route.
- The builders' `AuthConfigured` guard (forcing an explicit `WithNoAuth()` opt-out) is builder-state validation, not `AuthConfig` state validation, so it stays where it is.

## Testing

- `dotnet build src/Headless.Hosting --no-incremental` — clean (0 warnings, 0 errors); same for `src/Headless.MultiTenancy`, `src/Headless.Dashboard.Authentication`, `src/Headless.Blobs.SshNet`, `src/Headless.Messaging.Dashboard` and `src/Headless.Jobs.Dashboard` (`/p:BuildDashboardSpa=false`, prebuilt SPA assets present).
- `dotnet test --project tests/Headless.Hosting.Tests.Unit` — 67/67 passed.
- `dotnet test --project tests/Headless.Dashboard.Authentication.Tests.Unit` — 36/36 passed.
- `dotnet test --project tests/Headless.Messaging.Dashboard.Tests.Unit` — 119/119 passed.
- `dotnet test --project tests/Headless.Sms.Connekio.Tests.Unit` — 28/28 passed (representative SMS suite; the other SMS changes are identical using-directive moves).
- Built clean: `tests/Headless.Sms.{Cequens,Twilio,Aws,Vodafone,Infobip,VictoryLink}.Tests.Unit`, `tests/Headless.Blobs.SshNet.Tests.Integration`.
- Integration tests skipped: Docker unavailable on this machine (`Headless.Blobs.SshNet.Tests.Integration` compiled but not executed).
- Changed files formatted with CSharpier.

## Docs

- `src/Headless.Dashboard.Authentication/README.md` — validation story updated (see Changes).
- No `docs/llms/*` page or `src/Headless.Hosting/README.md` references `OptionsMonitorWrapper`/`OptionsSnapshotWrapper` or `AuthConfig.Validate()`, so no further doc sync was needed.
