### PR TITLE
refactor(jobs): dashboard DTO shapes and ABI hygiene

### DIFF
--- a/src/Headless.Jobs.Abstractions/Base/JobFunctionAttribute.cs
+++ b/src/Headless.Jobs.Abstractions/Base/JobFunctionAttribute.cs
@@ -21,6 +21,7 @@ namespace Headless.Jobs.Base;
 /// treated as a configuration key and resolved from <c>IConfiguration</c> at startup.
 /// </para>
 /// </remarks>
+[PublicAPI]
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class JobFunctionAttribute : Attribute
 {

--- a/src/Headless.Jobs.Abstractions/Base/JobFunctionContext.cs
+++ b/src/Headless.Jobs.Abstractions/Base/JobFunctionContext.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.ComponentModel;
 using Headless.Jobs.Enums;
 using Headless.Jobs.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
@@ -111,19 +110,25 @@ public class JobFunctionContext
 }
 
 /// <summary>
-/// Cron-specific runtime operations available to a job function during execution.
+/// Cron-specific runtime operations available to a job function during execution. Instances are
+/// constructed by the scheduler runtime, which wires the skip callback; consumers only call
+/// <see cref="SkipIfAlreadyRunning"/>.
 /// </summary>
 [PublicAPI]
-public class CronOccurrenceOperations
+public sealed class CronOccurrenceOperations
 {
+    private readonly Action _skipIfAlreadyRunning;
+
     /// <summary>
-    /// Delegate invoked by <see cref="SkipIfAlreadyRunning"/> to mark the current occurrence as
-    /// skipped when another occurrence of the same cron job is already executing on this node.
-    /// Wired by the scheduler; not intended to be set by consumers — call
-    /// <see cref="SkipIfAlreadyRunning"/> instead.
+    /// Wires the delegate invoked by <see cref="SkipIfAlreadyRunning"/> to mark the current occurrence
+    /// as skipped when another occurrence of the same cron job is already executing on this node.
+    /// Internal: the scheduler runtime is the only producer of execution contexts.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public required Action SkipIfAlreadyRunningAction { get; init; }
+    /// <param name="skipIfAlreadyRunning">Callback that skips the occurrence when a sibling is running.</param>
+    internal CronOccurrenceOperations(Action skipIfAlreadyRunning)
+    {
+        _skipIfAlreadyRunning = skipIfAlreadyRunning;
+    }
 
     /// <summary>
     /// Marks this cron occurrence as <c>Skipped</c> and stops execution if another occurrence of the
@@ -132,6 +137,6 @@ public class CronOccurrenceOperations
     /// </summary>
     public void SkipIfAlreadyRunning()
     {
-        SkipIfAlreadyRunningAction();
+        _skipIfAlreadyRunning();
     }
 }

--- a/src/Headless.Jobs.Abstractions/Base/JobFunctionDelegate.cs
+++ b/src/Headless.Jobs.Abstractions/Base/JobFunctionDelegate.cs
@@ -12,6 +12,7 @@ namespace Headless.Jobs;
 /// <param name="serviceProvider">The scoped service provider for this execution.</param>
 /// <param name="context">Scheduling metadata and cooperative-cancel hook for this execution.</param>
 /// <param name="cancellationToken">Token signalled when the job is cancelled or the host is shutting down.</param>
+[PublicAPI]
 public delegate Task JobFunctionDelegate(
     IServiceProvider serviceProvider,
     JobFunctionContext context,

--- a/src/Headless.Jobs.Abstractions/Base/JobsConstructorAttribute.cs
+++ b/src/Headless.Jobs.Abstractions/Base/JobsConstructorAttribute.cs
@@ -12,5 +12,6 @@ namespace Headless.Jobs.Base;
 /// should be used. Placing this attribute on more than one constructor in the same class is a compile-time
 /// error (diagnostic HF010).
 /// </remarks>
+[PublicAPI]
 [AttributeUsage(AttributeTargets.Constructor)]
 public sealed class JobsConstructorAttribute : Attribute;

--- a/src/Headless.Jobs.Abstractions/DashboardDtos/CronOccurrenceJobGraphData.cs
+++ b/src/Headless.Jobs.Abstractions/DashboardDtos/CronOccurrenceJobGraphData.cs
@@ -4,16 +4,14 @@ namespace Headless.Jobs.DashboardDtos;
 
 /// <summary>
 /// Per-day summary of cron occurrence outcomes, used to populate the dashboard execution graph.
-/// Each result tuple carries the succeeded and failed occurrence counts for that day.
+/// Each entry in <see cref="Results"/> carries the occurrence count for one lifecycle status on that day.
 /// </summary>
-public class CronOccurrenceJobGraphData
+[PublicAPI]
+public sealed class CronOccurrenceJobGraphData
 {
     /// <summary>The UTC date this summary covers.</summary>
-    public DateTime Date { get; set; }
+    public required DateTime Date { get; init; }
 
-    /// <summary>
-    /// Succeeded/failed pair for each cron job on this date.
-    /// Item1 = succeeded count, Item2 = failed count.
-    /// </summary>
-    public Tuple<int, int>[]? Results { get; set; }
+    /// <summary>Per-status occurrence counts on this date. Empty when the date has no occurrences.</summary>
+    public required JobStatusCount[] Results { get; init; }
 }

--- a/src/Headless.Jobs.Abstractions/DashboardDtos/JobGraphData.cs
+++ b/src/Headless.Jobs.Abstractions/DashboardDtos/JobGraphData.cs
@@ -4,16 +4,14 @@ namespace Headless.Jobs.DashboardDtos;
 
 /// <summary>
 /// Per-day summary of time job outcomes, used to populate the dashboard execution graph.
-/// Each result tuple carries the succeeded and failed job counts for that day.
+/// Each entry in <see cref="Results"/> carries the execution count for one lifecycle status on that day.
 /// </summary>
-public class JobGraphData
+[PublicAPI]
+public sealed class JobGraphData
 {
     /// <summary>The UTC date this summary covers.</summary>
-    public DateTime Date { get; set; }
+    public required DateTime Date { get; init; }
 
-    /// <summary>
-    /// Succeeded/failed pair for each job type on this date.
-    /// Item1 = succeeded count, Item2 = failed count.
-    /// </summary>
-    public required Tuple<int, int>[] Results { get; set; }
+    /// <summary>Per-status execution counts on this date. Empty when the date has no executions.</summary>
+    public required JobStatusCount[] Results { get; init; }
 }

--- a/src/Headless.Jobs.Abstractions/DashboardDtos/JobStatusCount.cs
+++ b/src/Headless.Jobs.Abstractions/DashboardDtos/JobStatusCount.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Runtime.InteropServices;
+using Headless.Jobs.Enums;
+
+namespace Headless.Jobs.DashboardDtos;
+
+/// <summary>
+/// Per-status execution count for a single dashboard graph day: the number of executions that carry
+/// <see cref="Status"/> on that day.
+/// </summary>
+/// <param name="Status">The lifecycle status counted by this entry.</param>
+/// <param name="Count">Number of executions with <paramref name="Status"/> on the graph day.</param>
+[PublicAPI]
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct JobStatusCount(JobStatus Status, int Count);

--- a/src/Headless.Jobs.Abstractions/DashboardDtos/LiveNodeView.cs
+++ b/src/Headless.Jobs.Abstractions/DashboardDtos/LiveNodeView.cs
@@ -3,6 +3,7 @@
 namespace Headless.Jobs.DashboardDtos;
 
 /// <summary>Dashboard projection of a single node's liveness, sourced from the coordination membership substrate.</summary>
+[PublicAPI]
 public sealed class LiveNodeView
 {
     /// <summary>Incarnation-qualified identity in the canonical <c>node@incarnation</c> form.</summary>

--- a/src/Headless.Jobs.Abstractions/DashboardDtos/UpdateCronJobRequest.cs
+++ b/src/Headless.Jobs.Abstractions/DashboardDtos/UpdateCronJobRequest.cs
@@ -5,6 +5,7 @@ namespace Headless.Jobs.DashboardDtos;
 /// <summary>
 /// Request body for the dashboard "update cron job" endpoint. Only non-null fields are applied.
 /// </summary>
+[PublicAPI]
 public class UpdateCronJobRequest
 {
     /// <summary>Registered function name to assign to the cron job.</summary>

--- a/src/Headless.Jobs.Abstractions/Entities/BaseEntity/BaseJobEntity.cs
+++ b/src/Headless.Jobs.Abstractions/Entities/BaseEntity/BaseJobEntity.cs
@@ -6,6 +6,7 @@ namespace Headless.Jobs.Entities.BaseEntity;
 /// Base entity shared by <c>TimeJobEntity</c> and <c>CronJobEntity</c>. Carries the identity,
 /// function binding, and audit timestamps common to all job types.
 /// </summary>
+[PublicAPI]
 public class BaseJobEntity
 {
     /// <summary>Unique identifier for this job row. Defaults to a new <see cref="Guid"/>.</summary>

--- a/src/Headless.Jobs.Abstractions/Entities/CronJobEntity.cs
+++ b/src/Headless.Jobs.Abstractions/Entities/CronJobEntity.cs
@@ -9,6 +9,7 @@ namespace Headless.Jobs.Entities;
 /// Persistent definition row for a recurring cron job. One <c>CronJobEntity</c> exists per registered
 /// cron function; the scheduler materializes <c>CronJobOccurrenceEntity</c> rows from it on each tick.
 /// </summary>
+[PublicAPI]
 public class CronJobEntity : BaseJobEntity
 {
     /// <summary>

--- a/src/Headless.Jobs.Abstractions/Entities/CronJobOccurrenceEntity.cs
+++ b/src/Headless.Jobs.Abstractions/Entities/CronJobOccurrenceEntity.cs
@@ -10,6 +10,7 @@ namespace Headless.Jobs.Entities;
 /// <c>JobStatus</c> lifecycle.
 /// </summary>
 /// <typeparam name="TCronJob">The concrete cron job definition type that owns this occurrence.</typeparam>
+[PublicAPI]
 public class CronJobOccurrenceEntity<TCronJob>
     where TCronJob : CronJobEntity
 {
@@ -17,13 +18,13 @@ public class CronJobOccurrenceEntity<TCronJob>
     public virtual Guid Id { get; set; }
 
     /// <summary>Current lifecycle state of this occurrence.</summary>
-    public virtual JobStatus Status { get; set; }
+    public virtual JobStatus Status { get; internal set; }
 
     /// <summary>
     /// The <c>node@incarnation</c> identifier of the node that claimed and is executing this
     /// occurrence, or <see langword="null"/> when unleased.
     /// </summary>
-    public virtual string? OwnerId { get; set; }
+    public virtual string? OwnerId { get; internal set; }
 
     /// <summary>UTC timestamp when this occurrence was scheduled to run.</summary>
     public virtual DateTime ExecutionTime { get; set; }
@@ -37,8 +38,10 @@ public class CronJobOccurrenceEntity<TCronJob>
     /// using the provider's time authority (injected <see cref="TimeProvider"/> for in-memory storage; database UTC
     /// clock for relational storage). Null means unleased.
     /// </summary>
-    public virtual DateTime? LockedUntil { get; set; }
-    public virtual DateTime? ExecutedAt { get; set; }
+    public virtual DateTime? LockedUntil { get; internal set; }
+
+    /// <summary>UTC timestamp when execution completed, or <see langword="null"/> if not yet completed.</summary>
+    public virtual DateTime? ExecutedAt { get; internal set; }
 
     /// <summary>
     /// Policy applied when the owning node dies mid-execution. Gates the claim predicate's lease-expiry arm
@@ -51,20 +54,20 @@ public class CronJobOccurrenceEntity<TCronJob>
     public virtual TCronJob CronJob { get; set; } = null!;
 
     /// <summary>Serialized exception message when the occurrence ended in <c>Failed</c> status.</summary>
-    public virtual string? ExceptionMessage { get; set; }
+    public virtual string? ExceptionMessage { get; internal set; }
 
     /// <summary>Human-readable reason when the occurrence was skipped.</summary>
-    public virtual string? SkippedReason { get; set; }
+    public virtual string? SkippedReason { get; internal set; }
 
     /// <summary>Wall-clock execution duration in milliseconds, set after the function completes.</summary>
-    public virtual long ElapsedTime { get; set; }
+    public virtual long ElapsedTime { get; internal set; }
 
     /// <summary>Number of retry attempts consumed so far for this occurrence.</summary>
-    public virtual int RetryCount { get; set; }
+    public virtual int RetryCount { get; internal set; }
 
     /// <summary>UTC timestamp when this occurrence row was first created.</summary>
-    public virtual DateTime CreatedAt { get; set; }
+    public virtual DateTime CreatedAt { get; internal set; }
 
     /// <summary>UTC timestamp of the most recent update to this occurrence row.</summary>
-    public virtual DateTime UpdatedAt { get; set; }
+    public virtual DateTime UpdatedAt { get; internal set; }
 }

--- a/src/Headless.Jobs.Abstractions/Entities/TimeJobEntity.cs
+++ b/src/Headless.Jobs.Abstractions/Entities/TimeJobEntity.cs
@@ -9,6 +9,7 @@ namespace Headless.Jobs.Entities;
 /// Concrete self-referential time job entity for applications that do not need a custom entity type.
 /// Equivalent to <c>TimeJobEntity&lt;TimeJobEntity&gt;</c>.
 /// </summary>
+[PublicAPI]
 public class TimeJobEntity : TimeJobEntity<TimeJobEntity>;
 
 /// <summary>
@@ -19,6 +20,7 @@ public class TimeJobEntity : TimeJobEntity<TimeJobEntity>;
 /// <typeparam name="TTicker">
 /// The concrete derived type used for the self-referential parent/child navigation properties.
 /// </typeparam>
+[PublicAPI]
 public class TimeJobEntity<TTicker> : BaseJobEntity
     where TTicker : TimeJobEntity<TTicker>
 {

--- a/src/Headless.Jobs.Abstractions/Exceptions/JobValidatorException.cs
+++ b/src/Headless.Jobs.Abstractions/Exceptions/JobValidatorException.cs
@@ -10,7 +10,8 @@ namespace Headless.Jobs.Exceptions;
 /// Batch operations aggregate all per-entity failures into <see cref="Errors"/> so the caller sees
 /// every problem at once. Single-entity operations produce exactly one entry.
 /// </remarks>
-public class JobValidatorException : Exception
+[PublicAPI]
+public sealed class JobValidatorException : Exception
 {
     /// <summary>
     /// Initializes a new instance with a single validation failure message.

--- a/src/Headless.Jobs.Abstractions/Interfaces/IJobExceptionHandler.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/IJobExceptionHandler.cs
@@ -23,6 +23,7 @@ namespace Headless.Jobs.Interfaces;
 /// progression.
 /// </para>
 /// </remarks>
+[PublicAPI]
 public interface IJobExceptionHandler
 {
     /// <summary>

--- a/src/Headless.Jobs.Abstractions/Interfaces/IJobFunctionConcurrencyGate.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/IJobFunctionConcurrencyGate.cs
@@ -5,6 +5,7 @@ namespace Headless.Jobs.Interfaces;
 /// <summary>
 /// Manages per-function concurrency limits using semaphores.
 /// </summary>
+[PublicAPI]
 public interface IJobFunctionConcurrencyGate
 {
     /// <summary>

--- a/src/Headless.Jobs.Abstractions/Interfaces/IJobsHostScheduler.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/IJobsHostScheduler.cs
@@ -7,6 +7,7 @@ namespace Headless.Jobs.Interfaces;
 /// manually start or stop job processing, for example in response to maintenance windows or when
 /// <c>JobsStartMode.Manual</c> is configured.
 /// </summary>
+[PublicAPI]
 public interface IJobsHostScheduler
 {
     /// <summary>

--- a/src/Headless.Jobs.Abstractions/Models/JobExecutionState.cs
+++ b/src/Headless.Jobs.Abstractions/Models/JobExecutionState.cs
@@ -14,6 +14,7 @@ namespace Headless.Jobs.Models;
 /// update instead of rewriting the whole row. A provider implementation reads the mutated members named in
 /// <see cref="PropertiesToUpdate"/> and persists only those.
 /// </summary>
+[PublicAPI]
 public class JobExecutionState
 {
     /// <summary>

--- a/src/Headless.Jobs.Abstractions/Models/JobManagerDispatchContext.cs
+++ b/src/Headless.Jobs.Abstractions/Models/JobManagerDispatchContext.cs
@@ -8,6 +8,7 @@ namespace Headless.Jobs.Models;
 /// SPI projection of a cron job definition that the manager dispatches to a persistence provider to generate and
 /// manage occurrences. Carries only the fields the scheduler loop needs, without loading the full entity graph.
 /// </summary>
+[PublicAPI]
 public class JobManagerDispatchContext(Guid id)
 {
     /// <summary>Identifier of the cron job definition.</summary>
@@ -36,6 +37,7 @@ public class JobManagerDispatchContext(Guid id)
 }
 
 /// <summary>Minimal projection of the most recent upcoming occurrence for a cron job definition.</summary>
+[PublicAPI]
 public class NextCronOccurrence(Guid id, DateTime createdAt)
 {
     /// <summary>Identifier of the upcoming occurrence row.</summary>

--- a/src/Headless.Jobs.Abstractions/Models/JobResult.cs
+++ b/src/Headless.Jobs.Abstractions/Models/JobResult.cs
@@ -12,6 +12,7 @@ namespace Headless.Jobs.Models;
 /// propagate through the caller's ambient transaction on the coordinated path.
 /// </remarks>
 /// <typeparam name="TEntity">The job entity type.</typeparam>
+[PublicAPI]
 public sealed class JobResult<TEntity>
     where TEntity : class
 {

--- a/src/Headless.Jobs.Abstractions/Models/PaginationResult.cs
+++ b/src/Headless.Jobs.Abstractions/Models/PaginationResult.cs
@@ -6,19 +6,20 @@ namespace Headless.Jobs.Models;
 /// A page of items from a larger result set, used by dashboard query endpoints.
 /// </summary>
 /// <typeparam name="T">The element type of the page.</typeparam>
-public class PaginationResult<T>
+[PublicAPI]
+public sealed class PaginationResult<T>
 {
     /// <summary>The items on the current page.</summary>
-    public IEnumerable<T> Items { get; set; }
+    public required IReadOnlyList<T> Items { get; init; }
 
     /// <summary>Total number of matching records across all pages.</summary>
-    public int TotalCount { get; set; }
+    public required int TotalCount { get; init; }
 
     /// <summary>The current 1-based page number.</summary>
-    public int PageNumber { get; set; }
+    public required int PageNumber { get; init; }
 
     /// <summary>Maximum number of items per page.</summary>
-    public int PageSize { get; set; }
+    public required int PageSize { get; init; }
 
     /// <summary>Total number of pages, computed from <see cref="TotalCount"/> and <see cref="PageSize"/>.</summary>
     public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
@@ -34,25 +35,4 @@ public class PaginationResult<T>
 
     /// <summary>1-based index of the last item on this page within the full result set.</summary>
     public int LastItemIndex => Math.Min(PageNumber * PageSize, TotalCount);
-
-    /// <summary>Initializes an empty pagination result.</summary>
-    public PaginationResult()
-    {
-        Items = new List<T>();
-    }
-
-    /// <summary>
-    /// Initializes a pagination result with the given items and pagination metadata.
-    /// </summary>
-    /// <param name="items">The items on this page; defaults to an empty list when <see langword="null"/>.</param>
-    /// <param name="totalCount">Total matching records across all pages.</param>
-    /// <param name="pageNumber">Current 1-based page number.</param>
-    /// <param name="pageSize">Maximum items per page.</param>
-    public PaginationResult(IEnumerable<T> items, int totalCount, int pageNumber, int pageSize)
-    {
-        Items = items ?? new List<T>();
-        TotalCount = totalCount;
-        PageNumber = pageNumber;
-        PageSize = pageSize;
-    }
 }

--- a/src/Headless.Jobs.Core/Exceptions/TerminateExecutionException.cs
+++ b/src/Headless.Jobs.Core/Exceptions/TerminateExecutionException.cs
@@ -26,12 +26,12 @@ public sealed class TerminateExecutionException : Exception
         : base(message) { }
 
     /// <summary>
-    /// Initializes a new instance that stamps a specific terminal <paramref name="jobType"/> status.
+    /// Initializes a new instance that stamps a specific terminal <paramref name="status"/>.
     /// </summary>
-    /// <param name="jobType">The terminal status to stamp on the job row.</param>
+    /// <param name="status">The terminal status to stamp on the job row.</param>
     /// <param name="message">Human-readable reason stored in the job's skip/fail reason field.</param>
-    public TerminateExecutionException(JobStatus jobType, string message)
-        : base(message) => Status = jobType;
+    public TerminateExecutionException(JobStatus status, string message)
+        : base(message) => Status = status;
 
     /// <summary>
     /// Initializes a new instance that marks the job as <see cref="JobStatus.Skipped"/>, preserving
@@ -43,14 +43,14 @@ public sealed class TerminateExecutionException : Exception
         : base(message, innerException) { }
 
     /// <summary>
-    /// Initializes a new instance that stamps a specific terminal <paramref name="jobType"/> status,
+    /// Initializes a new instance that stamps a specific terminal <paramref name="status"/>,
     /// preserving an inner exception for diagnostic purposes.
     /// </summary>
-    /// <param name="jobType">The terminal status to stamp on the job row.</param>
+    /// <param name="status">The terminal status to stamp on the job row.</param>
     /// <param name="message">Human-readable reason stored in the job's skip/fail reason field.</param>
     /// <param name="innerException">The underlying cause, for logging context.</param>
-    public TerminateExecutionException(JobStatus jobType, string message, Exception innerException)
-        : base(message, innerException) => Status = jobType;
+    public TerminateExecutionException(JobStatus status, string message, Exception innerException)
+        : base(message, innerException) => Status = status;
 }
 
 internal sealed class ExceptionDetailClassForSerialization

--- a/src/Headless.Jobs.Core/JobFunctionProvider.cs
+++ b/src/Headless.Jobs.Core/JobFunctionProvider.cs
@@ -81,6 +81,7 @@ public static class JobFunctionProvider
     /// <param name="functions">The functions to register. Cannot be null.</param>
     /// <exception cref="ArgumentNullException">Thrown when functions parameter is null.</exception>
     /// <exception cref="InvalidOperationException">Jobs discovery has completed or the catalog is frozen.</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void RegisterFunctions(IDictionary<string, JobFunctionRegistration> functions) =>
         _Register(functions, ref _functionRegistrations);
 
@@ -92,6 +93,7 @@ public static class JobFunctionProvider
     /// <param name="_">The total expected capacity (ignored - capacity calculated automatically).</param>
     /// <exception cref="ArgumentNullException">Thrown when functions parameter is null.</exception>
     /// <exception cref="InvalidOperationException">Jobs discovery has completed or the catalog is frozen.</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void RegisterFunctions(IDictionary<string, JobFunctionRegistration> functions, int _)
     {
         // For callback approach, capacity is calculated automatically in Build()
@@ -105,6 +107,7 @@ public static class JobFunctionProvider
     /// <param name="requestTypes">The request types to register. Cannot be null.</param>
     /// <exception cref="ArgumentNullException">Thrown when requestTypes parameter is null.</exception>
     /// <exception cref="InvalidOperationException">Jobs discovery has completed or the catalog is frozen.</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void RegisterRequestType(IDictionary<string, (string, Type)> requestTypes) =>
         _Register(requestTypes, ref _requestTypeRegistrations);
 
@@ -116,6 +119,7 @@ public static class JobFunctionProvider
     /// <param name="_">The total expected capacity (ignored - capacity calculated automatically).</param>
     /// <exception cref="ArgumentNullException">Thrown when requestTypes parameter is null.</exception>
     /// <exception cref="InvalidOperationException">Jobs discovery has completed or the catalog is frozen.</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void RegisterRequestType(IDictionary<string, (string, Type)> requestTypes, int _)
     {
         // For callback approach, capacity is calculated automatically in Build()

--- a/src/Headless.Jobs.Core/JobsExecutionTaskHandler.cs
+++ b/src/Headless.Jobs.Core/JobsExecutionTaskHandler.cs
@@ -201,7 +201,7 @@ internal sealed class JobsExecutionTaskHandler
         var cancellationTokenSource = new CancellationTokenSource();
 #pragma warning restore CA2000
 
-        // IMPORTANT: Register the job FIRST, before creating the SkipIfAlreadyRunningAction callback
+        // IMPORTANT: Register the job FIRST, before creating the skip-if-already-running callback
         // This ensures the current occurrence is properly tracked when the callback checks for siblings
         var cancellationRegistration = _cancellationRegistry.Register(cancellationTokenSource, context);
         await using var hostShutdownRegistration = cancellationToken.Register(() =>
@@ -215,27 +215,24 @@ internal sealed class JobsExecutionTaskHandler
             Type = context.Type,
             IsDue = isDue,
             ScheduledFor = context.ExecutionTime,
-            CronOccurrenceOperations = new CronOccurrenceOperations
+            CronOccurrenceOperations = new CronOccurrenceOperations(() =>
             {
-                SkipIfAlreadyRunningAction = () =>
+                if (context.Type == JobType.TimeJob)
                 {
-                    if (context.Type == JobType.TimeJob)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    // Check for other running occurrences of the same parent (excluding self)
-                    // Since we're already registered, we need to exclude ourselves from the check
-                    var isRunning =
-                        context.ParentId.HasValue
-                        && _cancellationRegistry.IsParentRunningExcludingSelf(context.ParentId.Value, context.JobId);
+                // Check for other running occurrences of the same parent (excluding self)
+                // Since we're already registered, we need to exclude ourselves from the check
+                var isRunning =
+                    context.ParentId.HasValue
+                    && _cancellationRegistry.IsParentRunningExcludingSelf(context.ParentId.Value, context.JobId);
 
-                    if (isRunning)
-                    {
-                        throw new TerminateExecutionException("Another CronOccurrence is already running!");
-                    }
-                },
-            },
+                if (isRunning)
+                {
+                    throw new TerminateExecutionException("Another CronOccurrence is already running!");
+                }
+            }),
         };
 
         // #316 sliding lease: renew this job's lease on a cadence for the whole execution (every retry attempt and

--- a/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
+++ b/src/Headless.Jobs.Dashboard/Infrastructure/Dashboard/JobsDashboardRepository.cs
@@ -142,7 +142,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             var statusCounts = groupedData.TryGetValue(date, out var statusData) ? statusData : [];
 
             var results = allStatuses
-                .Select(status => Tuple.Create((int)status, statusCounts.GetValueOrDefault(status, 0)))
+                .Select(status => new JobStatusCount(status, statusCounts.GetValueOrDefault(status, 0)))
                 .ToArray();
 
             return new JobGraphData { Date = date, Results = results };
@@ -195,7 +195,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             var statusCounts = groupedData.TryGetValue(date, out var statusData) ? statusData : [];
 
             var results = allStatuses
-                .Select(status => Tuple.Create((int)status, statusCounts.GetValueOrDefault(status, 0)))
+                .Select(status => new JobStatusCount(status, statusCounts.GetValueOrDefault(status, 0)))
                 .ToArray();
 
             return new JobGraphData { Date = date, Results = results };
@@ -269,7 +269,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             var statusCounts = groupedData.TryGetValue(date, out var statusData) ? statusData : [];
 
             var results = allStatuses
-                .Select(status => Tuple.Create((int)status, statusCounts.GetValueOrDefault(status, 0)))
+                .Select(status => new JobStatusCount(status, statusCounts.GetValueOrDefault(status, 0)))
                 .ToArray();
 
             return new JobGraphData { Date = date, Results = results };
@@ -434,7 +434,13 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             .GetCronJobsPaginatedAsync(predicate: null, pageNumber, pageSize, cancellationToken)
             .ConfigureAwait(false);
 
-        return new PaginationResult<CronJobEntity>(result.Items, result.TotalCount, result.PageNumber, result.PageSize);
+        return new PaginationResult<CronJobEntity>
+        {
+            Items = result.Items,
+            TotalCount = result.TotalCount,
+            PageNumber = result.PageNumber,
+            PageSize = result.PageSize,
+        };
     }
 
     public async Task AddOnDemandCronJobOccurrenceAsync(Guid id, CancellationToken cancellationToken = default)
@@ -539,7 +545,7 @@ internal sealed class JobsDashboardRepository<TTimeJob, TCronJob>(
             .GroupBy(x => x.Date)
             .ToDictionary(
                 group => group.Key,
-                group => group.Select(x => Tuple.Create((int)x.Status, x.Count)).ToArray()
+                group => group.Select(x => new JobStatusCount(x.Status, x.Count)).ToArray()
             );
         var allDates = Enumerable
             .Range(0, _GraphDayCount(startDate, endDate))

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/cronJobOccurrenceService.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/cronJobOccurrenceService.ts
@@ -85,7 +85,7 @@ const getCronJobOccurrenceGraphData = () => {
                 ...item,
                 date: formatDate(item.date, false, timeZoneStore.effectiveTimeZone),
                 type: "line",
-                statuses: item.results.map(x => Status[x.item1])
+                statuses: item.results.map(x => Status[x.status])
             }
         });
 

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/types/cronJobOccurrenceService.types.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/types/cronJobOccurrenceService.types.ts
@@ -24,7 +24,7 @@ export class GetCronJobOccurrenceGraphDataRequest{
 
 export class GetCronJobOccurrenceGraphDataResponse{
     date!:string;
-    results!:{item1:number, item2:number }[];
+    results!:{status:number, count:number }[];
     type!: string;
     statuses!:string[]
 }

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/types/cronJobService.types.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/types/cronJobService.types.ts
@@ -26,7 +26,7 @@ export class UpdateCronJobRequest {
 
 export class GetCronJobGraphDataRangeResponse{
     date!:string;
-    results!:{item1:number, item2:number }[];
+    results!:{status:number, count:number }[];
 }
 
 export class GetCronJobGraphDataResponse{

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/types/timeJobService.types.ts
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/http/services/types/timeJobService.types.ts
@@ -26,7 +26,7 @@ export class GetTimeJobResponse {
 
 export class GetTimeJobGraphDataRangeResponse{
     date!:string;
-    results!:{item1:number, item2:number }[];
+    results!:{status:number, count:number }[];
 }
 
 export class GetTimeJobGraphDataResponse{

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/CronJob.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/CronJob.vue
@@ -241,9 +241,9 @@ const updatePieChartForSelectedTicker = async (jobId: string, min: number, max: 
     // Count occurrences of each status in the selected range
     res.forEach(({ results }) => {
       if (results && Array.isArray(results)) {
-        results.forEach(({ item1, item2 }) => {
-          const currentCount = statusCounts.get(item1) || 0
-          statusCounts.set(item1, currentCount + item2)
+        results.forEach(({ status, count }) => {
+          const currentCount = statusCounts.get(status) || 0
+          statusCounts.set(status, currentCount + count)
         })
       }
     })
@@ -295,22 +295,22 @@ const GetCronJobRangeGraphData = (res: GetCronJobGraphDataRangeResponse[]) => {
     // Extract unique Dates for xAxis
     const uniqueDates = res.map((x) => x.date)
 
-    // Extract all unique item1 values (Status IDs)
-    const uniqueItem1Set = new Set<number>()
+    // Extract all unique status IDs
+    const uniqueStatusSet = new Set<number>()
 
     res.forEach(({ results }) => {
       if (results && Array.isArray(results)) {
-        results.forEach(({ item1 }) => uniqueItem1Set.add(item1))
+        results.forEach(({ status }) => uniqueStatusSet.add(status))
       }
     })
-    const uniqueItem1Array = Array.from(uniqueItem1Set) // Convert Set to Array
+    const uniqueStatusArray = Array.from(uniqueStatusSet) // Convert Set to Array
 
     // Create a Map to store series data
-    const seriesMap = new Map<number, number[]>() // item1 -> data array
+    const seriesMap = new Map<number, number[]>() // status -> data array
 
     // Initialize seriesMap with empty arrays
-    uniqueItem1Array.forEach((item1) => {
-      seriesMap.set(item1, Array(uniqueDates.length).fill(0)) // Fill with 0s initially
+    uniqueStatusArray.forEach((status) => {
+      seriesMap.set(status, Array(uniqueDates.length).fill(0)) // Fill with 0s initially
     })
     
     // Populate seriesMap with actual data
@@ -318,32 +318,32 @@ const GetCronJobRangeGraphData = (res: GetCronJobGraphDataRangeResponse[]) => {
       if (results && Array.isArray(results)) {
         const dateIndex = uniqueDates.indexOf(date) // Find index in xAxis
 
-        results.forEach(({ item1, item2 }) => {
-          const dataArray = seriesMap.get(item1)
+        results.forEach(({ status, count }) => {
+          const dataArray = seriesMap.get(status)
           if (dataArray) {
-            dataArray[dateIndex] = item2 // Assign value at the correct index
+            dataArray[dateIndex] = count // Assign value at the correct index
           }
         })
       }
     })
 
     // Generate series data
-    const composedData = Array.from(seriesMap.entries()).map(([item1, dataArray]) => ({
+    const composedData = Array.from(seriesMap.entries()).map(([status, dataArray]) => ({
       data: dataArray,
-      name: Status[item1] || `Unknown ${item1}`,
+      name: Status[status] || `Unknown ${status}`,
       type: 'line' as const,
       smooth: true,
       symbol: 'circle',
       symbolSize: 6,
       lineStyle: {
-        color: statusColors[item1] || '#999999',
+        color: statusColors[status] || '#999999',
         width: 3,
         shadowBlur: 10,
-        shadowColor: statusColors[item1] || '#999999',
+        shadowColor: statusColors[status] || '#999999',
         shadowOffsetY: 2,
       },
       itemStyle: {
-        color: statusColors[item1] || '#999999',
+        color: statusColors[status] || '#999999',
         borderColor: '#ffffff',
         borderWidth: 2,
         shadowBlur: 10,
@@ -358,15 +358,15 @@ const GetCronJobRangeGraphData = (res: GetCronJobGraphDataRangeResponse[]) => {
           x2: 0,
           y2: 1,
           colorStops: [
-            { offset: 0, color: (statusColors[item1] || '#999999') + '40' },
-            { offset: 1, color: (statusColors[item1] || '#999999') + '10' },
+            { offset: 0, color: (statusColors[status] || '#999999') + '40' },
+            { offset: 1, color: (statusColors[status] || '#999999') + '10' },
           ],
         },
       },
       emphasis: {
         itemStyle: {
           shadowBlur: 20,
-          shadowColor: statusColors[item1] || '#999999',
+          shadowColor: statusColors[status] || '#999999',
           scale: true,
           scaleSize: 2,
         },

--- a/src/Headless.Jobs.Dashboard/wwwroot/src/views/TimeJob.vue
+++ b/src/Headless.Jobs.Dashboard/wwwroot/src/views/TimeJob.vue
@@ -226,11 +226,11 @@ const processTimeSeriesData = (data: GetTimeJobGraphDataRangeResponse[]) => {
   data.forEach((item) => {
     if (!item.results) return
     item.results.forEach((result) => {
-      allStatuses.add(result.item1)
+      allStatuses.add(result.status)
       if (!dateMap.has(item.date)) {
         dateMap.set(item.date, new Map())
       }
-      dateMap.get(item.date)!.set(result.item1, result.item2)
+      dateMap.get(item.date)!.set(result.status, result.count)
     })
   })
 

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/HeadlessJobsPaginationExtensions.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/HeadlessJobsPaginationExtensions.cs
@@ -32,7 +32,13 @@ public static class HeadlessJobsPaginationExtensions
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return new PaginationResult<T>(items, count, pageNumber, pageSize);
+        return new PaginationResult<T>
+        {
+            Items = items,
+            TotalCount = count,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+        };
     }
 
     /// <summary>
@@ -60,7 +66,13 @@ public static class HeadlessJobsPaginationExtensions
         var projectedQuery = projection(paginatedSource);
         var items = await projectedQuery.ToListAsync(cancellationToken).ConfigureAwait(false);
 
-        return new PaginationResult<TResult>(items, count, pageNumber, pageSize);
+        return new PaginationResult<TResult>
+        {
+            Items = items,
+            TotalCount = count,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+        };
     }
 
     /// <summary>
@@ -75,6 +87,12 @@ public static class HeadlessJobsPaginationExtensions
         var items = await source.ToListAsync(cancellationToken).ConfigureAwait(false);
         var count = items.Count;
 
-        return new PaginationResult<T>(items, count, 1, count > 0 ? count : 1);
+        return new PaginationResult<T>
+        {
+            Items = items,
+            TotalCount = count,
+            PageNumber = 1,
+            PageSize = count > 0 ? count : 1,
+        };
     }
 }

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsDashboardRepositoryTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsDashboardRepositoryTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq.Expressions;
 using Headless.Jobs;
+using Headless.Jobs.DashboardDtos;
 using Headless.Jobs.Entities;
 using Headless.Jobs.Enums;
 using Headless.Jobs.Infrastructure.Dashboard;
@@ -90,15 +91,13 @@ public sealed class JobsDashboardRepositoryTests : TestBase
         var result = await repository.GetCronJobsOccurrencesGraphDataAsync(cronJobId, AbortToken);
 
         result.Select(x => x.Date).Should().Equal(_Today.AddDays(-1), _Today, _Today.AddDays(1));
-#pragma warning disable RS0030 // JobGraphData intentionally retains its public Tuple-based compatibility contract.
         result[0].Results.Should().BeEmpty();
         result[1]
             .Results.Should()
             .BeEquivalentTo(
-                new[] { Tuple.Create((int)JobStatus.Succeeded, 3), Tuple.Create((int)JobStatus.Failed, 2) }
+                new[] { new JobStatusCount(JobStatus.Succeeded, 3), new JobStatusCount(JobStatus.Failed, 2) }
             );
         result[2].Results.Should().BeEmpty();
-#pragma warning restore RS0030
     }
 
     private static (

--- a/tests/Headless.Jobs.Composition.Tests.Unit/JobFunctionContextTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/JobFunctionContextTests.cs
@@ -21,7 +21,7 @@ public sealed class JobFunctionContextTests : Headless.Testing.Tests.TestBase
             IsDue = true,
             ScheduledFor = scheduledFor,
             FunctionName = "TestFunction",
-            CronOccurrenceOperations = new CronOccurrenceOperations { SkipIfAlreadyRunningAction = () => { } },
+            CronOccurrenceOperations = new CronOccurrenceOperations(() => { }),
         };
 
         var request = new TestRequest { Value = 42 };
@@ -53,7 +53,7 @@ public sealed class JobFunctionContextTests : Headless.Testing.Tests.TestBase
             Id = id,
             Type = JobType.TimeJob,
             FunctionName = "TestFunction",
-            CronOccurrenceOperations = new CronOccurrenceOperations { SkipIfAlreadyRunningAction = () => { } },
+            CronOccurrenceOperations = new CronOccurrenceOperations(() => { }),
         };
         context.SetServiceScope(scope);
 


### PR DESCRIPTION
## Summary

Pre-v1 public-API hardening for the Jobs family, per the API review findings on `Headless.Jobs.Abstractions` / `Headless.Jobs.Core` / `Headless.Jobs.Dashboard`. Two themes:

1. **Dashboard DTO shapes** — the graph endpoints leaked `System.Tuple<int, int>` into the public contract and onto the wire as `{item1, item2}`. Reviewer finding: an anonymous positional tuple is neither self-describing for consumers nor evolvable. Replaced with a named record struct.
2. **ABI hygiene** — seal-by-default, `required`/`init` on DTOs, `internal` fencing of runtime-owned entity setters, `[EditorBrowsable(Never)]` on generator-only entry points, and a `[PublicAPI]` sweep across the remaining `Jobs.Abstractions` contracts.

Greenfield repo: breaking changes are intentional, no compat shims.

## Changes

**Dashboard DTOs**
- New `JobStatusCount(JobStatus Status, int Count)` — `public readonly record struct`, `[StructLayout(LayoutKind.Auto)]`.
- `JobGraphData` / `CronOccurrenceJobGraphData`: `Tuple<int, int>[]` -> `JobStatusCount[]`; both now `sealed`, `[PublicAPI]`, `required`/`init`. Nullability aligned between the two DTOs — `Results` was `Tuple<int,int>[]?` on one and `required Tuple<int,int>[]` on the other; both are now `required JobStatusCount[]` (producer already zero-fills, so `null` was unreachable).
- `PaginationResult<T>`: `sealed`, `[PublicAPI]`, `Items` -> `IReadOnlyList<T>`, all members `required`/`init`, both constructors dropped in favour of object initializers.

**Runtime surface**
- `TerminateExecutionException`: ctor parameter `jobType` (typed `JobStatus`) renamed to `status` — the name was simply wrong.
- `CronOccurrenceOperations`: `sealed`; the `public required Action SkipIfAlreadyRunningAction { get; init; }` leak replaced by an `internal` constructor taking the callback. Consumers call `SkipIfAlreadyRunning()`; tests stay constructible via existing `InternalsVisibleTo`.
- `JobFunctionProvider.RegisterFunctions` / `RegisterRequestType`: `[EditorBrowsable(EditorBrowsableState.Never)]` — these are source-generator entry points, not consumer API.
- `CronJobOccurrenceEntity<TCronJob>`: runtime-owned setters (`Status`, `OwnerId`, `LockedUntil`, `ExecutedAt`, `ExceptionMessage`, `SkippedReason`, `ElapsedTime`, `RetryCount`, `CreatedAt`, `UpdatedAt`) fenced to `internal set`, matching `TimeJobEntity`. Missing XML doc added on `ExecutedAt`.
- `JobValidatorException`: `sealed`.
- `[PublicAPI]` sweep across `Jobs.Abstractions` contracts that lacked it (attributes, entities, interfaces, models, `JobFunctionDelegate`, `LiveNodeView`, `UpdateCronJobRequest`).

**Dashboard SPA (TypeScript/Vue)**
- Response types `{item1, item2}` -> `{status, count}`; call sites in `CronJob.vue`, `TimeJob.vue`, and `cronJobOccurrenceService.ts` updated accordingly. The dashboard's `JsonSerializerOptions` uses camelCase with no `JsonStringEnumConverter`, so `JobStatus` still serializes as a number and the existing `Status[...]` / `statusColors[...]` numeric lookups keep working.

## Decisions

- **`internal set` on `CronJobOccurrenceEntity` is safe for the RetryCount projection learning.** Every writer of these members (`Headless.Jobs.Core`, `Headless.Jobs.EntityFramework`, the PostgreSql/SqlServer providers, the EF test harness) is already on the `InternalsVisibleTo` list in `Headless.Jobs.Abstractions.csproj`, so the pickup projections continue to carry `RetryCount` unchanged. The full-solution build confirms no writer was cut off.
- **Jobs.SourceGenerator helper types were already internal** — every type under `Models/`, `Utilities/`, `Validation/`, `Generators/`, and `AttributeSyntaxes/` is `internal`; only `JobsIncrementalSourceGenerator` itself is public (as it must be). The `public` hits in that project are members of internal types. No change made, no IVT needed.
- **`CronOccurrenceOperations` uses an internal constructor rather than an internal init-setter** so the callback is non-optional at the type level and the object cannot exist half-wired.
- **`JobStatusCount` carries `JobStatus` rather than `int`** — the previous `Tuple.Create((int)status, ...)` cast erased the enum for no benefit; the wire format is unchanged because no string-enum converter is configured.
- **No docs update required.** `rg` over `docs/` and `src/Headless.Jobs*/README.md` returns zero references to `PaginationResult`, `JobGraphData`, `CronOccurrenceJobGraphData`, `SkipIfAlreadyRunningAction`, or the tuple shape.

## Testing

- `dotnet build src/Headless.Jobs.Abstractions --no-incremental -v:minimal` -> 0 warnings, 0 errors
- `dotnet build src/Headless.Jobs.Core --no-incremental -v:minimal` -> 0 warnings, 0 errors
- `dotnet build src/Headless.Jobs.EntityFramework --no-incremental -v:minimal` -> 0 warnings, 0 errors
- `dotnet build src/Headless.Jobs.Dashboard --no-incremental -v:minimal` -> 0 warnings, 0 errors. This runs `npm ci` + `npm run build`, whose `build` script is `run-p type-check build-only`, so `vue-tsc --build` type-checked the changed TypeScript/Vue as part of the green build.
- `dotnet build src/Headless.Jobs.SourceGenerator --no-incremental -v:minimal` -> succeeds; the RS1007/RS1015/RS1028 analyzer warnings in `DiagnosticDescriptors.cs` are pre-existing on `main` and untouched by this PR.
- `dotnet test --project tests/Headless.Jobs.Composition.Tests.Unit/...` -> **348 passed, 0 failed**
- `dotnet test --project tests/Headless.Jobs.SourceGenerator.Tests.Unit/...` -> 17 passed, 0 failed
- `dotnet test --project tests/Headless.Jobs.MiddlewareDiscovery.Spike.Tests.Unit/...` -> 11 passed, 0 failed
- **Full-solution build**: `dotnet build headless-framework.slnx -c Release --no-incremental -v:q -nologo /clp:ErrorsOnly` -> **0 errors, 0 warnings**.

  Note on the full-solution number: `origin/main` is currently red with 24 pre-existing `error CS0122` in `Headless.DistributedLocks.Composition.Tests.Unit` and `Headless.Jobs.Composition.Tests.Unit`, caused by #749 internalizing DistributedLocks seams without granting those test assemblies `InternalsVisibleTo` (fix is up as #752). To get a meaningful signal, the full-solution build and the `Headless.Jobs.Composition.Tests.Unit` run above were done with `origin/xshaheen/fix-locks-composition-ivt` merged in **locally only**; that merge was reset out before committing and is not part of this branch. **Excluding those 24 pre-existing errors, this PR produces 0 errors.** This PR will show the same 24 in CI until #752 merges.

- **Integration tests skipped: Docker unavailable** in this environment (`Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration`, `Headless.Jobs.EntityFramework.SqlServer.Tests.Integration`).
- Changed files formatted with `dotnet csharpier format`.

## Docs

No documentation changes needed. Grepping `docs/llms/` and `src/Headless.Jobs*/README.md` for every renamed or reshaped identifier (`PaginationResult`, `JobGraphData`, `CronOccurrenceJobGraphData`, `SkipIfAlreadyRunningAction`, the `Tuple<int, int>` shape) returns zero hits, so no doc surface drifted.
