### PR TITLE
refactor(messaging): remove legacy SQL index repair

### DIFF
--- a/src/Headless.Messaging.Storage.SqlServer/SqlServerStorageInitializer.cs
+++ b/src/Headless.Messaging.Storage.SqlServer/SqlServerStorageInitializer.cs
@@ -204,22 +204,6 @@ internal sealed class SqlServerStorageInitializer(
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
             END CATCH;
 
-            -- Repair the pre-lane retry index in place. Name-only existence checks would preserve
-            -- (Version, NextRetryAt), leaving IntentType as a residual predicate for every lane claim.
-            IF EXISTS (
-                SELECT 1
-                FROM sys.indexes i
-                WHERE i.name = N'IX_{receivedPrefix}_Version_NextRetryAt'
-                  AND i.object_id = OBJECT_ID(N'{GetReceivedTableName()}')
-                  AND (
-                      (SELECT COUNT(*) FROM sys.index_columns ic WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.is_included_column = 0) <> 3
-                      OR NOT EXISTS (SELECT 1 FROM sys.index_columns ic JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal = 1 AND c.name = N'Version')
-                      OR NOT EXISTS (SELECT 1 FROM sys.index_columns ic JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal = 2 AND c.name = N'IntentType')
-                      OR NOT EXISTS (SELECT 1 FROM sys.index_columns ic JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal = 3 AND c.name = N'NextRetryAt')
-                  )
-            )
-                DROP INDEX [IX_{receivedPrefix}_Version_NextRetryAt] ON {GetReceivedTableName()};
-
             BEGIN TRY
                 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{receivedPrefix}_Version_NextRetryAt' AND object_id = OBJECT_ID(N'{GetReceivedTableName()}'))
                     CREATE NONCLUSTERED INDEX [IX_{receivedPrefix}_Version_NextRetryAt] ON {GetReceivedTableName()} ([Version] ASC,[IntentType] ASC,[NextRetryAt] ASC) INCLUDE ([Retries],[LockedUntil]) WHERE [NextRetryAt] IS NOT NULL;
@@ -287,21 +271,6 @@ internal sealed class SqlServerStorageInitializer(
             BEGIN CATCH
                 IF ERROR_NUMBER() NOT IN (1913, 2714) THROW;
             END CATCH;
-
-            -- Apply the same migration-safe shape repair to Published retry pickup.
-            IF EXISTS (
-                SELECT 1
-                FROM sys.indexes i
-                WHERE i.name = N'IX_{publishedPrefix}_Version_NextRetryAt'
-                  AND i.object_id = OBJECT_ID(N'{GetPublishedTableName()}')
-                  AND (
-                      (SELECT COUNT(*) FROM sys.index_columns ic WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.is_included_column = 0) <> 3
-                      OR NOT EXISTS (SELECT 1 FROM sys.index_columns ic JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal = 1 AND c.name = N'Version')
-                      OR NOT EXISTS (SELECT 1 FROM sys.index_columns ic JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal = 2 AND c.name = N'IntentType')
-                      OR NOT EXISTS (SELECT 1 FROM sys.index_columns ic JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal = 3 AND c.name = N'NextRetryAt')
-                  )
-            )
-                DROP INDEX [IX_{publishedPrefix}_Version_NextRetryAt] ON {GetPublishedTableName()};
 
             BEGIN TRY
                 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_{publishedPrefix}_Version_NextRetryAt' AND object_id = OBJECT_ID(N'{GetPublishedTableName()}'))

--- a/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
+++ b/tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/SqlServerStorageInitializerTests.cs
@@ -175,7 +175,7 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
     )
     {
         // Pin every equality predicate before the NextRetryAt range so each lane gets an isolated seek.
-        const string schema = "index_shape_test";
+        var schema = $"index_shape_test_{Guid.NewGuid():N}";
         var initializer = _CreateInitializer(schema, useStorageLock: false);
 
         await initializer.InitializeAsync(AbortToken);
@@ -184,17 +184,6 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
         await connection.OpenAsync(AbortToken);
 
         var indexName = indexNamePattern.Replace("{schema}", schema, StringComparison.Ordinal);
-
-        await connection.ExecuteAsync(
-            new CommandDefinition(
-                $"""
-                DROP INDEX [{indexName}] ON [{schema}].[{table}];
-                CREATE NONCLUSTERED INDEX [{indexName}] ON [{schema}].[{table}] ([Version] ASC,[NextRetryAt] ASC) INCLUDE ([Retries],[LockedUntil]) WHERE [NextRetryAt] IS NOT NULL;
-                """,
-                cancellationToken: AbortToken
-            )
-        );
-        await initializer.InitializeAsync(AbortToken);
 
         await _AssertRetryIndexShapeAsync(connection, schema, table, indexName);
 
@@ -208,26 +197,9 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
     }
 
     [Fact]
-    public async Task should_serialize_concurrent_retry_index_repairs()
+    public async Task should_serialize_concurrent_fresh_initialization()
     {
-        const string schema = "concurrent_index_repair_test";
-        var initializer = _CreateInitializer(schema, useStorageLock: false);
-        await initializer.InitializeAsync(AbortToken);
-
-        await using var connection = new SqlConnection(fixture.ConnectionString);
-        await connection.OpenAsync(AbortToken);
-
-        await connection.ExecuteAsync(
-            new CommandDefinition(
-                $"""
-                DROP INDEX [IX_{schema}_Published_Version_NextRetryAt] ON [{schema}].[Published];
-                CREATE NONCLUSTERED INDEX [IX_{schema}_Published_Version_NextRetryAt] ON [{schema}].[Published] ([Version] ASC,[NextRetryAt] ASC) INCLUDE ([Retries],[LockedUntil]) WHERE [NextRetryAt] IS NOT NULL;
-                DROP INDEX [IX_{schema}_Received_Version_NextRetryAt] ON [{schema}].[Received];
-                CREATE NONCLUSTERED INDEX [IX_{schema}_Received_Version_NextRetryAt] ON [{schema}].[Received] ([Version] ASC,[NextRetryAt] ASC) INCLUDE ([Retries],[LockedUntil]) WHERE [NextRetryAt] IS NOT NULL;
-                """,
-                cancellationToken: AbortToken
-            )
-        );
+        var schema = $"concurrent_init_test_{Guid.NewGuid():N}";
 
         var initializationTasks = Enumerable
             .Range(0, 8)
@@ -235,6 +207,9 @@ public sealed class SqlServerStorageInitializerTests(SqlServerTestFixture fixtur
             .ToArray();
 
         await Task.WhenAll(initializationTasks);
+
+        await using var connection = new SqlConnection(fixture.ConnectionString);
+        await connection.OpenAsync(AbortToken);
 
         await _AssertRetryIndexShapeAsync(
             connection,


### PR DESCRIPTION
## Summary

- Fresh SQL Server messaging schemas now create the final lane-qualified retry indexes directly, without carrying a runtime upgrade path for an index shape that has never reached consumers.
- Startup remains serialized across concurrent initializers and still repairs missing objects after partial initialization.

## Related Work

Related: #763

## Scope

Affected packages or domains:

- `Headless.Messaging.Storage.SqlServer`

Out of scope:

- Migration support for databases created by older unpublished builds
- PostgreSQL and other messaging storage providers

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Documentation only
- [ ] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A. This provider is greenfield with no deployed consumers or legacy databases to migrate.
```

## Validation

- [x] Focused build or test for the affected projects
- [ ] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
make build-project-no-restore PROJECT=tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/Headless.Messaging.Storage.SqlServer.Tests.Integration.csproj CONFIGURATION=Release
  Build succeeded, 0 warnings, 0 errors.

make test-project-fast TEST_PROJECT=tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/Headless.Messaging.Storage.SqlServer.Tests.Integration.csproj CONFIGURATION=Release TEST_FILTER='--filter-class "*SqlServerStorageInitializerTests"'
  13 passed, 0 failed, 0 skipped.

make test-project-fast TEST_PROJECT=tests/Headless.Messaging.Storage.SqlServer.Tests.Integration/Headless.Messaging.Storage.SqlServer.Tests.Integration.csproj CONFIGURATION=Release
  150 passed, 0 failed, 0 skipped.

make format-check
  Passed across 4,005 files.

Pre-push incremental Release solution build
  Build succeeded, 0 warnings, 0 errors.

The full repository `make build`, `make test-unit`, and `make test-integration` targets were not run; validation was scoped to the affected provider plus the repository pre-push build.
```

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
The behavior is SQL Server initializer-specific, so shared provider-conformance coverage is not applicable. No public API or documentation contract changed.
```

## Reviewer Guide

The key decision is intentional: a same-named legacy two-column retry index is no longer inspected or upgraded. Review the retained session-scoped application lock and the fresh-schema concurrency test together; they preserve safe concurrent startup while removing only unpublished compatibility behavior.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because no deployed consumers or legacy schemas exist. On the first consuming service startup, normal SQL initialization must complete without errors and both retry indexes must have key order `Version`, `IntentType`, `NextRetryAt`. Roll back by reverting this PR if that greenfield assumption is disproved before release.

## Release Notes

N/A. Internal cleanup before the SQL Server messaging storage provider has consumers.
