### PR TITLE
refactor(messaging): storage setup overload trio and discovery holder names

### DIFF
--- a/docs/llms/messaging.md
+++ b/docs/llms/messaging.md
@@ -1547,7 +1547,7 @@ Provides PostgreSQL durable storage for messaging publish/receive state, retries
 
 ### Key Features
 
-- `setup.UsePostgreSql(...)`.
+- `setup.UsePostgreSql(...)` — connection string, `IConfiguration` binding, `Action<PostgreSqlOptions>`, or `Action<PostgreSqlOptions, IServiceProvider>`.
 - PostgreSQL schema/table configuration.
 - EF/Core.Db integration and startup initialization.
 - **GUID Row IDs**: Message storage identifiers come from the `Version7` keyed `IGuidGenerator` and are persisted as PostgreSQL `UUID` columns.
@@ -1590,7 +1590,7 @@ Provides SQL Server durable storage for messaging publish/receive state, retries
 
 ### Key Features
 
-- `setup.UseSqlServer(...)`.
+- `setup.UseSqlServer(...)` — connection string, `IConfiguration` binding, `Action<SqlServerOptions>`, or `Action<SqlServerOptions, IServiceProvider>`.
 - SQL Server schema/table configuration.
 - EF/Core.Db integration and startup initialization.
 - **GUID Row IDs**: Message storage identifiers come from the `SqlServer` keyed `IGuidGenerator` and are persisted as SQL Server `uniqueidentifier` columns.

--- a/src/Headless.Messaging.Dashboard.K8s/MessagingK8sDiscoveryOptionsExtensions.cs
+++ b/src/Headless.Messaging.Dashboard.K8s/MessagingK8sDiscoveryOptionsExtensions.cs
@@ -26,7 +26,7 @@ internal sealed class K8sDiscoveryOptionsExtension(Action<K8sDiscoveryOptions>? 
     }
 }
 
-public static class MessagingDiscoveryOptionsExtensions
+public static class MessagingK8sDiscoveryOptionsExtensions
 {
     // ReSharper disable once InconsistentNaming
     /// <summary>

--- a/src/Headless.Messaging.Dashboard/NodeDiscovery/MessagingConsulDiscoveryOptionsExtensions.cs
+++ b/src/Headless.Messaging.Dashboard/NodeDiscovery/MessagingConsulDiscoveryOptionsExtensions.cs
@@ -27,7 +27,7 @@ internal sealed class ConsulDiscoveryOptionsExtension(Action<ConsulDiscoveryOpti
     }
 }
 
-public static class MessagingDiscoveryOptionsExtensions
+public static class MessagingConsulDiscoveryOptionsExtensions
 {
     /// <summary>
     /// Enables Consul-based node discovery for the Messaging Dashboard using default options.

--- a/src/Headless.Messaging.Storage.PostgreSql/README.md
+++ b/src/Headless.Messaging.Storage.PostgreSql/README.md
@@ -58,6 +58,11 @@ options.UsePostgreSql(config =>
 });
 ```
 
+`UsePostgreSql` ships the standard provider registration overloads: a connection string,
+an `IConfiguration` section bound to `PostgreSqlOptions`, an `Action<PostgreSqlOptions>`,
+and an `Action<PostgreSqlOptions, IServiceProvider>` (resolve secrets/connection settings from DI).
+The transactional-outbox auto-wiring applies only to the `UseEntityFramework<TContext>()` path.
+
 ### `pg_trgm` on managed PostgreSQL
 
 Dashboard content (ILIKE) search is accelerated by GIN trigram indexes that require the `pg_trgm`

--- a/src/Headless.Messaging.Storage.PostgreSql/Setup.cs
+++ b/src/Headless.Messaging.Storage.PostgreSql/Setup.cs
@@ -6,6 +6,7 @@ using Headless.Messaging.Configuration;
 using Headless.Messaging.Persistence;
 using Headless.Messaging.Storage.PostgreSql;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -33,19 +34,70 @@ public static class SetupPostgreSqlMessaging
         }
 
         /// <summary>
+        /// Configures PostgreSQL as the message storage, binding and validating
+        /// <see cref="PostgreSqlOptions"/> from configuration.
+        /// </summary>
+        /// <param name="configuration">Configuration section containing <see cref="PostgreSqlOptions"/> values.</param>
+        /// <returns>The setup builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is <see langword="null"/>.</exception>
+        public MessagingSetupBuilder UsePostgreSql(IConfiguration configuration)
+        {
+            Argument.IsNotNull(configuration);
+
+            return _AddPostgreSqlStorageCore(
+                setup,
+                services =>
+                    services
+                        .AddOptions<PostgreSqlOptions, PostgreSqlOptionsValidator>()
+                        .Bind(configuration)
+                        .Configure(x => x.Version = setup.Options.Version),
+                outboxProbe: options => configuration.Bind(options)
+            );
+        }
+
+        /// <summary>
         /// Configures PostgreSQL as the message storage with custom options.
         /// </summary>
         /// <param name="configure">Action to configure PostgreSQL options.</param>
         /// <returns>The setup builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
         public MessagingSetupBuilder UsePostgreSql(Action<PostgreSqlOptions> configure)
         {
             Argument.IsNotNull(configure);
 
             configure += x => x.Version = setup.Options.Version;
 
-            setup.RegisterExtension(new PostgreSqlMessagesOptionsExtension(configure));
+            return _AddPostgreSqlStorageCore(
+                setup,
+                services => services.Configure<PostgreSqlOptions, PostgreSqlOptionsValidator>(configure),
+                outboxProbe: configure
+            );
+        }
 
-            return setup;
+        /// <summary>
+        /// Configures PostgreSQL as the message storage, configuring <see cref="PostgreSqlOptions"/>
+        /// with access to the resolved service provider (for example to resolve secrets or connection
+        /// settings from DI).
+        /// </summary>
+        /// <remarks>
+        /// This overload targets the raw ADO.NET storage path. The transactional outbox auto-wiring
+        /// requires <c>UseEntityFramework&lt;TContext&gt;()</c>, whose configuration is inspectable at
+        /// registration time; a service-provider-dependent configure cannot be probed then.
+        /// </remarks>
+        /// <param name="configure">A delegate that configures <see cref="PostgreSqlOptions"/> using the service provider.</param>
+        /// <returns>The setup builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
+        public MessagingSetupBuilder UsePostgreSql(Action<PostgreSqlOptions, IServiceProvider> configure)
+        {
+            Argument.IsNotNull(configure);
+
+            configure += (x, _) => x.Version = setup.Options.Version;
+
+            return _AddPostgreSqlStorageCore(
+                setup,
+                services => services.Configure<PostgreSqlOptions, PostgreSqlOptionsValidator>(configure),
+                outboxProbe: null
+            );
         }
 
         /// <summary>
@@ -72,26 +124,41 @@ public static class SetupPostgreSqlMessaging
         {
             Argument.IsNotNull(configure);
 
-            setup.RegisterExtension(
-                new PostgreSqlMessagesOptionsExtension(x =>
-                {
-                    configure(x);
-                    x.Version = setup.Options.Version;
-                    x.DbContextType = typeof(TContext);
-                })
-            );
+            Action<PostgreSqlOptions> combined = x =>
+            {
+                configure(x);
+                x.Version = setup.Options.Version;
+                x.DbContextType = typeof(TContext);
+            };
 
-            return setup;
+            return _AddPostgreSqlStorageCore(
+                setup,
+                services => services.Configure<PostgreSqlOptions, PostgreSqlOptionsValidator>(combined),
+                outboxProbe: combined
+            );
         }
     }
 
-    private sealed class PostgreSqlMessagesOptionsExtension(Action<PostgreSqlOptions> configure)
-        : IMessagesOptionsExtension
+    private static MessagingSetupBuilder _AddPostgreSqlStorageCore(
+        MessagingSetupBuilder setup,
+        Action<IServiceCollection> configureOptions,
+        Action<PostgreSqlOptions>? outboxProbe
+    )
+    {
+        setup.RegisterExtension(new PostgreSqlMessagesOptionsExtension(configureOptions, outboxProbe));
+
+        return setup;
+    }
+
+    private sealed class PostgreSqlMessagesOptionsExtension(
+        Action<IServiceCollection> configureOptions,
+        Action<PostgreSqlOptions>? outboxProbe
+    ) : IMessagesOptionsExtension
     {
         public void AddServices(IServiceCollection services)
         {
             services.AddSingleton(new MessageStorageMarkerService("PostgreSql"));
-            services.Configure<PostgreSqlOptions, PostgreSqlOptionsValidator>(configure);
+            configureOptions(services);
             services.AddSingleton<IConfigureOptions<PostgreSqlOptions>, ConfigurePostgreSqlOptions>();
 
             services.AddSingleton<IDataStorage, PostgreSqlDataStorage>();
@@ -111,11 +178,19 @@ public static class SetupPostgreSqlMessaging
         // attach the interceptor to and stays opt-in.
         private void _AddTransactionalOutbox(IServiceCollection services)
         {
+            if (outboxProbe is null)
+            {
+                // Service-provider-dependent configuration cannot be probed at registration time. Only the EF
+                // overloads (which always supply a probe) set DbContextType, so this is the raw-ADO path —
+                // never auto-register.
+                return;
+            }
+
             // DbContextType / EnableTransactionalOutbox are set inside the captured configure action (only the EF
             // overload sets DbContextType), so materialize a throwaway options instance to read them without
             // depending on the DI-built options.
             var probe = new PostgreSqlOptions();
-            configure(probe);
+            outboxProbe(probe);
 
             if (probe.DbContextType is null)
             {

--- a/src/Headless.Messaging.Storage.SqlServer/README.md
+++ b/src/Headless.Messaging.Storage.SqlServer/README.md
@@ -52,6 +52,11 @@ options.UseSqlServer(config =>
 });
 ```
 
+`UseSqlServer` ships the standard provider registration overloads: a connection string,
+an `IConfiguration` section bound to `SqlServerOptions`, an `Action<SqlServerOptions>`,
+and an `Action<SqlServerOptions, IServiceProvider>` (resolve secrets/connection settings from DI).
+The transactional-outbox auto-wiring applies only to the `UseEntityFramework<TContext>()` path.
+
 ## Dependencies
 
 - `Headless.Messaging.Core`

--- a/src/Headless.Messaging.Storage.SqlServer/Setup.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/Setup.cs
@@ -6,6 +6,7 @@ using Headless.Messaging.Configuration;
 using Headless.Messaging.Persistence;
 using Headless.Messaging.Storage.SqlServer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -34,6 +35,28 @@ public static class SetupSqlServerMessaging
         }
 
         /// <summary>
+        /// Configures the messaging outbox to use SQL Server, binding and validating
+        /// <see cref="SqlServerOptions"/> from configuration.
+        /// </summary>
+        /// <param name="configuration">Configuration section containing <see cref="SqlServerOptions"/> values.</param>
+        /// <returns>The builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is <see langword="null"/>.</exception>
+        public MessagingSetupBuilder UseSqlServer(IConfiguration configuration)
+        {
+            Argument.IsNotNull(configuration);
+
+            return _AddSqlServerStorageCore(
+                setup,
+                services =>
+                    services
+                        .AddOptions<SqlServerOptions, SqlServerOptionsValidator>()
+                        .Bind(configuration)
+                        .Configure(x => x.Version = setup.Options.Version),
+                outboxProbe: options => configuration.Bind(options)
+            );
+        }
+
+        /// <summary>
         /// Configures the messaging outbox to use SQL Server, delegating all option configuration
         /// to the supplied <paramref name="configure"/> action.
         /// </summary>
@@ -46,9 +69,37 @@ public static class SetupSqlServerMessaging
 
             configure += x => x.Version = setup.Options.Version;
 
-            setup.RegisterExtension(new SqlServerMessagesOptionsExtension(configure));
+            return _AddSqlServerStorageCore(
+                setup,
+                services => services.Configure<SqlServerOptions, SqlServerOptionsValidator>(configure),
+                outboxProbe: configure
+            );
+        }
 
-            return setup;
+        /// <summary>
+        /// Configures the messaging outbox to use SQL Server, configuring <see cref="SqlServerOptions"/>
+        /// with access to the resolved service provider (for example to resolve secrets or connection
+        /// settings from DI).
+        /// </summary>
+        /// <remarks>
+        /// This overload targets the raw ADO.NET storage path. The transactional outbox auto-wiring
+        /// requires <c>UseEntityFramework&lt;TContext&gt;()</c>, whose configuration is inspectable at
+        /// registration time; a service-provider-dependent configure cannot be probed then.
+        /// </remarks>
+        /// <param name="configure">A delegate that configures <see cref="SqlServerOptions"/> using the service provider.</param>
+        /// <returns>The builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        public MessagingSetupBuilder UseSqlServer(Action<SqlServerOptions, IServiceProvider> configure)
+        {
+            Argument.IsNotNull(configure);
+
+            configure += (x, _) => x.Version = setup.Options.Version;
+
+            return _AddSqlServerStorageCore(
+                setup,
+                services => services.Configure<SqlServerOptions, SqlServerOptionsValidator>(configure),
+                outboxProbe: null
+            );
         }
 
         /// <summary>
@@ -81,21 +132,36 @@ public static class SetupSqlServerMessaging
         {
             Argument.IsNotNull(configure);
 
-            setup.RegisterExtension(
-                new SqlServerMessagesOptionsExtension(x =>
-                {
-                    configure(x);
-                    x.Version = setup.Options.Version;
-                    x.DbContextType = typeof(TContext);
-                })
-            );
+            Action<SqlServerOptions> combined = x =>
+            {
+                configure(x);
+                x.Version = setup.Options.Version;
+                x.DbContextType = typeof(TContext);
+            };
 
-            return setup;
+            return _AddSqlServerStorageCore(
+                setup,
+                services => services.Configure<SqlServerOptions, SqlServerOptionsValidator>(combined),
+                outboxProbe: combined
+            );
         }
     }
 
-    private sealed class SqlServerMessagesOptionsExtension(Action<SqlServerOptions> configure)
-        : IMessagesOptionsExtension
+    private static MessagingSetupBuilder _AddSqlServerStorageCore(
+        MessagingSetupBuilder setup,
+        Action<IServiceCollection> configureOptions,
+        Action<SqlServerOptions>? outboxProbe
+    )
+    {
+        setup.RegisterExtension(new SqlServerMessagesOptionsExtension(configureOptions, outboxProbe));
+
+        return setup;
+    }
+
+    private sealed class SqlServerMessagesOptionsExtension(
+        Action<IServiceCollection> configureOptions,
+        Action<SqlServerOptions>? outboxProbe
+    ) : IMessagesOptionsExtension
     {
         public void AddServices(IServiceCollection services)
         {
@@ -104,7 +170,7 @@ public static class SetupSqlServerMessaging
             services.AddSingleton<IDataStorage, SqlServerDataStorage>();
             services.AddSingleton<IStorageInitializer, SqlServerStorageInitializer>();
 
-            services.Configure<SqlServerOptions, SqlServerOptionsValidator>(configure);
+            configureOptions(services);
             services.AddSingleton<IConfigureOptions<SqlServerOptions>, ConfigureSqlServerOptions>();
 
             _AddTransactionalOutbox(services);
@@ -123,11 +189,19 @@ public static class SetupSqlServerMessaging
         // on EF-storage consumers.)
         private void _AddTransactionalOutbox(IServiceCollection services)
         {
+            if (outboxProbe is null)
+            {
+                // Service-provider-dependent configuration cannot be probed at registration time. Only the EF
+                // overloads (which always supply a probe) set DbContextType, so this is the raw-ADO path —
+                // never auto-register.
+                return;
+            }
+
             // DbContextType / EnableTransactionalOutbox are set inside the captured configure action (only the EF
             // overload sets DbContextType), so materialize a throwaway options instance to read them without
             // depending on the DI-built options.
             var probe = new SqlServerOptions();
-            configure(probe);
+            outboxProbe(probe);
 
             if (probe.DbContextType is null)
             {


### PR DESCRIPTION
## Summary

Pre-v1 hardening of the messaging storage registration surface and dashboard discovery holder names (review findings: `src/Headless.Messaging.Storage.PostgreSql/Setup.cs:28`, `src/Headless.Messaging.Storage.SqlServer/Setup.cs:29`, `src/Headless.Messaging.Dashboard/NodeDiscovery/ConsulDiscoveryOptionsExtensions.cs:30`, `src/Headless.Messaging.Dashboard.K8s/K8sDiscoveryOptionsExtensions.cs:29`).

- `UsePostgreSql` / `UseSqlServer` bind an options section but shipped only the `string` + `Action<TOptions>` overloads, violating the repo's provider overload-trio convention (`IConfiguration` / `Action<TOptions>` / `Action<TOptions, IServiceProvider>`).
- Both dashboard discovery holder classes were named `MessagingDiscoveryOptionsExtensions` — a CS0433-style collision trap for any consumer referencing both dashboard packages.

## Changes

- **`SetupPostgreSqlMessaging` / `SetupSqlServerMessaging`**: added `UsePostgreSql(IConfiguration)` / `UseSqlServer(IConfiguration)` (binds + validates via `AddOptions<TOptions, TValidator>().Bind(...)`) and `UsePostgreSql(Action<TOptions, IServiceProvider>)` / `UseSqlServer(Action<TOptions, IServiceProvider>)` overloads, mirroring the Kafka transport Setup shape. All overloads now delegate to a shared private `_AddPostgreSqlStorageCore` / `_AddSqlServerStorageCore` helper; the options extension takes an `Action<IServiceCollection>` (like Kafka's) plus a nullable registration-time `outboxProbe`.
- Version stamping (`x.Version = setup.Options.Version`) is preserved on every overload and still runs after the user's configuration (append for action overloads; `.Configure(...)` after `.Bind(...)` for the `IConfiguration` overload), still reading the builder lazily.
- The transactional-outbox registration-time probe now runs off the `outboxProbe` delegate: unchanged behavior for the action/connection-string/EF paths, and the `IConfiguration` overload probes via `configuration.Bind`. The service-provider overload passes `outboxProbe: null` (cannot be probed at registration time) — see Decisions.
- **Discovery holders**: renamed `MessagingDiscoveryOptionsExtensions` to `MessagingConsulDiscoveryOptionsExtensions` (Dashboard) and `MessagingK8sDiscoveryOptionsExtensions` (Dashboard.K8s); files renamed to match the public holder types (`git mv`). `rg` for the old holder name over src/tests/docs returns zero hits; the `UseConsulDiscovery` / `UseK8sDiscovery` member names are unchanged.
- Docs synced: overload trio noted in `docs/llms/messaging.md` (both storage Key Features bullets) and both storage package READMEs.

## Decisions

- **Service-provider overload never auto-wires the transactional outbox** (`outboxProbe: null`): the outbox probe must run at registration time on a throwaway options instance, which is impossible for a configure that needs the resolved `IServiceProvider`. This is behavior-safe: `DbContextType` (the outbox trigger) is only set by the `UseEntityFramework<TContext>()` overloads, which always supply a probe; the SP overload targets the raw-ADO path where the outbox has always been explicit opt-in. Documented in the overload's XML `<remarks>`.
- **`IConfiguration` overload uses `AddOptions<TOptions, TValidator>().Bind(config).Configure(versionStamp)`** rather than `Configure<TOptions, TValidator>(config)` so the version stamp is ordered after the binding inside a single options-builder chain, matching the existing "version always wins over user configuration" semantics of the action overloads.
- **Holder classes stay in their current namespaces** (`Headless.Messaging.Dashboard.NodeDiscovery` / `Headless.Messaging.Dashboard.K8s`) per the task scope. Possible follow-up: move these registration holders to the family root namespace (`Headless.Messaging`) per the repo's registration-surface namespace policy, so `using Headless.Messaging;` exposes `UseConsulDiscovery`/`UseK8sDiscovery` without an extra using.

## Testing

- `dotnet build --no-incremental -v:minimal` clean (0 warnings / 0 errors): `Headless.Messaging.Storage.PostgreSql`, `Headless.Messaging.Storage.SqlServer`, `Headless.Messaging.Dashboard` (with `BuildDashboardSpa=false`; no SPA sources touched), `Headless.Messaging.Dashboard.K8s`.
- Unit tests (all passed): `Headless.Messaging.Storage.PostgreSql.Tests.Unit` (47), `Headless.Messaging.Storage.SqlServer.Tests.Unit` (44), `Headless.Messaging.Dashboard.Tests.Unit` (122), `Headless.Messaging.Dashboard.K8s.Tests.Unit` (41).
- Compile-only (build clean): `Headless.Messaging.Storage.PostgreSql.Tests.Integration`, `Headless.Messaging.Storage.SqlServer.Tests.Integration`, `Headless.EntityFramework.Messaging.Tests.Integration`, `Headless.Messaging.NatsPostgreSql.Tests.Integration`.
- **Integration tests skipped: Docker unavailable.**

## Docs

- `docs/llms/messaging.md`: both storage "Key Features" bullets now list the full overload set.
- `src/Headless.Messaging.Storage.PostgreSql/README.md` and `src/Headless.Messaging.Storage.SqlServer/README.md`: Configuration sections note the overload trio and that outbox auto-wiring is EF-path only.
- No docs referenced the old `MessagingDiscoveryOptionsExtensions` holder name.
