### PR TITLE
refactor(messaging): harden transport and result contracts

### DIFF
--- a/src/Headless.Messaging.Abstractions/OperateResult.cs
+++ b/src/Headless.Messaging.Abstractions/OperateResult.cs
@@ -22,8 +22,7 @@ namespace Headless.Messaging;
 /// <param name="error">Additional error details, or null if no structured error information is available.</param>
 [PublicAPI]
 public readonly struct OperateResult(bool succeeded, Exception? exception = null, OperateError? error = null)
-    : IEqualityComparer<OperateResult>,
-        IEquatable<OperateResult>
+    : IEquatable<OperateResult>
 {
     private readonly OperateError? _operateError = error;
 
@@ -66,28 +65,16 @@ public readonly struct OperateResult(bool succeeded, Exception? exception = null
     }
 
     /// <summary>
-    /// Determines whether two <see cref="OperateResult"/> instances are equal based on success status,
+    /// Determines whether this result equals another based on success status,
     /// the wrapped exception reference, and the structured error.
     /// </summary>
-    /// <param name="x">The first result to compare.</param>
-    /// <param name="y">The second result to compare.</param>
+    /// <param name="other">The result to compare with.</param>
     /// <returns>true if both results match on all three fields; otherwise false.</returns>
-    public bool Equals(OperateResult x, OperateResult y)
+    public bool Equals(OperateResult other)
     {
-        return x.Succeeded == y.Succeeded
-            && ReferenceEquals(x.Exception, y.Exception)
-            && Nullable.Equals(x._operateError, y._operateError);
-    }
-
-    /// <summary>
-    /// Serves as the default hash function for the <see cref="OperateResult"/> struct.
-    /// Hashes the same fields <see cref="Equals(OperateResult, OperateResult)"/> compares.
-    /// </summary>
-    /// <param name="o">The result to compute the hash code for.</param>
-    /// <returns>A hash code combining the error, success status, and exception information.</returns>
-    public int GetHashCode(OperateResult o)
-    {
-        return HashCode.Combine(o._operateError, o.Succeeded, o.Exception);
+        return Succeeded == other.Succeeded
+            && ReferenceEquals(Exception, other.Exception)
+            && Nullable.Equals(_operateError, other._operateError);
     }
 
     public override bool Equals(object? obj)
@@ -95,19 +82,19 @@ public readonly struct OperateResult(bool succeeded, Exception? exception = null
         return obj is OperateResult other && Equals(other);
     }
 
+    /// <summary>
+    /// Serves as the default hash function for the <see cref="OperateResult"/> struct.
+    /// Hashes the same fields <see cref="Equals(OperateResult)"/> compares.
+    /// </summary>
+    /// <returns>A hash code combining the error, success status, and exception information.</returns>
     public override int GetHashCode()
     {
-        return GetHashCode(this);
+        return HashCode.Combine(_operateError, Succeeded, Exception);
     }
 
     public static bool operator ==(OperateResult left, OperateResult right) => left.Equals(right);
 
     public static bool operator !=(OperateResult left, OperateResult right) => !(left == right);
-
-    public bool Equals(OperateResult other)
-    {
-        return Equals(this, other);
-    }
 }
 
 /// <summary>
@@ -115,17 +102,17 @@ public readonly struct OperateResult(bool succeeded, Exception? exception = null
 /// This record provides a standardized way to report operation errors with code and description.
 /// </summary>
 [PublicAPI]
-public record struct OperateError
+public readonly record struct OperateError
 {
     /// <summary>
-    /// Gets or sets the error code identifying the type or source of the error.
+    /// Gets the error code identifying the type or source of the error.
     /// This might be a string representation of a numeric error code, a category name, or other identifier.
     /// </summary>
-    public string Code { get; set; }
+    public required string Code { get; init; }
 
     /// <summary>
-    /// Gets or sets a human-readable description of the error.
+    /// Gets a human-readable description of the error.
     /// This typically explains what went wrong and may include suggestions for resolution.
     /// </summary>
-    public string Description { get; set; }
+    public required string Description { get; init; }
 }

--- a/src/Headless.Messaging.Aws/AmazonSqsConsumerClient.cs
+++ b/src/Headless.Messaging.Aws/AmazonSqsConsumerClient.cs
@@ -41,6 +41,12 @@ internal sealed class AmazonSqsConsumerClient(
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress => new("aws_sqs", _queueUrl);
 
     public async ValueTask<ICollection<string>> FetchMessageNamesAsync(

--- a/src/Headless.Messaging.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/Headless.Messaging.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -43,6 +43,12 @@ internal sealed class AzureServiceBusConsumerClient(
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress =>
         ServiceBusHelpers.GetBrokerAddress(_asbOptions.ConnectionString, _asbOptions.Namespace);
 

--- a/src/Headless.Messaging.Core/Exceptions/BrokerConnectionException.cs
+++ b/src/Headless.Messaging.Core/Exceptions/BrokerConnectionException.cs
@@ -24,4 +24,5 @@ namespace Headless.Messaging.Exceptions;
 /// The underlying exception that caused the connection failure.
 /// This typically contains specific details about the connection error from the broker client library.
 /// </param>
-public class BrokerConnectionException(Exception innerException) : Exception("Broker Unreachable", innerException);
+public sealed class BrokerConnectionException(Exception innerException)
+    : Exception("Broker Unreachable", innerException);

--- a/src/Headless.Messaging.Core/Exceptions/SubscriberNotFoundException.cs
+++ b/src/Headless.Messaging.Core/Exceptions/SubscriberNotFoundException.cs
@@ -6,4 +6,4 @@ namespace Headless.Messaging.Exceptions;
 /// Thrown when a message is dispatched to a subscriber that has not been registered with the consumer registry.
 /// </summary>
 [PublicAPI]
-public class SubscriberNotFoundException(string message) : Exception(message);
+public sealed class SubscriberNotFoundException(string message) : Exception(message);

--- a/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
+++ b/src/Headless.Messaging.Core/Internal/IConsumerRegister.cs
@@ -368,7 +368,7 @@ internal sealed class ConsumerRegister(
                         _stoppingCts.Token
                     )
                     .ConfigureAwait(false);
-                client.OnLogCallback = _WriteLog;
+                client.AttachCallbacks(onMessage: null, onLog: _WriteLog);
                 messageNames = await client
                     .FetchMessageNamesAsync(matchGroup.Value.Select(x => x.MessageName), _stoppingCts.Token)
                     .ConfigureAwait(false);
@@ -677,8 +677,7 @@ internal sealed class ConsumerRegister(
         CancellationToken hostShutdownToken
     )
     {
-        client.OnLogCallback = _WriteLog;
-        client.OnMessageCallback = async (transportMessage, sender) =>
+        Func<TransportMessage, object?, Task> onMessageCallback = async (transportMessage, sender) =>
         {
             var probeAcquired = false;
             var probeOutcomeTransferred = false;
@@ -929,6 +928,8 @@ internal sealed class ConsumerRegister(
                 }
             }
         };
+
+        client.AttachCallbacks(onMessageCallback, _WriteLog);
     }
 
     private void _WriteLog(LogMessageEventArgs logMessage)

--- a/src/Headless.Messaging.Core/Messages/MediumMessage.cs
+++ b/src/Headless.Messaging.Core/Messages/MediumMessage.cs
@@ -2,6 +2,15 @@
 
 namespace Headless.Messaging.Messages;
 
+/// <summary>
+/// Storage-level envelope for a persisted outbox/inbox message row: pairs the original
+/// <see cref="Message"/> with its serialized content and the durable dispatch/retry bookkeeping
+/// columns (retries, lease, scheduling) that the storage providers and retry processors maintain.
+/// </summary>
+/// <remarks>
+/// Not sealed: storage providers may extend it with backend-specific row state
+/// (e.g., the in-memory provider's message row adds name/group/status columns).
+/// </remarks>
 [PublicAPI]
 public class MediumMessage
 {

--- a/src/Headless.Messaging.Core/Serialization/ISerializer.cs
+++ b/src/Headless.Messaging.Core/Serialization/ISerializer.cs
@@ -9,8 +9,17 @@ namespace Headless.Messaging.Serialization;
 /// (JSON string and <see cref="TransportMessage"/>).
 /// </summary>
 /// <remarks>
+/// <para>
 /// The default implementation uses <c>System.Text.Json</c>. Replace this contract in DI to
 /// substitute a different serializer (e.g., MessagePack, Newtonsoft.Json).
+/// </para>
+/// <para>
+/// <b>Evolution policy:</b> this is a consumer-replaceable extension point, so it evolves
+/// additively. New members ship as default interface methods with a behavior-preserving
+/// fallback; existing member signatures do not change within a major version. Custom
+/// implementations therefore keep compiling across minor releases and may override new
+/// defaults when they can do better.
+/// </para>
 /// </remarks>
 [PublicAPI]
 public interface ISerializer

--- a/src/Headless.Messaging.Core/Transport/IConsumerClient.cs
+++ b/src/Headless.Messaging.Core/Transport/IConsumerClient.cs
@@ -3,6 +3,13 @@
 namespace Headless.Messaging.Transport;
 
 /// <summary>Message queue consumer client interface that defines operations for consuming messages from various message brokers</summary>
+/// <remarks>
+/// <b>Evolution policy:</b> this is a transport-provider extension point, so it evolves additively.
+/// New members ship as default interface methods with a behavior-preserving fallback (see
+/// <see cref="ShutdownAsync"/> and <see cref="WaitUntilReadyAsync"/>); existing member signatures
+/// do not change within a major version, so custom transport implementations keep compiling
+/// across minor releases and may override new defaults when they can do better.
+/// </remarks>
 [PublicAPI]
 public interface IConsumerClient : IAsyncDisposable
 {
@@ -77,7 +84,13 @@ public interface IConsumerClient : IAsyncDisposable
     /// <summary>
     /// Manually commits message offset when the message consumption is complete
     /// </summary>
-    /// <param name="sender">The message or context object to commit</param>
+    /// <param name="sender">
+    /// The transport-specific settlement token for the message being committed. This is the exact
+    /// opaque value the client passed as the second argument to <see cref="OnMessageCallback"/>
+    /// (e.g., a Kafka consume result, a RabbitMQ delivery tag, an SQS receipt handle); callers must
+    /// round-trip it unchanged and must not interpret it. <see langword="null"/> when the transport
+    /// needs no per-message token, in which case implementations settle their current delivery.
+    /// </param>
     /// <param name="cancellationToken">Token to cancel the commit operation. Implementations may treat commit as must-complete.</param>
     /// <returns>A task that represents the asynchronous commit operation</returns>
     ValueTask CommitAsync(object? sender, CancellationToken cancellationToken = default);
@@ -85,7 +98,13 @@ public interface IConsumerClient : IAsyncDisposable
     /// <summary>
     /// Rejects the message and optionally returns it to the queue for reprocessing
     /// </summary>
-    /// <param name="sender">The message or context object to reject</param>
+    /// <param name="sender">
+    /// The transport-specific settlement token for the message being rejected. This is the exact
+    /// opaque value the client passed as the second argument to <see cref="OnMessageCallback"/>;
+    /// callers must round-trip it unchanged and must not interpret it. <see langword="null"/> when
+    /// the transport needs no per-message token, in which case implementations reject their
+    /// current delivery.
+    /// </param>
     /// <param name="cancellationToken">Token to cancel the reject operation. Implementations may treat reject as must-complete.</param>
     /// <returns>A task that represents the asynchronous reject operation</returns>
     ValueTask RejectAsync(object? sender, CancellationToken cancellationToken = default);
@@ -105,12 +124,24 @@ public interface IConsumerClient : IAsyncDisposable
     ValueTask ResumeAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Callback that is invoked when a message is received from the broker
+    /// Gets the callback invoked when a message is received from the broker. The second argument is
+    /// the transport-specific settlement token to round-trip into <see cref="CommitAsync"/> or
+    /// <see cref="RejectAsync"/>. Attached via <see cref="AttachCallbacks"/>.
     /// </summary>
-    Func<TransportMessage, object?, Task>? OnMessageCallback { get; set; }
+    Func<TransportMessage, object?, Task>? OnMessageCallback { get; }
 
     /// <summary>
-    /// Callback that is invoked when logging events occur in the consumer client
+    /// Gets the callback invoked when logging events occur in the consumer client.
+    /// Attached via <see cref="AttachCallbacks"/>.
     /// </summary>
-    Action<LogMessageEventArgs>? OnLogCallback { get; set; }
+    Action<LogMessageEventArgs>? OnLogCallback { get; }
+
+    /// <summary>
+    /// Attaches the message and log callbacks in one operation, replacing any previously attached
+    /// callbacks (<see langword="null"/> detaches). Attach before <see cref="ListeningAsync"/>;
+    /// swapping callbacks while the client is listening is not supported.
+    /// </summary>
+    /// <param name="onMessage">The callback invoked for each received message, or <see langword="null"/> for a client that does not consume (e.g., topology-only usage).</param>
+    /// <param name="onLog">The callback invoked for transport log events, or <see langword="null"/> to drop them.</param>
+    void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog);
 }

--- a/src/Headless.Messaging.InMemory/InMemoryConsumerClient.cs
+++ b/src/Headless.Messaging.InMemory/InMemoryConsumerClient.cs
@@ -57,6 +57,12 @@ internal sealed class InMemoryConsumerClient : IConsumerClient
     /// </summary>
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     /// <summary>
     /// Gets the broker address information.
     /// </summary>

--- a/src/Headless.Messaging.Kafka/KafkaConsumerClient.cs
+++ b/src/Headless.Messaging.Kafka/KafkaConsumerClient.cs
@@ -59,6 +59,12 @@ internal sealed class KafkaConsumerClient : IConsumerClient
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress => new("kafka", BrokerAddressDisplay.FormatMany(_kafkaOptions.Servers));
 
     public async ValueTask<ICollection<string>> FetchMessageNamesAsync(

--- a/src/Headless.Messaging.Nats/NatsConsumerClient.cs
+++ b/src/Headless.Messaging.Nats/NatsConsumerClient.cs
@@ -57,6 +57,12 @@ internal sealed class NatsConsumerClient(
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress => new("nats", BrokerAddressDisplay.FormatMany(_natsOptions.Servers));
 
     public async Task ConnectAsync(CancellationToken cancellationToken = default)

--- a/src/Headless.Messaging.Pulsar/PulsarConsumerClient.cs
+++ b/src/Headless.Messaging.Pulsar/PulsarConsumerClient.cs
@@ -35,6 +35,12 @@ internal sealed class PulsarConsumerClient(
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress => new("pulsar", BrokerAddressDisplay.Format(_pulsarOptions.ServiceUrl));
 
     public async ValueTask SubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken = default)

--- a/src/Headless.Messaging.RabbitMq/RabbitMqConsumerClient.cs
+++ b/src/Headless.Messaging.RabbitMq/RabbitMqConsumerClient.cs
@@ -56,6 +56,12 @@ internal sealed class RabbitMqConsumerClient : IConsumerClient
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress =>
         new(
             "rabbitmq",

--- a/src/Headless.Messaging.Redis/RedisConsumerClient.cs
+++ b/src/Headless.Messaging.Redis/RedisConsumerClient.cs
@@ -31,6 +31,12 @@ internal sealed class RedisConsumerClient(
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress => new("redis", options.Value.DisplayEndpoint);
 
     public async ValueTask SubscribeAsync(

--- a/src/Headless.Messaging.Redis/RedisPubSubConsumerClient.cs
+++ b/src/Headless.Messaging.Redis/RedisPubSubConsumerClient.cs
@@ -28,6 +28,12 @@ internal sealed class RedisPubSubConsumerClient(
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+    public void AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)
+    {
+        OnMessageCallback = onMessage;
+        OnLogCallback = onLog;
+    }
+
     public BrokerAddress BrokerAddress => new("redis_pubsub", options.Value.DisplayEndpoint);
 
     public ValueTask<ICollection<string>> FetchMessageNamesAsync(

--- a/tests/Headless.Messaging.Aws.Tests.Integration/MalformedMessageTests.cs
+++ b/tests/Headless.Messaging.Aws.Tests.Integration/MalformedMessageTests.cs
@@ -26,11 +26,14 @@ public sealed class MalformedMessageTests(LocalStackTestFixture fixture) : TestB
 
         var receivedMessageCount = 0;
         var consumerClient = await _CreateConsumerClientAsync(groupId);
-        consumerClient.OnMessageCallback = (_, _) =>
-        {
-            receivedMessageCount++;
-            return Task.CompletedTask;
-        };
+        consumerClient.AttachCallbacks(
+            onMessage: (_, _) =>
+            {
+                receivedMessageCount++;
+                return Task.CompletedTask;
+            },
+            onLog: null
+        );
 
         // Send malformed JSON directly to queue
         await sqsClient.SendMessageAsync(
@@ -64,11 +67,14 @@ public sealed class MalformedMessageTests(LocalStackTestFixture fixture) : TestB
 
         var receivedMessageCount = 0;
         var consumerClient = await _CreateConsumerClientAsync(groupId);
-        consumerClient.OnMessageCallback = (_, _) =>
-        {
-            receivedMessageCount++;
-            return Task.CompletedTask;
-        };
+        consumerClient.AttachCallbacks(
+            onMessage: (_, _) =>
+            {
+                receivedMessageCount++;
+                return Task.CompletedTask;
+            },
+            onLog: null
+        );
 
         // Send message that deserializes to null
         await sqsClient.SendMessageAsync(
@@ -102,11 +108,14 @@ public sealed class MalformedMessageTests(LocalStackTestFixture fixture) : TestB
 
         var receivedMessageCount = 0;
         var consumerClient = await _CreateConsumerClientAsync(groupId);
-        consumerClient.OnMessageCallback = (_, _) =>
-        {
-            receivedMessageCount++;
-            return Task.CompletedTask;
-        };
+        consumerClient.AttachCallbacks(
+            onMessage: (_, _) =>
+            {
+                receivedMessageCount++;
+                return Task.CompletedTask;
+            },
+            onLog: null
+        );
 
         // Send message with missing MessageAttributes field
         await sqsClient.SendMessageAsync(
@@ -141,12 +150,15 @@ public sealed class MalformedMessageTests(LocalStackTestFixture fixture) : TestB
         var receivedMessageCount = 0;
         TransportMessage? receivedMessage = null;
         var consumerClient = await _CreateConsumerClientAsync(groupId);
-        consumerClient.OnMessageCallback = async (msg, receiptHandle) =>
-        {
-            receivedMessageCount++;
-            receivedMessage = msg;
-            await consumerClient.CommitAsync(receiptHandle);
-        };
+        consumerClient.AttachCallbacks(
+            onMessage: async (msg, receiptHandle) =>
+            {
+                receivedMessageCount++;
+                receivedMessage = msg;
+                await consumerClient.CommitAsync(receiptHandle);
+            },
+            onLog: null
+        );
 
         // Send well-formed message
         const string validMessage = """

--- a/tests/Headless.Messaging.AzureServiceBus.Tests.Integration/AzureServiceBusFixture.cs
+++ b/tests/Headless.Messaging.AzureServiceBus.Tests.Integration/AzureServiceBusFixture.cs
@@ -163,7 +163,7 @@ public sealed class AzureServiceBusFixture : IAsyncLifetime
                 intent,
                 cancellationToken
             );
-            consumer.OnLogCallback = _ => { };
+            consumer.AttachCallbacks(onMessage: null, onLog: _ => { });
 
             try
             {

--- a/tests/Headless.Messaging.Core.Tests.Harness/ConsumerClientTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/ConsumerClientTestsBase.cs
@@ -75,7 +75,7 @@ public abstract class ConsumerClientTestsBase : TestBase
         // given
         await using var consumer = await GetConsumerClientAsync();
 
-        consumer.OnMessageCallback = (msg, sender) => Task.CompletedTask;
+        consumer.AttachCallbacks(onMessage: (msg, sender) => Task.CompletedTask, onLog: null);
         consumer.OnMessageCallback.Should().NotBeNull();
 
         var messageNames = await ResolveSubscriptionTopicsAsync(consumer, ["test-messageName"]);
@@ -201,7 +201,7 @@ public abstract class ConsumerClientTestsBase : TestBase
         await using var consumer = await GetConsumerClientAsync();
         var listenerStartCount = 0;
 
-        consumer.OnMessageCallback = (_, _) => Task.CompletedTask;
+        consumer.AttachCallbacks(onMessage: (_, _) => Task.CompletedTask, onLog: null);
 
         var messageNames = await ResolveSubscriptionTopicsAsync(consumer, ["concurrent-messageName"]);
         await consumer.SubscribeAsync(messageNames);
@@ -258,7 +258,7 @@ public abstract class ConsumerClientTestsBase : TestBase
         // given
         await using var consumer = await GetConsumerClientAsync();
 
-        consumer.OnLogCallback = _ => { };
+        consumer.AttachCallbacks(onMessage: null, onLog: _ => { });
         consumer.OnLogCallback.Should().NotBeNull();
 
         var messageNames = await ResolveSubscriptionTopicsAsync(consumer, ["log-test-messageName"]);

--- a/tests/Headless.Messaging.Core.Tests.Harness/TransportConsumerConformanceTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/TransportConsumerConformanceTestsBase.cs
@@ -60,17 +60,19 @@ public sealed class TransportConsumerConformanceSession(
             throw new InvalidOperationException("The conformance session has already started.");
         }
 
-        Consumer.OnMessageCallback = async (message, settlementValue) =>
-        {
-            var delivery = new TransportConformanceDelivery(message, settlementValue);
-            await _deliveries.Writer.WriteAsync(delivery, CancellationToken.None).ConfigureAwait(false);
-
-            if (onDelivery is not null)
+        Consumer.AttachCallbacks(
+            onMessage: async (message, settlementValue) =>
             {
-                await onDelivery(delivery).ConfigureAwait(false);
-            }
-        };
-        Consumer.OnLogCallback = _logs.Enqueue;
+                var delivery = new TransportConformanceDelivery(message, settlementValue);
+                await _deliveries.Writer.WriteAsync(delivery, CancellationToken.None).ConfigureAwait(false);
+
+                if (onDelivery is not null)
+                {
+                    await onDelivery(delivery).ConfigureAwait(false);
+                }
+            },
+            onLog: _logs.Enqueue
+        );
 
         _listeningCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _listeningTask = Task.Run(

--- a/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/ConsumerRegisterTests.cs
@@ -671,6 +671,15 @@ public sealed class ConsumerRegisterTests : TestBase
 
         public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+        public void AttachCallbacks(
+            Func<TransportMessage, object?, Task>? onMessage,
+            Action<LogMessageEventArgs>? onLog
+        )
+        {
+            OnMessageCallback = onMessage;
+            OnLogCallback = onLog;
+        }
+
         public async ValueTask<ICollection<string>> FetchMessageNamesAsync(
             IEnumerable<string> messageNames,
             CancellationToken cancellationToken = default
@@ -753,6 +762,15 @@ public sealed class ConsumerRegisterTests : TestBase
 
         public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+        public void AttachCallbacks(
+            Func<TransportMessage, object?, Task>? onMessage,
+            Action<LogMessageEventArgs>? onLog
+        )
+        {
+            OnMessageCallback = onMessage;
+            OnLogCallback = onLog;
+        }
+
         public ValueTask<ICollection<string>> FetchMessageNamesAsync(
             IEnumerable<string> messageNames,
             CancellationToken cancellationToken = default
@@ -809,6 +827,15 @@ public sealed class ConsumerRegisterTests : TestBase
         public Func<TransportMessage, object?, Task>? OnMessageCallback { get; set; }
 
         public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
+
+        public void AttachCallbacks(
+            Func<TransportMessage, object?, Task>? onMessage,
+            Action<LogMessageEventArgs>? onLog
+        )
+        {
+            OnMessageCallback = onMessage;
+            OnLogCallback = onLog;
+        }
 
         public ValueTask<ICollection<string>> FetchMessageNamesAsync(
             IEnumerable<string> messageNames,
@@ -880,6 +907,15 @@ public sealed class ConsumerRegisterTests : TestBase
 
         public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+        public void AttachCallbacks(
+            Func<TransportMessage, object?, Task>? onMessage,
+            Action<LogMessageEventArgs>? onLog
+        )
+        {
+            OnMessageCallback = onMessage;
+            OnLogCallback = onLog;
+        }
+
         public ValueTask<ICollection<string>> FetchMessageNamesAsync(
             IEnumerable<string> messageNames,
             CancellationToken cancellationToken = default
@@ -938,6 +974,15 @@ public sealed class ConsumerRegisterTests : TestBase
         public Func<TransportMessage, object?, Task>? OnMessageCallback { get; set; }
 
         public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
+
+        public void AttachCallbacks(
+            Func<TransportMessage, object?, Task>? onMessage,
+            Action<LogMessageEventArgs>? onLog
+        )
+        {
+            OnMessageCallback = onMessage;
+            OnLogCallback = onLog;
+        }
 
         public ValueTask<ICollection<string>> FetchMessageNamesAsync(
             IEnumerable<string> messageNames,

--- a/tests/Headless.Messaging.Core.Tests.Unit/Transport/ConsumerClientPauseResumeTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Transport/ConsumerClientPauseResumeTests.cs
@@ -141,6 +141,15 @@ public sealed class ConsumerClientPauseResumeTests
 
         public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
+        public void AttachCallbacks(
+            Func<TransportMessage, object?, Task>? onMessage,
+            Action<LogMessageEventArgs>? onLog
+        )
+        {
+            OnMessageCallback = onMessage;
+            OnLogCallback = onLog;
+        }
+
         public ValueTask SubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken = default)
         {
             return ValueTask.CompletedTask;

--- a/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryConsumerClientFactoryTests.cs
+++ b/tests/Headless.Messaging.InMemory.Tests.Unit/InMemoryConsumerClientFactoryTests.cs
@@ -130,20 +130,26 @@ public sealed class InMemoryConsumerClientFactoryTests : TestBase
         var client1Processed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client2Processed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        client1.OnMessageCallback = (msg, _) =>
-        {
-            messages1.Add(msg);
-            client1Processed.TrySetResult();
+        client1.AttachCallbacks(
+            onMessage: (msg, _) =>
+            {
+                messages1.Add(msg);
+                client1Processed.TrySetResult();
 
-            return Task.CompletedTask;
-        };
-        client2.OnMessageCallback = (msg, _) =>
-        {
-            messages2.Add(msg);
-            client2Processed.TrySetResult();
+                return Task.CompletedTask;
+            },
+            onLog: null
+        );
+        client2.AttachCallbacks(
+            onMessage: (msg, _) =>
+            {
+                messages2.Add(msg);
+                client2Processed.TrySetResult();
 
-            return Task.CompletedTask;
-        };
+                return Task.CompletedTask;
+            },
+            onLog: null
+        );
 
         using var cts = new CancellationTokenSource();
         var listen1 = Task.Run(

--- a/tests/Headless.Messaging.Pulsar.Tests.Integration/PulsarFixture.cs
+++ b/tests/Headless.Messaging.Pulsar.Tests.Integration/PulsarFixture.cs
@@ -69,7 +69,7 @@ public sealed class PulsarFixture : HeadlessPulsarFixture
                 intent,
                 cancellationToken
             );
-            consumer.OnLogCallback = _ => { };
+            consumer.AttachCallbacks(onMessage: null, onLog: _ => { });
 
             try
             {


### PR DESCRIPTION
## Summary

Pre-v1 hardening of the messaging transport and result contracts (review findings: `src/Headless.Messaging.Core/Transport/IConsumerClient.cs:83,110,115`, `src/Headless.Messaging.Core/Serialization/ISerializer.cs:16`, `src/Headless.Messaging.Abstractions/OperateResult.cs:24-25,118`, `src/Headless.Messaging.Core/Messages/MediumMessage.cs:6`, `Exceptions/BrokerConnectionException.cs:27`, `Exceptions/SubscriberNotFoundException.cs:9`).

## Changes

- **`IConsumerClient`**: removed the publicly mutable `OnMessageCallback { get; set; }` / `OnLogCallback { get; set; }` surface. The interface now exposes get-only properties plus a single `AttachCallbacks(Func<TransportMessage, object?, Task>? onMessage, Action<LogMessageEventArgs>? onLog)` member with replace-both semantics (null detaches; attach before `ListeningAsync`). All 9 internal consumer clients (Aws, AzureServiceBus, InMemory, Kafka, Nats, Pulsar, RabbitMq, Redis, RedisPubSub) implement it; the consumer register wires callbacks through it (the topology-only temporary client attaches `onMessage: null`). Added an interface-level DIM evolution-policy `<remarks>` and documented the `object? sender` settlement-token contract on `CommitAsync`/`RejectAsync` (opaque, round-trip unchanged, null = settle current delivery).
- **`ISerializer`**: added an interface-level `<remarks>` documenting the additive evolution policy (future members ship as default interface methods; existing signatures stable within a major version). Member docs were already complete; no signature changes.
- **`OperateResult`**: dropped the self-implemented `IEqualityComparer<OperateResult>` (comparer-shaped `Equals(x, y)` / `GetHashCode(o)` on the value itself); kept `IEquatable<OperateResult>` with the same field semantics (success flag, exception reference identity, structured error). No caller passed `OperateResult` as a comparer (verified via `rg`).
- **`OperateError`**: converted to `readonly record struct` with `required` init-only `Code`/`Description`. All construction sites already used object initializers setting both properties; no in-place mutation sites exist.
- **`MediumMessage`**: added a type-level `<summary>`/`<remarks>`. NOT sealed — see Decisions.
- **`BrokerConnectionException` / `SubscriberNotFoundException`**: sealed, matching the sealed siblings (`SubscriberExecutionFailedException`, `PublisherSentFailedException`). No derivations exist.

## Decisions

- **Callback shape**: chose get-only interface properties + a single `AttachCallbacks` method over constructor/factory injection. The consumer register wires callbacks after `IConsumerClientFactory.CreateAsync(...)` (and composes the per-group message processor separately from client creation), so constructor injection would have forced a callback parameter through 2 factory interfaces and 10 factory implementations for no modelling gain. `AttachCallbacks` replaces both callbacks atomically, which keeps wiring one-shot and prevents external code from silently overwriting the register's message pump at runtime (the original finding). The concrete clients are `internal sealed`, so their auto-property setters remain (satisfying the get-only interface properties) — the public API surface is immutable while test code using `InternalsVisibleTo` on concrete types keeps direct assignment.
- **`MediumMessage` NOT sealed** (task deviation): the seal was conditional on "verify nothing derives", and `Headless.Messaging.Storage.InMemory.MemoryMessage` derives from it as a load-bearing storage row type (adds Name/Group/StatusName/Version columns). Sealing would require restructuring the InMemory storage provider to composition — beyond this finding's scope. Added the type-level docs and an explicit remark that storage providers may extend it.
- **`OperateError` `required` members**: all existing initializers set both `Code` and `Description`; making them `required` turns a half-initialized error into a compile error, which fits the hardening intent at zero call-site cost.
- The `sender` parameter's typed redesign (e.g. a settlement-token wrapper struct) is out of scope per the task; only the XML contract was added.

## Testing

- `dotnet build --no-incremental -v:minimal` clean (0 warnings / 0 errors) for: `Headless.Messaging.Abstractions`, `Headless.Messaging.Core`, `Headless.Messaging.Testing`, and all 8 transport packages (`InMemory`, `Kafka`, `Nats`, `Pulsar`, `RabbitMq`, `Redis`, `Aws`, `AzureServiceBus`).
- Unit tests (all passed): `Headless.Messaging.Abstractions.Tests.Unit` (71), `Headless.Messaging.Core.Tests.Unit` (955), `Headless.Messaging.InMemory.Tests.Unit` (57), `Headless.Messaging.Kafka.Tests.Unit` (80), `Headless.Messaging.Nats.Tests.Unit` (116), `Headless.Messaging.Aws.Tests.Unit` (92), `Headless.Messaging.AzureServiceBus.Tests.Unit` (108), `Headless.Messaging.Pulsar.Tests.Unit` (43), `Headless.Messaging.RabbitMq.Tests.Unit` (154), `Headless.Messaging.Redis.Tests.Unit` (103), `Headless.Messaging.Testing.Tests.Unit` (56).
- Integration test projects (Aws, AzureServiceBus, Kafka, Nats, Pulsar, RabbitMq) compile clean; **integration tests skipped: Docker unavailable**.

## Docs

No sync needed: `rg` over `docs/llms/` and the messaging READMEs found no references to `OnMessageCallback`/`OnLogCallback`, `OperateError`, or the removed comparer surface. Existing doc mentions of `IConsumerClient`, `MediumMessage`, and `BrokerConnectionException` describe members/behavior that did not change.
