### PR TITLE
feat(jobs): cron misfire detection and skip/coalesce recovery (U6-U8)

### DIFF
--- a/docs/solutions/design-patterns/temporal-authority-standard.md
+++ b/docs/solutions/design-patterns/temporal-authority-standard.md
@@ -98,7 +98,7 @@ Mechanics, per-provider SQL shapes, and the EF-translation caveats: see
 | | PostgreSQL | SQL Server |
 |---|---|---|
 | **Use** | `clock_timestamp()` (real time) | `SYSUTCDATETIME()` (`datetime2`, 100 ns) |
-| **Never** | `now()`, `CURRENT_TIMESTAMP` — **transaction-start time**, frozen for the transaction's life | `GETUTCDATE()` — returns `datetime`, **~3.33 ms** precision, rounded to 1/300 s |
+| **Never** | `now()`, `CURRENT_TIMESTAMP` — **transaction-start time**, frozen for the transaction's life (one narrow carve-out below) | `GETUTCDATE()` — returns `datetime`, **~3.33 ms** precision, rounded to 1/300 s |
 | Column | `timestamptz` | `datetime2(7)` |
 | Atomic claim | `FOR UPDATE SKIP LOCKED` + `UPDATE … RETURNING` | `UPDLOCK, READPAST, ROWLOCK` + `OUTPUT inserted.*` |
 
@@ -112,6 +112,38 @@ instants. `clock_timestamp()` advances *during* execution.
 > native SQL. This is self-consistent inside a single autocommit statement, and silently wrong the moment
 > the call is wrapped in a transaction. Prove provider translation with an integration test; never infer
 > it from LINQ.
+
+#### Carve-out: bounded-staleness position fields
+
+The "never inside a transaction" rule above is written for **lease deadlines**, where the error direction
+is unsafe: a deadline anchored to transaction-open is *shorter* than intended, so a second node can
+reclaim a row while its owner still believes it holds the lease — duplicate execution.
+
+A narrow class of ownership-adjacent timestamps tolerates the same staleness, and Jobs relies on this in
+`ResumeCronJobAsync` and `UpdateCronJobsAtomicallyAsync`, which stamp the cron **schedule watermark**
+(`ReconciledThroughUtc`) from the DB clock inside an already-open transaction. All four conditions must
+hold before treating a field this way:
+
+1. **The write is irreducibly multi-statement.** Those transitions must persist pause state, the schedule
+   revision, and a replacement occurrence together; splitting them to get autocommit would expose a window
+   where a resumed definition still carries its pre-pause position, which is a worse defect than the drift.
+2. **The error direction is benign.** A frozen `now()` makes the watermark *earlier* than true, so at worst
+   one boundary occurrence is reconsidered as pending. The opposite direction — skipping an occurrence —
+   is not reachable.
+3. **The magnitude is bounded by the transaction's own duration**, and the alternative is worse. The app
+   clock is the only other option and reintroduces *unbounded* node skew.
+4. **Nothing evaluates the field as an expiry predicate against a different node's clock.** The moment a
+   field decides ownership, it is a lease and this carve-out does not apply.
+
+Note the magnitude claim weakens with batch size: a loop inside one transaction sees `now()` frozen at
+transaction-open, so the Nth iteration's drift is however long the first N−1 round trips took, not the
+single-digit milliseconds a batch of one costs.
+
+The cron **dispatch advance** deliberately does *not* use this carve-out — it runs in autocommit and is
+guarded by `JobsDatabaseClockConformanceTests.schedule_advance_sql_is_owned_by_the_database_clock`, which
+fails if any schedule-position statement runs inside an explicit transaction. Introduced by the durable
+cron watermark work (#676); if you are adding a fifth site, re-check all four conditions rather than citing
+this precedent.
 
 ## 2. Elapsed time — a monotonic counter is the authority
 

--- a/src/Headless.Jobs.Abstractions/Entities/CronJobEntity.cs
+++ b/src/Headless.Jobs.Abstractions/Entities/CronJobEntity.cs
@@ -73,7 +73,13 @@ public class CronJobEntity : BaseJobEntity
     /// creation from the scheduler-wide setting and persisted here, so every node evaluates the same threshold and
     /// no node's local configuration can decide whether an instant misfired.
     /// </summary>
-    public virtual int MissedRunGraceSeconds { get; set; }
+    /// <remarks>
+    /// A persisted zero — a row migrated from before this column existed — is read as "not yet resolved" and falls
+    /// back to <see cref="JobsRecoveryDefaults.MissedRunGraceSeconds"/>. Zero is not a usable threshold in its own
+    /// right: dispatch is always at or after the scheduled instant, so a zero grace would classify every ordinary
+    /// tick delayed by a garbage collection as a misfire.
+    /// </remarks>
+    public virtual int MissedRunGraceSeconds { get; set; } = JobsRecoveryDefaults.MissedRunGraceSeconds;
 
     /// <summary>
     /// Policy applied when this definition enters recovery. Seeded from the job function attribute at creation and

--- a/src/Headless.Jobs.Abstractions/Interfaces/IJobPersistenceProvider.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/IJobPersistenceProvider.cs
@@ -437,6 +437,38 @@ public interface IJobPersistenceProvider<TTimeJob, TCronJob>
     );
 
     /// <summary>
+    /// Applies a recovery policy to a definition whose watermark fell behind: resolves the occurrences already sitting
+    /// in the missed window, materializes the policy's run or none, and carries the watermark to the recovery instant.
+    /// Returns <see langword="null"/> when the advance fence was lost and nothing was written.
+    /// </summary>
+    /// <param name="request">The observed position to recover from, the policy, and the recovery instant.</param>
+    /// <param name="cancellationToken">Token that aborts the recovery.</param>
+    /// <returns>What the recovery did, or <see langword="null"/> when another node recovered first.</returns>
+    /// <remarks>
+    /// Fenced by the same compare-and-advance as ordinary dispatch, so concurrent nodes recovering the same backlog
+    /// produce exactly one winner and the loser writes nothing.
+    /// <para>
+    /// Unlike the ordinary advance this is expected to be one <b>transaction</b>, not one statement: the occurrence
+    /// resolution and the watermark move must not interleave, or a crash between them leaves the backlog partly
+    /// resolved with the watermark already past it. That is safe here specifically because
+    /// <see cref="CronRecoveryRequest.RecoveredThroughUtc"/> is a caller-supplied store instant rather than a live
+    /// clock read, so no database-clock expression is frozen at transaction open.
+    /// </para>
+    /// <para>
+    /// Occurrence resolution follows the not-yet-executing boundary the pause path already uses. An <c>Idle</c> or
+    /// <c>Queued</c> row in the window is the policy's to resolve — repurposed as the coalesced run with its ownership
+    /// revoked so its former owner's in-progress stamp fails and it drops the row, or transitioned to skipped. An
+    /// <c>InProgress</c> or terminal row is stepped past untouched, and its instant is never duplicated: an occurrence
+    /// already running or already finished has accounted for that instant.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was signalled.</exception>
+    Task<CronRecoveryResult<TCronJob>?> ApplyCronRecoveryAsync(
+        CronRecoveryRequest request,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Recovers the time jobs held by a node that coordination has declared dead, applying each row's
     /// <c>OnNodeDeath</c> policy: <c>Retry</c> → released to <c>Idle</c>, <c>MarkFailed</c> → <c>Failed</c>,
     /// <c>Skip</c> → <c>Skipped</c>.

--- a/src/Headless.Jobs.Abstractions/JobsRecoveryDefaults.cs
+++ b/src/Headless.Jobs.Abstractions/JobsRecoveryDefaults.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Jobs;
+
+/// <summary>Framework-level defaults for cron misfire detection and recovery.</summary>
+[PublicAPI]
+public static class JobsRecoveryDefaults
+{
+    /// <summary>
+    /// Seconds of lateness tolerated before a single pending occurrence counts as a misfire.
+    /// </summary>
+    /// <remarks>
+    /// Matches Quartz.NET's misfire threshold. A grace of zero is not a meaningful setting: every dispatch is
+    /// necessarily at or after its scheduled instant, so a zero threshold would make an ordinary tick delayed by a
+    /// garbage collection or a thread-pool stall indistinguishable from a genuine misfire and route routine work into
+    /// recovery. A definition persisting zero is therefore treated as "not yet resolved" and falls back to this value.
+    /// </remarks>
+    public const int MissedRunGraceSeconds = 60;
+
+    /// <summary>
+    /// Maximum occurrences enumerated when counting a backlog, after which the count is reported as a lower bound.
+    /// </summary>
+    /// <remarks>
+    /// Bounds reporting only — never the decision. Whether a definition enters recovery is known after at most two
+    /// evaluations (more than one pending instant, or one older than the grace threshold), so the ceiling can never
+    /// change the outcome. It exists because a seconds-resolution schedule after a long outage would otherwise walk
+    /// millions of instants to produce a number nothing acts on.
+    /// </remarks>
+    public const int EvaluationCeiling = 1000;
+}

--- a/src/Headless.Jobs.Abstractions/Models/CronDispatchCandidate.cs
+++ b/src/Headless.Jobs.Abstractions/Models/CronDispatchCandidate.cs
@@ -43,6 +43,15 @@ public sealed record CronDispatchCandidate
 
     /// <summary>Node-death policy, carried onto materialized occurrences.</summary>
     public required NodeDeathPolicy OnNodeDeath { get; init; }
+
+    /// <summary>
+    /// The definition's own persisted misfire grace, so every node evaluates the same threshold for it rather than
+    /// each applying its local configuration.
+    /// </summary>
+    public required int MissedRunGraceSeconds { get; init; }
+
+    /// <summary>The definition's persisted recovery policy, applied when its watermark falls behind.</summary>
+    public required MissedRunPolicy OnMissedRun { get; init; }
 }
 
 /// <summary>

--- a/src/Headless.Jobs.Abstractions/Models/CronRecovery.cs
+++ b/src/Headless.Jobs.Abstractions/Models/CronRecovery.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+
+namespace Headless.Jobs.Models;
+
+/// <summary>
+/// Applies a recovery policy to a cron definition whose watermark fell behind: resolves whatever occurrences already
+/// sit in the missed window, materializes the policy's run (or none), and carries the watermark to the recovery
+/// instant — as one step, so no interleaving can leave the backlog half-resolved.
+/// </summary>
+[PublicAPI]
+public sealed record CronRecoveryRequest
+{
+    /// <summary>The cron definition entering recovery.</summary>
+    public required Guid CronJobId { get; init; }
+
+    /// <summary>The exact durable watermark the caller observed. Also the exclusive lower bound of the missed window.</summary>
+    public required DateTime ObservedReconciledThroughUtc { get; init; }
+
+    /// <summary>The exact durable schedule revision the caller observed.</summary>
+    public required long ExpectedScheduleRevision { get; init; }
+
+    /// <summary>
+    /// The recovery instant — the store instant recovery ran at. Becomes the new watermark and the inclusive upper
+    /// bound of the missed window, so the backlog it resolved is never reconsidered.
+    /// </summary>
+    public required DateTime RecoveredThroughUtc { get; init; }
+
+    /// <summary>The projection to persist: the first occurrence after <see cref="RecoveredThroughUtc"/>.</summary>
+    public required DateTime NextDueUtc { get; init; }
+
+    /// <summary>Which policy resolves the backlog.</summary>
+    public required MissedRunPolicy Policy { get; init; }
+
+    /// <summary>
+    /// First occurrence after the observed watermark. The coalesced run's scheduled instant and its durable recovery
+    /// stamp, and exact even when the backlog count saturated, because it is the first instant the walk visits.
+    /// </summary>
+    public required DateTime EarliestMissedUtc { get; init; }
+
+    /// <summary>Identifier to use when the coalesced run has to be created rather than repurposed.</summary>
+    public required Guid CoalescedOccurrenceId { get; init; }
+
+    /// <summary>Node-death policy stamped onto a materialized or repurposed run.</summary>
+    public NodeDeathPolicy OnNodeDeath { get; init; } = NodeDeathPolicy.Retry;
+
+    /// <summary>Observational timestamp for audit fields on rows this recovery touches.</summary>
+    public required DateTimeOffset OperationTimeUtc { get; init; }
+}
+
+/// <summary>What a recovery actually did, read back from the store.</summary>
+/// <typeparam name="TCronJob">The application's concrete cron job entity type.</typeparam>
+[PublicAPI]
+public sealed record CronRecoveryResult<TCronJob>
+    where TCronJob : CronJobEntity, new()
+{
+    /// <summary>
+    /// The single run standing in for the backlog, or <see langword="null"/> under skip — and also under coalesce when
+    /// the earliest missed instant was already occupied, since a second row there would duplicate it.
+    /// </summary>
+    public CronJobOccurrenceEntity<TCronJob>? CoalescedRun { get; init; }
+
+    /// <summary>Not-yet-executing occurrences in the missed window transitioned to skipped.</summary>
+    public required int SkippedOccurrenceCount { get; init; }
+
+    /// <summary>The persisted watermark after recovery.</summary>
+    public required DateTime ReconciledThroughUtc { get; init; }
+
+    /// <summary>The persisted projection after recovery.</summary>
+    public required DateTime NextDueUtc { get; init; }
+}

--- a/src/Headless.Jobs.Abstractions/Models/CronRecovery.cs
+++ b/src/Headless.Jobs.Abstractions/Models/CronRecovery.cs
@@ -35,10 +35,20 @@ public sealed record CronRecoveryRequest
     public required MissedRunPolicy Policy { get; init; }
 
     /// <summary>
-    /// First occurrence after the observed watermark. The coalesced run's scheduled instant and its durable recovery
-    /// stamp, and exact even when the backlog count saturated, because it is the first instant the walk visits.
+    /// First occurrence after the observed watermark. The coalesced run's preferred scheduled instant and durable
+    /// recovery stamp, and exact even when the backlog count saturated, because it is the first instant the walk
+    /// visits.
     /// </summary>
     public required DateTime EarliestMissedUtc { get; init; }
+
+    /// <summary>
+    /// Every missed instant the evaluation walk visited, in schedule order — the first element is
+    /// <see cref="EarliestMissedUtc"/>, and the list is bounded by the evaluation ceiling. Coalesce materializes its
+    /// run at the FIRST of these not already accounted for by an executing or terminal occurrence (R7 steps past an
+    /// occupied instant; R18 still owes the backlog a run when later instants were genuinely missed). Transient
+    /// input only — never persisted (KD13).
+    /// </summary>
+    public required IReadOnlyList<DateTime> MissedInstantsUtc { get; init; }
 
     /// <summary>Identifier to use when the coalesced run has to be created rather than repurposed.</summary>
     public required Guid CoalescedOccurrenceId { get; init; }
@@ -57,8 +67,10 @@ public sealed record CronRecoveryResult<TCronJob>
     where TCronJob : CronJobEntity, new()
 {
     /// <summary>
-    /// The single run standing in for the backlog, or <see langword="null"/> under skip — and also under coalesce when
-    /// the earliest missed instant was already occupied, since a second row there would duplicate it.
+    /// The single run standing in for the backlog, or <see langword="null"/> under skip — and under coalesce only
+    /// when EVERY missed instant is already accounted for by an executing or terminal occurrence. Its
+    /// <c>ExecutionTime</c> is the earliest unaccounted-for instant, which is later than the earliest missed
+    /// instant when recovery stepped past occupied ones.
     /// </summary>
     public CronJobOccurrenceEntity<TCronJob>? CoalescedRun { get; init; }
 

--- a/src/Headless.Jobs.Core/CronPendingEvaluation.cs
+++ b/src/Headless.Jobs.Core/CronPendingEvaluation.cs
@@ -29,11 +29,18 @@ internal readonly record struct CronPendingEvaluation
     public bool CountSaturated { get; init; }
 
     /// <summary>
+    /// Every pending instant the walk visited, in schedule order — the first element is
+    /// <see cref="EarliestPendingUtc"/>. Bounded by the evaluation ceiling. Coalesce recovery walks this list to
+    /// find the earliest instant not already accounted for by an executing or terminal occurrence.
+    /// </summary>
+    public IReadOnlyList<DateTime> PendingInstantsUtc { get; init; }
+
+    /// <summary>
     /// Whether this backlog is a misfire: more than one pending instant, or a single one older than the definition's
     /// grace threshold. Decided from the watermark, never from a complete count.
     /// </summary>
     public bool IsRecovery { get; init; }
 
     /// <summary>Nothing pending — the schedule is fully reconciled as of the evaluated instant.</summary>
-    public static CronPendingEvaluation None => new();
+    public static CronPendingEvaluation None => new() { PendingInstantsUtc = [] };
 }

--- a/src/Headless.Jobs.Core/CronPendingEvaluation.cs
+++ b/src/Headless.Jobs.Core/CronPendingEvaluation.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Jobs;
+
+/// <summary>
+/// What a definition's schedule owes as of one store instant: the occurrences that fall at or before it which the
+/// watermark has not yet passed, and whether that backlog is a misfire rather than ordinary lateness.
+/// </summary>
+/// <remarks>
+/// Pending-ness is a property of the schedule and the watermark alone — an instant is pending whether or not an
+/// occurrence row was ever materialized for it. That is the whole point of a durable watermark: a process that died
+/// mid-sleep left no row behind, so a row-based definition of "missed" could not see it.
+/// </remarks>
+internal readonly record struct CronPendingEvaluation
+{
+    /// <summary>
+    /// First occurrence after the watermark, or <see langword="null"/> when nothing is pending. Always exact, even when
+    /// the count saturated, because it is the first instant the walk visits.
+    /// </summary>
+    public DateTime? EarliestPendingUtc { get; init; }
+
+    /// <summary>Last pending instant the walk reached. Equals the earliest when exactly one is pending.</summary>
+    public DateTime? LatestPendingUtc { get; init; }
+
+    /// <summary>Pending occurrences counted. A lower bound when <see cref="CountSaturated"/> is set.</summary>
+    public int PendingCount { get; init; }
+
+    /// <summary>Whether the walk stopped at the evaluation ceiling with more pending instants beyond it.</summary>
+    public bool CountSaturated { get; init; }
+
+    /// <summary>
+    /// Whether this backlog is a misfire: more than one pending instant, or a single one older than the definition's
+    /// grace threshold. Decided from the watermark, never from a complete count.
+    /// </summary>
+    public bool IsRecovery { get; init; }
+
+    /// <summary>Nothing pending — the schedule is fully reconciled as of the evaluated instant.</summary>
+    public static CronPendingEvaluation None => new();
+}

--- a/src/Headless.Jobs.Core/CronScheduleCache.cs
+++ b/src/Headless.Jobs.Core/CronScheduleCache.cs
@@ -129,6 +129,7 @@ internal sealed partial class CronScheduleCache(TimeZoneInfo timeZoneInfo)
         DateTime? latest = null;
         var count = 0;
         var cursor = reconciledThroughUtc;
+        var instants = new List<DateTime>();
 
         while (count < ceiling)
         {
@@ -142,6 +143,7 @@ internal sealed partial class CronScheduleCache(TimeZoneInfo timeZoneInfo)
             earliest ??= next.Value;
             latest = next.Value;
             cursor = next.Value;
+            instants.Add(next.Value);
             count++;
         }
 
@@ -165,6 +167,7 @@ internal sealed partial class CronScheduleCache(TimeZoneInfo timeZoneInfo)
             LatestPendingUtc = latest,
             PendingCount = count,
             CountSaturated = saturated,
+            PendingInstantsUtc = instants,
             IsRecovery = isRecovery,
         };
     }

--- a/src/Headless.Jobs.Core/CronScheduleCache.cs
+++ b/src/Headless.Jobs.Core/CronScheduleCache.cs
@@ -92,6 +92,83 @@ internal sealed partial class CronScheduleCache(TimeZoneInfo timeZoneInfo)
         return TimeZoneInfo.ConvertTimeToUtc(localTime, timeZone);
     }
 
+    /// <summary>
+    /// Walks the schedule forward from <paramref name="reconciledThroughUtc"/> to decide what it owes as of
+    /// <paramref name="storeUtcNow"/>, and whether that backlog is a misfire.
+    /// </summary>
+    /// <remarks>
+    /// Evaluation goes through <see cref="GetNextOccurrenceOrDefault(string, DateTime, string?)"/> so the DST gap and
+    /// overlap rules are applied exactly once, here as on the dispatch path. Re-deriving them would let a definition's
+    /// backlog disagree with its own projection across a transition.
+    /// <para>
+    /// A paused span needs no special case: pause suspends selection and resume rebases the watermark to the resume
+    /// instant, so the paused interval is never between the watermark and now and cannot produce a pending instant.
+    /// </para>
+    /// <para>
+    /// The recovery decision is settled by the second pending instant at the latest, so the walk continues past that
+    /// point purely to report a count. Both instants it returns stay exact regardless of saturation, because the walk
+    /// visits them in order.
+    /// </para>
+    /// </remarks>
+    public CronPendingEvaluation EvaluatePending(
+        string expression,
+        string? timeZoneId,
+        DateTime reconciledThroughUtc,
+        DateTime storeUtcNow,
+        int graceSeconds,
+        int evaluationCeiling = JobsRecoveryDefaults.EvaluationCeiling
+    )
+    {
+        var ceiling = evaluationCeiling > 0 ? evaluationCeiling : JobsRecoveryDefaults.EvaluationCeiling;
+
+        // A zero or negative persisted grace means the definition predates grace resolution; every dispatch is
+        // necessarily at or after its instant, so honoring zero would classify routine lateness as a misfire.
+        var grace = graceSeconds > 0 ? graceSeconds : JobsRecoveryDefaults.MissedRunGraceSeconds;
+
+        DateTime? earliest = null;
+        DateTime? latest = null;
+        var count = 0;
+        var cursor = reconciledThroughUtc;
+
+        while (count < ceiling)
+        {
+            var next = GetNextOccurrenceOrDefault(expression, cursor, timeZoneId);
+
+            if (next is null || next.Value > storeUtcNow)
+            {
+                break;
+            }
+
+            earliest ??= next.Value;
+            latest = next.Value;
+            cursor = next.Value;
+            count++;
+        }
+
+        if (count == 0)
+        {
+            return CronPendingEvaluation.None;
+        }
+
+        // Saturated only when the walk stopped at the ceiling AND another pending instant exists past it, so a backlog
+        // that lands exactly on the ceiling still reports an exact count.
+        var saturated =
+            count == ceiling
+            && GetNextOccurrenceOrDefault(expression, cursor, timeZoneId) is { } beyond
+            && beyond <= storeUtcNow;
+
+        var isRecovery = count > 1 || earliest!.Value < storeUtcNow.AddSeconds(-grace);
+
+        return new CronPendingEvaluation
+        {
+            EarliestPendingUtc = earliest,
+            LatestPendingUtc = latest,
+            PendingCount = count,
+            CountSaturated = saturated,
+            IsRecovery = isRecovery,
+        };
+    }
+
     public bool Invalidate(string expression)
     {
         return _cache.TryRemove(_Normalize(expression), out _);

--- a/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
@@ -430,7 +430,12 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
                         wave[index] =
                             candidate.NextDueUtc == default
                                 ? _InitializeAndSkipDispatchAsync(candidate, candidates.StoreUtcNow, cancellationToken)
-                                : _TryAdvanceForDispatchAsync(candidate, existing, cancellationToken);
+                                : _TryAdvanceForDispatchAsync(
+                                    candidate,
+                                    existing,
+                                    candidates.StoreUtcNow,
+                                    cancellationToken
+                                );
                     }
 
                     var waveResults = await Task.WhenAll(wave).ConfigureAwait(false);
@@ -554,15 +559,122 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
     }
 
     /// <summary>
+    /// Resolves a backlog under the definition's recovery policy and, when a run was produced, returns the dispatch
+    /// context that will claim it.
+    /// </summary>
+    /// <remarks>
+    /// The watermark lands on the recovery instant under both policies (R20), so the backlog they resolved is never
+    /// reconsidered. A schedule whose interval is shorter than the wake latency will legitimately re-enter recovery on
+    /// the following wake — that is the correct outcome, not a fault.
+    /// </remarks>
+    private async Task<JobManagerDispatchContext?> _ApplyRecoveryForDispatchAsync(
+        CronDispatchCandidate candidate,
+        CronPendingEvaluation pending,
+        DateTime earliestMissedUtc,
+        DateTime storeUtcNow,
+        CancellationToken cancellationToken
+    )
+    {
+        // The projection restarts from the recovery instant, not from the backlog, so nothing already resolved can be
+        // selected again.
+        var nextAfterRecovery = cronScheduleCache.GetNextOccurrenceOrDefault(
+            candidate.Expression,
+            storeUtcNow,
+            candidate.TimeZoneId
+        );
+
+        var recovery = await persistenceProvider
+            .ApplyCronRecoveryAsync(
+                new CronRecoveryRequest
+                {
+                    CronJobId = candidate.CronJobId,
+                    ObservedReconciledThroughUtc = candidate.ReconciledThroughUtc,
+                    ExpectedScheduleRevision = candidate.ScheduleRevision,
+                    RecoveredThroughUtc = storeUtcNow,
+                    NextDueUtc = nextAfterRecovery ?? DateTime.MaxValue,
+                    Policy = candidate.OnMissedRun,
+                    EarliestMissedUtc = earliestMissedUtc,
+                    CoalescedOccurrenceId = guidGenerator.Create(),
+                    OnNodeDeath = candidate.OnNodeDeath,
+                    OperationTimeUtc = timeProvider.GetUtcNow(),
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        if (recovery is null)
+        {
+            // Another node recovered this backlog first. Ordinary on a cluster; nothing was written by this node.
+            return null;
+        }
+
+        logger.LogCronRecoveryApplied(
+            candidate.CronJobId,
+            candidate.FunctionName,
+            candidate.OnMissedRun.ToString(),
+            pending.PendingCount,
+            pending.CountSaturated,
+            earliestMissedUtc,
+            pending.LatestPendingUtc ?? earliestMissedUtc,
+            storeUtcNow,
+            recovery.SkippedOccurrenceCount
+        );
+
+        if (recovery.CoalescedRun is null)
+        {
+            // Skip materialized nothing, or coalesce found the earliest missed instant already occupied by a row that
+            // is running or has finished. Either way there is nothing for this wake to claim.
+            return null;
+        }
+
+        return new JobManagerDispatchContext(candidate.CronJobId)
+        {
+            FunctionName = candidate.FunctionName,
+            Expression = candidate.Expression,
+            TimeZoneId = candidate.TimeZoneId,
+            IsPaused = false,
+            ScheduleRevision = candidate.ScheduleRevision,
+            Retries = candidate.Retries,
+            RetryIntervals = candidate.RetryIntervals,
+            OnNodeDeath = candidate.OnNodeDeath,
+            NextCronOccurrence = new NextCronOccurrence(recovery.CoalescedRun.Id, recovery.CoalescedRun.CreatedAt),
+        };
+    }
+
+    /// <summary>
     /// Advances one due definition's watermark and, when it wins the fence, returns the dispatch context for the
     /// instant it just claimed responsibility for.
     /// </summary>
     private async Task<JobManagerDispatchContext?> _TryAdvanceForDispatchAsync(
         CronDispatchCandidate candidate,
         NextCronOccurrence? existingOccurrence,
+        DateTime storeUtcNow,
         CancellationToken cancellationToken
     )
     {
+        // Misfire check before ordinary dispatch. A definition whose watermark fell behind must not be dispatched one
+        // tick at a time — that would replay the whole backlog occurrence by occurrence, which is the behavior the
+        // recovery policies exist to replace.
+        var pending = cronScheduleCache.EvaluatePending(
+            candidate.Expression,
+            candidate.TimeZoneId,
+            candidate.ReconciledThroughUtc,
+            storeUtcNow,
+            candidate.MissedRunGraceSeconds
+        );
+
+        if (pending.IsRecovery && pending.EarliestPendingUtc is { } earliestMissed)
+        {
+            return await _ApplyRecoveryForDispatchAsync(
+                    candidate,
+                    pending,
+                    earliestMissed,
+                    storeUtcNow,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
         // The only expression evaluation on this path, and only for a definition that is actually due. Deriving a fire
         // time from an expression is tz-database authority and stays here (KTD2); the store owns due-ness and the
         // fence, never the derivation.
@@ -1140,6 +1252,30 @@ internal static partial class InternalJobsManagerLog
             + "fallback sweep's set-based reconcile instead. Scheduling continues."
     )]
     public static partial void LogTimedChildSafetyNetFailed(this ILogger logger, Exception exception);
+
+    // MissedCount is a lower bound whenever CountSaturated is true — the walk stops at the evaluation ceiling rather
+    // than enumerating an unbounded backlog. The two are logged together so an operator can tell "exactly 3 missed"
+    // from "at least 1000 missed"; reporting a saturated count as exact is the misreading this pairing prevents.
+    [LoggerMessage(
+        EventId = 3220,
+        Level = LogLevel.Warning,
+        Message = "Cron definition {CronJobId} ({Function}) fell behind and was recovered with policy {Policy}: "
+            + "{MissedCount} missed occurrence(s) (lower bound: {CountSaturated}) spanning {EarliestMissedUtc:O} to "
+            + "{LatestMissedUtc:O}; watermark advanced to {RecoveredThroughUtc:O} and {SkippedCount} pending "
+            + "occurrence(s) were skipped."
+    )]
+    public static partial void LogCronRecoveryApplied(
+        this ILogger logger,
+        Guid cronJobId,
+        string function,
+        string policy,
+        int missedCount,
+        bool countSaturated,
+        DateTime earliestMissedUtc,
+        DateTime latestMissedUtc,
+        DateTime recoveredThroughUtc,
+        int skippedCount
+    );
 
     [LoggerMessage(
         EventId = 3215,

--- a/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
@@ -321,6 +321,10 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
     // anything beyond this lands on the following wake. Sized well above any realistic same-instant tie count.
     private const int _MaxCronDispatchCandidates = 64;
 
+    // Concurrent advances per wave. Sized so one wave covers a single advance's round-trip latency without letting a
+    // cluster open (nodes x tie-group) connections at once; the pool, not the CPU, is the scarce resource here.
+    private const int _MaxAdvanceConcurrency = 8;
+
     private async Task<(DateTime Key, JobManagerDispatchContext[] Items)?> _GetEarliestCronJobGroupAsync(
         CancellationToken cancellationToken = default
     )
@@ -377,45 +381,68 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
             // The advance re-asserts it atomically, so this comparison selects work rather than authorizing it.
             if (!storedWinsOutright && earliestProjection <= candidates.StoreUtcNow)
             {
-                foreach (var candidate in candidates.Candidates)
+                // Ordered by projection, so the tie group is a prefix.
+                var tieGroup = candidates.Candidates.TakeWhile(x => x.NextDueUtc == earliestProjection).ToArray();
+
+                // Pair each candidate with the already-materialized occurrence it reuses BEFORE any I/O starts. This
+                // is a pure comparison, and resolving it up front is what lets the advances run concurrently without
+                // racing on `storedConsumed`.
+                //
+                // R6: a row already sitting at this instant is REUSED, not duplicated. Carrying it as
+                // NextCronOccurrence makes the claim path take the existing row while the watermark still advances
+                // past the instant — skipping the advance instead would leave the definition due forever.
+                var reuse = new NextCronOccurrence?[tieGroup.Length];
+                for (var index = 0; index < tieGroup.Length; index++)
                 {
-                    if (candidate.NextDueUtc != earliestProjection)
-                    {
-                        break; // ordered by projection, so the tie group ends here
-                    }
-
-                    // R9: a definition with no position yet — seeded before this field existed, or created by a path
-                    // that did not set it — is initialized from the CREATION rule (watermark at the store's instant)
-                    // and never from its occurrence history. That is what makes an upgrade unable to replay a
-                    // backlog: an unset watermark sorts first and would otherwise look infinitely behind.
-                    if (candidate.NextDueUtc == default)
-                    {
-                        await _InitializeSchedulePositionAsync(candidate, candidates.StoreUtcNow, cancellationToken)
-                            .ConfigureAwait(false);
-
-                        continue;
-                    }
-
-                    // R6: a row already sitting at this instant is REUSED, not duplicated. Carrying it as
-                    // NextCronOccurrence makes the claim path take the existing row while the watermark still advances
-                    // past the instant — skipping the advance instead would leave the definition due forever.
-                    NextCronOccurrence? existing = null;
                     if (
                         earliestStored is not null
-                        && earliestStored.CronJobId == candidate.CronJobId
-                        && earliestStored.ExecutionTime == candidate.NextDueUtc
+                        && earliestStored.CronJobId == tieGroup[index].CronJobId
+                        && earliestStored.ExecutionTime == tieGroup[index].NextDueUtc
                     )
                     {
-                        existing = new NextCronOccurrence(earliestStored.Id, earliestStored.CreatedAt);
+                        reuse[index] = new NextCronOccurrence(earliestStored.Id, earliestStored.CreatedAt);
                         storedConsumed = true;
                     }
+                }
 
-                    var context = await _TryAdvanceForDispatchAsync(candidate, existing, cancellationToken)
-                        .ConfigureAwait(false);
+                // Each candidate targets a disjoint row fenced by its own watermark/revision CAS, so concurrent
+                // advances across different definitions never contend and the exactly-one-winner guarantee is
+                // unchanged. Serializing them cost 815ms for a 64-definition group against a real PostgreSQL
+                // container (12.7ms each); running them in bounded waves cut that to 127ms. That is not a
+                // micro-optimization on this path — a wake stalls the whole node's scheduling loop, and the first
+                // wake after this feature migrates in is exactly a maximal tie group, because every legacy row shares
+                // the same unset projection. The bound keeps an N-node cluster from opening N x group-size
+                // connections at once.
+                for (var offset = 0; offset < tieGroup.Length; offset += _MaxAdvanceConcurrency)
+                {
+                    var waveLength = Math.Min(_MaxAdvanceConcurrency, tieGroup.Length - offset);
+                    var wave = new Task<JobManagerDispatchContext?>[waveLength];
 
-                    if (context is not null)
+                    for (var index = 0; index < waveLength; index++)
                     {
-                        (dispatched ??= []).Add(context);
+                        var candidate = tieGroup[offset + index];
+                        var existing = reuse[offset + index];
+
+                        // R9: a definition with no position yet — seeded before this field existed, or created by a
+                        // path that did not set it — is initialized from the CREATION rule (watermark at the store's
+                        // instant) and never from its occurrence history. That is what makes an upgrade unable to
+                        // replay a backlog: an unset watermark sorts first and would otherwise look infinitely behind.
+                        wave[index] =
+                            candidate.NextDueUtc == default
+                                ? _InitializeAndSkipDispatchAsync(candidate, candidates.StoreUtcNow, cancellationToken)
+                                : _TryAdvanceForDispatchAsync(candidate, existing, cancellationToken);
+                    }
+
+                    var waveResults = await Task.WhenAll(wave).ConfigureAwait(false);
+
+                    // Appended in candidate order: the claim path preserves the order it is given, and a wave-ordered
+                    // result set would make dispatch order depend on completion timing.
+                    foreach (var context in waveResults)
+                    {
+                        if (context is not null)
+                        {
+                            (dispatched ??= []).Add(context);
+                        }
                     }
                 }
 
@@ -484,6 +511,21 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
     /// nodes initializing the same definition converge on one position instead of racing. Nothing is dispatched on
     /// this wake; the definition becomes selectable at its real projection on the next one.
     /// </remarks>
+    /// <summary>
+    /// Initializes a positionless definition and dispatches nothing this wake, so it can share the advance wave's
+    /// result shape. The definition becomes selectable at its real projection on the next wake.
+    /// </summary>
+    private async Task<JobManagerDispatchContext?> _InitializeAndSkipDispatchAsync(
+        CronDispatchCandidate candidate,
+        DateTime storeUtcNow,
+        CancellationToken cancellationToken
+    )
+    {
+        await _InitializeSchedulePositionAsync(candidate, storeUtcNow, cancellationToken).ConfigureAwait(false);
+
+        return null;
+    }
+
     private async Task _InitializeSchedulePositionAsync(
         CronDispatchCandidate candidate,
         DateTime storeUtcNow,

--- a/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
@@ -594,6 +594,7 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
                     NextDueUtc = nextAfterRecovery ?? DateTime.MaxValue,
                     Policy = candidate.OnMissedRun,
                     EarliestMissedUtc = earliestMissedUtc,
+                    MissedInstantsUtc = pending.PendingInstantsUtc,
                     CoalescedOccurrenceId = guidGenerator.Create(),
                     OnNodeDeath = candidate.OnNodeDeath,
                     OperationTimeUtc = timeProvider.GetUtcNow(),
@@ -622,8 +623,17 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
 
         if (recovery.CoalescedRun is null)
         {
-            // Skip materialized nothing, or coalesce found the earliest missed instant already occupied by a row that
-            // is running or has finished. Either way there is nothing for this wake to claim.
+            // Skip materialized nothing, or coalesce found every missed instant already accounted for by executing or
+            // terminal rows. Either way there is nothing for this wake to claim.
+            return null;
+        }
+
+        if (recovery.CoalescedRun.ExecutionTime != earliestMissedUtc)
+        {
+            // Coalesce stepped past the occupied earliest instant, so the run's instant no longer matches this
+            // wake's dispatch key and the keyed claim would find zero rows. The run is durably Idle at a past
+            // instant — exactly the shape the timed-out sweep claims (~1s), the same path that already recovers a
+            // coalesced run whose caller crashed after commit. Deliberately deferred rather than re-keyed.
             return null;
         }
 

--- a/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
+++ b/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
@@ -1453,57 +1453,68 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
                 )
                 .ToArray();
 
-            // A live row takes precedence over a terminal one sharing the instant.
-            var atEarliest = inWindow
-                .Where(x => x.ExecutionTime == request.EarliestMissedUtc)
-                .OrderBy(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress ? 0 : 1)
-                .FirstOrDefault();
-
             CronJobOccurrenceEntity<TCronJob>? coalescedRun = null;
             var repurposedId = Guid.Empty;
 
             if (request.Policy is MissedRunPolicy.Coalesce)
             {
-                if (atEarliest is null)
+                // R18 owes the backlog exactly one run; R7 forbids duplicating an instant an executing or terminal
+                // row already accounts for. Walk the missed instants in schedule order and materialize at the FIRST
+                // unaccounted-for one — an occupied instant is stepped past (AE9, AE10), never duplicated, and only
+                // a fully-accounted-for backlog produces no run at all. Mirrors the relational provider.
+                foreach (var missedInstant in request.MissedInstantsUtc)
                 {
-                    var created = new CronJobOccurrenceEntity<TCronJob>
+                    // A live row takes precedence over a terminal one sharing the instant.
+                    var atInstant = inWindow
+                        .Where(x => x.ExecutionTime == missedInstant)
+                        .OrderBy(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress ? 0 : 1)
+                        .FirstOrDefault();
+
+                    if (atInstant is null)
                     {
-                        Id = request.CoalescedOccurrenceId,
-                        CronJobId = request.CronJobId,
-                        Status = JobStatus.Idle,
-                        OwnerId = null,
-                        LockedUntil = null,
-                        ExecutionTime = request.EarliestMissedUtc,
-                        RecoveredFromUtc = request.EarliestMissedUtc,
-                        OnNodeDeath = request.OnNodeDeath,
-                        CreatedAt = request.OperationTimeUtc,
-                        UpdatedAt = request.OperationTimeUtc,
-                        // Execution reads Function off this navigation; the relational provider gets it from an
-                        // Include on the claim read, so attach it here to keep the two providers interchangeable.
-                        CronJob = current,
-                    };
+                        var created = new CronJobOccurrenceEntity<TCronJob>
+                        {
+                            Id = request.CoalescedOccurrenceId,
+                            CronJobId = request.CronJobId,
+                            Status = JobStatus.Idle,
+                            OwnerId = null,
+                            LockedUntil = null,
+                            ExecutionTime = missedInstant,
+                            RecoveredFromUtc = missedInstant,
+                            OnNodeDeath = request.OnNodeDeath,
+                            CreatedAt = request.OperationTimeUtc,
+                            UpdatedAt = request.OperationTimeUtc,
+                            // Execution reads Function off this navigation; the relational provider gets it from an
+                            // Include on the claim read, so attach it here to keep the two providers interchangeable.
+                            CronJob = current,
+                        };
 
-                    _cronOccurrences[created.Id] = created;
-                    coalescedRun = _CloneCronOccurrence(created);
-                }
-                else if (atEarliest.Status is JobStatus.Idle or JobStatus.Queued)
-                {
-                    // KTD5: clearing the owner is the whole mechanism — the claim path's in-progress transition
-                    // requires OwnerId == owner, so the prior owner fails that predicate and drops the row.
-                    repurposedId = atEarliest.Id;
-                    var repurposed = _CloneCronOccurrence(atEarliest);
-                    repurposed.Status = JobStatus.Idle;
-                    repurposed.OwnerId = null;
-                    repurposed.LockedUntil = null;
-                    repurposed.RecoveredFromUtc = request.EarliestMissedUtc;
-                    repurposed.UpdatedAt = request.OperationTimeUtc;
-                    repurposed.CronJob ??= current;
-                    _cronOccurrences[repurposed.Id] = repurposed;
-                    coalescedRun = _CloneCronOccurrence(repurposed);
-                }
+                        _cronOccurrences[created.Id] = created;
+                        coalescedRun = _CloneCronOccurrence(created);
+                        break;
+                    }
 
-                // Otherwise the instant is occupied by a row that is executing or already finished; it has accounted
-                // for that instant, so recovery steps past rather than duplicating it.
+                    if (atInstant.Status is JobStatus.Idle or JobStatus.Queued)
+                    {
+                        // KTD5: clearing the owner is the whole mechanism — the claim path's in-progress transition
+                        // requires OwnerId == owner, so the prior owner fails that predicate and drops the row.
+                        // Unlike the relational provider no re-check CAS is needed: the per-definition lock already
+                        // serializes this against every status transition.
+                        repurposedId = atInstant.Id;
+                        var repurposed = _CloneCronOccurrence(atInstant);
+                        repurposed.Status = JobStatus.Idle;
+                        repurposed.OwnerId = null;
+                        repurposed.LockedUntil = null;
+                        repurposed.RecoveredFromUtc = missedInstant;
+                        repurposed.UpdatedAt = request.OperationTimeUtc;
+                        repurposed.CronJob ??= current;
+                        _cronOccurrences[repurposed.Id] = repurposed;
+                        coalescedRun = _CloneCronOccurrence(repurposed);
+                        break;
+                    }
+
+                    // Executing or terminal: the instant is accounted for — step past it (AE9, AE10).
+                }
             }
 
             var skippedCount = 0;

--- a/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
+++ b/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
@@ -1423,6 +1423,126 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         return Task.FromResult(job is null ? null : _CloneCronJob(job));
     }
 
+    public Task<CronRecoveryResult<TCronJob>?> ApplyCronRecoveryAsync(
+        CronRecoveryRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // The per-definition lock is this provider's equivalent of the relational transaction: the fence check, the
+        // occurrence resolution, and the watermark move are one indivisible step, so no interleaving can leave the
+        // backlog partly resolved with the watermark already past it.
+        lock (_GetCronDefinitionLock(request.CronJobId))
+        {
+            if (
+                !_cronJobs.TryGetValue(request.CronJobId, out var current)
+                || current.IsPaused
+                || current.ScheduleRevision != request.ExpectedScheduleRevision
+                || current.ReconciledThroughUtc != request.ObservedReconciledThroughUtc
+            )
+            {
+                return Task.FromResult<CronRecoveryResult<TCronJob>?>(null);
+            }
+
+            var inWindow = _cronOccurrences
+                .Values.Where(x =>
+                    x.CronJobId == request.CronJobId
+                    && x.ExecutionTime > request.ObservedReconciledThroughUtc
+                    && x.ExecutionTime <= request.RecoveredThroughUtc
+                )
+                .ToArray();
+
+            // A live row takes precedence over a terminal one sharing the instant.
+            var atEarliest = inWindow
+                .Where(x => x.ExecutionTime == request.EarliestMissedUtc)
+                .OrderBy(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress ? 0 : 1)
+                .FirstOrDefault();
+
+            CronJobOccurrenceEntity<TCronJob>? coalescedRun = null;
+            var repurposedId = Guid.Empty;
+
+            if (request.Policy is MissedRunPolicy.Coalesce)
+            {
+                if (atEarliest is null)
+                {
+                    var created = new CronJobOccurrenceEntity<TCronJob>
+                    {
+                        Id = request.CoalescedOccurrenceId,
+                        CronJobId = request.CronJobId,
+                        Status = JobStatus.Idle,
+                        OwnerId = null,
+                        LockedUntil = null,
+                        ExecutionTime = request.EarliestMissedUtc,
+                        RecoveredFromUtc = request.EarliestMissedUtc,
+                        OnNodeDeath = request.OnNodeDeath,
+                        CreatedAt = request.OperationTimeUtc,
+                        UpdatedAt = request.OperationTimeUtc,
+                        // Execution reads Function off this navigation; the relational provider gets it from an
+                        // Include on the claim read, so attach it here to keep the two providers interchangeable.
+                        CronJob = current,
+                    };
+
+                    _cronOccurrences[created.Id] = created;
+                    coalescedRun = _CloneCronOccurrence(created);
+                }
+                else if (atEarliest.Status is JobStatus.Idle or JobStatus.Queued)
+                {
+                    // KTD5: clearing the owner is the whole mechanism — the claim path's in-progress transition
+                    // requires OwnerId == owner, so the prior owner fails that predicate and drops the row.
+                    repurposedId = atEarliest.Id;
+                    var repurposed = _CloneCronOccurrence(atEarliest);
+                    repurposed.Status = JobStatus.Idle;
+                    repurposed.OwnerId = null;
+                    repurposed.LockedUntil = null;
+                    repurposed.RecoveredFromUtc = request.EarliestMissedUtc;
+                    repurposed.UpdatedAt = request.OperationTimeUtc;
+                    repurposed.CronJob ??= current;
+                    _cronOccurrences[repurposed.Id] = repurposed;
+                    coalescedRun = _CloneCronOccurrence(repurposed);
+                }
+
+                // Otherwise the instant is occupied by a row that is executing or already finished; it has accounted
+                // for that instant, so recovery steps past rather than duplicating it.
+            }
+
+            var skippedCount = 0;
+
+            foreach (var occurrence in inWindow)
+            {
+                if (occurrence.Id == repurposedId || occurrence.Status is not (JobStatus.Idle or JobStatus.Queued))
+                {
+                    continue;
+                }
+
+                var skipped = _CloneCronOccurrence(occurrence);
+                skipped.Status = JobStatus.Skipped;
+                skipped.OwnerId = null;
+                skipped.LockedUntil = null;
+                skipped.ExecutedAt = request.OperationTimeUtc;
+                skipped.UpdatedAt = request.OperationTimeUtc;
+                skipped.SkippedReason = "Cron occurrence missed and resolved by recovery";
+                _cronOccurrences[skipped.Id] = skipped;
+                skippedCount++;
+            }
+
+            var updated = _CloneCronJob(current);
+            updated.ReconciledThroughUtc = request.RecoveredThroughUtc;
+            updated.NextDueUtc = request.NextDueUtc;
+            _cronJobs[request.CronJobId] = updated;
+
+            return Task.FromResult<CronRecoveryResult<TCronJob>?>(
+                new CronRecoveryResult<TCronJob>
+                {
+                    CoalescedRun = coalescedRun,
+                    SkippedOccurrenceCount = skippedCount,
+                    ReconciledThroughUtc = updated.ReconciledThroughUtc,
+                    NextDueUtc = updated.NextDueUtc,
+                }
+            );
+        }
+    }
+
     public Task<CronDispatchCandidates?> GetEarliestCronDispatchCandidatesAsync(
         int limit,
         CancellationToken cancellationToken = default
@@ -1447,6 +1567,8 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
                 Retries = x.Retries,
                 RetryIntervals = x.RetryIntervals,
                 OnNodeDeath = x.OnNodeDeath,
+                MissedRunGraceSeconds = x.MissedRunGraceSeconds,
+                OnMissedRun = x.OnMissedRun,
             })
             .ToArray();
 
@@ -1908,6 +2030,10 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
                     updatedOccurrence.Status = JobStatus.Queued;
                     // #464: re-stamp the policy from the cron def (context) so EF and in-memory agree on re-queue.
                     updatedOccurrence.OnNodeDeath = context.OnNodeDeath;
+                    // Execution reads Function off this navigation. A row created by a path that did not attach it
+                    // (recovery, or any future inserter) would otherwise null-ref at dispatch rather than here, so
+                    // re-attach on the way out instead of trusting every producer to have done it.
+                    updatedOccurrence.CronJob ??= currentDefinition;
 
                     if (_cronOccurrences.TryUpdate(occurrenceId, updatedOccurrence, existingOccurrence))
                     {
@@ -2691,6 +2817,10 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
             CronJobId = occurrence.CronJobId,
             Status = occurrence.Status,
             RetryCount = occurrence.RetryCount,
+            // R23: the recovery stamp must survive every projection. Dropping it here would silently turn a coalesced
+            // run back into an ordinary one the moment it round-trips — the same defect shape that once reset
+            // RetryCount and handed a restarted job a fresh retry budget.
+            RecoveredFromUtc = occurrence.RecoveredFromUtc,
             ExecutionTime = occurrence.ExecutionTime,
             OwnerId = occurrence.OwnerId,
             LockedUntil = occurrence.LockedUntil,

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
@@ -1395,75 +1395,93 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
             .Select(x => x.Id)
             .ToArray();
 
-        // A live row takes precedence over a terminal one sharing the instant, so pick the non-terminal occupant first.
-        var atEarliest = inWindow
-            .Where(x => x.ExecutionTime == request.EarliestMissedUtc)
-            .OrderBy(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress ? 0 : 1)
-            .FirstOrDefault();
-
         CronJobOccurrenceEntity<TCronJob>? coalescedRun = null;
         var repurposedId = Guid.Empty;
 
         if (request.Policy is MissedRunPolicy.Coalesce)
         {
-            if (atEarliest is null)
+            // R18 owes the backlog exactly one run; R7 forbids duplicating an instant an executing or terminal row
+            // already accounts for. Reconciled by walking the missed instants in schedule order and materializing at
+            // the FIRST unaccounted-for one — an occupied instant is stepped past (AE9, AE10), never duplicated, and
+            // only a fully-accounted-for backlog produces no run at all.
+            foreach (var missedInstant in request.MissedInstantsUtc)
             {
-                coalescedRun = new CronJobOccurrenceEntity<TCronJob>
+                // A live row takes precedence over a terminal one sharing the instant.
+                var atInstant = inWindow
+                    .Where(x => x.ExecutionTime == missedInstant)
+                    .OrderBy(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress ? 0 : 1)
+                    .FirstOrDefault();
+
+                if (atInstant is null)
                 {
-                    Id = request.CoalescedOccurrenceId,
-                    CronJobId = cronJobId,
-                    Status = JobStatus.Idle,
-                    OwnerId = null,
-                    LockedUntil = null,
-                    ExecutionTime = request.EarliestMissedUtc,
-                    RecoveredFromUtc = request.EarliestMissedUtc,
-                    OnNodeDeath = request.OnNodeDeath,
-                    CreatedAt = request.OperationTimeUtc,
-                    UpdatedAt = request.OperationTimeUtc,
-                };
+                    coalescedRun = new CronJobOccurrenceEntity<TCronJob>
+                    {
+                        Id = request.CoalescedOccurrenceId,
+                        CronJobId = cronJobId,
+                        Status = JobStatus.Idle,
+                        OwnerId = null,
+                        LockedUntil = null,
+                        ExecutionTime = missedInstant,
+                        RecoveredFromUtc = missedInstant,
+                        OnNodeDeath = request.OnNodeDeath,
+                        CreatedAt = request.OperationTimeUtc,
+                        UpdatedAt = request.OperationTimeUtc,
+                    };
 
-                await occurrences.AddAsync(coalescedRun, cancellationToken).ConfigureAwait(false);
-                await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                dbContext.Entry(coalescedRun).State = EntityState.Detached;
-            }
-            else if (atEarliest.Status is JobStatus.Idle or JobStatus.Queued)
-            {
-                // KTD5: revoking ownership is the whole mechanism. The claim path's in-progress transition already
-                // requires OwnerId == owner, so a prior owner that was holding this row simply fails that predicate
-                // and drops it — no new machinery, and no cost on the normal execution path.
-                repurposedId = atEarliest.Id;
+                    await occurrences.AddAsync(coalescedRun, cancellationToken).ConfigureAwait(false);
+                    await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    dbContext.Entry(coalescedRun).State = EntityState.Detached;
+                    break;
+                }
 
-                await occurrences
-                    .Where(x => x.Id == repurposedId)
-                    .ExecuteUpdateAsync(
-                        setter =>
-                            setter
-                                .SetProperty(x => x.Status, JobStatus.Idle)
-                                .SetProperty(x => x.OwnerId, _ => null)
-                                .SetProperty(x => x.LockedUntil, _ => null)
-                                .SetProperty(x => x.RecoveredFromUtc, request.EarliestMissedUtc)
-                                .SetProperty(x => x.UpdatedAt, request.OperationTimeUtc),
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false);
-
-                coalescedRun = new CronJobOccurrenceEntity<TCronJob>
+                if (atInstant.Status is JobStatus.Idle or JobStatus.Queued)
                 {
-                    Id = atEarliest.Id,
-                    CronJobId = cronJobId,
-                    Status = JobStatus.Idle,
-                    OwnerId = null,
-                    LockedUntil = null,
-                    ExecutionTime = request.EarliestMissedUtc,
-                    RecoveredFromUtc = request.EarliestMissedUtc,
-                    OnNodeDeath = request.OnNodeDeath,
-                    CreatedAt = atEarliest.CreatedAt,
-                    UpdatedAt = request.OperationTimeUtc,
-                };
-            }
+                    // KTD5: revoking ownership is the whole mechanism. The claim path's in-progress transition
+                    // already requires OwnerId == owner, so a prior owner that was holding this row simply fails
+                    // that predicate and drops it — no new machinery, and no cost on the normal execution path.
+                    //
+                    // The status predicate makes this a CAS rather than a blind write: the window read above takes
+                    // no lock, so the row can begin executing between the read and this statement. Zero rows
+                    // affected means exactly that — the instant is now accounted for, and the walk steps past it.
+                    var candidateId = atInstant.Id;
+                    var repurposed = await occurrences
+                        .Where(x => x.Id == candidateId && (x.Status == JobStatus.Idle || x.Status == JobStatus.Queued))
+                        .ExecuteUpdateAsync(
+                            setter =>
+                                setter
+                                    .SetProperty(x => x.Status, JobStatus.Idle)
+                                    .SetProperty(x => x.OwnerId, _ => null)
+                                    .SetProperty(x => x.LockedUntil, _ => null)
+                                    .SetProperty(x => x.RecoveredFromUtc, missedInstant)
+                                    .SetProperty(x => x.UpdatedAt, request.OperationTimeUtc),
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
 
-            // Otherwise the earliest missed instant is occupied by a row that is executing or already finished. It has
-            // accounted for that instant, so recovery steps past it rather than creating a duplicate (AE9, AE10).
+                    if (repurposed == 0)
+                    {
+                        continue;
+                    }
+
+                    repurposedId = atInstant.Id;
+                    coalescedRun = new CronJobOccurrenceEntity<TCronJob>
+                    {
+                        Id = atInstant.Id,
+                        CronJobId = cronJobId,
+                        Status = JobStatus.Idle,
+                        OwnerId = null,
+                        LockedUntil = null,
+                        ExecutionTime = missedInstant,
+                        RecoveredFromUtc = missedInstant,
+                        OnNodeDeath = request.OnNodeDeath,
+                        CreatedAt = atInstant.CreatedAt,
+                        UpdatedAt = request.OperationTimeUtc,
+                    };
+                    break;
+                }
+
+                // Executing or terminal: the instant is accounted for — step past it (AE9, AE10).
+            }
         }
 
         // Everything else not yet executing in the window is retired: under skip because nothing may run, under
@@ -1473,8 +1491,10 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
 
         if (toSkip.Length > 0)
         {
+            // Same CAS discipline as the repurpose: a row that began executing since the unlocked window read fails
+            // the status predicate and is left alone rather than blindly stamped Skipped over a running execution.
             skippedCount = await occurrences
-                .Where(x => toSkip.Contains(x.Id))
+                .Where(x => toSkip.Contains(x.Id) && (x.Status == JobStatus.Idle || x.Status == JobStatus.Queued))
                 .ExecuteUpdateAsync(
                     setter =>
                         setter

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
@@ -1326,6 +1326,180 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
             .ConfigureAwait(false);
     }
 
+    public async Task<CronRecoveryResult<TCronJob>?> ApplyCronRecoveryAsync(
+        CronRecoveryRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var dbContext = await DbContextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // One transaction, unlike the ordinary advance. The occurrence resolution and the watermark move must not
+        // interleave: a crash between them would leave the backlog partly resolved with the watermark already past it,
+        // and nothing to re-derive the remainder from. Safe here precisely because the recovery instant is a
+        // caller-supplied store instant, so no database-clock expression is frozen at transaction open (KTD1 governs
+        // clock EXPRESSIONS inside transactions, not transactions as such).
+        await using var transaction = await dbContext
+            .Database.BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var definitions = dbContext.Set<TCronJob>();
+        var recoveredThroughUtc = request.RecoveredThroughUtc;
+        var nextDueUtc = request.NextDueUtc;
+
+        var advanced = await definitions
+            .WhereScheduleAdvanceFenceHolds(
+                request.CronJobId,
+                request.ObservedReconciledThroughUtc,
+                request.ExpectedScheduleRevision
+            )
+            .ExecuteUpdateAsync(
+                setter =>
+                    setter
+                        .SetProperty(x => x.ReconciledThroughUtc, recoveredThroughUtc)
+                        .SetProperty(x => x.NextDueUtc, nextDueUtc),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        if (advanced == 0)
+        {
+            // Another node recovered this backlog first. Nothing was written; the transaction rolls back on dispose.
+            return null;
+        }
+
+        var occurrences = dbContext.Set<CronJobOccurrenceEntity<TCronJob>>();
+        var cronJobId = request.CronJobId;
+        var windowStart = request.ObservedReconciledThroughUtc;
+        var windowEnd = request.RecoveredThroughUtc;
+
+        // Every row in the missed window, whatever its state: the non-terminal ones are the policy's to resolve, and
+        // the terminal ones still matter because a terminal row occupying the earliest missed instant means that
+        // instant already ran and must not be materialized a second time (R7).
+        var inWindow = await occurrences
+            .AsNoTracking()
+            .Where(x => x.CronJobId == cronJobId && x.ExecutionTime > windowStart && x.ExecutionTime <= windowEnd)
+            .Select(x => new
+            {
+                x.Id,
+                x.ExecutionTime,
+                x.Status,
+                x.CreatedAt,
+            })
+            .ToArrayAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var resolvable = inWindow
+            .Where(x => x.Status is JobStatus.Idle or JobStatus.Queued)
+            .Select(x => x.Id)
+            .ToArray();
+
+        // A live row takes precedence over a terminal one sharing the instant, so pick the non-terminal occupant first.
+        var atEarliest = inWindow
+            .Where(x => x.ExecutionTime == request.EarliestMissedUtc)
+            .OrderBy(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress ? 0 : 1)
+            .FirstOrDefault();
+
+        CronJobOccurrenceEntity<TCronJob>? coalescedRun = null;
+        var repurposedId = Guid.Empty;
+
+        if (request.Policy is MissedRunPolicy.Coalesce)
+        {
+            if (atEarliest is null)
+            {
+                coalescedRun = new CronJobOccurrenceEntity<TCronJob>
+                {
+                    Id = request.CoalescedOccurrenceId,
+                    CronJobId = cronJobId,
+                    Status = JobStatus.Idle,
+                    OwnerId = null,
+                    LockedUntil = null,
+                    ExecutionTime = request.EarliestMissedUtc,
+                    RecoveredFromUtc = request.EarliestMissedUtc,
+                    OnNodeDeath = request.OnNodeDeath,
+                    CreatedAt = request.OperationTimeUtc,
+                    UpdatedAt = request.OperationTimeUtc,
+                };
+
+                await occurrences.AddAsync(coalescedRun, cancellationToken).ConfigureAwait(false);
+                await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                dbContext.Entry(coalescedRun).State = EntityState.Detached;
+            }
+            else if (atEarliest.Status is JobStatus.Idle or JobStatus.Queued)
+            {
+                // KTD5: revoking ownership is the whole mechanism. The claim path's in-progress transition already
+                // requires OwnerId == owner, so a prior owner that was holding this row simply fails that predicate
+                // and drops it — no new machinery, and no cost on the normal execution path.
+                repurposedId = atEarliest.Id;
+
+                await occurrences
+                    .Where(x => x.Id == repurposedId)
+                    .ExecuteUpdateAsync(
+                        setter =>
+                            setter
+                                .SetProperty(x => x.Status, JobStatus.Idle)
+                                .SetProperty(x => x.OwnerId, _ => null)
+                                .SetProperty(x => x.LockedUntil, _ => null)
+                                .SetProperty(x => x.RecoveredFromUtc, request.EarliestMissedUtc)
+                                .SetProperty(x => x.UpdatedAt, request.OperationTimeUtc),
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                coalescedRun = new CronJobOccurrenceEntity<TCronJob>
+                {
+                    Id = atEarliest.Id,
+                    CronJobId = cronJobId,
+                    Status = JobStatus.Idle,
+                    OwnerId = null,
+                    LockedUntil = null,
+                    ExecutionTime = request.EarliestMissedUtc,
+                    RecoveredFromUtc = request.EarliestMissedUtc,
+                    OnNodeDeath = request.OnNodeDeath,
+                    CreatedAt = atEarliest.CreatedAt,
+                    UpdatedAt = request.OperationTimeUtc,
+                };
+            }
+
+            // Otherwise the earliest missed instant is occupied by a row that is executing or already finished. It has
+            // accounted for that instant, so recovery steps past it rather than creating a duplicate (AE9, AE10).
+        }
+
+        // Everything else not yet executing in the window is retired: under skip because nothing may run, under
+        // coalesce because the single coalesced run already stands in for the whole backlog.
+        var toSkip = resolvable.Where(id => id != repurposedId).ToArray();
+        var skippedCount = 0;
+
+        if (toSkip.Length > 0)
+        {
+            skippedCount = await occurrences
+                .Where(x => toSkip.Contains(x.Id))
+                .ExecuteUpdateAsync(
+                    setter =>
+                        setter
+                            .SetProperty(x => x.Status, JobStatus.Skipped)
+                            .SetProperty(x => x.OwnerId, _ => null)
+                            .SetProperty(x => x.LockedUntil, _ => null)
+                            .SetProperty(x => x.ExecutedAt, request.OperationTimeUtc)
+                            .SetProperty(x => x.UpdatedAt, request.OperationTimeUtc)
+                            .SetProperty(x => x.SkippedReason, "Cron occurrence missed and resolved by recovery"),
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        return new CronRecoveryResult<TCronJob>
+        {
+            CoalescedRun = coalescedRun,
+            SkippedOccurrenceCount = skippedCount,
+            ReconciledThroughUtc = recoveredThroughUtc,
+            NextDueUtc = nextDueUtc,
+        };
+    }
+
     public async Task<CronDispatchCandidates?> GetEarliestCronDispatchCandidatesAsync(
         int limit,
         CancellationToken cancellationToken = default
@@ -1357,6 +1531,8 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
                 x.Retries,
                 x.RetryIntervals,
                 x.OnNodeDeath,
+                x.MissedRunGraceSeconds,
+                x.OnMissedRun,
                 StoreUtcNow = DateTime.UtcNow,
             })
             .ToArrayAsync(cancellationToken)
@@ -1384,6 +1560,8 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
                     Retries = x.Retries,
                     RetryIntervals = x.RetryIntervals,
                     OnNodeDeath = x.OnNodeDeath,
+                    MissedRunGraceSeconds = x.MissedRunGraceSeconds,
+                    OnMissedRun = x.OnMissedRun,
                 }),
             ],
         };

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/MappingExtensions.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/MappingExtensions.cs
@@ -168,6 +168,10 @@ internal static class MappingExtensions
             UpdatedAt = e.UpdatedAt,
             CronJobId = e.CronJobId,
             RetryCount = e.RetryCount,
+            // R23: the recovery stamp rides every pickup/claim projection, so a coalesced run reclaimed after a
+            // restart still reports the instant it stands for. Dropping it here silently demotes it to an ordinary
+            // run — the RetryCount defect shape this repo has already paid for once.
+            RecoveredFromUtc = e.RecoveredFromUtc,
             ExecutionTime = e.ExecutionTime,
             OnNodeDeath = e.OnNodeDeath,
             CronJob = new TCronJob
@@ -203,6 +207,8 @@ internal static class MappingExtensions
             // Retry enum default when re-queued.
             OnNodeDeath = e.OnNodeDeath,
             RetryCount = e.RetryCount,
+            // R23: see the sibling projection — the recovery stamp must survive this read too.
+            RecoveredFromUtc = e.RecoveredFromUtc,
             CronJob = new TCronJob
             {
                 Id = e.CronJob.Id,

--- a/tests/Headless.Jobs.Composition.Tests.Unit/CronPendingEvaluationTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/CronPendingEvaluationTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+/// <summary>
+/// Misfire detection: what a schedule owes as of one store instant, and whether that backlog is a misfire rather than
+/// ordinary lateness. Every scenario is decided from the watermark and the schedule alone — never from occurrence
+/// rows, because the case this exists to catch is precisely the one where no row was ever written.
+/// </summary>
+public sealed class CronPendingEvaluationTests : TestBase
+{
+    private const string _EveryMinute = "0 * * * * *";
+    private const string _EverySecond = "* * * * * *";
+
+    // Grace scenarios need a schedule coarse enough that a single instant can be minutes late without a second one
+    // becoming pending; on an every-minute schedule "90s late" necessarily means two pending instants, not one.
+    private const string _Hourly = "0 0 * * * *";
+    private const int _Grace = 60;
+
+    private static readonly DateTime _Now = new(2026, 07, 26, 12, 00, 00, DateTimeKind.Utc);
+
+    private static CronScheduleCache _Cache() => new(TimeZoneInfo.Utc);
+
+    [Fact]
+    public void should_report_nothing_pending_when_the_watermark_is_current()
+    {
+        // Reconciled through now: the next occurrence is in the future, so the schedule owes nothing.
+        var result = _Cache().EvaluatePending(_EveryMinute, timeZoneId: null, _Now, _Now, _Grace);
+
+        result.Should().Be(CronPendingEvaluation.None);
+        result.IsRecovery.Should().BeFalse();
+        result.EarliestPendingUtc.Should().BeNull();
+    }
+
+    /// <summary>AE3: a single occurrence delayed by less than the grace threshold dispatches normally.</summary>
+    [Fact]
+    public void should_not_treat_a_single_occurrence_inside_the_grace_threshold_as_a_misfire()
+    {
+        // Watermark at 11:30, so 12:00 is the one pending instant — evaluated 30s late, inside the 60s grace.
+        var result = _Cache()
+            .EvaluatePending(_Hourly, timeZoneId: null, _Now.AddMinutes(-30), _Now.AddSeconds(30), _Grace);
+
+        result.PendingCount.Should().Be(1);
+        result.EarliestPendingUtc.Should().Be(_Now);
+        result.IsRecovery.Should().BeFalse("30s of lateness is inside the 60s grace threshold");
+    }
+
+    [Fact]
+    public void should_enter_recovery_when_a_single_occurrence_exceeds_the_grace_threshold()
+    {
+        // The same single pending instant, now 90s late. Still one instant: the next hourly tick is 13:00.
+        var result = _Cache()
+            .EvaluatePending(_Hourly, timeZoneId: null, _Now.AddMinutes(-30), _Now.AddSeconds(90), _Grace);
+
+        result.PendingCount.Should().Be(1);
+        result.EarliestPendingUtc.Should().Be(_Now);
+        result.IsRecovery.Should().BeTrue("90s of lateness exceeds the 60s grace threshold");
+    }
+
+    [Fact]
+    public void should_enter_recovery_on_two_pending_occurrences_regardless_of_age()
+    {
+        // Both instants are well inside the grace threshold individually; the COUNT is what makes this a misfire.
+        var result = _Cache()
+            .EvaluatePending(_EveryMinute, timeZoneId: null, _Now.AddSeconds(-1), _Now.AddMinutes(1), _Grace);
+
+        result.PendingCount.Should().Be(2);
+        result.IsRecovery.Should().BeTrue("more than one pending instant is a misfire however recent each one is");
+    }
+
+    /// <summary>AE7: a sub-grace backlog still routes to recovery.</summary>
+    [Fact]
+    public void should_enter_recovery_for_a_sub_grace_backlog_on_a_high_frequency_schedule()
+    {
+        // A one-second schedule stalled for ten seconds: ten pending instants, none older than the 60s grace.
+        var result = _Cache().EvaluatePending(_EverySecond, timeZoneId: null, _Now, _Now.AddSeconds(10), _Grace);
+
+        result.PendingCount.Should().Be(10);
+        result.EarliestPendingUtc.Should().Be(_Now.AddSeconds(1));
+        result.CountSaturated.Should().BeFalse();
+        result.IsRecovery.Should().BeTrue("ten pending instants is a backlog even though no single one is late");
+    }
+
+    /// <summary>AE12: a backlog past the evaluation ceiling still decides correctly and reports a lower bound.</summary>
+    [Fact]
+    public void should_report_a_lower_bound_count_without_unbounded_evaluation()
+    {
+        // A one-second schedule after an hour of downtime is 3600 instants behind, well past a ceiling of 50.
+        var result = _Cache()
+            .EvaluatePending(_EverySecond, timeZoneId: null, _Now, _Now.AddHours(1), _Grace, evaluationCeiling: 50);
+
+        result.PendingCount.Should().Be(50, "the walk stops at the ceiling rather than enumerating the full backlog");
+        result.CountSaturated.Should().BeTrue("the count is a lower bound, not the real backlog size");
+        result.IsRecovery.Should().BeTrue("saturation never changes the decision — it was settled at the 2nd instant");
+        result
+            .EarliestPendingUtc.Should()
+            .Be(
+                _Now.AddSeconds(1),
+                "the earliest instant stays exact under saturation because the walk visits it first — that is what "
+                    + "lets a coalesced run report an accurate scheduled instant for an unbounded backlog"
+            );
+    }
+
+    [Fact]
+    public void should_report_an_exact_count_when_the_backlog_lands_on_the_ceiling()
+    {
+        // Exactly 10 pending instants with a ceiling of 10: the walk fills the ceiling but nothing lies beyond it.
+        var result = _Cache()
+            .EvaluatePending(_EverySecond, timeZoneId: null, _Now, _Now.AddSeconds(10), _Grace, evaluationCeiling: 10);
+
+        result.PendingCount.Should().Be(10);
+        result.CountSaturated.Should().BeFalse("a backlog that exactly fills the ceiling is still an exact count");
+    }
+
+    [Fact]
+    public void should_use_the_definitions_own_grace_rather_than_the_framework_default()
+    {
+        // 90s late: a misfire under the 60s default, but not under this definition's own 300s threshold.
+        var lenient = _Cache()
+            .EvaluatePending(_Hourly, timeZoneId: null, _Now.AddMinutes(-30), _Now.AddSeconds(90), graceSeconds: 300);
+
+        lenient.PendingCount.Should().Be(1);
+        lenient.IsRecovery.Should().BeFalse("the definition tolerates 300s of lateness");
+
+        var strict = _Cache()
+            .EvaluatePending(_Hourly, timeZoneId: null, _Now.AddMinutes(-30), _Now.AddSeconds(90), graceSeconds: 10);
+
+        strict.IsRecovery.Should().BeTrue("the same lateness exceeds a 10s threshold");
+    }
+
+    [Fact]
+    public void should_fall_back_to_the_framework_grace_when_the_definition_persists_zero()
+    {
+        // A row migrated from before the column existed. Honoring zero literally would make this 1s-late tick a
+        // misfire, routing ordinary dispatch into recovery for every definition in an upgraded database.
+        var result = _Cache()
+            .EvaluatePending(_Hourly, timeZoneId: null, _Now.AddMinutes(-30), _Now.AddSeconds(1), graceSeconds: 0);
+
+        result.PendingCount.Should().Be(1);
+        result.IsRecovery.Should().BeFalse("zero is read as unresolved and falls back to the framework default");
+    }
+
+    /// <summary>
+    /// AE6: pause needs no special case here. Resume rebases the watermark to the resume instant, so the paused span
+    /// is never between the watermark and now and cannot produce a pending instant.
+    /// </summary>
+    [Fact]
+    public void should_produce_no_pending_instants_for_a_paused_span()
+    {
+        // Paused at 12:00, resumed at 15:30 (watermark rebased there by the resume path), evaluated moments later.
+        var resumeInstant = _Now.AddHours(3).AddMinutes(30);
+
+        var result = _Cache()
+            .EvaluatePending(_EveryMinute, timeZoneId: null, resumeInstant, resumeInstant.AddSeconds(5), _Grace);
+
+        result
+            .Should()
+            .Be(CronPendingEvaluation.None, "the three-and-a-half-hour pause is behind the rebased watermark");
+    }
+
+    [Fact]
+    public void should_report_the_latest_pending_instant_the_walk_reached()
+    {
+        var result = _Cache().EvaluatePending(_EveryMinute, timeZoneId: null, _Now, _Now.AddMinutes(3), _Grace);
+
+        result.PendingCount.Should().Be(3);
+        result.EarliestPendingUtc.Should().Be(_Now.AddMinutes(1));
+        result.LatestPendingUtc.Should().Be(_Now.AddMinutes(3));
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronDispatchSelectionManagerTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronDispatchSelectionManagerTests.cs
@@ -263,7 +263,8 @@ public sealed class CronDispatchSelectionManagerTests : TestBase
             Expression = "0 * * * * *",
             IsPaused = isPaused,
             ScheduleRevision = 0,
-            ReconciledThroughUtc = _Now.AddMinutes(-5),
+            // Exactly one pending instant, dispatched on time: these scenarios exercise NORMAL dispatch, not recovery.
+            ReconciledThroughUtc = _Now.AddSeconds(-30),
             NextDueUtc = nextDue,
             CreatedAt = new DateTimeOffset(_Now.AddHours(-1), TimeSpan.Zero),
             UpdatedAt = new DateTimeOffset(_Now.AddMinutes(-1), TimeSpan.Zero),

--- a/tests/Headless.Jobs.Composition.Tests.Unit/MissedRunPolicyMigrationDefaultTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/MissedRunPolicyMigrationDefaultTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs.Enums;
+using Headless.Testing.Tests;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Tests;
+
+/// <summary>
+/// Pins the two facts that together make an upgraded database read its recovery policy correctly.
+/// </summary>
+/// <remarks>
+/// <c>OnMissedRun</c> is mapped with <c>HasConversion&lt;string&gt;()</c> and is NOT NULL, so EF's migration scaffolder
+/// backfilled every pre-existing row with the CLR default for <see cref="string"/> — the empty string, which is not a
+/// member name. That reads back correctly today only because EF's enum converter falls back to
+/// <c>default(TEnum)</c> and <see cref="MissedRunPolicy.Coalesce"/> is ordinal zero.
+/// <para>
+/// Both halves are load-bearing and neither is self-evident at the call site, so they are asserted rather than
+/// assumed. Reordering the enum, or an EF change to that fallback, would silently switch every legacy definition's
+/// recovery policy with nothing failing — the exact shape of defect a passing test suite would otherwise hide.
+/// </para>
+/// </remarks>
+public sealed class MissedRunPolicyMigrationDefaultTests : TestBase
+{
+    [Fact]
+    public void coalesce_must_stay_ordinal_zero()
+    {
+        ((int)MissedRunPolicy.Coalesce)
+            .Should()
+            .Be(
+                0,
+                "rows migrated from before the OnMissedRun column existed carry an empty string, which resolves to "
+                    + "default(MissedRunPolicy); if Coalesce stops being ordinal zero every one of them silently "
+                    + "changes recovery policy"
+            );
+    }
+
+    [Fact]
+    public void the_migrated_empty_string_default_must_resolve_to_the_documented_default_policy()
+    {
+        var converter = new EnumToStringConverter<MissedRunPolicy>();
+
+        converter
+            .ConvertFromProvider(string.Empty)
+            .Should()
+            .Be(
+                MissedRunPolicy.Coalesce,
+                "the generated migration backfills existing rows with an empty string, so this conversion is what "
+                    + "every pre-existing cron definition is read through after an upgrade"
+            );
+    }
+
+    [Fact]
+    public void a_real_policy_name_must_still_round_trip()
+    {
+        var converter = new EnumToStringConverter<MissedRunPolicy>();
+
+        foreach (var policy in Enum.GetValues<MissedRunPolicy>())
+        {
+            var stored = converter.ConvertToProvider(policy);
+            converter.ConvertFromProvider(stored).Should().Be(policy);
+        }
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Provider/CronRecoveryPolicyProviderTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Provider/CronRecoveryPolicyProviderTests.cs
@@ -236,7 +236,8 @@ public sealed class CronRecoveryPolicyProviderTests : TestBase
 
     private static CronRecoveryRequest _Request(
         FakeCronJob definition,
-        MissedRunPolicy policy = MissedRunPolicy.Coalesce
+        MissedRunPolicy policy = MissedRunPolicy.Coalesce,
+        DateTime[]? missedInstants = null
     ) =>
         new()
         {
@@ -247,6 +248,7 @@ public sealed class CronRecoveryPolicyProviderTests : TestBase
             NextDueUtc = _RecoveredThrough.AddMinutes(30),
             Policy = policy,
             EarliestMissedUtc = _EarliestMissed,
+            MissedInstantsUtc = missedInstants ?? [_EarliestMissed],
             CoalescedOccurrenceId = Guid.NewGuid(),
             OnNodeDeath = NodeDeathPolicy.Retry,
             OperationTimeUtc = _Now,
@@ -275,6 +277,68 @@ public sealed class CronRecoveryPolicyProviderTests : TestBase
             CreatedAt = _Now.AddDays(-1),
             UpdatedAt = _Now.AddHours(-4),
         };
+
+    /// <summary>
+    /// R18 over an occupied earliest instant: an executing or terminal row at the earliest missed instant accounts
+    /// for that instant only. The rest of the backlog still gets its one run, materialized at the next
+    /// unaccounted-for missed instant — not abandoned wholesale.
+    /// </summary>
+    [Fact]
+    public async Task should_coalesce_at_the_next_missed_instant_when_the_earliest_is_occupied()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        var finished = _Occurrence(definition.Id, _EarliestMissed, JobStatus.Succeeded);
+        await provider.InsertCronJobOccurrencesAsync([finished], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(
+            _Request(definition, missedInstants: [_EarliestMissed, _SecondMissed]),
+            AbortToken
+        );
+
+        result.Should().NotBeNull();
+        result!.CoalescedRun.Should().NotBeNull("the 16:00 tick was genuinely missed even though 15:00 already ran");
+        result.CoalescedRun!.ExecutionTime.Should().Be(_SecondMissed);
+        result
+            .CoalescedRun.RecoveredFromUtc.Should()
+            .Be(_SecondMissed, "the run stands for the backlog from the first unaccounted-for instant");
+
+        var occurrences = await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken);
+        occurrences.Should().HaveCount(2);
+        occurrences.Single(x => x.Id == finished.Id).Status.Should().Be(JobStatus.Succeeded, "left undisturbed");
+    }
+
+    /// <summary>
+    /// The degenerate case of the step-past walk: when EVERY missed instant is accounted for by executing or
+    /// terminal rows, there is genuinely nothing to recover and no run is materialized.
+    /// </summary>
+    [Fact]
+    public async Task should_materialize_nothing_when_every_missed_instant_is_occupied()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        await provider.InsertCronJobOccurrencesAsync(
+            [
+                _Occurrence(definition.Id, _EarliestMissed, JobStatus.Succeeded),
+                _Occurrence(definition.Id, _SecondMissed, JobStatus.InProgress, _Owner),
+            ],
+            AbortToken
+        );
+
+        var result = await provider.ApplyCronRecoveryAsync(
+            _Request(definition, missedInstants: [_EarliestMissed, _SecondMissed]),
+            AbortToken
+        );
+
+        result.Should().NotBeNull();
+        result!.CoalescedRun.Should().BeNull("every missed instant already ran or is running");
+
+        var occurrences = await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken);
+        occurrences.Should().HaveCount(2, "nothing was materialized and nothing was disturbed");
+        occurrences.Single(x => x.ExecutionTime == _SecondMissed).Status.Should().Be(JobStatus.InProgress);
+    }
 
     private static CronJobOccurrenceEntity<FakeCronJob> _Occurrence(
         Guid definitionId,

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Provider/CronRecoveryPolicyProviderTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Provider/CronRecoveryPolicyProviderTests.cs
@@ -1,0 +1,296 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.Jobs;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+using Headless.Jobs.Models;
+using Headless.Jobs.Provider;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.Provider;
+
+/// <summary>
+/// The two recovery policies and how each resolves occurrences already sitting in the missed window. The invariant
+/// underneath every scenario: recovery must never leave two live occurrences for one instant, and must never execute
+/// an instant twice.
+/// </summary>
+public sealed class CronRecoveryPolicyProviderTests : TestBase
+{
+    private sealed class FakeTimeJob : TimeJobEntity<FakeTimeJob>;
+
+    private sealed class FakeCronJob : CronJobEntity;
+
+    private const string _Owner = "node-a@incarnation";
+    private static readonly DateTimeOffset _Now = new(2026, 7, 26, 17, 30, 0, TimeSpan.Zero);
+
+    // An hourly definition reconciled through 14:00, recovered at 17:30 — the plan's outage shape.
+    private static readonly DateTime _Watermark = new(2026, 7, 26, 14, 00, 0, DateTimeKind.Utc);
+    private static readonly DateTime _EarliestMissed = new(2026, 7, 26, 15, 00, 0, DateTimeKind.Utc);
+    private static readonly DateTime _SecondMissed = new(2026, 7, 26, 16, 00, 0, DateTimeKind.Utc);
+    private static readonly DateTime _RecoveredThrough = _Now.UtcDateTime;
+
+    /// <summary>AE1: coalesce over a multi-occurrence outage produces ONE run reporting the earliest missed instant.</summary>
+    [Fact]
+    public async Task should_materialize_exactly_one_run_reporting_the_earliest_missed_instant()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+
+        result.Should().NotBeNull();
+        result!.CoalescedRun.Should().NotBeNull();
+        result
+            .CoalescedRun!.ExecutionTime.Should()
+            .Be(_EarliestMissed, "a coalesced run reports the earliest missed instant as its scheduled instant");
+        result
+            .CoalescedRun.RecoveredFromUtc.Should()
+            .Be(_EarliestMissed, "the marker must survive independently — the watermark has already moved past it");
+        result.CoalescedRun.IsRecoveryRun.Should().BeTrue();
+
+        var occurrences = await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken);
+        occurrences.Should().ContainSingle("coalesce materializes one run regardless of how many were missed");
+
+        var stored = await provider.GetCronJobByIdAsync(definition.Id, AbortToken);
+        stored!.ReconciledThroughUtc.Should().Be(_RecoveredThrough, "the backlog it resolved is never reconsidered");
+    }
+
+    /// <summary>AE2: skip over the same outage produces no run and still advances the watermark.</summary>
+    [Fact]
+    public async Task should_materialize_nothing_under_skip_and_still_advance_the_watermark()
+    {
+        var provider = _Create();
+        var definition = _Definition(MissedRunPolicy.Skip);
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(_Request(definition, MissedRunPolicy.Skip), AbortToken);
+
+        result.Should().NotBeNull();
+        result!.CoalescedRun.Should().BeNull();
+        (await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken))
+            .Should()
+            .BeEmpty();
+
+        var stored = await provider.GetCronJobByIdAsync(definition.Id, AbortToken);
+        stored!.ReconciledThroughUtc.Should().Be(_RecoveredThrough);
+        stored.NextDueUtc.Should().BeAfter(_RecoveredThrough);
+    }
+
+    /// <summary>AE8: skip transitions an unowned pre-existing occurrence to skipped instead of executing it.</summary>
+    [Fact]
+    public async Task should_skip_a_pre_existing_unowned_occurrence_rather_than_execute_it()
+    {
+        var provider = _Create();
+        var definition = _Definition(MissedRunPolicy.Skip);
+        var resumeCreated = _Occurrence(definition.Id, _EarliestMissed, JobStatus.Idle);
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        await provider.InsertCronJobOccurrencesAsync([resumeCreated], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(_Request(definition, MissedRunPolicy.Skip), AbortToken);
+
+        result!.SkippedOccurrenceCount.Should().Be(1);
+        var stored = (
+            await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken)
+        ).Single();
+        stored.Status.Should().Be(JobStatus.Skipped, "an unowned row in the missed window must not run under skip");
+        stored.OwnerId.Should().BeNull();
+    }
+
+    /// <summary>AE15: a queued occurrence repurposed by coalesce has its ownership revoked and carries the stamp.</summary>
+    [Fact]
+    public async Task should_repurpose_a_queued_occurrence_and_revoke_its_ownership()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        var queued = _Occurrence(definition.Id, _EarliestMissed, JobStatus.Queued, owner: "node-b@1");
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        await provider.InsertCronJobOccurrencesAsync([queued], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+
+        result!.CoalescedRun.Should().NotBeNull();
+        result.CoalescedRun!.Id.Should().Be(queued.Id, "the existing row is reused, not duplicated");
+
+        var stored = (
+            await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken)
+        ).Single();
+        stored
+            .OwnerId.Should()
+            .BeNull(
+                "revoking ownership is the whole mechanism — the claim path's in-progress transition requires "
+                    + "OwnerId == owner, so the prior owner fails that predicate and drops the row"
+            );
+        stored.LockedUntil.Should().BeNull();
+        stored.RecoveredFromUtc.Should().Be(_EarliestMissed);
+        stored.Status.Should().Be(JobStatus.Idle, "released for re-claim rather than left queued to its old owner");
+    }
+
+    /// <summary>AE9: an occurrence another node is executing is left alone and not duplicated.</summary>
+    [Fact]
+    public async Task should_leave_an_executing_occurrence_alone_and_not_duplicate_its_instant()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        var running = _Occurrence(definition.Id, _EarliestMissed, JobStatus.InProgress, owner: "node-b@1");
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        await provider.InsertCronJobOccurrencesAsync([running], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+
+        result!.CoalescedRun.Should().BeNull("the instant is already being executed; a second run would duplicate it");
+
+        var occurrences = await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken);
+        var stored = occurrences.Should().ContainSingle().Subject;
+        stored.Status.Should().Be(JobStatus.InProgress, "running work is never disturbed by recovery");
+        stored.OwnerId.Should().Be("node-b@1", "its owner keeps it");
+
+        (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!
+            .ReconciledThroughUtc.Should()
+            .Be(_RecoveredThrough, "the watermark still advances past the instant");
+    }
+
+    /// <summary>AE10: an occurrence that already completed is not executed a second time.</summary>
+    [Fact]
+    public async Task should_not_re_execute_an_already_completed_occurrence()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        var completed = _Occurrence(definition.Id, _EarliestMissed, JobStatus.Succeeded);
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        await provider.InsertCronJobOccurrencesAsync([completed], AbortToken);
+
+        var result = await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+
+        result!.CoalescedRun.Should().BeNull("that instant already ran; the filtered index no longer covers it");
+
+        var occurrences = await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken);
+        occurrences.Should().ContainSingle().Which.Status.Should().Be(JobStatus.Succeeded);
+        (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!
+            .ReconciledThroughUtc.Should()
+            .Be(_RecoveredThrough);
+    }
+
+    [Fact]
+    public async Task should_leave_no_more_than_one_live_occurrence_per_instant()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        // Two idle rows in the window: one at the earliest missed instant, one later.
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+        await provider.InsertCronJobOccurrencesAsync(
+            [
+                _Occurrence(definition.Id, _EarliestMissed, JobStatus.Idle),
+                _Occurrence(definition.Id, _SecondMissed, JobStatus.Idle),
+            ],
+            AbortToken
+        );
+
+        await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+
+        var occurrences = await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken);
+        occurrences
+            .Count(x => x.Status is JobStatus.Idle or JobStatus.Queued or JobStatus.InProgress)
+            .Should()
+            .Be(1, "the coalesced run stands in for the whole backlog; the rest are retired");
+        occurrences.Single(x => x.ExecutionTime == _SecondMissed).Status.Should().Be(JobStatus.Skipped);
+    }
+
+    [Fact]
+    public async Task should_report_null_when_another_node_recovered_the_same_backlog_first()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var first = await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+        first.Should().NotBeNull();
+
+        // Same observed watermark: the losing node's view of the definition is now stale.
+        var second = await provider.ApplyCronRecoveryAsync(_Request(definition), AbortToken);
+
+        second.Should().BeNull("losing the fence is reported by a null result, never by an exception");
+        (await provider.GetAllCronJobOccurrencesAsync(x => x.CronJobId == definition.Id, AbortToken))
+            .Should()
+            .ContainSingle("the loser must not materialize a second run for the same backlog");
+    }
+
+    [Fact]
+    public async Task should_report_null_and_write_nothing_when_the_revision_moved()
+    {
+        var provider = _Create();
+        var definition = _Definition();
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var stale = _Request(definition) with { ExpectedScheduleRevision = definition.ScheduleRevision + 1 };
+        var result = await provider.ApplyCronRecoveryAsync(stale, AbortToken);
+
+        result.Should().BeNull();
+        (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!
+            .ReconciledThroughUtc.Should()
+            .Be(_Watermark, "a node holding a superseded definition must not resolve a backlog derived from it");
+    }
+
+    private static CronRecoveryRequest _Request(
+        FakeCronJob definition,
+        MissedRunPolicy policy = MissedRunPolicy.Coalesce
+    ) =>
+        new()
+        {
+            CronJobId = definition.Id,
+            ObservedReconciledThroughUtc = _Watermark,
+            ExpectedScheduleRevision = definition.ScheduleRevision,
+            RecoveredThroughUtc = _RecoveredThrough,
+            NextDueUtc = _RecoveredThrough.AddMinutes(30),
+            Policy = policy,
+            EarliestMissedUtc = _EarliestMissed,
+            CoalescedOccurrenceId = Guid.NewGuid(),
+            OnNodeDeath = NodeDeathPolicy.Retry,
+            OperationTimeUtc = _Now,
+        };
+
+    private static JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob> _Create()
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessGuidGenerator();
+        services.AddSingleton<TimeProvider>(new FakeTimeProvider(_Now));
+        services.AddSingleton(new SchedulerOptionsBuilder { NodeId = _Owner });
+        return new JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob>(services.BuildServiceProvider());
+    }
+
+    private static FakeCronJob _Definition(MissedRunPolicy policy = MissedRunPolicy.Coalesce) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Function = "cron-recovery",
+            Expression = "0 0 * * * *",
+            ScheduleRevision = 4,
+            ReconciledThroughUtc = _Watermark,
+            NextDueUtc = _EarliestMissed,
+            OnMissedRun = policy,
+            MissedRunGraceSeconds = 60,
+            CreatedAt = _Now.AddDays(-1),
+            UpdatedAt = _Now.AddHours(-4),
+        };
+
+    private static CronJobOccurrenceEntity<FakeCronJob> _Occurrence(
+        Guid definitionId,
+        DateTime executionTime,
+        JobStatus status,
+        string? owner = null
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CronJobId = definitionId,
+            Status = status,
+            OwnerId = owner,
+            LockedUntil = owner is null ? null : _Now.UtcDateTime.AddMinutes(5),
+            ExecutionTime = executionTime,
+            CreatedAt = _Now.AddHours(-3),
+            UpdatedAt = _Now.AddHours(-3),
+        };
+}

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlRecoveryTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlRecoveryTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Tests;
+
+#pragma warning disable CA1707 // Test names follow the repo's readable snake_case convention.
+
+/// <summary>Runs the misfire-recovery conformance suite against PostgreSQL.</summary>
+[Collection<PostgreSqlJobsCoordinationFixture>]
+public sealed class PostgreSqlRecoveryTests(PostgreSqlJobsCoordinationFixture fixture)
+    : JobsRecoveryConformanceTests<PostgreSqlJobsCoordinationFixture>(fixture)
+{
+    [Fact]
+    public override Task coalesce_materializes_one_run_stamped_with_the_earliest_missed_instant()
+    {
+        return base.coalesce_materializes_one_run_stamped_with_the_earliest_missed_instant();
+    }
+
+    [Fact]
+    public override Task skip_materializes_nothing_and_still_advances_the_watermark()
+    {
+        return base.skip_materializes_nothing_and_still_advances_the_watermark();
+    }
+
+    [Fact]
+    public override Task coalesce_repurposes_a_queued_occurrence_and_revokes_ownership()
+    {
+        return base.coalesce_repurposes_a_queued_occurrence_and_revokes_ownership();
+    }
+
+    [Fact]
+    public override Task recovery_leaves_an_executing_occurrence_untouched()
+    {
+        return base.recovery_leaves_an_executing_occurrence_untouched();
+    }
+
+    [Fact]
+    public override Task recovery_does_not_re_execute_a_completed_occurrence()
+    {
+        return base.recovery_does_not_re_execute_a_completed_occurrence();
+    }
+
+    [Fact]
+    public override Task concurrent_recovery_of_one_backlog_produces_exactly_one_winner()
+    {
+        return base.concurrent_recovery_of_one_backlog_produces_exactly_one_winner();
+    }
+}

--- a/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlRecoveryTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.PostgreSql.Tests.Integration/PostgreSqlRecoveryTests.cs
@@ -44,4 +44,10 @@ public sealed class PostgreSqlRecoveryTests(PostgreSqlJobsCoordinationFixture fi
     {
         return base.concurrent_recovery_of_one_backlog_produces_exactly_one_winner();
     }
+
+    [Fact]
+    public override Task coalesce_steps_past_an_occupied_earliest_instant_to_the_next_missed_instant()
+    {
+        return base.coalesce_steps_past_an_occupied_earliest_instant_to_the_next_missed_instant();
+    }
 }

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerRecoveryTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerRecoveryTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Tests;
+
+#pragma warning disable CA1707 // Test names follow the repo's readable snake_case convention.
+
+/// <summary>Runs the misfire-recovery conformance suite against SQL Server.</summary>
+[Collection<SqlServerJobsCoordinationFixture>]
+public sealed class SqlServerRecoveryTests(SqlServerJobsCoordinationFixture fixture)
+    : JobsRecoveryConformanceTests<SqlServerJobsCoordinationFixture>(fixture)
+{
+    [Fact]
+    public override Task coalesce_materializes_one_run_stamped_with_the_earliest_missed_instant()
+    {
+        return base.coalesce_materializes_one_run_stamped_with_the_earliest_missed_instant();
+    }
+
+    [Fact]
+    public override Task skip_materializes_nothing_and_still_advances_the_watermark()
+    {
+        return base.skip_materializes_nothing_and_still_advances_the_watermark();
+    }
+
+    [Fact]
+    public override Task coalesce_repurposes_a_queued_occurrence_and_revokes_ownership()
+    {
+        return base.coalesce_repurposes_a_queued_occurrence_and_revokes_ownership();
+    }
+
+    [Fact]
+    public override Task recovery_leaves_an_executing_occurrence_untouched()
+    {
+        return base.recovery_leaves_an_executing_occurrence_untouched();
+    }
+
+    [Fact]
+    public override Task recovery_does_not_re_execute_a_completed_occurrence()
+    {
+        return base.recovery_does_not_re_execute_a_completed_occurrence();
+    }
+
+    [Fact]
+    public override Task concurrent_recovery_of_one_backlog_produces_exactly_one_winner()
+    {
+        return base.concurrent_recovery_of_one_backlog_produces_exactly_one_winner();
+    }
+}

--- a/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerRecoveryTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.SqlServer.Tests.Integration/SqlServerRecoveryTests.cs
@@ -44,4 +44,10 @@ public sealed class SqlServerRecoveryTests(SqlServerJobsCoordinationFixture fixt
     {
         return base.concurrent_recovery_of_one_backlog_produces_exactly_one_winner();
     }
+
+    [Fact]
+    public override Task coalesce_steps_past_an_occupied_earliest_instant_to_the_next_missed_instant()
+    {
+        return base.coalesce_steps_past_an_occupied_earliest_instant_to_the_next_missed_instant();
+    }
 }

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsRecoveryConformanceTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsRecoveryConformanceTests.cs
@@ -149,6 +149,62 @@ public abstract class JobsRecoveryConformanceTests<TFixture>(TFixture fixture) :
         stored.Status.Should().Be(JobStatus.Idle);
     }
 
+    /// <summary>
+    /// R18 over an occupied earliest instant: an executing or terminal row at the earliest missed instant accounts
+    /// for that instant only. The rest of the backlog still gets its one run, materialized at the next
+    /// unaccounted-for missed instant — not abandoned wholesale.
+    /// </summary>
+    public virtual async Task coalesce_steps_past_an_occupied_earliest_instant_to_the_next_missed_instant()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-step-past");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-step-past",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+        var secondMissed = seeded.NextDueUtc.AddHours(1);
+
+        // The earliest missed instant already ran to completion (a resume-created row the fallback picked up).
+        var finishedId = Guid.NewGuid();
+        await fixture.SeedCronOccurrenceAsync(
+            finishedId,
+            cronId,
+            (int)JobStatus.Succeeded,
+            ownerId: null,
+            NodeDeathPolicy.Retry,
+            lockedUntil: null,
+            seeded.NextDueUtc,
+            ct
+        );
+
+        var result = await persistence.ApplyCronRecoveryAsync(
+            _Request(cronId, seeded, MissedRunPolicy.Coalesce, [seeded.NextDueUtc, secondMissed]),
+            ct
+        );
+
+        result!.CoalescedRun.Should().NotBeNull("the later tick was genuinely missed even though the earliest ran");
+        result.CoalescedRun!.ExecutionTime.Should().BeCloseTo(secondMissed, TimeSpan.FromMicroseconds(1));
+        result.CoalescedRun.RecoveredFromUtc.Should().NotBeNull();
+        result
+            .CoalescedRun.RecoveredFromUtc!.Value.Should()
+            .BeCloseTo(secondMissed, TimeSpan.FromMicroseconds(1), "the run stands for the first unaccounted instant");
+
+        var rows = await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct);
+        rows.Should().HaveCount(2);
+        rows.Single(x => x.Id == finishedId).Status.Should().Be(JobStatus.Succeeded, "left undisturbed");
+    }
+
     /// <summary>AE9: an occurrence another node is executing is left alone and its instant is not duplicated.</summary>
     public virtual async Task recovery_leaves_an_executing_occurrence_untouched()
     {
@@ -289,7 +345,8 @@ public abstract class JobsRecoveryConformanceTests<TFixture>(TFixture fixture) :
     private static CronRecoveryRequest _Request(
         Guid cronJobId,
         (DateTime ReconciledThroughUtc, DateTime NextDueUtc) seeded,
-        MissedRunPolicy policy
+        MissedRunPolicy policy,
+        DateTime[]? missedInstants = null
     ) =>
         new()
         {
@@ -300,6 +357,7 @@ public abstract class JobsRecoveryConformanceTests<TFixture>(TFixture fixture) :
             NextDueUtc = _RecoveryInstant(seeded).AddHours(1),
             Policy = policy,
             EarliestMissedUtc = seeded.NextDueUtc,
+            MissedInstantsUtc = missedInstants ?? [seeded.NextDueUtc],
             CoalescedOccurrenceId = Guid.NewGuid(),
             OnNodeDeath = NodeDeathPolicy.Retry,
             OperationTimeUtc = DateTimeOffset.UtcNow,

--- a/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsRecoveryConformanceTests.cs
+++ b/tests/Headless.Jobs.EntityFramework.Tests.Harness/JobsRecoveryConformanceTests.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+using Headless.Jobs.Interfaces;
+using Headless.Jobs.Models;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Tests;
+
+#pragma warning disable CA1707 // Test names follow the repo's readable snake_case convention.
+
+/// <summary>
+/// Cross-provider conformance for misfire recovery. The in-memory suite proves the same scenarios, but it cannot
+/// prove them <i>for</i> a relational backend: recovery resolves occurrences and moves the watermark inside one
+/// transaction, and whether that composition holds is a property of the store, not of the shared contract.
+/// </summary>
+/// <remarks>
+/// The invariant every scenario shares: recovery never leaves two live occurrences for one instant, and never
+/// executes an instant twice.
+/// </remarks>
+public abstract class JobsRecoveryConformanceTests<TFixture>(TFixture fixture) : TestBase
+    where TFixture : class, IJobsCoordinationFixture
+{
+    /// <summary>AE1: coalesce over a multi-occurrence outage produces one run reporting the earliest missed instant.</summary>
+    public virtual async Task coalesce_materializes_one_run_stamped_with_the_earliest_missed_instant()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-coalesce");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        // Reconciled through an hour ago; recovery runs now. An hourly schedule is therefore behind by several ticks.
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-coalesce",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+
+        var result = await persistence.ApplyCronRecoveryAsync(_Request(cronId, seeded, MissedRunPolicy.Coalesce), ct);
+
+        result.Should().NotBeNull();
+        result!.CoalescedRun.Should().NotBeNull();
+        result
+            .CoalescedRun!.ExecutionTime.Should()
+            .BeCloseTo(seeded.NextDueUtc, TimeSpan.FromMicroseconds(1), "the run reports the earliest missed instant");
+        result
+            .CoalescedRun.RecoveredFromUtc.Should()
+            .NotBeNull("the marker must be durable — the watermark has already moved past the backlog");
+        result.CoalescedRun.IsRecoveryRun.Should().BeTrue();
+
+        var occurrences = await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct);
+        occurrences.Should().ContainSingle("coalesce materializes one run however many were missed");
+
+        var position = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+        position
+            .ReconciledThroughUtc.Should()
+            .BeCloseTo(_RecoveryInstant(seeded), TimeSpan.FromMicroseconds(1), "the backlog is never reconsidered");
+    }
+
+    /// <summary>AE2: skip produces no run and still carries the watermark to the recovery instant.</summary>
+    public virtual async Task skip_materializes_nothing_and_still_advances_the_watermark()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-skip");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-skip",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+
+        var result = await persistence.ApplyCronRecoveryAsync(_Request(cronId, seeded, MissedRunPolicy.Skip), ct);
+
+        result.Should().NotBeNull();
+        result!.CoalescedRun.Should().BeNull();
+        (await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct)).Should().BeEmpty();
+
+        var position = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+        position.ReconciledThroughUtc.Should().BeCloseTo(_RecoveryInstant(seeded), TimeSpan.FromMicroseconds(1));
+    }
+
+    /// <summary>AE15: a queued occurrence repurposed by coalesce has its ownership revoked and carries the stamp.</summary>
+    public virtual async Task coalesce_repurposes_a_queued_occurrence_and_revokes_ownership()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-repurpose");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-repurpose",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+
+        // A row already claimed and queued by another node, but not yet executing.
+        var occurrenceId = Guid.NewGuid();
+        await fixture.SeedCronOccurrenceAsync(
+            occurrenceId,
+            cronId,
+            (int)JobStatus.Queued,
+            "node-b@1",
+            NodeDeathPolicy.Retry,
+            DateTime.UtcNow.AddMinutes(5),
+            seeded.NextDueUtc,
+            ct
+        );
+
+        var result = await persistence.ApplyCronRecoveryAsync(_Request(cronId, seeded, MissedRunPolicy.Coalesce), ct);
+
+        result!.CoalescedRun.Should().NotBeNull();
+        result.CoalescedRun!.Id.Should().Be(occurrenceId, "the existing row is reused, not duplicated");
+
+        var stored = (await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct)).Single();
+        stored
+            .OwnerId.Should()
+            .BeNull(
+                "the claim path's in-progress transition requires OwnerId == owner, so revoking it is what makes the "
+                    + "prior owner drop the row"
+            );
+        stored.LockedUntil.Should().BeNull();
+        stored.RecoveredFromUtc.Should().NotBeNull();
+        stored.Status.Should().Be(JobStatus.Idle);
+    }
+
+    /// <summary>AE9: an occurrence another node is executing is left alone and its instant is not duplicated.</summary>
+    public virtual async Task recovery_leaves_an_executing_occurrence_untouched()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-inflight");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-inflight",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+
+        var occurrenceId = Guid.NewGuid();
+        await fixture.SeedCronOccurrenceAsync(
+            occurrenceId,
+            cronId,
+            (int)JobStatus.InProgress,
+            "node-b@1",
+            NodeDeathPolicy.Retry,
+            DateTime.UtcNow.AddMinutes(5),
+            seeded.NextDueUtc,
+            ct
+        );
+
+        var result = await persistence.ApplyCronRecoveryAsync(_Request(cronId, seeded, MissedRunPolicy.Coalesce), ct);
+
+        result!.CoalescedRun.Should().BeNull("a second run at that instant would duplicate work already in flight");
+
+        var stored = (await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct)).Single();
+        stored.Status.Should().Be(JobStatus.InProgress, "running work is never disturbed by recovery");
+        stored.OwnerId.Should().Be("node-b@1");
+
+        var position = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+        position
+            .ReconciledThroughUtc.Should()
+            .BeCloseTo(_RecoveryInstant(seeded), TimeSpan.FromMicroseconds(1), "the watermark still advances past it");
+    }
+
+    /// <summary>AE10: an occurrence that already completed is not executed a second time.</summary>
+    public virtual async Task recovery_does_not_re_execute_a_completed_occurrence()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-completed");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-completed",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+
+        // Terminal, so the filtered uniqueness index no longer covers it — only R7 prevents a re-run.
+        await fixture.SeedCronOccurrenceAsync(
+            Guid.NewGuid(),
+            cronId,
+            (int)JobStatus.Succeeded,
+            ownerId: null,
+            NodeDeathPolicy.Retry,
+            lockedUntil: null,
+            seeded.NextDueUtc,
+            ct
+        );
+
+        var result = await persistence.ApplyCronRecoveryAsync(_Request(cronId, seeded, MissedRunPolicy.Coalesce), ct);
+
+        result!.CoalescedRun.Should().BeNull("that instant already ran");
+        (await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct))
+            .Should()
+            .ContainSingle()
+            .Which.Status.Should()
+            .Be(JobStatus.Succeeded);
+    }
+
+    public virtual async Task concurrent_recovery_of_one_backlog_produces_exactly_one_winner()
+    {
+        var ct = AbortToken;
+        await fixture.ResetDatabaseAsync(ct);
+        using var host = fixture.BuildHost("recovery-race");
+        await JobsCoordinationFixtureExtensions.CreateJobsSchemaAsync(host, ct);
+        var persistence = _Persistence(host);
+
+        var cronId = Guid.NewGuid();
+        await fixture.SeedCronJobAsync(
+            cronId,
+            "recovery-race",
+            "0 0 * * * *",
+            NodeDeathPolicy.Retry,
+            ct,
+            reconciledThroughOffsetSeconds: -14400,
+            nextDueOffsetSeconds: -10800
+        );
+        var seeded = await fixture.ReadCronSchedulePositionAsync(cronId, ct);
+
+        // Every racer submits the SAME observed watermark, as N nodes waking together on one backlog would. Each needs
+        // its own occurrence id: two winners writing the same id would look like one winner and hide the defect.
+        var results = await Task.WhenAll(
+            Enumerable
+                .Range(0, 6)
+                .Select(async _ =>
+                {
+                    await Task.Yield();
+                    return await persistence.ApplyCronRecoveryAsync(
+                        _Request(cronId, seeded, MissedRunPolicy.Coalesce),
+                        ct
+                    );
+                })
+        );
+
+        results
+            .Count(x => x is not null)
+            .Should()
+            .Be(1, "the watermark fence must serialize concurrent recoveries down to a single winner");
+        (await persistence.GetAllCronJobOccurrencesAsync(x => x.CronJobId == cronId, ct))
+            .Should()
+            .ContainSingle("a losing racer must not materialize a second run for the same backlog");
+    }
+
+    private static DateTime _RecoveryInstant((DateTime ReconciledThroughUtc, DateTime NextDueUtc) seeded) =>
+        seeded.NextDueUtc.AddHours(2);
+
+    private static CronRecoveryRequest _Request(
+        Guid cronJobId,
+        (DateTime ReconciledThroughUtc, DateTime NextDueUtc) seeded,
+        MissedRunPolicy policy
+    ) =>
+        new()
+        {
+            CronJobId = cronJobId,
+            ObservedReconciledThroughUtc = seeded.ReconciledThroughUtc,
+            ExpectedScheduleRevision = 0L,
+            RecoveredThroughUtc = _RecoveryInstant(seeded),
+            NextDueUtc = _RecoveryInstant(seeded).AddHours(1),
+            Policy = policy,
+            EarliestMissedUtc = seeded.NextDueUtc,
+            CoalescedOccurrenceId = Guid.NewGuid(),
+            OnNodeDeath = NodeDeathPolicy.Retry,
+            OperationTimeUtc = DateTimeOffset.UtcNow,
+        };
+
+    private static IJobPersistenceProvider<TimeJobEntity, CronJobEntity> _Persistence(IHost host) =>
+        host.Services.GetRequiredService<IJobPersistenceProvider<TimeJobEntity, CronJobEntity>>();
+}


### PR DESCRIPTION
> **Stacked PR — base is `xshaheen/jobs-cron-misfire-watermark` (#785), not `main`.**
> Review #785 first; this branch builds directly on its dispatch path and cannot merge before it.

## Summary

- Makes missed cron occurrences **detectable and recoverable**. Slice 1 gave each definition a durable watermark; this slice reads it to decide when a definition has fallen behind, and resolves that backlog under a policy instead of replaying it one tick at a time.
- **Coalesce** (the default) materializes exactly one run stamped with the earliest missed instant; **skip** materializes none. Both carry the watermark to the recovery instant, so a resolved backlog is never reconsidered.
- Occurrences already sitting in the missed window are resolved by the same policy rather than left to run: a not-yet-executing row is repurposed as the coalesced run **with its ownership revoked**, or transitioned to skipped. An in-flight or terminal row is stepped past untouched and its instant is never duplicated.
- This is **slice 2 of 5** (U6–U8). Configuration surface, job-visible context, the evaluation-fingerprint sweep, observability, and docs follow.

## Related Work

Related: #676. Builds on #785 (slice 1). Plan: `docs/plans/2026-07-26-001-feat-jobs-cron-misfire-cursor-plan.md`

## Scope

Affected packages or domains:

- `Headless.Jobs.Abstractions` — `CronRecoveryRequest`/`CronRecoveryResult<T>`, two new `CronDispatchCandidate` members, `JobsRecoveryDefaults`, one new `IJobPersistenceProvider` member
- `Headless.Jobs.Core` — `CronScheduleCache.EvaluatePending`, `CronPendingEvaluation`, recovery wiring in `InternalJobsManager`, in-memory provider implementation
- `Headless.Jobs.EntityFramework` — relational recovery implementation, occurrence projection fixes
- Test harness + both relational integration suites
- `docs/solutions/design-patterns/temporal-authority-standard.md`

Out of scope (later slices):

- Policy and grace configuration surface (U9) — the attribute and runtime API. U9 also retires the "persisted zero means unresolved" fallback introduced here by resolving grace explicitly at creation.
- Job-visible scheduling context (U10), evaluation fingerprint and sweep (U11–U12), observability (U13), docs sync (U14)
- Bounded catch-up, overlap policy, operator backfill — see the plan's Scope Boundaries

Three commits here are **slice-1 follow-ups** that landed on this branch because #785 was already open: the measured tie-group parallelization, the `OnMissedRun` invariant guard, and the temporal-standard carve-out.

## Change Type

- [x] Feature
- [x] Performance
- [x] Bug fix

## Compatibility and Breaking Changes

- [ ] No breaking changes
- [x] Breaking change (apply the `major` label and complete the details below)

- [x] Source/API compatibility
- [x] Binary compatibility
- [x] Behavioral compatibility (including changed defaults)

Breaking-change details:

```text
1. IJobPersistenceProvider<TTimeJob, TCronJob> gains a required member.

   Previous: no recovery surface.
   New: ApplyCronRecoveryAsync is a required member.
   Affected: any consumer with a custom IJobPersistenceProvider implementation.
   Why: recovery must resolve occurrences and move the watermark without interleaving; that
        composition is a property of the store and cannot be defaulted.
   Migration: implement it. The relational and in-memory providers are the reference
        implementations; note the contract requires ONE transaction, not one statement.

2. CronDispatchCandidate gains two required init members (MissedRunGraceSeconds, OnMissedRun).
   Affected: any code constructing this record — in practice only a custom provider's candidate
   read. Migration: populate both from the definition.

3. CronJobEntity.MissedRunGraceSeconds default changes from 0 to 60.

   Previous: CLR default of 0.
   New: JobsRecoveryDefaults.MissedRunGraceSeconds (60s, matching Quartz's misfire threshold), and
        a persisted 0 is read as "unresolved" rather than literal.
   Why: zero is not a usable threshold. Dispatch is always at or after its scheduled instant, so a
        zero grace classifies every tick delayed by a GC pause as a misfire -- and every row
        migrated by slice 1 carries zero, so honoring it literally would route essentially all
        normal dispatch into recovery on any upgraded database.
   Migration: none required. Set MissedRunGraceSeconds explicitly to override.

4. Behavioral: a definition whose watermark has fallen behind now enters recovery instead of
   dispatching each missed tick. That is the feature, but it changes observable behavior for any
   deployment that was silently relying on backlog replay.
```

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [x] `make test-unit`
- [x] `make test-integration`

Validation details:

```text
make build         -> Build succeeded. 0 Warning(s) 0 Error(s)
make format-check  -> Checked 4033 files, clean

Jobs unit             -> 681/681 passed
PostgreSQL integration -> 105/105 passed
SqlServer integration  -> 109/110  (see below)

CI runs unit tests only, so both relational suites were run locally and re-run after every change.

The one SqlServer failure is
JobsClaimConformanceTests.synchronized_workers_claim_disjoint_fallback_cron_occurrences -- a
PRE-EXISTING contention flake in a harness file this branch never touches (last modified by #768).
Verified rather than assumed: it fails roughly one run in two when run in isolation, on a code path
(fallback occurrence claiming) unrelated to anything here.

Measured, not estimated: the tie-group parallelization commit is backed by a benchmark against a
real PostgreSQL container -- 64 advances took 815ms sequentially (12.73ms each) versus 127ms in
bounded parallel waves, a 6.4x difference on the scheduler's wake path.
```

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [x] Added provider-conformance coverage where shared behavior changed
- [x] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files

```text
Consumer-facing docs are owned by U14 in the final slice, when the behavior they describe has
stopped moving -- and they carry superseded "no catch-up" statements that must be corrected rather
than left standing, which cannot be written accurately until the configuration surface (U9) exists.

docs/solutions/design-patterns/temporal-authority-standard.md IS updated here, because slice 1
introduced a deliberate deviation from it that existed only as inline comments.

New cross-provider conformance lives in the existing Jobs harness rather than duplicated per
provider project: JobsRecoveryConformanceTests (6 scenarios) running on PostgreSQL and SqlServer.
```

## Reviewer Guide

**The atomicity decision is the one to scrutinise.** `ApplyCronRecoveryAsync` uses an explicit transaction, unlike the slice-1 advance primitive which is autocommit-by-construction. That is deliberate and the reasoning is narrow: the occurrence resolution and the watermark move must not interleave, or a crash between them leaves the backlog partly resolved with the watermark already past it and *nothing left to re-derive the remainder from* — unlike normal dispatch, which is self-healing. It is safe specifically because the recovery instant is a caller-supplied store instant rather than a live clock read, so no database-clock expression is frozen at transaction open. KTD1 governs clock *expressions* inside transactions, not transactions as such.

**Ownership revocation is the whole repurposing mechanism** (`KTD5`). The claim path's in-progress transition already requires `OwnerId == owner`, so clearing the owner is sufficient to make a prior owner drop the row — no new machinery and no cost on the normal execution path.

**Two defects found while wiring this up, both the shape this repo has already paid for once.** `_CloneCronOccurrence` and *both* EF cron-occurrence projections dropped `RecoveredFromUtc`, silently demoting a coalesced run to an ordinary one the moment it round-tripped — the same failure mode `CLAUDE.md` records for `RetryCount`. This is exactly why R23 requires the stamp on every pickup, claim, and retry projection: by the time a recovery run executes, the watermark has moved past the backlog, so the row is the only thing that still knows what it stands for. Separately, the in-memory claim's existing-occurrence branch never attached the `CronJob` navigation.

**Where recovery decides nothing:** the backlog *count* is bounded by an evaluation ceiling and never gates the decision. Whether a definition enters recovery is settled by the second pending instant at the latest, so the ceiling only bounds a reported number. Both returned instants stay exact under saturation because the walk visits them in order — which is what lets a coalesced run report an accurate scheduled instant for an unbounded backlog.

**Pause needs no special case** (R16). Resume rebases the watermark to the resume instant, so a paused span is never between the watermark and now and cannot produce a pending instant. That property is bought by slice 1 and pinned with a test here rather than re-implemented as a guard.

## Release Notes

Cron definitions that fall behind — after downtime, a stalled scheduler, or a crash — are now detected and recovered rather than silently losing their missed occurrences. Recovery ships with two policies: `Coalesce` (the default) runs the schedule once for the whole missed window, reporting the earliest missed instant as its scheduled time; `Skip` runs nothing and simply moves past the backlog. Both match the defaults that Quartz, Hangfire, and systemd independently converged on.

A late occurrence is not a misfire: a grace threshold (60 seconds by default, matching Quartz) separates ordinary lateness from a genuine miss, and recovery triggers only when more than one occurrence is pending or a single one exceeds that threshold.

Recovery never runs an instant twice — an occurrence already executing or already finished is left alone — and never leaves two live occurrences for one instant.
