### PR TITLE
test(caching): widen Redis sliding absolute-cap test margins to whole seconds

### DIFF
--- a/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
+++ b/tests/Headless.Caching.Redis.Tests.Integration/RedisCacheConformanceTests.cs
@@ -194,10 +194,32 @@ public sealed class RedisCacheConformanceTests(RedisCacheFixture fixture) : Cach
         idleRead.HasValue.Should().BeFalse();
     }
 
+    // Overridden with whole-second timings (see note above): the base's 150ms sliding window leaves only tens
+    // of ms of slack per keep-alive read, which parallel-suite scheduling jitter can consume. Every keep-alive
+    // read below sits 1s inside its window, and the final read lands past the absolute cap while the sliding
+    // window is still open, so the cap - not an accidental sliding lapse - is what expires the entry.
     [Fact]
-    public override Task should_expire_sliding_entry_at_absolute_duration_cap()
+    public override async Task should_expire_sliding_entry_at_absolute_duration_cap()
     {
-        return base.should_expire_sliding_entry_at_absolute_duration_cap();
+        await ResetAsync();
+        var cache = CreateCache(Faker.Random.AlphaNumeric(8));
+        var key = Faker.Random.AlphaNumeric(10);
+        var sliding = TimeSpan.FromSeconds(2);
+        var options = new CacheEntryOptions { Duration = TimeSpan.FromSeconds(4), SlidingExpiration = sliding };
+
+        await cache.GetOrAddAsync(key, _ => ValueTask.FromResult<string?>("value"), options, AbortToken);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1), AbortToken);
+            (await cache.GetAsync<string>(key, AbortToken)).HasValue.Should().BeTrue();
+        }
+
+        // 1.5s after the last keep-alive read: inside the re-armed sliding window (2s), past the 4s cap.
+        await Task.Delay(TimeSpan.FromMilliseconds(1500), AbortToken);
+        var capped = await cache.GetAsync<string>(key, AbortToken);
+
+        capped.HasValue.Should().BeFalse();
     }
 
     // Overridden with a whole-second window (see note above): ExistsAsync must not extend the window, so after


### PR DESCRIPTION
## Summary

`RedisCacheConformanceTests.should_expire_sliding_entry_at_absolute_duration_cap` failed once under a full-suite run (passing in isolation): the base scenario's **150ms sliding window** leaves only tens of milliseconds of slack per keep-alive read, which parallel-suite scheduling jitter can consume — the sliding TTL lapses before the keep-alive read reaches Redis and the test fails at the keep-alive assertion.

The two sibling sliding scenarios in this class are already overridden with whole-second windows for exactly this reason (see the class-level note); this PR gives the absolute-cap scenario the same treatment.

## Changes

- Override `should_expire_sliding_entry_at_absolute_duration_cap` with whole-second timings: sliding **2s**, absolute cap **4s**, keep-alive reads at ~1s intervals (each 1s inside its window).
- The final read lands at ~4.5s: **past the 4s cap but inside the still-open sliding window** (re-armed at ~3s → open until ~5s), so the assertion proves the absolute cap — not an accidental sliding lapse — expires the entry. This is a strictly stronger property than the base scenario exercised on Redis, matching `RedisCacheEntryFrame`'s `LogicalExpiresAt` cap semantics.

## Testing

- `Headless.Caching.Redis.Tests.Integration` `RedisCacheConformanceTests`: **55/55 passed, 3 consecutive runs**.