### PR TITLE
fix(messaging-dashboard): skip caching failed Consul node lookups

### DIFF
--- a/src/Headless.Messaging.Dashboard/GatewayProxy/GatewayProxyAgent.cs
+++ b/src/Headless.Messaging.Dashboard/GatewayProxy/GatewayProxyAgent.cs
@@ -99,7 +99,10 @@ internal sealed class GatewayProxyAgent(
                 node = await discoveryProvider
                     .GetNodeAsync(requestNodeName, cancellationToken: context.RequestAborted)
                     .ConfigureAwait(false);
-                cache.Set(requestNodeName, node);
+                if (node != null)
+                {
+                    cache.Set(requestNodeName, node, TimeSpan.FromSeconds(30));
+                }
             }
         }
 

--- a/tests/Headless.Messaging.Dashboard.Tests.Unit/GatewayProxy/GatewayProxyAgentTests.cs
+++ b/tests/Headless.Messaging.Dashboard.Tests.Unit/GatewayProxy/GatewayProxyAgentTests.cs
@@ -104,6 +104,48 @@ public sealed class GatewayProxyAgentTests : TestBase
     }
 
     [Fact]
+    public async Task should_not_cache_failed_consul_lookup_when_invoke()
+    {
+        // A transient Consul failure returns null; that result must not be cached, so the next request retries
+        // discovery and reaches the node once it is available again instead of failing until process restart.
+        var firstContext = _CreateHttpContext();
+        var secondContext = _CreateHttpContext();
+        firstContext.Request.Headers.Cookie = $"{GatewayProxyAgent.CookieNodeName}=node1";
+        secondContext.Request.Headers.Cookie = $"{GatewayProxyAgent.CookieNodeName}=node1";
+
+        var node = new Node
+        {
+            Id = "1",
+            Name = "node1",
+            Address = "http://10.0.0.1",
+            Port = 8080,
+            Tags = "web",
+        };
+
+        var discoveryProvider = Substitute.For<INodeDiscoveryProvider>();
+        discoveryProvider
+            .GetNodeAsync("node1", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Node?>(null), Task.FromResult<Node?>(node));
+
+        var responseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("OK") };
+        using var httpMessageHandler = new MockHttpMessageHandler(responseMessage);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        using var httpClient = new HttpClient(httpMessageHandler);
+        httpClientFactory.CreateClient("GatewayProxy").Returns(httpClient);
+
+        var agent = _CreateAgent(firstContext, discoveryProvider, httpClientFactory);
+
+        // when
+        var firstResult = await agent.Invoke(firstContext);
+        var secondResult = await agent.Invoke(secondContext);
+
+        // then
+        firstResult.Should().BeFalse();
+        secondResult.Should().BeTrue();
+        await discoveryProvider.Received(2).GetNodeAsync("node1", null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task should_return_false_when_invoke_same_node_as_current()
     {
         // given


### PR DESCRIPTION
## Summary

A transient Consul discovery failure returns `null` from `GetNodeAsync`, and `GatewayProxyAgent`'s Consul branch cached that `null` under the node name with no expiration — one hiccup permanently broke dashboard proxying to an otherwise-healthy node until process restart. The sibling k8s branch was hardened in #726, but the Consul branch was missed when #707 was split.

The Consul branch now mirrors the k8s shape: only non-null nodes are cached, with a 30-second TTL. A regression test locks the behavior (a failed lookup is retried on the next request and reaches the node once discovery recovers).

Found by the #707 x-code-review run — flagged independently by the adversarial and reliability reviewers and confirmed by a dedicated validation pass.

## Validation

- `Headless.Messaging.Dashboard.Tests.Unit`: 123/123 pass (includes the new `should_not_cache_failed_consul_lookup_when_invoke`).
- Pre-push incremental solution build: 0 warnings, 0 errors.
