### PR TITLE
refactor(messaging): monitoring API naming and time-keyed stats

### DIFF
--- a/src/Headless.Messaging.Core/Monitoring/IMonitoringApi.cs
+++ b/src/Headless.Messaging.Core/Monitoring/IMonitoringApi.cs
@@ -73,42 +73,44 @@ public interface IMonitoringApi
     /// Returns the total number of published message rows in a failed state.
     /// </summary>
     /// <param name="cancellationToken">A token to cancel the query.</param>
-    ValueTask<long> PublishedFailedCount(CancellationToken cancellationToken = default);
+    ValueTask<long> GetPublishedFailedCountAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the total number of published message rows in a succeeded state.
     /// </summary>
     /// <param name="cancellationToken">A token to cancel the query.</param>
-    ValueTask<long> PublishedSucceededCount(CancellationToken cancellationToken = default);
+    ValueTask<long> GetPublishedSucceededCountAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the total number of received message rows in a failed state.
     /// </summary>
     /// <param name="cancellationToken">A token to cancel the query.</param>
-    ValueTask<long> ReceivedFailedCount(CancellationToken cancellationToken = default);
+    ValueTask<long> GetReceivedFailedCountAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the total number of received message rows in a succeeded state.
     /// </summary>
     /// <param name="cancellationToken">A token to cancel the query.</param>
-    ValueTask<long> ReceivedSucceededCount(CancellationToken cancellationToken = default);
+    ValueTask<long> GetReceivedSucceededCountAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns per-hour succeeded message counts for the last 24 hours, keyed by UTC hour bucket.
+    /// Returns per-hour succeeded message counts for the last 24 hours, keyed by UTC hour bucket
+    /// (a <see cref="DateTimeOffset"/> with zero offset, truncated to the start of the hour).
     /// </summary>
     /// <param name="type">Whether to query the published or received message table.</param>
     /// <param name="cancellationToken">A token to cancel the query.</param>
-    ValueTask<Dictionary<DateTime, int>> HourlySucceededJobs(
+    ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlySucceededJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     );
 
     /// <summary>
-    /// Returns per-hour failed message counts for the last 24 hours, keyed by UTC hour bucket.
+    /// Returns per-hour failed message counts for the last 24 hours, keyed by UTC hour bucket
+    /// (a <see cref="DateTimeOffset"/> with zero offset, truncated to the start of the hour).
     /// </summary>
     /// <param name="type">Whether to query the published or received message table.</param>
     /// <param name="cancellationToken">A token to cancel the query.</param>
-    ValueTask<Dictionary<DateTime, int>> HourlyFailedJobs(
+    ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlyFailedJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     );

--- a/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
+++ b/src/Headless.Messaging.Dashboard/Endpoints/MessagingDashboardEndpoints.cs
@@ -271,20 +271,23 @@ public static class MessagingDashboardEndpoints
         var dataStorage = sp.GetRequiredService<IDataStorage>();
         var monitoringApi = dataStorage.GetMonitoringApi();
 
-        var ps = await monitoringApi.HourlySucceededJobs(MessageType.Publish).ConfigureAwait(false);
-        var pf = await monitoringApi.HourlyFailedJobs(MessageType.Publish).ConfigureAwait(false);
-        var ss = await monitoringApi.HourlySucceededJobs(MessageType.Subscribe).ConfigureAwait(false);
-        var sf = await monitoringApi.HourlyFailedJobs(MessageType.Subscribe).ConfigureAwait(false);
+        var ps = await monitoringApi.GetHourlySucceededJobsAsync(MessageType.Publish).ConfigureAwait(false);
+        var pf = await monitoringApi.GetHourlyFailedJobsAsync(MessageType.Publish).ConfigureAwait(false);
+        var ss = await monitoringApi.GetHourlySucceededJobsAsync(MessageType.Subscribe).ConfigureAwait(false);
+        var sf = await monitoringApi.GetHourlyFailedJobsAsync(MessageType.Subscribe).ConfigureAwait(false);
 
-        var dayHour = ps.Keys.Order().Select(x => new DateTimeOffset(x).ToUnixTimeSeconds());
+        // Align all four series to one ascending hour axis instead of relying on dictionary
+        // enumeration order; a bucket missing from a series (the clock ticking over an hour
+        // between the four queries) counts as zero.
+        var hours = ps.Keys.Order().ToArray();
 
         var result = new
         {
-            DayHour = dayHour.ToArray(),
-            PublishSuccessed = ps.Values.Reverse(),
-            PublishFailed = pf.Values.Reverse(),
-            SubscribeSuccessed = ss.Values.Reverse(),
-            SubscribeFailed = sf.Values.Reverse(),
+            DayHour = hours.Select(x => x.ToUnixTimeSeconds()).ToArray(),
+            PublishSuccessed = hours.Select(x => ps.GetValueOrDefault(x)).ToArray(),
+            PublishFailed = hours.Select(x => pf.GetValueOrDefault(x)).ToArray(),
+            SubscribeSuccessed = hours.Select(x => ss.GetValueOrDefault(x)).ToArray(),
+            SubscribeFailed = hours.Select(x => sf.GetValueOrDefault(x)).ToArray(),
         };
 
         cache.Set(cacheKey, result, TimeSpan.FromMinutes(10));

--- a/src/Headless.Messaging.Storage.InMemory/InMemoryMonitoringApi.cs
+++ b/src/Headless.Messaging.Storage.InMemory/InMemoryMonitoringApi.cs
@@ -130,22 +130,22 @@ internal sealed class InMemoryMonitoringApi(InMemoryDataStorage storage, TimePro
         return ValueTask.FromResult(stats);
     }
 
-    public ValueTask<Dictionary<DateTime, int>> HourlyFailedJobs(
+    public ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlyFailedJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return _GetHourlyTimelineStats(type, nameof(StatusName.Failed));
+        return _GetHourlyTimelineStats(type, StatusName.Failed);
     }
 
-    public ValueTask<Dictionary<DateTime, int>> HourlySucceededJobs(
+    public ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlySucceededJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return _GetHourlyTimelineStats(type, nameof(StatusName.Succeeded));
+        return _GetHourlyTimelineStats(type, StatusName.Succeeded);
     }
 
     public ValueTask<IndexPage<MessageView>> GetMessagesAsync(
@@ -271,81 +271,64 @@ internal sealed class InMemoryMonitoringApi(InMemoryDataStorage storage, TimePro
         }
     }
 
-    public ValueTask<long> PublishedFailedCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetPublishedFailedCountAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return new ValueTask<long>(storage.PublishedMessages.Values.Count(x => x.StatusName == StatusName.Failed));
     }
 
-    public ValueTask<long> PublishedSucceededCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetPublishedSucceededCountAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return new ValueTask<long>(storage.PublishedMessages.Values.Count(x => x.StatusName == StatusName.Succeeded));
     }
 
-    public ValueTask<long> ReceivedFailedCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetReceivedFailedCountAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return new ValueTask<long>(storage.ReceivedMessages.Values.Count(x => x.StatusName == StatusName.Failed));
     }
 
-    public ValueTask<long> ReceivedSucceededCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetReceivedSucceededCountAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return new ValueTask<long>(storage.ReceivedMessages.Values.Count(x => x.StatusName == StatusName.Succeeded));
     }
 
-    private ValueTask<Dictionary<DateTime, int>> _GetHourlyTimelineStats(MessageType type, string statusName)
+    private ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> _GetHourlyTimelineStats(
+        MessageType type,
+        StatusName statusName
+    )
     {
-        // Hourly buckets are label keys, not persisted instants.
-        var endDate = timeProvider.GetUtcNow().UtcDateTime;
-        var dates = new List<DateTime>();
+        // Buckets cover the current UTC hour and the 23 preceding hours, keyed by hour start
+        // (newest first, matching the SQL-backed monitoring implementations).
+        var currentHour = timeProvider.GetUtcNow().TruncateToHours();
+        var oldestHour = currentHour.AddHours(-23);
+
+        var result = new Dictionary<DateTimeOffset, int>(capacity: 24);
+
         for (var i = 0; i < 24; i++)
         {
-            dates.Add(endDate);
-            endDate = endDate.AddHours(-1);
+            result[currentHour.AddHours(-i)] = 0;
         }
 
-        var keyMaps = dates.ToDictionary(
-            x => x.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture),
-            x => x,
-            StringComparer.Ordinal
-        );
+        var messages = type == MessageType.Publish ? storage.PublishedMessages.Values : storage.ReceivedMessages.Values;
 
-        var valuesMap =
-            type == MessageType.Publish
-                ? storage
-                    .PublishedMessages.Values.Where(x =>
-                        string.Equals(x.StatusName.ToString(), statusName, StringComparison.Ordinal)
-                    )
-                    .GroupBy(
-                        x => x.Added.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture),
-                        StringComparer.Ordinal
-                    )
-                    .ToDictionary(x => x.Key, x => x.Count(), StringComparer.Ordinal)
-                : storage
-                    .ReceivedMessages.Values.Where(x =>
-                        string.Equals(x.StatusName.ToString(), statusName, StringComparison.Ordinal)
-                    )
-                    .GroupBy(
-                        x => x.Added.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture),
-                        StringComparer.Ordinal
-                    )
-                    .ToDictionary(x => x.Key, x => x.Count(), StringComparer.Ordinal);
-
-        foreach (var key in keyMaps.Keys)
+        foreach (var message in messages)
         {
-            valuesMap.TryAdd(key, 0);
+            if (message.StatusName != statusName)
+            {
+                continue;
+            }
+
+            var bucket = message.Added.ToUniversalTime().TruncateToHours();
+
+            if (bucket >= oldestHour && bucket <= currentHour)
+            {
+                result[bucket]++;
+            }
         }
 
-        var result = new Dictionary<DateTime, int>();
-
-        for (var i = 0; i < keyMaps.Count; i++)
-        {
-            var value = valuesMap[keyMaps.ElementAt(i).Key];
-            result.Add(keyMaps.ElementAt(i).Value, value);
-        }
-
-        return ValueTask.FromResult(result);
+        return ValueTask.FromResult<IReadOnlyDictionary<DateTimeOffset, int>>(result);
     }
 }

--- a/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -265,25 +265,25 @@ internal sealed class PostgreSqlMonitoringApi(
     }
 
     /// <summary>Returns the total count of published messages in the <c>Failed</c> state.</summary>
-    public ValueTask<long> PublishedFailedCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetPublishedFailedCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_publishedTable, nameof(StatusName.Failed), cancellationToken);
     }
 
     /// <summary>Returns the total count of published messages in the <c>Succeeded</c> state.</summary>
-    public ValueTask<long> PublishedSucceededCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetPublishedSucceededCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_publishedTable, nameof(StatusName.Succeeded), cancellationToken);
     }
 
     /// <summary>Returns the total count of received messages in the <c>Failed</c> state.</summary>
-    public ValueTask<long> ReceivedFailedCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetReceivedFailedCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_receivedTable, nameof(StatusName.Failed), cancellationToken);
     }
 
     /// <summary>Returns the total count of received messages in the <c>Succeeded</c> state.</summary>
-    public ValueTask<long> ReceivedSucceededCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetReceivedSucceededCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_receivedTable, nameof(StatusName.Succeeded), cancellationToken);
     }
@@ -292,7 +292,7 @@ internal sealed class PostgreSqlMonitoringApi(
     /// Returns a dictionary of UTC hour buckets to <c>Succeeded</c> message counts for the past 24 hours,
     /// from the published or received table depending on <paramref name="type"/>.
     /// </summary>
-    public async ValueTask<Dictionary<DateTime, int>> HourlySucceededJobs(
+    public async ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlySucceededJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     )
@@ -307,7 +307,7 @@ internal sealed class PostgreSqlMonitoringApi(
     /// Returns a dictionary of UTC hour buckets to <c>Failed</c> message counts for the past 24 hours,
     /// from the published or received table depending on <paramref name="type"/>.
     /// </summary>
-    public async ValueTask<Dictionary<DateTime, int>> HourlyFailedJobs(
+    public async ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlyFailedJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     )
@@ -339,49 +339,56 @@ internal sealed class PostgreSqlMonitoringApi(
             .ConfigureAwait(false);
     }
 
-    private Task<Dictionary<DateTime, int>> _GetHourlyTimelineStats(
+    private Task<IReadOnlyDictionary<DateTimeOffset, int>> _GetHourlyTimelineStats(
         string tableName,
         string statusName,
         CancellationToken cancellationToken = default
     )
     {
-        var now = timeProvider.GetUtcNow();
-        var dates = new List<DateTime>();
-        // Hourly buckets are label keys, not persisted instants: keep them DateTime.
-        var nowUtc = now.UtcDateTime;
+        // Buckets cover the current UTC hour and the 23 preceding hours, keyed by hour start
+        // (a DateTimeOffset with zero offset), newest first.
+        var currentHour = timeProvider.GetUtcNow().TruncateToHours();
+
+        var keyMaps = new Dictionary<string, DateTimeOffset>(capacity: 24, StringComparer.Ordinal);
 
         for (var i = 0; i < 24; i++)
         {
-            dates.Add(nowUtc.AddHours(-i));
+            var bucket = currentHour.AddHours(-i);
+            keyMaps[bucket.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture)] = bucket;
         }
 
-        var keyMaps = dates.ToDictionary(
-            x => x.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture),
-            x => x,
-            StringComparer.Ordinal
-        );
+        var oldestHour = currentHour.AddHours(-23);
 
-        return _GetTimelineStats(tableName, statusName, keyMaps, dates[^1], nowUtc, cancellationToken);
+        return _GetTimelineStats(
+            tableName,
+            statusName,
+            keyMaps,
+            oldestHour,
+            currentHour.AddHours(1),
+            cancellationToken
+        );
     }
 
-    private async Task<Dictionary<DateTime, int>> _GetTimelineStats(
+    private async Task<IReadOnlyDictionary<DateTimeOffset, int>> _GetTimelineStats(
         string tableName,
         string statusName,
-        Dictionary<string, DateTime> keyMaps,
-        DateTime minAdded,
-        DateTime maxAdded,
+        Dictionary<string, DateTimeOffset> keyMaps,
+        DateTimeOffset minAdded,
+        DateTimeOffset maxAddedExclusive,
         CancellationToken cancellationToken = default
     )
     {
         var sqlQuery = $"""
             WITH Aggr AS (
-                -- HH24 (24-hour) matches the C# key built with DateTime.ToString("yyyy-MM-dd-HH"); Postgres 'HH'
-                -- is 12-hour, which silently mismatched buckets for hours 00 and 13-23.
-                SELECT to_char("Added",'yyyy-MM-dd-HH24') AS "Key",
+                -- AT TIME ZONE 'UTC' renders the timestamptz in UTC regardless of the session TimeZone,
+                -- matching the UTC hour-bucket keys built in C#. HH24 (24-hour) matches the C# key built
+                -- with ToString("yyyy-MM-dd-HH"); Postgres 'HH' is 12-hour, which silently mismatched
+                -- buckets for hours 00 and 13-23.
+                SELECT to_char("Added" AT TIME ZONE 'UTC','yyyy-MM-dd-HH24') AS "Key",
                 COUNT("Id") AS "Count"
                 FROM {tableName}
-                    WHERE "StatusName" = @StatusName AND "Added" >= @MinAdded AND "Added" <= @MaxAdded
-                GROUP BY to_char("Added", 'yyyy-MM-dd-HH24')
+                    WHERE "StatusName" = @StatusName AND "Added" >= @MinAdded AND "Added" < @MaxAdded
+                GROUP BY to_char("Added" AT TIME ZONE 'UTC', 'yyyy-MM-dd-HH24')
             )
             SELECT "Key","Count" from Aggr;
             """;
@@ -389,8 +396,8 @@ internal sealed class PostgreSqlMonitoringApi(
         object[] sqlParams =
         [
             new NpgsqlParameter("@StatusName", statusName),
-            new NpgsqlParameter("@MinAdded", minAdded),
-            new NpgsqlParameter("@MaxAdded", maxAdded),
+            new NpgsqlParameter("@MinAdded", minAdded.UtcDateTime),
+            new NpgsqlParameter("@MaxAdded", maxAddedExclusive.UtcDateTime),
         ];
 
         await using var connection = _options.CreateConnection();
@@ -417,12 +424,12 @@ internal sealed class PostgreSqlMonitoringApi(
             )
             .ConfigureAwait(false);
 
-        var result = new Dictionary<DateTime, int>();
+        var result = new Dictionary<DateTimeOffset, int>(capacity: keyMaps.Count);
 
-        foreach (var (key, dateTime) in keyMaps)
+        foreach (var (key, hourBucket) in keyMaps)
         {
             var value = valuesMap.GetValueOrDefault(key, 0);
-            result.Add(dateTime, value);
+            result.Add(hourBucket, value);
         }
 
         return result;

--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerMonitoringApi.cs
@@ -80,7 +80,7 @@ internal sealed class SqlServerMonitoringApi(
     /// Returns a dictionary of UTC hour buckets to <c>Failed</c> message counts for the past 24 hours,
     /// from the published or received table depending on <paramref name="type"/>.
     /// </summary>
-    public async ValueTask<Dictionary<DateTime, int>> HourlyFailedJobs(
+    public async ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlyFailedJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     )
@@ -94,7 +94,7 @@ internal sealed class SqlServerMonitoringApi(
     /// Returns a dictionary of UTC hour buckets to <c>Succeeded</c> message counts for the past 24 hours,
     /// from the published or received table depending on <paramref name="type"/>.
     /// </summary>
-    public async ValueTask<Dictionary<DateTime, int>> HourlySucceededJobs(
+    public async ValueTask<IReadOnlyDictionary<DateTimeOffset, int>> GetHourlySucceededJobsAsync(
         MessageType type,
         CancellationToken cancellationToken = default
     )
@@ -247,25 +247,25 @@ internal sealed class SqlServerMonitoringApi(
     }
 
     /// <summary>Returns the total count of published messages in the <c>Failed</c> state.</summary>
-    public ValueTask<long> PublishedFailedCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetPublishedFailedCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_publishedTable, nameof(StatusName.Failed), cancellationToken);
     }
 
     /// <summary>Returns the total count of published messages in the <c>Succeeded</c> state.</summary>
-    public ValueTask<long> PublishedSucceededCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetPublishedSucceededCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_publishedTable, nameof(StatusName.Succeeded), cancellationToken);
     }
 
     /// <summary>Returns the total count of received messages in the <c>Failed</c> state.</summary>
-    public ValueTask<long> ReceivedFailedCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetReceivedFailedCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_receivedTable, nameof(StatusName.Failed), cancellationToken);
     }
 
     /// <summary>Returns the total count of received messages in the <c>Succeeded</c> state.</summary>
-    public ValueTask<long> ReceivedSucceededCount(CancellationToken cancellationToken = default)
+    public ValueTask<long> GetReceivedSucceededCountAsync(CancellationToken cancellationToken = default)
     {
         return _GetNumberOfMessage(_receivedTable, nameof(StatusName.Succeeded), cancellationToken);
     }
@@ -325,50 +325,57 @@ internal sealed class SqlServerMonitoringApi(
             .ConfigureAwait(false);
     }
 
-    private Task<Dictionary<DateTime, int>> _GetHourlyTimelineStats(
+    private Task<IReadOnlyDictionary<DateTimeOffset, int>> _GetHourlyTimelineStats(
         string tableName,
         string statusName,
         CancellationToken cancellationToken = default
     )
     {
-        var now = timeProvider.GetUtcNow();
-        var dates = new List<DateTime>();
-        // Hourly buckets are label keys, not persisted instants: keep them DateTime.
-        var nowUtc = now.UtcDateTime;
+        // Buckets cover the current UTC hour and the 23 preceding hours, keyed by hour start
+        // (a DateTimeOffset with zero offset), newest first.
+        var currentHour = timeProvider.GetUtcNow().TruncateToHours();
+
+        var keyMaps = new Dictionary<string, DateTimeOffset>(capacity: 24, StringComparer.Ordinal);
 
         for (var i = 0; i < 24; i++)
         {
-            dates.Add(nowUtc.AddHours(-i));
+            var bucket = currentHour.AddHours(-i);
+            keyMaps[bucket.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture)] = bucket;
         }
 
-        var keyMaps = dates.ToDictionary(
-            x => x.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture),
-            x => x,
-            StringComparer.Ordinal
-        );
+        var oldestHour = currentHour.AddHours(-23);
 
-        return _GetTimelineStats(tableName, statusName, keyMaps, dates[^1], nowUtc, cancellationToken);
+        return _GetTimelineStats(
+            tableName,
+            statusName,
+            keyMaps,
+            oldestHour,
+            currentHour.AddHours(1),
+            cancellationToken
+        );
     }
 
-    private async Task<Dictionary<DateTime, int>> _GetTimelineStats(
+    private async Task<IReadOnlyDictionary<DateTimeOffset, int>> _GetTimelineStats(
         string tableName,
         string statusName,
-        Dictionary<string, DateTime> keyMaps,
-        DateTime minAdded,
-        DateTime maxAdded,
+        Dictionary<string, DateTimeOffset> keyMaps,
+        DateTimeOffset minAdded,
+        DateTimeOffset maxAddedExclusive,
         CancellationToken cancellationToken = default
     )
     {
-        // Use CONVERT instead of FORMAT to avoid CLR dependency (Azure SQL Edge doesn't support CLR)
+        // SWITCHOFFSET(Added, 0) normalizes the datetimeoffset column to UTC before formatting, so the
+        // SQL bucket keys match the UTC hour-bucket keys built in C# even when rows carry a non-zero offset.
+        // Use CONVERT instead of FORMAT to avoid CLR dependency (Azure SQL Edge doesn't support CLR).
         var sqlQuery = $"""
             WITH Aggr AS (
             -- COUNT (int) not COUNT_BIG: the reader maps [Count] via GetInt32 into a Dictionary<string,int>, and
             -- a single-hour bucket can never overflow int. SqlClient.GetInt32 rejects a bigint column outright.
-            SELECT CONVERT(CHAR(10), Added, 120) + '-' + RIGHT('0' + CAST(DATEPART(HOUR, Added) AS VARCHAR(2)), 2) AS [Key],
+            SELECT CONVERT(CHAR(10), SWITCHOFFSET(Added, 0), 120) + '-' + RIGHT('0' + CAST(DATEPART(HOUR, SWITCHOFFSET(Added, 0)) AS VARCHAR(2)), 2) AS [Key],
                 COUNT(Id) [Count]
             FROM  {tableName}
-            WHERE StatusName = @StatusName AND Added >= @MinAdded AND Added <= @MaxAdded
-            GROUP BY CONVERT(CHAR(10), Added, 120) + '-' + RIGHT('0' + CAST(DATEPART(HOUR, Added) AS VARCHAR(2)), 2)
+            WHERE StatusName = @StatusName AND Added >= @MinAdded AND Added < @MaxAdded
+            GROUP BY CONVERT(CHAR(10), SWITCHOFFSET(Added, 0), 120) + '-' + RIGHT('0' + CAST(DATEPART(HOUR, SWITCHOFFSET(Added, 0)) AS VARCHAR(2)), 2)
             )
             SELECT [Key], [Count] FROM Aggr WITH (NOLOCK);
             """;
@@ -377,7 +384,7 @@ internal sealed class SqlServerMonitoringApi(
         [
             new SqlParameter("@StatusName", statusName),
             new SqlParameter("@MinAdded", minAdded),
-            new SqlParameter("@MaxAdded", maxAdded),
+            new SqlParameter("@MaxAdded", maxAddedExclusive),
         ];
 
         Dictionary<string, int> valuesMap;
@@ -407,10 +414,10 @@ internal sealed class SqlServerMonitoringApi(
                 .ConfigureAwait(false);
         }
 
-        var result = new Dictionary<DateTime, int>(keyMaps.Count);
-        foreach (var (key, dateTime) in keyMaps)
+        var result = new Dictionary<DateTimeOffset, int>(keyMaps.Count);
+        foreach (var (key, hourBucket) in keyMaps)
         {
-            result[dateTime] = valuesMap.TryGetValue(key, out var count) ? count : 0;
+            result[hourBucket] = valuesMap.TryGetValue(key, out var count) ? count : 0;
         }
 
         return result;

--- a/tests/Headless.Messaging.NatsPostgreSql.Tests.Integration/NatsPostgreSqlMessagingIntegrationTests.cs
+++ b/tests/Headless.Messaging.NatsPostgreSql.Tests.Integration/NatsPostgreSqlMessagingIntegrationTests.cs
@@ -184,8 +184,8 @@ public sealed class NatsPostgreSqlMessagingIntegrationTests(NatsPostgreSqlFixtur
         subscriber.Clear();
 
         var monitoringApi = DataStorage.GetMonitoringApi();
-        var publishedBefore = await monitoringApi.PublishedSucceededCount(AbortToken);
-        var receivedBefore = await monitoringApi.ReceivedSucceededCount(AbortToken);
+        var publishedBefore = await monitoringApi.GetPublishedSucceededCountAsync(AbortToken);
+        var receivedBefore = await monitoringApi.GetReceivedSucceededCountAsync(AbortToken);
 
         var message = new Fixtures.TestMessage
         {
@@ -203,8 +203,8 @@ public sealed class NatsPostgreSqlMessagingIntegrationTests(NatsPostgreSqlFixtur
 
         await Task.Delay(TimeSpan.FromSeconds(2), AbortToken);
 
-        var publishedAfter = await monitoringApi.PublishedSucceededCount(AbortToken);
-        var receivedAfter = await monitoringApi.ReceivedSucceededCount(AbortToken);
+        var publishedAfter = await monitoringApi.GetPublishedSucceededCountAsync(AbortToken);
+        var receivedAfter = await monitoringApi.GetReceivedSucceededCountAsync(AbortToken);
 
         publishedAfter.Should().Be(publishedBefore, "direct publish bypasses durable outbox persistence");
         receivedAfter.Should().BeGreaterThan(receivedBefore, "the consumer side should still persist received records");

--- a/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlMonitoringTest.cs
+++ b/tests/Headless.Messaging.Storage.PostgreSql.Tests.Integration/PostgreSqlMonitoringTest.cs
@@ -84,8 +84,8 @@ public sealed class PostgreSqlMonitoringTest(PostgreSqlTestFixture fixture) : Te
 
         // when
         var monitoringApi = storage.GetMonitoringApi();
-        var succeededCount = await monitoringApi.PublishedSucceededCount(AbortToken);
-        var failedCount = await monitoringApi.PublishedFailedCount(AbortToken);
+        var succeededCount = await monitoringApi.GetPublishedSucceededCountAsync(AbortToken);
+        var failedCount = await monitoringApi.GetPublishedFailedCountAsync(AbortToken);
 
         // then
         succeededCount.Should().Be(1);
@@ -250,7 +250,7 @@ public sealed class PostgreSqlMonitoringTest(PostgreSqlTestFixture fixture) : Te
 
         // when
         var monitoringApi = storage.GetMonitoringApi();
-        var hourly = await monitoringApi.HourlySucceededJobs(MessageType.Publish, AbortToken);
+        var hourly = await monitoringApi.GetHourlySucceededJobsAsync(MessageType.Publish, AbortToken);
 
         // then — should have 24 hour buckets, at least one with count > 0
         hourly.Should().HaveCount(24);
@@ -268,7 +268,7 @@ public sealed class PostgreSqlMonitoringTest(PostgreSqlTestFixture fixture) : Te
 
         // when
         var monitoringApi = storage.GetMonitoringApi();
-        var hourly = await monitoringApi.HourlyFailedJobs(MessageType.Publish, AbortToken);
+        var hourly = await monitoringApi.GetHourlyFailedJobsAsync(MessageType.Publish, AbortToken);
 
         // then
         hourly.Should().HaveCount(24);

--- a/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerMonitoringApiTests.cs
+++ b/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerMonitoringApiTests.cs
@@ -133,7 +133,7 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
         await _CreatePublishedMessage(StatusName.Succeeded);
 
         // when
-        var count = await _monitoringApi.PublishedFailedCount(AbortToken);
+        var count = await _monitoringApi.GetPublishedFailedCountAsync(AbortToken);
 
         // then
         count.Should().Be(2);
@@ -147,7 +147,7 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
         await _CreatePublishedMessage(StatusName.Failed);
 
         // when
-        var count = await _monitoringApi.PublishedSucceededCount(AbortToken);
+        var count = await _monitoringApi.GetPublishedSucceededCountAsync(AbortToken);
 
         // then
         count.Should().Be(1);
@@ -162,7 +162,7 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
         await _CreateReceivedMessage(StatusName.Failed);
 
         // when
-        var count = await _monitoringApi.ReceivedFailedCount(AbortToken);
+        var count = await _monitoringApi.GetReceivedFailedCountAsync(AbortToken);
 
         // then
         count.Should().Be(3);
@@ -175,7 +175,7 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
         await _CreateReceivedMessage(StatusName.Succeeded);
 
         // when
-        var count = await _monitoringApi.ReceivedSucceededCount(AbortToken);
+        var count = await _monitoringApi.GetReceivedSucceededCountAsync(AbortToken);
 
         // then
         count.Should().Be(1);
@@ -395,7 +395,7 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
         await _CreatePublishedMessage(StatusName.Failed);
 
         // when
-        var timeline = await _monitoringApi.HourlyFailedJobs(MessageType.Publish, AbortToken);
+        var timeline = await _monitoringApi.GetHourlyFailedJobsAsync(MessageType.Publish, AbortToken);
 
         // then
         timeline.Should().NotBeEmpty();
@@ -409,7 +409,7 @@ public sealed class SqlServerMonitoringApiTests(SqlServerTestFixture fixture) : 
         await _CreateReceivedMessage(StatusName.Succeeded);
 
         // when
-        var timeline = await _monitoringApi.HourlySucceededJobs(MessageType.Subscribe, AbortToken);
+        var timeline = await _monitoringApi.GetHourlySucceededJobsAsync(MessageType.Subscribe, AbortToken);
 
         // then
         timeline.Should().NotBeEmpty();


### PR DESCRIPTION
## Summary

Pre-v1 public-API hardening for the messaging monitoring surface (review finding: `src/Headless.Messaging.Core/Monitoring/IMonitoringApi.cs:76-114`).

- Six `ValueTask`-returning members lacked the `Async` suffix (`PublishedFailedCount`, `PublishedSucceededCount`, `ReceivedFailedCount`, `ReceivedSucceededCount`, `HourlySucceededJobs`, `HourlyFailedJobs`) while every sibling on the same interface uses the `Get...Async` shape.
- The hourly histogram members returned a mutable concrete `Dictionary<DateTime, int>`; framework time policy is `DateTimeOffset` in UTC, and query results should not hand out mutable concrete collections.

## Changes

- `IMonitoringApi`: renamed the six members to `GetPublishedFailedCountAsync`, `GetPublishedSucceededCountAsync`, `GetReceivedFailedCountAsync`, `GetReceivedSucceededCountAsync`, `GetHourlySucceededJobsAsync`, `GetHourlyFailedJobsAsync` (matching the `Get...Async` sibling style).
- Hourly members now return `IReadOnlyDictionary<DateTimeOffset, int>` keyed by UTC hour bucket (zero offset, truncated to the start of the hour via `Headless.Extensions`' `TruncateToHours()`), documented on the interface.
- `InMemoryMonitoringApi`: rewrote `_GetHourlyTimelineStats` to bucket by UTC hour-start keys; messages are now normalized with `ToUniversalTime()` before bucketing (previously a non-UTC `Added` offset would have been formatted with its own offset and mis-bucketed). Status matching now compares the `StatusName` enum directly instead of formatted strings.
- `PostgreSqlMonitoringApi`: hour-bucket keys are UTC hour starts; the SQL grouping now formats `"Added" AT TIME ZONE 'UTC'` so bucket strings are UTC-correct regardless of the session `TimeZone` (previously `to_char` on a `timestamptz` rendered in the session zone). Range is now `[oldest hour start, current hour start + 1h)` so the oldest bucket covers its full hour.
- `SqlServerMonitoringApi`: same shape; SQL grouping now formats `SWITCHOFFSET(Added, 0)` so `datetimeoffset` rows with non-zero offsets bucket into the correct UTC hour.
- `MessagingDashboardEndpoints._MetricsHistory`: renamed calls, and the four chart series are now aligned to one explicitly-sorted ascending hour axis (`hours.Select(x => series.GetValueOrDefault(x))`) instead of relying on dictionary insertion order plus `Values.Reverse()` — the previous pairing silently depended on newest-first enumeration order. The serialized JSON shape (`DayHour` unix seconds + count arrays) is unchanged.
- Renamed all call sites in the three integration test projects (NatsPostgreSql, Storage.PostgreSql, Storage.SqlServer).

## Decisions

- Used the `Get...Async` prefix form (not a bare `Async` suffix) because every sibling member on `IMonitoringApi` follows `Get...Async`.
- Kept the "Jobs" wording in `GetHourlySucceededJobsAsync`/`GetHourlyFailedJobsAsync`; renaming to "Messages" is a semantic rename beyond this finding's scope.
- Hour-bucket keys are truncated to the start of the hour. Previously keys carried the query-time minutes/seconds (e.g. `14:37:22`) even though counts were grouped per hour — truncation makes the key match the documented "UTC hour bucket" contract. The dashboard converts keys to unix seconds, so consumers see slightly different (top-of-hour) axis values, not a shape change.
- Added `AT TIME ZONE 'UTC'` (PostgreSQL) and `SWITCHOFFSET(..., 0)` (SQL Server) to the bucket-formatting SQL so buckets are UTC-correct regardless of session time zone or stored offsets — required by the "verify each storage implementation produces UTC-correct buckets" part of the task.
- Dashboard SPA needs no change: `wwwroot/src/stores/messagingStore.ts` consumes `DayHour` as `number[]` (unix seconds) and the response shape is unchanged, so the SPA build was skipped (`BuildDashboardSpa=false`).

## Testing

- `dotnet build src/Headless.Messaging.Core --no-incremental -v:minimal` — clean (0 warnings/errors)
- `dotnet build src/Headless.Messaging.Storage.InMemory --no-incremental -v:minimal` — clean
- `dotnet build src/Headless.Messaging.Storage.PostgreSql --no-incremental -v:minimal` — clean
- `dotnet build src/Headless.Messaging.Storage.SqlServer --no-incremental -v:minimal` — clean
- `BuildDashboardSpa=false dotnet build src/Headless.Messaging.Dashboard --no-incremental -v:minimal` — clean
- Compiled (build-only) the three touched integration test projects — clean
- `dotnet test --project tests/Headless.Messaging.Storage.InMemory.Tests.Unit` — 79 passed
- `dotnet test --project tests/Headless.Messaging.Storage.PostgreSql.Tests.Unit` — 47 passed
- `dotnet test --project tests/Headless.Messaging.Storage.SqlServer.Tests.Unit` — 44 passed
- `dotnet test --project tests/Headless.Messaging.Dashboard.Tests.Unit` — 122 passed
- `dotnet test --project tests/Headless.Messaging.Core.Tests.Unit` — 955 passed
- Integration tests skipped: Docker unavailable (Storage.PostgreSql/Storage.SqlServer/NatsPostgreSql integration suites compile but were not run).

## Docs

No sync needed: `rg` over `docs/llms/` and the affected package READMEs found zero references to `IMonitoringApi` or the renamed members.
