### PR TITLE
fix(distributed-locks): restore test access to internalized seams

### DIFF
--- a/src/Headless.DistributedLocks.Core.Database/Headless.DistributedLocks.Core.Database.csproj
+++ b/src/Headless.DistributedLocks.Core.Database/Headless.DistributedLocks.Core.Database.csproj
@@ -10,6 +10,7 @@
     <InternalsVisibleTo Include="Headless.DistributedLocks.SqlServer" />
     <InternalsVisibleTo Include="Headless.DistributedLocks.Core.Database.Tests.Unit" />
     <InternalsVisibleTo Include="Headless.DistributedLocks.Tests.Unit" />
+    <InternalsVisibleTo Include="Headless.DistributedLocks.Composition.Tests.Unit" />
     <InternalsVisibleTo Include="Headless.DistributedLocks.PostgreSql.Tests.Integration" />
     <InternalsVisibleTo Include="Headless.DistributedLocks.SqlServer.Tests.Integration" />
   </ItemGroup>

--- a/src/Headless.DistributedLocks.InMemory/Headless.DistributedLocks.InMemory.csproj
+++ b/src/Headless.DistributedLocks.InMemory/Headless.DistributedLocks.InMemory.csproj
@@ -9,6 +9,8 @@
     <InternalsVisibleTo Include="Headless.DistributedLocks.InMemory.Tests.Integration" />
     <InternalsVisibleTo Include="Headless.Jobs.Tests.Unit" />
     <InternalsVisibleTo Include="Headless.Messaging.Core.Tests.Unit" />
+    <InternalsVisibleTo Include="Headless.DistributedLocks.Composition.Tests.Unit" />
+    <InternalsVisibleTo Include="Headless.Jobs.Composition.Tests.Unit" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Headless.DistributedLocks.Core\Headless.DistributedLocks.Core.csproj" />


### PR DESCRIPTION
## Summary

Fixes `main`, which is currently **red**: CI on `790936737` fails with **24 × CS0122 "inaccessible due to its protection level"**.

PR #749 internalized the `DistributedLocks.Core.Database` engine seams and the `InMemory` storages (correct — mirroring the sibling `Coordination.Core.Database`), but two pre-existing test projects consume those types and were not granted access, so the solution no longer compiles.

## Changes

Adds the missing `InternalsVisibleTo` entries, matching the pattern the same csprojs already use for other test assemblies:

- `Headless.DistributedLocks.Core.Database` → `Headless.DistributedLocks.Composition.Tests.Unit`
- `Headless.DistributedLocks.InMemory` → `Headless.DistributedLocks.Composition.Tests.Unit`, `Headless.Jobs.Composition.Tests.Unit`

Verified coverage by mapping every internalized type to its consuming test projects:

| Type | Consumed by | Access |
|---|---|---|
| `IConnectionScopedLockStorage` | Composition.Tests.Unit, SqlServer.Tests.Integration | added / existing |
| `IFencingTokenSource`, `IReleaseSignal`, `ConnectionScopedLockHandle` | Composition.Tests.Unit | added |
| `ConnectionScopedDistributedLock` | Composition.Tests.Unit, PostgreSql + SqlServer Tests.Integration | added / existing |
| `InMemoryDistributedLockStorage` | Composition.Tests.Unit, Jobs.Composition.Tests.Unit, InMemory.Tests.Integration, Messaging.Core.Tests.Unit | added / existing |
| `InMemoryDistributed{ReadWriteLock,Semaphore}Storage` | Composition.Tests.Unit, InMemory.Tests.Integration | added / existing |

## Decisions

- **IVT over rewriting the tests.** These tests exercise genuinely-internal engine seams (fencing tokens, connection-scoped handles, release signals) with hand-built fakes; driving them through the public surface would lose meaningful coverage. Both csprojs already grant IVT to several test assemblies, so this is the established pattern here, not a new exception.
- **No production code changed** — the internalization from #749 stands as designed.

## Testing

- `dotnet build tests/Headless.DistributedLocks.Composition.Tests.Unit -c Release` → **0 warnings, 0 errors**
- `dotnet build tests/Headless.Jobs.Composition.Tests.Unit -c Release` → **0 warnings, 0 errors**
- Integration tests skipped: Docker unavailable in this environment.

## Docs

None needed — build-configuration only, no public API surface change.

## Process note

#749 passed per-project builds and review, then broke CI: a `public → internal` change cannot be validated by building only the changed projects. Solution-wide verification is required for any visibility change.
