### PR TITLE
test(distributed-locks): consolidate drain helper

### DIFF
--- a/tests/Headless.DistributedLocks.Composition.Tests.Unit/DistributedLockTestSupport.cs
+++ b/tests/Headless.DistributedLocks.Composition.Tests.Unit/DistributedLockTestSupport.cs
@@ -22,6 +22,21 @@ internal static class DistributedLockTestSupport
     /// <summary>Mirrors <c>_NonBlockingAcquireDeadline</c> in the providers (seconds).</summary>
     public const int NonBlockingAcquireDeadlineSeconds = 10;
 
+    public static async Task DrainUntilAsync(Func<bool> condition, CancellationToken cancellationToken = default)
+    {
+        for (var i = 0; i < 2000 && !condition(); i++)
+        {
+            if (i % 100 == 0)
+            {
+                await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+    }
+
     /// <summary>
     /// Captures the namespaced reason tag values (<c>headless.lock.reason</c> /
     /// <c>headless.semaphore.reason</c>) recorded on the named failure counter

--- a/tests/Headless.DistributedLocks.Composition.Tests.Unit/ReaderWriterLocks/LeaseMonitorIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Composition.Tests.Unit/ReaderWriterLocks/LeaseMonitorIntegrationTests.cs
@@ -41,7 +41,7 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
         for (var i = 0; i < 5; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(1));
-            await _DrainUntilAsync(() => handle.RenewalCount >= i + 1, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(() => handle.RenewalCount >= i + 1, AbortToken);
         }
 
         // then
@@ -71,7 +71,10 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
         for (var i = 0; i < 10 && !handle.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(1));
-            await _DrainUntilAsync(() => handle.LostToken.IsCancellationRequested, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(
+                () => handle.LostToken.IsCancellationRequested,
+                AbortToken
+            );
         }
 
         // then
@@ -98,7 +101,7 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
         for (var i = 0; i < 5; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(1));
-            await _DrainUntilAsync(() => handle.RenewalCount >= i + 1, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(() => handle.RenewalCount >= i + 1, AbortToken);
         }
 
         // then
@@ -136,7 +139,10 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
         for (var i = 0; i < 10 && !handle.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(1));
-            await _DrainUntilAsync(() => handle.LostToken.IsCancellationRequested, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(
+                () => handle.LostToken.IsCancellationRequested,
+                AbortToken
+            );
         }
 
         // then
@@ -192,7 +198,10 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
         for (var i = 0; i < 10 && !handle.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(3));
-            await _DrainUntilAsync(() => handle.LostToken.IsCancellationRequested, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(
+                () => handle.LostToken.IsCancellationRequested,
+                AbortToken
+            );
         }
 
         // then
@@ -229,7 +238,10 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
         for (var i = 0; i < 10 && !handle.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(3));
-            await _DrainUntilAsync(() => handle.LostToken.IsCancellationRequested, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(
+                () => handle.LostToken.IsCancellationRequested,
+                AbortToken
+            );
         }
 
         // then
@@ -381,21 +393,6 @@ public sealed class LeaseMonitorIntegrationTests : TestBase
             _timeProvider,
             LoggerFactory.CreateLogger<DistributedReadWriteLock>()
         );
-    }
-
-    private static async Task _DrainUntilAsync(Func<bool> condition, CancellationToken cancellationToken = default)
-    {
-        for (var i = 0; i < 2000 && !condition(); i++)
-        {
-            if (i % 100 == 0)
-            {
-                await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
-            }
-            else
-            {
-                await Task.Yield();
-            }
-        }
     }
 
     private sealed class CountingStorage : IDistributedReadWriteLockStorage

--- a/tests/Headless.DistributedLocks.Composition.Tests.Unit/RegularLocks/DistributedSemaphoreProviderTests.cs
+++ b/tests/Headless.DistributedLocks.Composition.Tests.Unit/RegularLocks/DistributedSemaphoreProviderTests.cs
@@ -169,7 +169,7 @@ public sealed class DistributedSemaphoreProviderTests : TestBase
         for (var i = 0; i < 10 && !slot.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(2));
-            await _DrainUntilAsync(() => slot.LostToken.IsCancellationRequested);
+            await DistributedLockTestSupport.DrainUntilAsync(() => slot.LostToken.IsCancellationRequested);
         }
 
         // then
@@ -423,20 +423,5 @@ public sealed class DistributedSemaphoreProviderTests : TestBase
             _timeProvider,
             LoggerFactory.CreateLogger<DistributedSemaphoreProvider>()
         );
-    }
-
-    private static async Task _DrainUntilAsync(Func<bool> condition)
-    {
-        for (var i = 0; i < 2000 && !condition(); i++)
-        {
-            if (i % 100 == 0)
-            {
-                await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(1));
-            }
-            else
-            {
-                await Task.Yield();
-            }
-        }
     }
 }

--- a/tests/Headless.DistributedLocks.Composition.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
+++ b/tests/Headless.DistributedLocks.Composition.Tests.Unit/RegularLocks/LeaseLifecycleIntegrationTests.cs
@@ -185,7 +185,10 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         for (var i = 0; i < 20 && !handle!.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(2));
-            await _DrainUntilAsync(() => handle!.LostToken.IsCancellationRequested, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(
+                () => handle!.LostToken.IsCancellationRequested,
+                AbortToken
+            );
         }
 
         // then
@@ -237,7 +240,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         for (var i = 0; i < 4; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(1));
-            await _DrainUntilAsync(() => handle!.RenewalCount >= i + 1, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(() => handle!.RenewalCount >= i + 1, AbortToken);
         }
 
         // then - LostToken still not fired (auto-extend kept storage row alive).
@@ -266,7 +269,7 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         for (var i = 0; i < 5; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(1));
-            await _DrainUntilAsync(() => handle!.RenewalCount >= i + 1, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(() => handle!.RenewalCount >= i + 1, AbortToken);
         }
 
         // then - background renewals were recorded.
@@ -392,7 +395,10 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         await provider.ReleaseAsync(resource, handle!.LeaseId, AbortToken);
         ((ICanReceiveLockReleased)provider).OnLockReleased(new DistributedLockReleased(resource, handle.LeaseId));
         _timeProvider.Advance(TimeSpan.FromSeconds(6));
-        await _DrainUntilAsync(() => provider.GetActiveMonitorCount(resource) == 0, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(
+            () => provider.GetActiveMonitorCount(resource) == 0,
+            AbortToken
+        );
 
         // then - LostToken stays unfired after a monitor cadence opportunity.
         handle.LostToken.IsCancellationRequested.Should().BeFalse();
@@ -457,7 +463,10 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         for (var i = 0; i < 10 && !handle!.LostToken.IsCancellationRequested; i++)
         {
             _timeProvider.Advance(TimeSpan.FromSeconds(6));
-            await _DrainUntilAsync(() => handle.LostToken.IsCancellationRequested, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(
+                () => handle.LostToken.IsCancellationRequested,
+                AbortToken
+            );
         }
 
         // then - polling cadence alone (no nudge) was sufficient to detect loss.
@@ -502,20 +511,5 @@ public sealed class LeaseLifecycleIntegrationTests : TestBase
         provider.GetActiveMonitorCount(resource).Should().Be(1);
         provider.GetActiveMonitorResourceCount().Should().Be(1);
         GC.KeepAlive(handle);
-    }
-
-    private static async Task _DrainUntilAsync(Func<bool> condition, CancellationToken cancellationToken = default)
-    {
-        for (var i = 0; i < 2000 && !condition(); i++)
-        {
-            if (i % 100 == 0)
-            {
-                await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
-            }
-            else
-            {
-                await Task.Yield();
-            }
-        }
     }
 }

--- a/tests/Headless.DistributedLocks.Composition.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
+++ b/tests/Headless.DistributedLocks.Composition.Tests.Unit/RegularLocks/LeaseMonitorTests.cs
@@ -22,7 +22,7 @@ public sealed class LeaseMonitorTests : TestBase
 
         // when
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
 
         // then
         sut.LostToken.IsCancellationRequested.Should().BeTrue();
@@ -40,13 +40,13 @@ public sealed class LeaseMonitorTests : TestBase
 
         // when - Unknown then Renewed within budget — must NOT cancel.
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.InvocationCount == 1, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount == 1, AbortToken);
         _timeProvider.Advance(TimeSpan.FromSeconds(3));
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.InvocationCount == 2, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount == 2, AbortToken);
         _timeProvider.Advance(TimeSpan.FromSeconds(6));
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.InvocationCount == 3, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount == 3, AbortToken);
 
         // then - still alive after Unknown → Renewed.
         sut.LostToken.IsCancellationRequested.Should().BeFalse();
@@ -55,7 +55,7 @@ public sealed class LeaseMonitorTests : TestBase
         // confirm the monitor DOES react when storage subsequently confirms loss.
         handle.Enqueue(LeaseMonitor.LeaseState.Lost);
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
         sut.LostToken.IsCancellationRequested.Should().BeTrue();
     }
 
@@ -69,10 +69,10 @@ public sealed class LeaseMonitorTests : TestBase
 
         // when
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.InvocationCount == 1, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount == 1, AbortToken);
         _timeProvider.Advance(handle.LeaseDuration);
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
 
         // then
         sut.LostToken.IsCancellationRequested.Should().BeTrue();
@@ -131,12 +131,12 @@ public sealed class LeaseMonitorTests : TestBase
         for (var i = 0; i < 6; i++)
         {
             sut.TriggerImmediateValidation();
-            await _DrainUntilAsync(() => handle.InvocationCount >= i + 1, AbortToken);
+            await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount >= i + 1, AbortToken);
             _timeProvider.Advance(TimeSpan.FromSeconds(5));
         }
 
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.InvocationCount >= 7, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount >= 7, AbortToken);
 
         // then - storage repeatedly confirmed ownership; monitor must not declare Lost.
         sut.LostToken.IsCancellationRequested.Should().BeFalse();
@@ -144,7 +144,7 @@ public sealed class LeaseMonitorTests : TestBase
         // and - positive observation: when storage subsequently confirms loss, the monitor DOES react.
         handle.Enqueue(LeaseMonitor.LeaseState.Lost);
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
         sut.LostToken.IsCancellationRequested.Should().BeTrue();
     }
 
@@ -174,7 +174,7 @@ public sealed class LeaseMonitorTests : TestBase
 
         // when
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => sut.LostToken.IsCancellationRequested, AbortToken);
 
         // then
         sut.LostToken.IsCancellationRequested.Should().BeTrue();
@@ -259,7 +259,7 @@ public sealed class LeaseMonitorTests : TestBase
 
         // Trigger an iteration that will block inside RenewOrValidateLeaseAsync.
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.IsBlocking, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.IsBlocking, AbortToken);
 
         // when
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -321,7 +321,7 @@ public sealed class LeaseMonitorTests : TestBase
     private static async Task _RunIterationAndWait(LeaseMonitor sut, FakeLeaseHandle handle, int expectedCount)
     {
         sut.TriggerImmediateValidation();
-        await _DrainUntilAsync(() => handle.InvocationCount >= expectedCount, AbortToken);
+        await DistributedLockTestSupport.DrainUntilAsync(() => handle.InvocationCount >= expectedCount, AbortToken);
     }
 
     private LeaseMonitor _CreateMonitor(FakeLeaseHandle handle)
@@ -393,20 +393,5 @@ public sealed class LeaseMonitorTests : TestBase
         // Synchronous callback disposal should complete without hanging/deadlocking.
         await callbackCompleted.Task.WaitAsync(TimeSpan.FromSeconds(30), AbortToken);
         sut.MonitoringTask.IsCompleted.Should().BeTrue();
-    }
-
-    private static async Task _DrainUntilAsync(Func<bool> condition, CancellationToken cancellationToken = default)
-    {
-        for (var i = 0; i < 2000 && !condition(); i++)
-        {
-            if (i % 100 == 0)
-            {
-                await TimeProvider.System.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
-            }
-            else
-            {
-                await Task.Yield();
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary

- Distributed-lock lease and monitor tests now share one scheduler-drain implementation, preventing the duplicated helpers from drifting while preserving their existing behavior.
- All 25 call sites retain the same bounded-yield and cancellation semantics.

## Related Work

Fixes #445

## Scope

Affected packages or domains:

- `Headless.DistributedLocks.Composition.Tests.Unit`

Out of scope:

- Production distributed-lock behavior
- `CompositeTestScheduler.DrainUntilAsync`, which has distinct timeout and assertion semantics

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A
```

## Validation

- [x] Focused build or test for the affected projects
- [ ] `make build`
- [ ] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
make restore
Passed.

make build-project PROJECT=tests/Headless.DistributedLocks.Composition.Tests.Unit/Headless.DistributedLocks.Composition.Tests.Unit.csproj
Passed: 0 warnings, 0 errors.

make test-project TEST_PROJECT=tests/Headless.DistributedLocks.Composition.Tests.Unit/Headless.DistributedLocks.Composition.Tests.Unit.csproj
Passed: 424 tests, 0 failed, 0 skipped.

Pre-push changed-file CSharpier check
Passed: 5 files.

Pre-push incremental solution build
Passed: 0 warnings, 0 errors.
```

## Tests and Documentation

- [ ] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [x] Tests and documentation are not affected

```text
Pure test-infrastructure consolidation; no test behavior, production behavior, public API, or documentation contract changed.
```

## Reviewer Guide

Verify that the shared helper preserves the prior 2,000-iteration yield/delay loop and optional cancellation token. The composite-test scheduler helper is intentionally unchanged because it asserts completion against a wall-clock timeout.

## Release Notes

N/A
