### PR TITLE
fix(security): resolve frontend dependency alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # Mirror the local 7-day supply-chain quarantine: don't open PRs for versions published <7 days ago
-    # (majors soak 14 days), so a compromised fresh release isn't auto-proposed before it's flagged.
+    # Mirror the local 7-day supply-chain quarantine for version updates. Majors soak 14 days.
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -125,6 +124,8 @@ updates:
         applies-to: "security-updates"
         patterns:
           - "*"
+    # Dependabot security updates bypass cooldowns; review their release age against the local
+    # 7-day quarantine before merging.
     cooldown:
       default-days: 7
       semver-major-days: 14

--- a/demo/Headless.Tus.Demo/frontend/package-lock.json
+++ b/demo/Headless.Tus.Demo/frontend/package-lock.json
@@ -1348,9 +1348,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
-      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {

--- a/demo/Headless.Tus.Demo/frontend/package.json
+++ b/demo/Headless.Tus.Demo/frontend/package.json
@@ -27,5 +27,8 @@
     "@vitejs/plugin-react": "^6.0.3",
     "typescript": "~5.8.3",
     "vite": "^8.1.4"
+  },
+  "overrides": {
+    "postcss": "8.5.18"
   }
 }

--- a/src/Headless.Jobs.Dashboard/Endpoints/DashboardRequestBodyReader.cs
+++ b/src/Headless.Jobs.Dashboard/Endpoints/DashboardRequestBodyReader.cs
@@ -21,7 +21,7 @@ internal static class DashboardRequestBodyReader
 
         try
         {
-            using var limitedBody = new SizeLimitedReadStream(
+            await using var limitedBody = new SizeLimitedReadStream(
                 context.Request.Body,
                 DashboardOptionsBuilder.MaxRequestBodyBytes,
                 leaveOpen: true

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -2438,16 +2438,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4711,9 +4711,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5038,9 +5038,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -51,8 +51,10 @@
     "vue-tsc": "^3.3.7"
   },
   "overrides": {
+    "brace-expansion": "5.0.8",
     "fast-uri": "3.1.2",
-    "shell-quote": "1.8.4",
+    "postcss": "8.5.18",
+    "shell-quote": "1.9.0",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",
     "@babel/core": "^7.29.6",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -2461,16 +2461,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4666,9 +4666,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4972,9 +4972,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -49,8 +49,10 @@
     "vue-tsc": "^3.3.7"
   },
   "overrides": {
+    "brace-expansion": "5.0.8",
     "fast-uri": "3.1.2",
-    "shell-quote": "1.8.4",
+    "postcss": "8.5.18",
+    "shell-quote": "1.9.0",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",
     "@babel/core": "^7.29.6"


### PR DESCRIPTION
## Summary

The repository's frontend dependency graphs now resolve all five open GitHub high-severity alerts plus the additional high-severity `brace-expansion` advisory found by the official npm audit. The fix pins the first safe, quarantined PostCSS and shell-quote releases, while `brace-expansion@5.0.8` uses the explicitly approved one-time release-age exception after registry provenance, integrity, signing-key, and package-diff verification.

Dependabot's configuration now accurately documents that cooldowns apply to version updates but not security updates, so fresh security releases receive an explicit release-age review instead of a false automated-soak assumption. The Jobs request-body reader also uses async disposal, clearing its scoped analyzer gate without changing the leave-open contract.

Supersedes #769, which only updated PostCSS and selected a release still inside the repository's normal quarantine window.

## Test scenarios

- Fresh script-disabled installs completed for all affected frontend graphs; the authorized `brace-expansion` exception was limited to Jobs and Messaging lock generation and install verification.
- Official-registry `npm audit --audit-level=high` reports 0 vulnerabilities for Tus, Jobs, and Messaging.
- Tus production build passed (283 modules).
- Jobs: lint clean, 34 Vitest tests passed, and the production type-check/build passed.
- Messaging: lint clean, 24 Vitest tests passed, and the production type-check/build passed.
- Jobs and Messaging dashboard project builds passed with 0 warnings and 0 errors.
- Focused Jobs and Messaging analyzer gates passed.
- Jobs composition tests passed: 637/637.
- The full repository analyzer sweep still reports pre-existing informational suggestions outside this diff.

## Review

Independent correctness, supply-chain security, and project-standards passes found no actionable issues. Post-merge verification will confirm GitHub closes the alerts after rescanning the default branch.
