### PR TITLE
feat(jobs): evaluation fingerprint, rebase sweep, observability, and docs (U11-U14)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -172,6 +172,50 @@ The per-gate strictness setting: off (skip), warn (log and continue, recording d
 strict (throw and fail host startup). A gate resolves its mode from an explicit operator value when
 set, otherwise from an environment-aware default keyed to its tier.
 
+## Jobs (misfire recovery)
+
+### Schedule watermark
+
+The UTC instant through which one cron definition's schedule has been reconciled. Records what was
+*accounted for* rather than what was promised, which is why it stays true when a rule change
+invalidates a derived prediction and why a skip advances it without anything firing. Distinct from
+`ScheduleRevision`, which is definition-version metadata rather than a schedule position.
+
+### Dispatch projection
+
+The first occurrence after the watermark, persisted and indexed. It is the key the scheduler selects
+on, so deciding what is due costs an indexed read rather than evaluating every definition's
+expression on every node. Always derivable from the watermark and the definition, so it can be
+rebuilt whenever schedule interpretation changes.
+
+### Pending instant
+
+A scheduled instant at or before now that the watermark has not passed — whether or not an
+occurrence row exists for it. Row-independence is the point: a process that died mid-sleep left no
+row behind, so a row-based definition of "missed" is blind to exactly the case recovery exists for.
+
+### Misfire
+
+A backlog that warrants recovery rather than ordinary dispatch: more than one pending instant, or a
+single pending instant older than the definition's grace threshold.
+
+### Grace threshold
+
+Seconds of lateness tolerated before a single pending occurrence counts as a misfire. Resolved once
+at creation and persisted per definition, so no node's local configuration can decide whether an
+instant misfired.
+
+### Recovery run
+
+An occurrence materialized by recovery rather than normal dispatch, stamped with the earliest missed
+instant it stands in for. A coalesced run represents the whole missed window, not one instant.
+
+### Evaluation fingerprint
+
+An opaque hash of the rules a projection was derived under — cron-library semantics and the
+effective timezone's DST rules. Only equality is meaningful: a mismatch means an identical
+expression and timezone would now resolve to a different instant.
+
 ## Jobs (chains)
 
 ### Job chain

--- a/docs/llms/jobs.md
+++ b/docs/llms/jobs.md
@@ -17,6 +17,12 @@ packages: Jobs.Abstractions, Jobs.Core, Jobs.Dashboard, Jobs.SourceGenerator, Jo
     - [Distributed Coordination and Node Identity](#distributed-coordination-and-node-identity)
     - [Commit-Coordinated Enqueue (Atomic Enqueue)](#commit-coordinated-enqueue-atomic-enqueue)
     - [Tenant Propagation](#tenant-propagation)
+- [Misfire recovery](#misfire-recovery)
+    - [When a definition enters recovery](#when-a-definition-enters-recovery)
+    - [Policies](#policies)
+    - [Configuring it](#configuring-it)
+    - [What an executing job sees](#what-an-executing-job-sees)
+    - [Schedule-interpretation drift](#schedule-interpretation-drift)
 - [Choosing a Provider](#choosing-a-provider)
 - [Headless.Jobs.Abstractions](#headlessjobsabstractions)
     - [Problem Solved](#problem-solved)
@@ -149,7 +155,7 @@ Mark job methods with `[JobFunction("name")]` (or `[JobFunction("name", cronExpr
 - `EnqueueOptions` / `RecurringJobOptions` support description, durable retry count/intervals, and node-death policy; recurring options additionally accept nullable IANA `TimeZoneId`. Execution time and cron expression are method arguments. Do not add priority to scheduling options; priority remains immutable `[JobFunction]` / descriptor metadata.
 - Author multi-step workflows with the typed `JobChain` model (it replaces the removed fluent chain builder): `JobChain.Start(payload | descriptor)`, extend node handles with `Then` (on-success) / `Catch` (on-failure), then `await scheduler.EnqueueAsync(chain.Build(), ct)`. Each node allows one `Then` and one `Catch`; chains are capped at `SchedulerOptionsBuilder.MaxChainDepth` nodes deep (default 10); `Catch` is on-failure sugar and never recovers the parent. See [Typed Job Chains](#typed-job-chains).
 - For multi-tenant hosts, enable Jobs tenancy through the root tenancy seam: `AddHeadlessTenancy(t => t.Jobs(jobs => jobs.PropagateTenant().RequireTenantOnEnqueue()))`. Time jobs then capture the ambient tenant at schedule time and restore it around every execution attempt. Pass `EnqueueOptions.TenantId` to override capture, or `EnqueueOptions.IsSystemJob = true` for a deliberate tenantless job. Cron is always system-scope — never give a cron definition a tenant; fan out explicit-tenant time jobs from application code. See [Tenant Propagation](#tenant-propagation).
-- `PauseCronAsync` / `ResumeCronAsync` control one durable cron definition by ID. Pause skips pending work but preserves `InProgress`; resume schedules one strictly-future occurrence and never performs catch-up replay.
+- `PauseCronAsync` / `ResumeCronAsync` control one durable cron definition by ID. Pause skips pending work but preserves `InProgress`; resume schedules one strictly-future occurrence and rebases the watermark to the resume instant, so the paused interval is never replayed as missed.
 - For testing, call `options.DisableBackgroundServices()` to suppress background scheduler execution.
 - To use `JobsStartMode.Manual`, set `scheduler.StartMode = JobsStartMode.Manual` inside `ConfigureScheduler`.
 - Managers remain supported: inject `ITimeJobManager<TTimeJob>` / `ICronJobManager<TCronJob>` for CRUD, batching, seeding, custom entities, chains, and advanced persistence workflows.
@@ -388,6 +394,103 @@ public static async Task FanOutAsync(IServiceProvider sp, CancellationToken ct)
 
 The framework owns no tenant enumeration, `ITenantStore`, per-tenant cron rows, or per-tenant cron expressions — fan-out is application code by design (`IReportService` and `IAppTenantDirectory` above are application-owned).
 
+## Misfire recovery
+
+A cron definition carries a durable **schedule watermark** — the instant through which its schedule has been
+reconciled — plus a **projection** of the first occurrence after it. The watermark records what was *accounted for*
+rather than what was promised, so it stays true when a rule change invalidates the derived projection, and a skip
+advances it without anything firing.
+
+That record is what makes a missed occurrence detectable at all. Before it, reconciliation state lived only as an
+in-memory sleep timer: a process that died mid-sleep left no trace, and on restart simply recomputed from the current
+time. The occurrence was gone with nothing to notice it had ever been due.
+
+### When a definition enters recovery
+
+An instant is **pending** when it falls at or before now and the watermark has not passed it — whether or not an
+occurrence row exists for it. A definition enters recovery when more than one instant is pending, or when its single
+pending instant is older than that definition's grace threshold.
+
+The grace threshold separates ordinary lateness from a genuine miss. It defaults to 60 seconds (matching Quartz) and
+is resolved once at creation and persisted **per definition**, so every node evaluates the same threshold. A locally
+configured value must never decide whether an instant misfired, or two nodes would disagree about the same tick.
+
+### Policies
+
+| Policy | Behaviour |
+|---|---|
+| `Coalesce` (default) | Materializes exactly **one** run for the whole missed window, reporting the earliest missed instant as its scheduled instant. |
+| `Skip` | Materializes **no** run and simply carries the watermark past the backlog. |
+
+Both leave the watermark at the recovery instant, so a resolved backlog is never reconsidered. A schedule whose
+interval is shorter than the scheduler's wake latency will legitimately re-enter recovery on the following wake —
+that is the correct outcome, not a fault.
+
+The default matches what Hangfire, Quartz, and systemd independently converged on. Bounded catch-up — replaying more
+than one missed occurrence — is deliberately not offered.
+
+Recovery never runs an instant twice and never leaves two live occurrences for one instant. An occurrence already
+executing or already finished is stepped past untouched; one that has not begun executing is either repurposed as the
+coalesced run or transitioned to `Skipped`.
+
+### Configuring it
+
+```csharp
+// Declared in code: seeds the definition when it is first created.
+[JobFunction("reports.nightly", "0 0 2 * * *", OnMissedRun = MissedRunPolicy.Skip, MissedRunGraceSeconds = 300)]
+public Task RunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+```
+
+```csharp
+// Scheduler-wide defaults for definitions that declare neither.
+builder.ConfigureScheduler(scheduler =>
+{
+    scheduler.DefaultMissedRunPolicy = MissedRunPolicy.Coalesce;
+    scheduler.DefaultMissedRunGraceSeconds = 60;
+});
+```
+
+**The persisted value is the authority.** The attribute seeds a definition only when it is created and is never
+reapplied during startup reconciliation, so a value later changed through `ICronJobManager.UpdateAsync` stays in force
+across restarts and redeploys. That single rule is what makes an operator override self-evident without persisting a
+provenance marker — and it means changing the attribute in code does **not** change an existing definition.
+
+### What an executing job sees
+
+```csharp
+public async Task RunAsync(JobFunctionContext context, CancellationToken cancellationToken)
+{
+    if (context.IsRecoveryRun)
+    {
+        // One coalesced run stands in for EVERY occurrence missed during the outage, not just this instant.
+        // Treat RecoveredFromUtc as the lower bound of the window to process.
+        await ProcessSinceAsync(context.RecoveredFromUtc!.Value, cancellationToken);
+        return;
+    }
+
+    await ProcessSinceAsync(context.ScheduledFor, cancellationToken);
+}
+```
+
+`Lateness` reports how late the run actually started. For a recovery run it measures from the earliest missed instant,
+so it spans the outage rather than the dispatch delay. It never goes negative.
+
+### Schedule-interpretation drift
+
+An expression and a timezone identifier can stay byte-identical while the instant they resolve to moves — a tzdata
+update shifts a zone's transitions, or the cron library changes how it reads a field. Each definition therefore stores
+an opaque **evaluation fingerprint** of the rules its projection was derived under; only equality is meaningful.
+
+A background sweep rebases definitions whose fingerprint no longer matches, independently of whether their projection
+is due. That independence is the point: a rule change that moves an occurrence *earlier* hides behind the stale later
+projection, so a sweep keyed on due-ness would skip exactly the definitions that need it. The rebase anchors the new
+projection at or after the current instant, so a tick the changed rules moved into the past is surfaced rather than
+replayed as a misfire.
+
+Recovery and rebase outcomes are reported through the framework's existing logging instrumentation. A missed count is
+always accompanied by whether it is exact or a lower bound — a long outage on a seconds-resolution schedule stops
+counting at a ceiling, and "at least 1000" calls for a different response than "exactly 1000".
+
 ## Choosing a Provider
 
 The base EF package is the compatibility layer. Native claim packages optimize pickup without changing the scheduler contract, lease rules, descendant stamping, or fallback-window behavior.
@@ -513,7 +616,7 @@ var resumeAccepted = await scheduler.ResumeCronAsync(recurringId, ct);
 
 All facade methods return the persisted entity `Guid`; recurring scheduling returns the persisted cron-definition ID. Unknown request types or descriptor names throw `JobFunctionNotFoundException` before persistence. Duplicate function names or typed request mappings fail deterministically while `JobFunctionProvider` builds its configuration-independent canonical indexes; Core projects a separate configuration-resolved runtime registry for each `IHost`. Low-level managers remain supported for CRUD, batching, seeding, custom entity types, chains, and advanced scenarios.
 
-Cron control is durable and definition-specific. Pause returns `true` only when it atomically marks the definition and skips pending `Idle` / `Queued` occurrences; it never cancels `InProgress` work. Resume returns `true` only when it wins the schedule-revision fence and creates exactly one next occurrence strictly after the resume time. It never replays the paused interval. `TimeZoneId` accepts IANA identifiers only; null falls back to the scheduler-global timezone, while occurrence persistence remains UTC with deterministic gap/overlap handling.
+Cron control is durable and definition-specific. Pause returns `true` only when it atomically marks the definition and skips pending `Idle` / `Queued` occurrences; it never cancels `InProgress` work. Resume returns `true` only when it wins the schedule-revision fence and creates exactly one next occurrence strictly after the resume time. It never replays the paused interval — resume rebases the schedule watermark to the resume instant, so misfire recovery sees no backlog for the paused span. `TimeZoneId` accepts IANA identifiers only; null falls back to the scheduler-global timezone, while occurrence persistence remains UTC with deterministic gap/overlap handling.
 
 ### Configuration
 
@@ -572,7 +675,7 @@ Claiming a chained time job leases its non-timed descendants down to the configu
 
 Time-job cancellation is durable and job-ID-only through `IJobScheduler.CancelAsync(jobId)` or `context.RequestCancellationAsync()`. Idle jobs become `Cancelled` atomically; queued and in-progress jobs retain their status and set `CancelRequested`. The owning execution observes the flag before user code and then on a bounded `TimeProvider` cadence. Only a cooperative exit with that execution's exact token after durable observation writes terminal `Cancelled`. Host shutdown and lease loss are distinct causes; lease loss writes no terminal status, while an uncooperative handler keeps its natural result and leaves `CancelRequested` as audit data. An unrelated `OperationCanceledException` remains a failure.
 
-Cron pause/resume is durable and definition-specific. Pause atomically marks the definition and skips pending `Idle` / `Queued` occurrences while preserving `InProgress` work. Resume uses a schedule-revision fence so concurrent nodes create at most one occurrence strictly after the injected `TimeProvider` instant. The paused interval is never replayed; catch-up and misfire policy are outside this contract.
+Cron pause/resume is durable and definition-specific. Pause atomically marks the definition and skips pending `Idle` / `Queued` occurrences while preserving `InProgress` work. Resume uses a schedule-revision fence so concurrent nodes create at most one occurrence strictly after the injected `TimeProvider` instant, and rebases the definition's schedule watermark to the resume instant — which is what keeps the paused interval from being replayed once misfire recovery exists. Catch-up is no longer outside this contract: see [Misfire recovery](#misfire-recovery).
 
 Relational consumers must apply the Jobs migrations for `TimeJobs.CancelRequested`, `CronJobs.TimeZoneId`, `CronJobs.IsPaused`, `CronJobs.ScheduleRevision`, and the live-state cron-occurrence unique index before deployment. Quiesce every scheduler node sharing the store while the occurrence index is replaced because the reference PostgreSQL and SQL Server migrations use blocking index DDL. The PostgreSQL demos and SQL Server conformance project include reference migrations; custom-schema applications own the equivalent migration. Custom persistence providers must implement the new atomic pause, resume, and definition-update SPI before upgrading.
 

--- a/docs/llms/jobs.md
+++ b/docs/llms/jobs.md
@@ -487,6 +487,12 @@ projection, so a sweep keyed on due-ness would skip exactly the definitions that
 projection at or after the current instant, so a tick the changed rules moved into the past is surfaced rather than
 replayed as a misfire.
 
+The sweep runs every `FingerprintSweepInterval` (default 1h) over batches of `FingerprintSweepBatchSize` (default 100),
+and starts a batch immediately whenever the previous one came back full — a tzdata update stales every definition in
+the affected zone at once, so waiting out the interval between batches would leave a large set dispatching under the
+old interpretation for hours. A definition naming a timezone this host cannot resolve is logged and skipped: its
+schedule cannot be re-derived here, and letting the failure escape would abandon the rest of the sweep.
+
 Recovery and rebase outcomes are reported through the framework's existing logging instrumentation. A missed count is
 always accompanied by whether it is exact or a lower bound — a long outage on a seconds-resolution schedule stops
 counting at a ceiling, and "at least 1000" calls for a different response than "exactly 1000".

--- a/src/Headless.Jobs.Abstractions/Instrumentation/IJobsInstrumentation.cs
+++ b/src/Headless.Jobs.Abstractions/Instrumentation/IJobsInstrumentation.cs
@@ -19,6 +19,57 @@ internal interface IJobsInstrumentation
     void LogJobSkipped(Guid jobId, string functionName, string reason);
     void LogSeedingDataStarted(string seedingDataType);
     void LogSeedingDataCompleted(string seedingDataType);
+
+    /// <summary>
+    /// Records that a cron definition's schedule fell behind and was resolved by a recovery policy.
+    /// </summary>
+    /// <param name="cronJobId">The definition that fell behind.</param>
+    /// <param name="functionName">Its registered function name.</param>
+    /// <param name="policy">The policy applied — the recovery's outcome, not merely its trigger.</param>
+    /// <param name="missedCount">Occurrences counted as missed.</param>
+    /// <param name="countIsLowerBound">
+    /// Whether <paramref name="missedCount"/> saturated the evaluation ceiling. An operator reading "1000 missed" must
+    /// be able to tell an exact count from "at least 1000" — reporting a saturated count as exact is the misreading
+    /// this flag exists to prevent, and no consumer can recover the distinction afterwards.
+    /// </param>
+    /// <param name="earliestMissedUtc">First occurrence after the watermark; exact even when the count saturated.</param>
+    /// <param name="latestMissedUtc">Last instant the bounded walk reached.</param>
+    /// <param name="skippedOccurrenceCount">Pending occurrences the policy retired.</param>
+    /// <remarks>
+    /// The count and the latest instant are emitted here and deliberately never persisted: only what the job itself
+    /// consumes lives on the occurrence row, and threading a count through every pickup, claim, and retry projection
+    /// would be considerable work purely for reporting.
+    /// </remarks>
+    void LogCronRecoveryApplied(
+        Guid cronJobId,
+        string functionName,
+        MissedRunPolicy policy,
+        int missedCount,
+        bool countIsLowerBound,
+        DateTime earliestMissedUtc,
+        DateTime latestMissedUtc,
+        int skippedOccurrenceCount
+    );
+
+    /// <summary>
+    /// Records that a definition was positioned under schedule-interpretation rules that have since changed, and was
+    /// rebased under the current ones.
+    /// </summary>
+    /// <param name="cronJobId">The rebased definition.</param>
+    /// <param name="functionName">Its registered function name.</param>
+    /// <param name="previousNextDueUtc">The projection derived under the superseded rules.</param>
+    /// <param name="rebasedNextDueUtc">The projection under current rules.</param>
+    /// <remarks>
+    /// Surfacing this is the entire point of the fingerprint: the expression and timezone are unchanged, so without
+    /// this signal a schedule silently starts firing at a different instant with nothing in the definition to show it.
+    /// </remarks>
+    void LogCronFingerprintRebased(
+        Guid cronJobId,
+        string functionName,
+        DateTime previousNextDueUtc,
+        DateTime rebasedNextDueUtc
+    );
+
     void LogRequestDeserializationFailure(
         string requestType,
         string functionName,

--- a/src/Headless.Jobs.Abstractions/Interfaces/IJobPersistenceProvider.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/IJobPersistenceProvider.cs
@@ -466,6 +466,32 @@ public interface IJobPersistenceProvider<TTimeJob, TCronJob>
     );
 
     /// <summary>
+    /// Reads definitions whose persisted evaluation fingerprint differs from <paramref name="currentFingerprints"/>,
+    /// independently of whether their projection is due.
+    /// </summary>
+    /// <param name="currentFingerprints">
+    /// Every fingerprint the running evaluator currently produces, across the timezones it knows about. A definition
+    /// whose fingerprint is absent from this set — or null — is a <i>candidate</i>; the caller confirms staleness by
+    /// recomputing for that definition's own timezone, so an unknown timezone yields a wasted read rather than a
+    /// missed rebase.
+    /// </param>
+    /// <param name="limit">Maximum definitions to return in one sweep pass.</param>
+    /// <param name="cancellationToken">Token that aborts the query.</param>
+    /// <returns>Candidate definitions with the store instant they were read against; <see langword="null"/> when none.</returns>
+    /// <remarks>
+    /// Selection is deliberately the OPPOSITE criterion from dispatch. A rule change that moves an occurrence
+    /// <i>earlier</i> is hidden behind the stale later projection, so a sweep keyed on due-ness would never see the
+    /// definitions that most need rebasing — which is why this is its own read and its own hosted service rather than
+    /// a branch inside the scheduler loop.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was signalled.</exception>
+    Task<CronDispatchCandidates?> GetStaleFingerprintDefinitionsAsync(
+        IReadOnlyCollection<string> currentFingerprints,
+        int limit,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Recovers the time jobs held by a node that coordination has declared dead, applying each row's
     /// <c>OnNodeDeath</c> policy: <c>Retry</c> → released to <c>Idle</c>, <c>MarkFailed</c> → <c>Failed</c>,
     /// <c>Skip</c> → <c>Skipped</c>.

--- a/src/Headless.Jobs.Abstractions/Interfaces/Managers/IInternalJobManager.cs
+++ b/src/Headless.Jobs.Abstractions/Interfaces/Managers/IInternalJobManager.cs
@@ -47,6 +47,12 @@ internal interface IInternalJobManager
     Task<T?> GetRequestAsync<T>(Guid jobId, JobType type, CancellationToken cancellationToken = default);
     Task<JobExecutionState[]> RunTimedOutTickers(CancellationToken cancellationToken = default);
     Task MigrateDefinedCronJobs(CronSeedDefinition[] cronExpressions, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rebases every cron definition whose persisted evaluation fingerprint no longer matches the running evaluator,
+    /// and reports how many were rebased.
+    /// </summary>
+    Task<int> RebaseStaleFingerprintsAsync(int limit, CancellationToken cancellationToken = default);
     Task DeleteJob(Guid jobId, JobType type, CancellationToken cancellationToken = default);
     Task ReleaseDeadNodeResources(string instanceIdentifier, CancellationToken cancellationToken = default);
 

--- a/src/Headless.Jobs.Abstractions/Models/CronDispatchCandidate.cs
+++ b/src/Headless.Jobs.Abstractions/Models/CronDispatchCandidate.cs
@@ -52,6 +52,13 @@ public sealed record CronDispatchCandidate
 
     /// <summary>The definition's persisted recovery policy, applied when its watermark falls behind.</summary>
     public required MissedRunPolicy OnMissedRun { get; init; }
+
+    /// <summary>
+    /// Fingerprint of the rules this definition's projection was derived under, or <see langword="null"/> when it was
+    /// positioned before fingerprinting existed. Compared for equality only; a mismatch means the same expression and
+    /// timezone would now resolve to a different instant.
+    /// </summary>
+    public string? EvaluationFingerprint { get; init; }
 }
 
 /// <summary>

--- a/src/Headless.Jobs.Abstractions/Models/CronScheduleAdvance.cs
+++ b/src/Headless.Jobs.Abstractions/Models/CronScheduleAdvance.cs
@@ -34,6 +34,17 @@ public sealed record CronScheduleAdvance
     public required DateTime NextDueUtc { get; init; }
 
     /// <summary>
+    /// Fingerprint of the rules the new projection was derived under, or <see langword="null"/> to leave the persisted
+    /// value untouched.
+    /// </summary>
+    /// <remarks>
+    /// Written with the position rather than separately, so the two can never disagree: a projection is only ever
+    /// meaningful alongside the rules that produced it, and a fingerprint refreshed independently would claim a
+    /// position was current under rules it was never derived under.
+    /// </remarks>
+    public string? EvaluationFingerprint { get; init; }
+
+    /// <summary>
     /// Whether the advance additionally requires the observed projection to be due against the <i>store's</i> clock.
     /// </summary>
     /// <remarks>

--- a/src/Headless.Jobs.Core/BackgroundServices/JobsFingerprintSweepBackgroundService.cs
+++ b/src/Headless.Jobs.Core/BackgroundServices/JobsFingerprintSweepBackgroundService.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs.Interfaces.Managers;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable IDE0130 // ReSharper disable once CheckNamespace
+namespace Headless.Jobs.BackgroundServices;
+
+/// <summary>
+/// Rebases cron definitions whose schedule-interpretation rules changed underneath them — a tzdata update that moves
+/// a zone's transitions, or a cron-library upgrade that reads a field differently — while the expression and timezone
+/// string stay byte-identical.
+/// </summary>
+/// <remarks>
+/// <b>Its own service rather than a branch in the scheduler loop (KTD7).</b> It selects on the exact OPPOSITE
+/// criterion from dispatch: a rule change that moves an occurrence <i>earlier</i> is hidden behind the stale later
+/// projection, so a sweep keyed on due-ness would systematically skip the definitions that most need rebasing. Two
+/// opposed selection criteria in one loop is how one of them ends up quietly subordinated to the other.
+/// <para>
+/// Rules change on the timescale of an OS package update, so this runs on a long period rather than the scheduler
+/// cadence. It is also deliberately best-effort: a sweep that throws must not take the host down, because a stale
+/// projection still dispatches — just under the old interpretation — whereas a dead host dispatches nothing.
+/// </para>
+/// </remarks>
+internal sealed class JobsFingerprintSweepBackgroundService(
+    IInternalJobManager internalJobsManager,
+    SchedulerOptionsBuilder schedulerOptions,
+    TimeProvider timeProvider,
+    ILogger<JobsFingerprintSweepBackgroundService> logger
+) : BackgroundService
+{
+    private int _started;
+    private readonly TimeSpan _period = schedulerOptions.FingerprintSweepInterval;
+    private readonly int _batchSize = schedulerOptions.FingerprintSweepBatchSize;
+
+    public override Task StartAsync(CancellationToken ct)
+    {
+        return Interlocked.CompareExchange(ref _started, 1, 0) != 0 ? Task.CompletedTask : base.StartAsync(ct);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Sweep once at startup before waiting out a period: a process that just came up on a host with new tzdata is
+        // the single most likely moment for a fingerprint to be stale, and making it wait out the interval means
+        // dispatching under the old interpretation for exactly as long as the interval.
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var rebased = await internalJobsManager
+                    .RebaseStaleFingerprintsAsync(_batchSize, stoppingToken)
+                    .ConfigureAwait(false);
+
+                if (rebased > 0)
+                {
+                    JobsFingerprintSweepLog.RebasedDefinitions(logger, rebased);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+#pragma warning disable ERP022 // Best-effort by design: see the class remarks.
+            catch (Exception exception)
+            {
+                JobsFingerprintSweepLog.SweepFailed(logger, exception);
+            }
+#pragma warning restore ERP022
+
+            try
+            {
+                await timeProvider.Delay(_period, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+}
+
+internal static partial class JobsFingerprintSweepLog
+{
+    [LoggerMessage(
+        EventId = 3230,
+        Level = LogLevel.Information,
+        Message = "Rebased {Count} cron definition(s) whose schedule-interpretation rules had changed."
+    )]
+    public static partial void RebasedDefinitions(ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 3231,
+        Level = LogLevel.Warning,
+        Message = "The cron evaluation-fingerprint sweep failed; affected definitions keep dispatching under their "
+            + "previous interpretation until the next sweep succeeds."
+    )]
+    public static partial void SweepFailed(ILogger logger, Exception exception);
+}

--- a/src/Headless.Jobs.Core/BackgroundServices/JobsFingerprintSweepBackgroundService.cs
+++ b/src/Headless.Jobs.Core/BackgroundServices/JobsFingerprintSweepBackgroundService.cs
@@ -34,6 +34,11 @@ internal sealed class JobsFingerprintSweepBackgroundService(
     private readonly TimeSpan _period = schedulerOptions.FingerprintSweepInterval;
     private readonly int _batchSize = schedulerOptions.FingerprintSweepBatchSize;
 
+    // Back-to-back full batches before the sweep returns to its interval. At the default batch size this drains 10,000
+    // definitions in one pass, which is far beyond any realistic cron-definition count, so the bound is a backstop
+    // against a provider that never persists rather than a limit real deployments meet.
+    private const int _MaxConsecutiveFullBatches = 100;
+
     public override Task StartAsync(CancellationToken ct)
     {
         return Interlocked.CompareExchange(ref _started, 1, 0) != 0 ? Task.CompletedTask : base.StartAsync(ct);
@@ -41,6 +46,8 @@ internal sealed class JobsFingerprintSweepBackgroundService(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        var consecutiveFullBatches = 0;
+
         // Sweep once at startup before waiting out a period: a process that just came up on a host with new tzdata is
         // the single most likely moment for a fingerprint to be stale, and making it wait out the interval means
         // dispatching under the old interpretation for exactly as long as the interval.
@@ -56,6 +63,27 @@ internal sealed class JobsFingerprintSweepBackgroundService(
                 {
                     JobsFingerprintSweepLog.RebasedDefinitions(logger, rebased);
                 }
+
+                if (rebased >= _batchSize && ++consecutiveFullBatches < _MaxConsecutiveFullBatches)
+                {
+                    // A full batch means the store almost certainly holds more. The event this sweep exists for — a
+                    // tzdata update — stales every definition in the affected zone AT ONCE, so waiting out the
+                    // interval between batches would drain a large set at batch-size-per-interval and keep dispatching
+                    // under the old interpretation for hours. Loop straight into the next batch instead; the sweep
+                    // settles back onto the interval as soon as one batch comes back short.
+                    continue;
+                }
+
+                if (consecutiveFullBatches >= _MaxConsecutiveFullBatches)
+                {
+                    // Progress is guaranteed only while a rebase actually persists a current fingerprint, which is a
+                    // provider contract this service cannot verify. A provider that reports success without persisting
+                    // would otherwise keep this loop hammering the store with no delay between batches, so the drain is
+                    // bounded and what it stopped short of is reported rather than passed over in silence.
+                    JobsFingerprintSweepLog.DrainBoundReached(logger, _MaxConsecutiveFullBatches * _batchSize);
+                }
+
+                consecutiveFullBatches = 0;
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -88,6 +116,15 @@ internal static partial class JobsFingerprintSweepLog
         Message = "Rebased {Count} cron definition(s) whose schedule-interpretation rules had changed."
     )]
     public static partial void RebasedDefinitions(ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 3232,
+        Level = LogLevel.Warning,
+        Message = "The cron evaluation-fingerprint sweep stopped after rebasing {Count} definition(s) in one pass and "
+            + "will resume on its next interval; every batch was full, which can also mean rebases are not being "
+            + "persisted."
+    )]
+    public static partial void DrainBoundReached(ILogger logger, int count);
 
     [LoggerMessage(
         EventId = 3231,

--- a/src/Headless.Jobs.Core/CronEvaluationFingerprint.cs
+++ b/src/Headless.Jobs.Core/CronEvaluationFingerprint.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Globalization;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using NCrontab;
+
+namespace Headless.Jobs;
+
+/// <summary>
+/// Fingerprints the rules a schedule position was derived under: the cron library's semantics and the effective
+/// timezone's actual DST rules. Only equality is meaningful — a mismatch says "an identical expression and timezone
+/// would now resolve to a different instant", which is a signal, not a value to interpret.
+/// </summary>
+/// <remarks>
+/// This exists because an expression and a timezone id can stay byte-identical while the instant they resolve to
+/// moves: a tzdata update shifts a zone's transition rules, or a cron library changes how it interprets a field.
+/// Nothing in the persisted definition would record that, so a position derived under the old rules keeps a meaning
+/// nobody can see has changed.
+/// <para>
+/// The zone's <see cref="TimeZoneInfo.GetAdjustmentRules"/> are hashed rather than a tzdata version string, for two
+/// reasons: .NET exposes no portable tzdata version, and the rules are the thing that actually decides the instant.
+/// It also makes a rule change testable by constructing a zone with different rules, instead of depending on whatever
+/// tzdata the host happens to ship.
+/// </para>
+/// <para>
+/// Deliberately excludes the cron expression. A changed expression already bumps <c>ScheduleRevision</c> and rebases
+/// the projection through the edit path; this fingerprint covers only what changes <i>underneath</i> an unchanged
+/// definition.
+/// </para>
+/// </remarks>
+internal static class CronEvaluationFingerprint
+{
+    // The cron library's own version stands in for its parsing and traversal semantics: an upgrade that changes how a
+    // field is interpreted ships as a new version, and nothing finer-grained is observable from outside the library.
+    private static readonly string _CronLibraryVersion =
+        typeof(CrontabSchedule).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+    /// <summary>Computes the fingerprint for the rules <paramref name="timeZone"/> currently defines.</summary>
+    /// <param name="timeZone">The effective zone, already resolved from the definition's optional identifier.</param>
+    /// <returns>A stable, opaque, 64-character lowercase hex digest.</returns>
+    public static string Compute(TimeZoneInfo timeZone)
+    {
+        var builder = new StringBuilder(256);
+
+        builder.Append("ncrontab=").Append(_CronLibraryVersion).Append('\n');
+        builder.Append("zone=").Append(timeZone.Id).Append('\n');
+        builder
+            .Append("baseOffset=")
+            .Append(timeZone.BaseUtcOffset.Ticks.ToString(CultureInfo.InvariantCulture))
+            .Append('\n');
+        builder.Append("supportsDst=").Append(timeZone.SupportsDaylightSavingTime ? '1' : '0').Append('\n');
+
+        // Rules come back in chronological order, so the digest is stable without sorting. Every field that moves a
+        // transition is included: a tzdata update that only shifts a transition time by an hour must still register.
+        foreach (var rule in timeZone.GetAdjustmentRules())
+        {
+            builder
+                .Append("rule=")
+                .Append(rule.DateStart.Ticks.ToString(CultureInfo.InvariantCulture))
+                .Append('|')
+                .Append(rule.DateEnd.Ticks.ToString(CultureInfo.InvariantCulture))
+                .Append('|')
+                .Append(rule.DaylightDelta.Ticks.ToString(CultureInfo.InvariantCulture))
+                .Append('|')
+                .Append(_Transition(rule.DaylightTransitionStart))
+                .Append('|')
+                .Append(_Transition(rule.DaylightTransitionEnd))
+                .Append('\n');
+        }
+
+        // SHA-256 rather than a runtime string hash: string.GetHashCode is randomized per process, so a fingerprint
+        // built from it would differ after every restart and make every definition look stale on every boot.
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+
+        return Convert.ToHexStringLower(digest);
+    }
+
+    private static string _Transition(TimeZoneInfo.TransitionTime transition)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{(transition.IsFixedDateRule ? 1 : 0)}:{transition.Month}:{transition.Day}:{transition.Week}:{(int)transition.DayOfWeek}:{transition.TimeOfDay.TimeOfDay.Ticks}"
+        );
+    }
+}

--- a/src/Headless.Jobs.Core/CronScheduleCache.cs
+++ b/src/Headless.Jobs.Core/CronScheduleCache.cs
@@ -169,6 +169,20 @@ internal sealed partial class CronScheduleCache(TimeZoneInfo timeZoneInfo)
         };
     }
 
+    /// <summary>
+    /// The fingerprint of the rules this cache would currently evaluate <paramref name="timeZoneId"/> under. A
+    /// definition whose persisted fingerprint differs was positioned under rules that have since changed.
+    /// </summary>
+    /// <remarks>
+    /// Resolved through the same <c>CronTimeZoneResolver</c> the evaluation path uses, so the fingerprint describes the
+    /// zone actually applied — including the scheduler-wide fallback when the definition names none — rather than the
+    /// identifier stored on the row.
+    /// </remarks>
+    public string ComputeEvaluationFingerprint(string? timeZoneId)
+    {
+        return CronEvaluationFingerprint.Compute(CronTimeZoneResolver.Resolve(timeZoneId, TimeZoneInfo));
+    }
+
     public bool Invalidate(string expression)
     {
         return _cache.TryRemove(_Normalize(expression), out _);

--- a/src/Headless.Jobs.Core/DependencyInjection/SetupJobs.cs
+++ b/src/Headless.Jobs.Core/DependencyInjection/SetupJobs.cs
@@ -197,6 +197,8 @@ public static class SetupJobs
             services.AddHostedService(provider => provider.GetRequiredService<JobsSchedulerBackgroundService>());
             services.AddHostedService(provider => provider.GetRequiredService<JobsFallbackBackgroundService>());
             services.AddSingleton<JobsFallbackBackgroundService>();
+            // KTD7: its own service, because it selects on staleness — the opposite criterion from dispatch.
+            services.AddHostedService<JobsFingerprintSweepBackgroundService>();
             services.AddSingleton<JobsExecutionTaskHandler>();
             services.AddSingleton<JobsExecutionCancellationRegistry>();
             services.AddSingleton<IJobsDispatcher, JobsDispatcher>();

--- a/src/Headless.Jobs.Core/Instrumentation/BaseLoggerInstrumentation.cs
+++ b/src/Headless.Jobs.Core/Instrumentation/BaseLoggerInstrumentation.cs
@@ -45,6 +45,39 @@ internal abstract partial class JobsBaseLoggerInstrumentation(ILogger logger, IJ
         logger.JobSkipped(functionName, jobId, reason);
     }
 
+    public virtual void LogCronRecoveryApplied(
+        Guid cronJobId,
+        string functionName,
+        MissedRunPolicy policy,
+        int missedCount,
+        bool countIsLowerBound,
+        DateTime earliestMissedUtc,
+        DateTime latestMissedUtc,
+        int skippedOccurrenceCount
+    )
+    {
+        logger.CronRecoveryApplied(
+            cronJobId,
+            functionName,
+            policy.ToString(),
+            missedCount,
+            countIsLowerBound,
+            earliestMissedUtc,
+            latestMissedUtc,
+            skippedOccurrenceCount
+        );
+    }
+
+    public virtual void LogCronFingerprintRebased(
+        Guid cronJobId,
+        string functionName,
+        DateTime previousNextDueUtc,
+        DateTime rebasedNextDueUtc
+    )
+    {
+        logger.CronFingerprintRebased(cronJobId, functionName, previousNextDueUtc, rebasedNextDueUtc);
+    }
+
     public virtual void LogSeedingDataStarted(string seedingDataType)
     {
         logger.SeedingDataStarted(seedingDataType, InstanceIdentifier);
@@ -115,6 +148,42 @@ internal static partial class JobsBaseLoggerInstrumentationLog
         Message = "Jobs Job skipped: {Function} ({JobId}) - {Reason}"
     )]
     public static partial void JobSkipped(this ILogger logger, string function, Guid jobId, string reason);
+
+    // MissedCount and CountIsLowerBound are emitted as a PAIR on purpose: "1000 missed" and "at least 1000 missed"
+    // call for different operator responses, and nothing downstream can recover the distinction once it is lost.
+    [LoggerMessage(
+        EventId = 3240,
+        Level = LogLevel.Warning,
+        Message = "Cron {Function} ({CronJobId}) fell behind and was resolved by policy {Policy}: {MissedCount} "
+            + "missed occurrence(s) (lower bound: {CountIsLowerBound}) spanning {EarliestMissedUtc:O} to "
+            + "{LatestMissedUtc:O}; {SkippedOccurrenceCount} pending occurrence(s) retired."
+    )]
+    public static partial void CronRecoveryApplied(
+        this ILogger logger,
+        Guid cronJobId,
+        string function,
+        string policy,
+        int missedCount,
+        bool countIsLowerBound,
+        DateTime earliestMissedUtc,
+        DateTime latestMissedUtc,
+        int skippedOccurrenceCount
+    );
+
+    [LoggerMessage(
+        EventId = 3241,
+        Level = LogLevel.Warning,
+        Message = "Cron {Function} ({CronJobId}) was positioned under schedule-interpretation rules that have since "
+            + "changed; projection rebased from {PreviousNextDueUtc:O} to {RebasedNextDueUtc:O}. The expression and "
+            + "timezone are unchanged — only how they resolve."
+    )]
+    public static partial void CronFingerprintRebased(
+        this ILogger logger,
+        Guid cronJobId,
+        string function,
+        DateTime previousNextDueUtc,
+        DateTime rebasedNextDueUtc
+    );
 
     [LoggerMessage(
         EventId = 1005,

--- a/src/Headless.Jobs.Core/JobsOptionsBuilder.cs
+++ b/src/Headless.Jobs.Core/JobsOptionsBuilder.cs
@@ -318,6 +318,24 @@ public sealed class SchedulerOptionsBuilder
     public MissedRunPolicy DefaultMissedRunPolicy { get; set; } = MissedRunPolicy.Coalesce;
 
     /// <summary>
+    /// How often the evaluation-fingerprint sweep looks for definitions whose schedule-interpretation rules changed.
+    /// Defaults to one hour.
+    /// </summary>
+    /// <remarks>
+    /// Rules change on the timescale of an OS package update, not a scheduler tick, so this is deliberately long. The
+    /// sweep also runs once at startup, which is when a fingerprint is most likely to have gone stale.
+    /// </remarks>
+    public TimeSpan FingerprintSweepInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>Maximum definitions the fingerprint sweep rebases per pass. Defaults to 100.</summary>
+    /// <remarks>
+    /// A tzdata update invalidates every definition in the affected zone at once, so the first sweep after one can
+    /// have a large working set. Bounding each pass keeps that from becoming one long transaction-heavy burst;
+    /// the remainder is picked up on the next pass.
+    /// </remarks>
+    public int FingerprintSweepBatchSize { get; set; } = 100;
+
+    /// <summary>
     /// Misfire grace, in seconds, seeded onto cron definitions created without one on their <c>[JobFunction]</c>
     /// attribute. Defaults to <see cref="JobsRecoveryDefaults.MissedRunGraceSeconds"/>.
     /// </summary>

--- a/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
@@ -519,15 +519,6 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
     }
 
     /// <summary>
-    /// Gives a definition its first schedule position, anchored at the store's instant rather than at anything in its
-    /// history, so nothing before this moment is ever treated as missed.
-    /// </summary>
-    /// <remarks>
-    /// Uses the same compare-and-advance as ordinary dispatch — the unset watermark IS the observed value — so two
-    /// nodes initializing the same definition converge on one position instead of racing. Nothing is dispatched on
-    /// this wake; the definition becomes selectable at its real projection on the next one.
-    /// </remarks>
-    /// <summary>
     /// Initializes a positionless definition and dispatches nothing this wake, so it can share the advance wave's
     /// result shape. The definition becomes selectable at its real projection on the next wake.
     /// </summary>
@@ -542,6 +533,14 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
         return null;
     }
 
+    /// <summary>
+    /// Gives a definition its first schedule position, anchored at the store's instant rather than at anything in its
+    /// history, so nothing before this moment is ever treated as missed.
+    /// </summary>
+    /// <remarks>
+    /// Uses the same compare-and-advance as ordinary dispatch — the unset watermark IS the observed value — so two
+    /// nodes initializing the same definition converge on one position instead of racing.
+    /// </remarks>
     private async Task _InitializeSchedulePositionAsync(
         CronDispatchCandidate candidate,
         DateTime storeUtcNow,
@@ -1150,14 +1149,7 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
 
     public async Task<int> RebaseStaleFingerprintsAsync(int limit, CancellationToken cancellationToken = default)
     {
-        // The set of fingerprints this evaluator currently produces, across every timezone the registry declares plus
-        // the scheduler-wide fallback. A definition outside this set is a CANDIDATE, not proven stale — a runtime
-        // definition may name a timezone no declared function uses, so each candidate is confirmed below by
-        // recomputing for its own zone. Erring this way costs a wasted read; the opposite would miss a rebase.
-        var knownFingerprints = new HashSet<string>(StringComparer.Ordinal)
-        {
-            cronScheduleCache.ComputeEvaluationFingerprint(timeZoneId: null),
-        };
+        var knownFingerprints = await _CurrentFingerprintsAsync(cancellationToken).ConfigureAwait(false);
 
         var candidates = await persistenceProvider
             .GetStaleFingerprintDefinitionsAsync(knownFingerprints, limit, cancellationToken)
@@ -1174,11 +1166,33 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var current = cronScheduleCache.ComputeEvaluationFingerprint(candidate.TimeZoneId);
+            string current;
+
+            try
+            {
+                current = cronScheduleCache.ComputeEvaluationFingerprint(candidate.TimeZoneId);
+            }
+            catch (ArgumentException exception)
+            {
+                // This host cannot resolve the definition's zone — a zone dropped by the very tzdata update that made
+                // things stale, or a trimmed container image. Such a definition is permanently a candidate (its
+                // fingerprint can never match), so letting the exception escape would abort the sweep on this row and
+                // every row after it, on every sweep, forever. Skipping keeps the rest of the sweep working; the
+                // definition cannot be repositioned here anyway, because deriving its next occurrence needs the same
+                // zone.
+                logger.LogUnresolvableCronTimeZone(
+                    exception,
+                    candidate.CronJobId,
+                    candidate.FunctionName,
+                    candidate.TimeZoneId ?? "<default>"
+                );
+
+                continue;
+            }
 
             if (string.Equals(candidate.EvaluationFingerprint, current, StringComparison.Ordinal))
             {
-                // A candidate only because its zone was outside the known set — its rules are in fact current.
+                // Its rules are in fact current: possible when a zone entered use between the two reads below.
                 continue;
             }
 
@@ -1189,6 +1203,55 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
         }
 
         return rebased;
+    }
+
+    /// <summary>
+    /// Every fingerprint this evaluator currently produces: one per timezone actually in use, plus the scheduler-wide
+    /// fallback.
+    /// </summary>
+    /// <remarks>
+    /// Completeness is what makes the store-side predicate precise, and it is load-bearing rather than an
+    /// optimization. A zone missing from this set makes every definition using it match "fingerprint not known" on
+    /// every sweep, forever — and because the store applies the batch limit BEFORE the per-candidate confirmation
+    /// above, those permanent false positives crowd genuinely stale definitions out of the batch and starve them
+    /// indefinitely. The zones in use come from the store rather than from the declared functions because a runtime
+    /// definition may name a zone no <c>[JobFunction]</c> mentions.
+    /// </remarks>
+    private async Task<HashSet<string>> _CurrentFingerprintsAsync(CancellationToken cancellationToken)
+    {
+        var fingerprints = new HashSet<string>(StringComparer.Ordinal)
+        {
+            cronScheduleCache.ComputeEvaluationFingerprint(timeZoneId: null),
+        };
+
+        // The one read whose result may legitimately be served from a cache (see IJobPersistenceProvider): a zone that
+        // entered use since it was cached only costs one wasted candidate, which the confirmation above absorbs.
+        var definitions = await persistenceProvider
+            .GetAllCronJobExpressionsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var seenZones = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var definition in definitions)
+        {
+            if (definition.TimeZoneId is not { } zone || !seenZones.Add(zone))
+            {
+                continue;
+            }
+
+            try
+            {
+                fingerprints.Add(cronScheduleCache.ComputeEvaluationFingerprint(zone));
+            }
+            catch (ArgumentException)
+            {
+                // Unresolvable on this host. Contributing nothing is correct — there is no fingerprint that would make
+                // definitions in this zone look current — and the per-candidate guard reports it once per sweep with
+                // the definition it belongs to, rather than once per zone with no owner.
+            }
+        }
+
+        return fingerprints;
     }
 
     /// <summary>
@@ -1382,5 +1445,20 @@ internal static partial class InternalJobsManagerLog
         this ILogger logger,
         Exception exception,
         Guid jobId
+    );
+
+    [LoggerMessage(
+        EventId = 3216,
+        Level = LogLevel.Warning,
+        Message = "Cron definition {CronJobId} ({FunctionName}) names time zone '{TimeZoneId}', which this host "
+            + "cannot resolve. Its schedule interpretation cannot be re-derived here and it is skipped by the "
+            + "fingerprint sweep; the rest of the sweep continues."
+    )]
+    public static partial void LogUnresolvableCronTimeZone(
+        this ILogger logger,
+        Exception exception,
+        Guid cronJobId,
+        string functionName,
+        string timeZoneId
     );
 }

--- a/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
+++ b/src/Headless.Jobs.Core/Managers/InternalJobsManager.cs
@@ -3,6 +3,7 @@
 using Headless.Abstractions;
 using Headless.Jobs.Entities;
 using Headless.Jobs.Enums;
+using Headless.Jobs.Instrumentation;
 using Headless.Jobs.Interfaces;
 using Headless.Jobs.Interfaces.Managers;
 using Headless.Jobs.Internal;
@@ -29,6 +30,17 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
     // R1/KTD1: start-tick of the last stranded-child sweep. long.MinValue means "never run", so the first poll after
     // startup always sweeps and a host that starts with an already-stranded child does not wait out an interval.
     private long _lastStrandedSweepTicks = long.MinValue;
+
+    // Resolved from the container rather than taken as a constructor parameter: the recovery and rebase paths are the
+    // only consumers, and threading a new required dependency through every construction site (including tests that
+    // legitimately do not care about telemetry) would be churn for one optional signal. Null in hosts that register no
+    // instrumentation, which is a supported configuration.
+    private IJobsInstrumentation? _instrumentation;
+
+    private IJobsInstrumentation? _ResolveInstrumentation()
+    {
+        return _instrumentation ??= serviceProvider.GetService<IJobsInstrumentation>();
+    }
 
     private readonly TimeSpan _strandedSweepInterval = schedulerOptions.FallbackIntervalChecker;
 
@@ -551,6 +563,9 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
                     ExpectedScheduleRevision = candidate.ScheduleRevision,
                     ReconciledThroughUtc = storeUtcNow,
                     NextDueUtc = firstOccurrence ?? DateTime.MaxValue,
+                    // Stamped with the position it describes, so the sweep can tell a definition positioned under
+                    // current rules from one carrying no record of how it was positioned at all.
+                    EvaluationFingerprint = cronScheduleCache.ComputeEvaluationFingerprint(candidate.TimeZoneId),
                 },
                 cancellationToken
             )
@@ -607,17 +622,17 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
             return null;
         }
 
-        logger.LogCronRecoveryApplied(
-            candidate.CronJobId,
-            candidate.FunctionName,
-            candidate.OnMissedRun.ToString(),
-            pending.PendingCount,
-            pending.CountSaturated,
-            earliestMissedUtc,
-            pending.LatestPendingUtc ?? earliestMissedUtc,
-            storeUtcNow,
-            recovery.SkippedOccurrenceCount
-        );
+        _ResolveInstrumentation()
+            ?.LogCronRecoveryApplied(
+                candidate.CronJobId,
+                candidate.FunctionName,
+                candidate.OnMissedRun,
+                pending.PendingCount,
+                pending.CountSaturated,
+                earliestMissedUtc,
+                pending.LatestPendingUtc ?? earliestMissedUtc,
+                recovery.SkippedOccurrenceCount
+            );
 
         if (recovery.CoalescedRun is null)
         {
@@ -1133,6 +1148,104 @@ internal sealed class InternalJobsManager<TTimeJob, TCronJob>(
         return [.. results];
     }
 
+    public async Task<int> RebaseStaleFingerprintsAsync(int limit, CancellationToken cancellationToken = default)
+    {
+        // The set of fingerprints this evaluator currently produces, across every timezone the registry declares plus
+        // the scheduler-wide fallback. A definition outside this set is a CANDIDATE, not proven stale — a runtime
+        // definition may name a timezone no declared function uses, so each candidate is confirmed below by
+        // recomputing for its own zone. Erring this way costs a wasted read; the opposite would miss a rebase.
+        var knownFingerprints = new HashSet<string>(StringComparer.Ordinal)
+        {
+            cronScheduleCache.ComputeEvaluationFingerprint(timeZoneId: null),
+        };
+
+        var candidates = await persistenceProvider
+            .GetStaleFingerprintDefinitionsAsync(knownFingerprints, limit, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (candidates is null)
+        {
+            return 0;
+        }
+
+        var rebased = 0;
+
+        foreach (var candidate in candidates.Candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var current = cronScheduleCache.ComputeEvaluationFingerprint(candidate.TimeZoneId);
+
+            if (string.Equals(candidate.EvaluationFingerprint, current, StringComparison.Ordinal))
+            {
+                // A candidate only because its zone was outside the known set — its rules are in fact current.
+                continue;
+            }
+
+            if (await _RebaseAsync(candidate, current, candidates.StoreUtcNow, cancellationToken).ConfigureAwait(false))
+            {
+                rebased++;
+            }
+        }
+
+        return rebased;
+    }
+
+    /// <summary>
+    /// Re-derives one definition's projection under current rules and refreshes its fingerprint, in a single
+    /// compare-and-advance so a pause, resume, or edit racing the sweep wins instead of being clobbered.
+    /// </summary>
+    private async Task<bool> _RebaseAsync(
+        CronDispatchCandidate candidate,
+        string currentFingerprint,
+        DateTime storeUtcNow,
+        CancellationToken cancellationToken
+    )
+    {
+        // Derived from the watermark so no interval is skipped, then anchored at or after the store instant so a tick
+        // the changed rules moved into the past is NOT replayed as a misfire. That anchoring is the difference between
+        // surfacing a rule change and manufacturing a backlog out of one.
+        var anchor = candidate.ReconciledThroughUtc > storeUtcNow ? candidate.ReconciledThroughUtc : storeUtcNow;
+        var rebased = cronScheduleCache.GetNextOccurrenceOrDefault(candidate.Expression, anchor, candidate.TimeZoneId);
+
+        var advanced = await persistenceProvider
+            .AdvanceCronScheduleAsync(
+                new CronScheduleAdvance
+                {
+                    CronJobId = candidate.CronJobId,
+                    ObservedReconciledThroughUtc = candidate.ReconciledThroughUtc,
+                    ExpectedScheduleRevision = candidate.ScheduleRevision,
+                    // The watermark does NOT move: nothing was reconciled, only re-interpreted. Moving it would
+                    // silently declare the span between it and now as accounted for.
+                    ReconciledThroughUtc = candidate.ReconciledThroughUtc,
+                    NextDueUtc = rebased ?? DateTime.MaxValue,
+                    EvaluationFingerprint = currentFingerprint,
+                    // Never gated on due-ness: a rule change that moves an occurrence earlier is invisible behind the
+                    // stale later projection, which is exactly the case this sweep exists for.
+                    RequireProjectionDue = false,
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        if (advanced is null)
+        {
+            // A pause, resume, or edit committed first. Its transition is newer and already carries a correct
+            // position, so losing here is the right outcome — the next sweep re-reads whatever it left.
+            return false;
+        }
+
+        _ResolveInstrumentation()
+            ?.LogCronFingerprintRebased(
+                candidate.CronJobId,
+                candidate.FunctionName,
+                candidate.NextDueUtc,
+                advanced.NextDueUtc
+            );
+
+        return true;
+    }
+
     public async Task MigrateDefinedCronJobs(
         CronSeedDefinition[] cronExpressions,
         CancellationToken cancellationToken = default
@@ -1257,30 +1370,6 @@ internal static partial class InternalJobsManagerLog
             + "fallback sweep's set-based reconcile instead. Scheduling continues."
     )]
     public static partial void LogTimedChildSafetyNetFailed(this ILogger logger, Exception exception);
-
-    // MissedCount is a lower bound whenever CountSaturated is true — the walk stops at the evaluation ceiling rather
-    // than enumerating an unbounded backlog. The two are logged together so an operator can tell "exactly 3 missed"
-    // from "at least 1000 missed"; reporting a saturated count as exact is the misreading this pairing prevents.
-    [LoggerMessage(
-        EventId = 3220,
-        Level = LogLevel.Warning,
-        Message = "Cron definition {CronJobId} ({Function}) fell behind and was recovered with policy {Policy}: "
-            + "{MissedCount} missed occurrence(s) (lower bound: {CountSaturated}) spanning {EarliestMissedUtc:O} to "
-            + "{LatestMissedUtc:O}; watermark advanced to {RecoveredThroughUtc:O} and {SkippedCount} pending "
-            + "occurrence(s) were skipped."
-    )]
-    public static partial void LogCronRecoveryApplied(
-        this ILogger logger,
-        Guid cronJobId,
-        string function,
-        string policy,
-        int missedCount,
-        bool countSaturated,
-        DateTime earliestMissedUtc,
-        DateTime latestMissedUtc,
-        DateTime recoveredThroughUtc,
-        int skippedCount
-    );
 
     [LoggerMessage(
         EventId = 3215,

--- a/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
+++ b/src/Headless.Jobs.Core/Provider/JobsInMemoryPersistenceProvider.cs
@@ -1422,6 +1422,50 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
         return Task.FromResult(job is null ? null : _CloneCronJob(job));
     }
 
+    public Task<CronDispatchCandidates?> GetStaleFingerprintDefinitionsAsync(
+        IReadOnlyCollection<string> currentFingerprints,
+        int limit,
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var known = currentFingerprints.ToHashSet(StringComparer.Ordinal);
+
+        var candidates = _cronJobs
+            .Values.Where(x =>
+                !x.IsPaused && (x.EvaluationFingerprint is null || !known.Contains(x.EvaluationFingerprint))
+            )
+            .OrderBy(x => x.Id)
+            .Take(limit)
+            .Select(x => new CronDispatchCandidate
+            {
+                CronJobId = x.Id,
+                FunctionName = x.Function,
+                Expression = x.Expression,
+                TimeZoneId = x.TimeZoneId,
+                ScheduleRevision = x.ScheduleRevision,
+                ReconciledThroughUtc = x.ReconciledThroughUtc,
+                NextDueUtc = x.NextDueUtc,
+                Retries = x.Retries,
+                RetryIntervals = x.RetryIntervals,
+                OnNodeDeath = x.OnNodeDeath,
+                MissedRunGraceSeconds = x.MissedRunGraceSeconds,
+                OnMissedRun = x.OnMissedRun,
+                EvaluationFingerprint = x.EvaluationFingerprint,
+            })
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return Task.FromResult<CronDispatchCandidates?>(null);
+        }
+
+        return Task.FromResult<CronDispatchCandidates?>(
+            new CronDispatchCandidates { Candidates = candidates, StoreUtcNow = _timeProvider.GetUtcNow().UtcDateTime }
+        );
+    }
+
     public Task<CronRecoveryResult<TCronJob>?> ApplyCronRecoveryAsync(
         CronRecoveryRequest request,
         CancellationToken cancellationToken = default
@@ -1568,6 +1612,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
                 OnNodeDeath = x.OnNodeDeath,
                 MissedRunGraceSeconds = x.MissedRunGraceSeconds,
                 OnMissedRun = x.OnMissedRun,
+                EvaluationFingerprint = x.EvaluationFingerprint,
             })
             .ToArray();
 
@@ -1617,6 +1662,7 @@ internal sealed class JobsInMemoryPersistenceProvider<TTimeJob, TCronJob> : IJob
             var updated = _CloneCronJob(current);
             updated.ReconciledThroughUtc = advance.ReconciledThroughUtc;
             updated.NextDueUtc = advance.NextDueUtc;
+            updated.EvaluationFingerprint = advance.EvaluationFingerprint ?? updated.EvaluationFingerprint;
             _cronJobs[advance.CronJobId] = updated;
 
             // Read back off the stored instance rather than echoing the request, so this provider's result is

--- a/src/Headless.Jobs.Core/README.md
+++ b/src/Headless.Jobs.Core/README.md
@@ -45,7 +45,7 @@ The whole chain executes in-process under the root's single pickup lease. If the
 
 Time-job cancellation is durable and job-ID-only through `IJobScheduler.CancelAsync` or `context.RequestCancellationAsync()`. Idle jobs become `Cancelled` atomically; queued and in-progress jobs retain their status and set `CancelRequested`. The owning execution observes that flag immediately before user code and then on `CancellationObservationInterval`, using the same owner/status fence as lease renewal.
 
-Cron pause/resume is durable and definition-specific. Pause atomically marks the definition and skips pending `Idle` / `Queued` occurrences while preserving `InProgress` work. Resume uses a schedule revision fence so concurrent nodes create at most one occurrence strictly after the injected `TimeProvider` instant. The paused interval is never replayed; catch-up and misfire policy are outside this contract.
+Cron pause/resume is durable and definition-specific. Pause atomically marks the definition and skips pending `Idle` / `Queued` occurrences while preserving `InProgress` work. Resume uses a schedule revision fence so concurrent nodes create at most one occurrence strictly after the injected `TimeProvider` instant, and rebases the definition's schedule watermark to the resume instant — which is what keeps the paused interval from being replayed once misfire recovery exists. Catch-up is no longer outside this contract: see [Misfire recovery](#misfire-recovery).
 
 Each host owns an independent execution-cancellation registry. Durable cancellation, host shutdown, and lease loss are distinct causes tied to one opaque execution handle. Only a cooperative exit with that execution's exact token after durable observation writes terminal `Cancelled`. Lease loss and cooperative host shutdown leave the row `InProgress` for recovery; an uncooperative handler keeps its natural success/failure result while `CancelRequested` remains audit data. An unrelated `OperationCanceledException` remains a failure and follows retry policy.
 
@@ -56,6 +56,103 @@ Cron expressions use `RecurringJobOptions.TimeZoneId` when present and otherwise
 Jobs uses reusable Polly.Core `ResiliencePipeline` instances for runtime retry execution. `JobsRetryOptions.RetryStrategy` is the public Polly configuration surface, while `Retries`, `RetryCount`, and `RetryIntervals` remain the durable authority. `RetryCount` is persisted before every wait; lease renewal stays active across attempts and delays, and a lost lease cancels the pipeline and fences terminal writes. Per-row `RetryIntervals` override Polly delay generation and reuse their last value when shorter than `Retries`. Polly configuration and delegates are never serialized.
 
 There is no `app.UseJobs()` call — the scheduler starts automatically through the `IHostedService` registrations added by `AddHeadlessJobs`.
+
+## Misfire recovery
+
+A cron definition carries a durable **schedule watermark** — the instant through which its schedule has been
+reconciled — plus a **projection** of the first occurrence after it. The watermark records what was *accounted for*
+rather than what was promised, so it stays true when a rule change invalidates the derived projection, and a skip
+advances it without anything firing.
+
+That record is what makes a missed occurrence detectable at all. Before it, reconciliation state lived only as an
+in-memory sleep timer: a process that died mid-sleep left no trace, and on restart simply recomputed from the current
+time. The occurrence was gone with nothing to notice it had ever been due.
+
+### When a definition enters recovery
+
+An instant is **pending** when it falls at or before now and the watermark has not passed it — whether or not an
+occurrence row exists for it. A definition enters recovery when more than one instant is pending, or when its single
+pending instant is older than that definition's grace threshold.
+
+The grace threshold separates ordinary lateness from a genuine miss. It defaults to 60 seconds (matching Quartz) and
+is resolved once at creation and persisted **per definition**, so every node evaluates the same threshold. A locally
+configured value must never decide whether an instant misfired, or two nodes would disagree about the same tick.
+
+### Policies
+
+| Policy | Behaviour |
+|---|---|
+| `Coalesce` (default) | Materializes exactly **one** run for the whole missed window, reporting the earliest missed instant as its scheduled instant. |
+| `Skip` | Materializes **no** run and simply carries the watermark past the backlog. |
+
+Both leave the watermark at the recovery instant, so a resolved backlog is never reconsidered. A schedule whose
+interval is shorter than the scheduler's wake latency will legitimately re-enter recovery on the following wake —
+that is the correct outcome, not a fault.
+
+The default matches what Hangfire, Quartz, and systemd independently converged on. Bounded catch-up — replaying more
+than one missed occurrence — is deliberately not offered.
+
+Recovery never runs an instant twice and never leaves two live occurrences for one instant. An occurrence already
+executing or already finished is stepped past untouched; one that has not begun executing is either repurposed as the
+coalesced run or transitioned to `Skipped`.
+
+### Configuring it
+
+```csharp
+// Declared in code: seeds the definition when it is first created.
+[JobFunction("reports.nightly", "0 0 2 * * *", OnMissedRun = MissedRunPolicy.Skip, MissedRunGraceSeconds = 300)]
+public Task RunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+```
+
+```csharp
+// Scheduler-wide defaults for definitions that declare neither.
+builder.ConfigureScheduler(scheduler =>
+{
+    scheduler.DefaultMissedRunPolicy = MissedRunPolicy.Coalesce;
+    scheduler.DefaultMissedRunGraceSeconds = 60;
+});
+```
+
+**The persisted value is the authority.** The attribute seeds a definition only when it is created and is never
+reapplied during startup reconciliation, so a value later changed through `ICronJobManager.UpdateAsync` stays in force
+across restarts and redeploys. That single rule is what makes an operator override self-evident without persisting a
+provenance marker — and it means changing the attribute in code does **not** change an existing definition.
+
+### What an executing job sees
+
+```csharp
+public async Task RunAsync(JobFunctionContext context, CancellationToken cancellationToken)
+{
+    if (context.IsRecoveryRun)
+    {
+        // One coalesced run stands in for EVERY occurrence missed during the outage, not just this instant.
+        // Treat RecoveredFromUtc as the lower bound of the window to process.
+        await ProcessSinceAsync(context.RecoveredFromUtc!.Value, cancellationToken);
+        return;
+    }
+
+    await ProcessSinceAsync(context.ScheduledFor, cancellationToken);
+}
+```
+
+`Lateness` reports how late the run actually started. For a recovery run it measures from the earliest missed instant,
+so it spans the outage rather than the dispatch delay. It never goes negative.
+
+### Schedule-interpretation drift
+
+An expression and a timezone identifier can stay byte-identical while the instant they resolve to moves — a tzdata
+update shifts a zone's transitions, or the cron library changes how it reads a field. Each definition therefore stores
+an opaque **evaluation fingerprint** of the rules its projection was derived under; only equality is meaningful.
+
+A background sweep rebases definitions whose fingerprint no longer matches, independently of whether their projection
+is due. That independence is the point: a rule change that moves an occurrence *earlier* hides behind the stale later
+projection, so a sweep keyed on due-ness would skip exactly the definitions that need it. The rebase anchors the new
+projection at or after the current instant, so a tick the changed rules moved into the past is surfaced rather than
+replayed as a misfire.
+
+Recovery and rebase outcomes are reported through the framework's existing logging instrumentation. A missed count is
+always accompanied by whether it is exact or a lower bound — a long outage on a seconds-resolution schedule stops
+counting at a ceiling, and "at least 1000" calls for a different response than "exactly 1000".
 
 ## Installation
 

--- a/src/Headless.Jobs.Core/README.md
+++ b/src/Headless.Jobs.Core/README.md
@@ -150,6 +150,12 @@ projection, so a sweep keyed on due-ness would skip exactly the definitions that
 projection at or after the current instant, so a tick the changed rules moved into the past is surfaced rather than
 replayed as a misfire.
 
+The sweep runs every `FingerprintSweepInterval` (default 1h) over batches of `FingerprintSweepBatchSize` (default 100),
+and starts a batch immediately whenever the previous one came back full — a tzdata update stales every definition in
+the affected zone at once, so waiting out the interval between batches would leave a large set dispatching under the
+old interpretation for hours. A definition naming a timezone this host cannot resolve is logged and skipped: its
+schedule cannot be re-derived here, and letting the failure escape would abandon the rest of the sweep.
+
 Recovery and rebase outcomes are reported through the framework's existing logging instrumentation. A missed count is
 always accompanied by whether it is exact or a lower bound — a long outage on a seconds-resolution schedule stops
 counting at a ceiling, and "at least 1000" calls for a different response than "exactly 1000".

--- a/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
+++ b/src/Headless.Jobs.EntityFramework/Infrastructure/BasePersistenceProvider.cs
@@ -1324,6 +1324,79 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
             .ConfigureAwait(false);
     }
 
+    public async Task<CronDispatchCandidates?> GetStaleFingerprintDefinitionsAsync(
+        IReadOnlyCollection<string> currentFingerprints,
+        int limit,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var dbContext = await DbContextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var known = currentFingerprints.ToArray();
+
+        // Selects on STALENESS, never on due-ness — a rule change that moves an occurrence earlier hides behind the
+        // stale later projection, so the definitions that most need rebasing are exactly the ones a due-ness query
+        // would skip. Backed by IX_CronJobs_EvaluationFingerprint. A null fingerprint is a definition positioned
+        // before fingerprinting existed and is swept in for the same treatment.
+        var rows = await dbContext
+            .Set<TCronJob>()
+            .AsNoTracking()
+            .Where(x => !x.IsPaused)
+            .Where(x => x.EvaluationFingerprint == null || !known.Contains(x.EvaluationFingerprint))
+            .OrderBy(x => x.Id)
+            .Take(limit)
+            .Select(x => new
+            {
+                x.Id,
+                x.Function,
+                x.Expression,
+                x.TimeZoneId,
+                x.ScheduleRevision,
+                x.ReconciledThroughUtc,
+                x.NextDueUtc,
+                x.Retries,
+                x.RetryIntervals,
+                x.OnNodeDeath,
+                x.MissedRunGraceSeconds,
+                x.OnMissedRun,
+                x.EvaluationFingerprint,
+                StoreUtcNow = DateTime.UtcNow,
+            })
+            .ToArrayAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (rows.Length == 0)
+        {
+            return null;
+        }
+
+        return new CronDispatchCandidates
+        {
+            StoreUtcNow = rows[0].StoreUtcNow,
+            Candidates =
+            [
+                .. rows.Select(x => new CronDispatchCandidate
+                {
+                    CronJobId = x.Id,
+                    FunctionName = x.Function,
+                    Expression = x.Expression,
+                    TimeZoneId = x.TimeZoneId,
+                    ScheduleRevision = x.ScheduleRevision,
+                    ReconciledThroughUtc = x.ReconciledThroughUtc,
+                    NextDueUtc = x.NextDueUtc,
+                    Retries = x.Retries,
+                    RetryIntervals = x.RetryIntervals,
+                    OnNodeDeath = x.OnNodeDeath,
+                    MissedRunGraceSeconds = x.MissedRunGraceSeconds,
+                    OnMissedRun = x.OnMissedRun,
+                    EvaluationFingerprint = x.EvaluationFingerprint,
+                }),
+            ],
+        };
+    }
+
     public async Task<CronRecoveryResult<TCronJob>?> ApplyCronRecoveryAsync(
         CronRecoveryRequest request,
         CancellationToken cancellationToken = default
@@ -1531,6 +1604,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
                 x.OnNodeDeath,
                 x.MissedRunGraceSeconds,
                 x.OnMissedRun,
+                x.EvaluationFingerprint,
                 StoreUtcNow = DateTime.UtcNow,
             })
             .ToArrayAsync(cancellationToken)
@@ -1560,6 +1634,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
                     OnNodeDeath = x.OnNodeDeath,
                     MissedRunGraceSeconds = x.MissedRunGraceSeconds,
                     OnMissedRun = x.OnMissedRun,
+                    EvaluationFingerprint = x.EvaluationFingerprint,
                 }),
             ],
         };
@@ -1602,13 +1677,17 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeJob, TCronJob>(
         // `advance` would put a property access on the record inside the tree for EF to translate.
         var reconciledThroughUtc = advance.ReconciledThroughUtc;
         var nextDueUtc = advance.NextDueUtc;
+        var fingerprint = advance.EvaluationFingerprint;
 
         var affected = await fenced
             .ExecuteUpdateAsync(
                 setter =>
                     setter
                         .SetProperty(x => x.ReconciledThroughUtc, reconciledThroughUtc)
-                        .SetProperty(x => x.NextDueUtc, nextDueUtc),
+                        .SetProperty(x => x.NextDueUtc, nextDueUtc)
+                        // Null leaves the persisted value alone, so an ordinary dispatch advance does not have to know
+                        // or restate the fingerprint just to move the watermark.
+                        .SetProperty(x => x.EvaluationFingerprint, x => fingerprint ?? x.EvaluationFingerprint),
                 cancellationToken
             )
             .ConfigureAwait(false);

--- a/tests/Headless.Jobs.Composition.Tests.Unit/CronEvaluationFingerprintTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/CronEvaluationFingerprintTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+/// <summary>
+/// The fingerprint's whole job is to make an invisible change visible: an expression and a timezone identifier can
+/// stay byte-identical while the instant they resolve to moves, because the zone's rules changed underneath them.
+/// </summary>
+/// <remarks>
+/// The rule-change scenarios use synthetic zones rather than real ones. Asserting on a real zone's rules would make
+/// the test a hostage to whatever tzdata the machine ships — it would pass or fail on the CI image's IANA version
+/// rather than on this code, which is exactly the kind of test that erodes trust in a suite.
+/// </remarks>
+public sealed class CronEvaluationFingerprintTests : TestBase
+{
+    private static CronScheduleCache _Cache() => new(TimeZoneInfo.Utc);
+
+    [Fact]
+    public void should_produce_the_same_fingerprint_for_the_same_zone_under_the_same_rules()
+    {
+        var first = _Cache().ComputeEvaluationFingerprint("Europe/Berlin");
+        var second = _Cache().ComputeEvaluationFingerprint("Europe/Berlin");
+
+        second.Should().Be(first);
+        first.Should().HaveLength(64, "a SHA-256 digest, and it must fit the 128-char persisted column");
+    }
+
+    [Fact]
+    public void should_produce_a_different_fingerprint_for_a_different_zone()
+    {
+        var berlin = _Cache().ComputeEvaluationFingerprint("Europe/Berlin");
+        var cairo = _Cache().ComputeEvaluationFingerprint("Africa/Cairo");
+
+        cairo.Should().NotBe(berlin, "two zones interpret the same wall-clock expression as different instants");
+    }
+
+    [Fact]
+    public void should_reflect_the_scheduler_wide_fallback_when_the_definition_names_no_zone()
+    {
+        // A definition with no timezone takes the scheduler's zone, so its fingerprint must describe THAT zone —
+        // otherwise changing the scheduler's zone would leave every such definition claiming to be current.
+        var utcScheduler = new CronScheduleCache(TimeZoneInfo.Utc).ComputeEvaluationFingerprint(timeZoneId: null);
+        var berlinScheduler = new CronScheduleCache(
+            TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin")
+        ).ComputeEvaluationFingerprint(timeZoneId: null);
+
+        berlinScheduler.Should().NotBe(utcScheduler);
+    }
+
+    /// <summary>
+    /// AE14's premise: a tzdata update shifts a zone's transition while the expression and zone string stay identical.
+    /// </summary>
+    [Fact]
+    public void should_change_when_the_zones_transition_rules_change()
+    {
+        var before = CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 3));
+        var after = CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 4));
+
+        after
+            .Should()
+            .NotBe(
+                before,
+                "the identifier and offset are unchanged — only the transition month moved, which is precisely the "
+                    + "shape of a tzdata update that silently changes what an unchanged expression resolves to"
+            );
+    }
+
+    [Fact]
+    public void should_change_when_the_daylight_delta_changes()
+    {
+        var before = CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 3, deltaHours: 1));
+        var after = CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 3, deltaHours: 2));
+
+        after.Should().NotBe(before);
+    }
+
+    [Fact]
+    public void should_not_change_for_an_identically_defined_zone()
+    {
+        var first = CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 3));
+        var second = CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 3));
+
+        second.Should().Be(first, "identical rules must fingerprint identically or every sweep would rebase forever");
+    }
+
+    /// <summary>
+    /// Stability across restarts is load-bearing: a fingerprint built from a per-process randomized hash would make
+    /// every definition look stale on every boot and rebase the entire schedule set on startup.
+    /// </summary>
+    [Fact]
+    public void should_be_stable_rather_than_derived_from_a_randomized_runtime_hash()
+    {
+        var zone = _Zone(daylightStartMonth: 3);
+        var fingerprint = CronEvaluationFingerprint.Compute(zone);
+
+        // A randomized hash would differ between two structurally identical inputs built independently in the same
+        // process only across restarts, which a single-process test cannot observe. What it CAN prove is that the
+        // digest is a pure function of the declared rules and carries no instance identity.
+        CronEvaluationFingerprint.Compute(_Zone(daylightStartMonth: 3)).Should().Be(fingerprint);
+        fingerprint.Should().MatchRegex("^[0-9a-f]{64}$", "a hex SHA-256 digest, not a runtime hash code");
+    }
+
+    private static TimeZoneInfo _Zone(int daylightStartMonth, int deltaHours = 1)
+    {
+        var start = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(
+            new DateTime(1, 1, 1, 2, 0, 0, DateTimeKind.Unspecified),
+            daylightStartMonth,
+            5,
+            DayOfWeek.Sunday
+        );
+        var end = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(
+            new DateTime(1, 1, 1, 3, 0, 0, DateTimeKind.Unspecified),
+            10,
+            5,
+            DayOfWeek.Sunday
+        );
+        var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            DateTime.MinValue.Date,
+            DateTime.MaxValue.Date,
+            TimeSpan.FromHours(deltaHours),
+            start,
+            end
+        );
+
+        return TimeZoneInfo.CreateCustomTimeZone(
+            "Test/Synthetic",
+            TimeSpan.FromHours(1),
+            "Synthetic",
+            "Synthetic Standard",
+            "Synthetic Daylight",
+            [rule]
+        );
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/DocumentedRecoveryApiTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/DocumentedRecoveryApiTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs;
+using Headless.Jobs.Base;
+using Headless.Jobs.Enums;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+/// <summary>
+/// Compiles the exact API shapes the misfire-recovery documentation shows. Documentation drift is silent — a renamed
+/// property or changed default leaves the prose looking authoritative while it quietly stops being true — so the
+/// examples are pinned here rather than trusted to review.
+/// </summary>
+public sealed class DocumentedRecoveryApiTests : TestBase
+{
+    private sealed class DocumentedJob
+    {
+        // The attribute example from "Configuring it".
+        [JobFunction("reports.nightly", "0 0 2 * * *", OnMissedRun = MissedRunPolicy.Skip, MissedRunGraceSeconds = 300)]
+        public Task RunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        // The job-visible context example from "What an executing job sees".
+        public Task ExecuteAsync(JobFunctionContext context, CancellationToken cancellationToken)
+        {
+            if (context.IsRecoveryRun)
+            {
+                _ = context.RecoveredFromUtc!.Value;
+                _ = context.Lateness;
+
+                return Task.CompletedTask;
+            }
+
+            _ = context.ScheduledFor;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void the_documented_attribute_shape_compiles_and_round_trips()
+    {
+        var attribute = typeof(DocumentedJob)
+            .GetMethod(nameof(DocumentedJob.RunAsync))!
+            .GetCustomAttributes(typeof(JobFunctionAttribute), inherit: false)
+            .Cast<JobFunctionAttribute>()
+            .Single();
+
+        attribute.OnMissedRun.Should().Be(MissedRunPolicy.Skip);
+        attribute.MissedRunGraceSeconds.Should().Be(300);
+    }
+
+    [Fact]
+    public void the_documented_scheduler_defaults_compile_and_match_the_documented_values()
+    {
+        var scheduler = new SchedulerOptionsBuilder();
+
+        // The documented defaults, asserted so the prose cannot drift from them silently.
+        scheduler.DefaultMissedRunPolicy.Should().Be(MissedRunPolicy.Coalesce);
+        scheduler.DefaultMissedRunGraceSeconds.Should().Be(60);
+
+        // The documented configuration example.
+        scheduler.DefaultMissedRunPolicy = MissedRunPolicy.Coalesce;
+        scheduler.DefaultMissedRunGraceSeconds = 60;
+
+        scheduler.DefaultMissedRunGraceSeconds.Should().Be(JobsRecoveryDefaults.MissedRunGraceSeconds);
+    }
+
+    [Fact]
+    public void the_documented_default_policy_is_coalesce()
+    {
+        // Stated in the policy table and in the release notes; a reordered enum would break both.
+        default(MissedRunPolicy).Should().Be(MissedRunPolicy.Coalesce);
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronFingerprintSweepTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronFingerprintSweepTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.Jobs;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Interfaces;
+using Headless.Jobs.Managers;
+using Headless.Jobs.Models;
+using Headless.Jobs.Provider;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.Managers;
+
+/// <summary>
+/// The fingerprint sweep: detecting that a definition was positioned under schedule-interpretation rules that have
+/// since changed, and rebasing it without manufacturing a backlog out of the change.
+/// </summary>
+/// <remarks>
+/// Staleness is simulated by persisting a fingerprint the running evaluator does not produce, which is exactly what a
+/// tzdata update looks like from the store's side. That keeps the tests independent of whatever IANA data the host
+/// ships — a test that only fails on certain CI images teaches nothing.
+/// </remarks>
+public sealed class CronFingerprintSweepTests : TestBase
+{
+    public sealed class FakeTimeJob : TimeJobEntity<FakeTimeJob>;
+
+    public sealed class FakeCronJob : CronJobEntity;
+
+    private const string _NodeA = "node-a";
+    private static readonly DateTime _Now = new(2026, 07, 26, 12, 00, 00, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task should_rebase_a_definition_whose_interpretation_rules_changed()
+    {
+        var (manager, provider) = _Create();
+        // Projection far in the future, so a due-ness-gated sweep would never look at it — the case AE14 is about.
+        var definition = _Definition(nextDue: _Now.AddDays(20), fingerprint: "stale-from-an-older-tzdata");
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var rebased = await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        rebased.Should().Be(1);
+        var after = (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!;
+        after
+            .NextDueUtc.Should()
+            .NotBe(definition.NextDueUtc, "the projection is re-derived under the rules now in force");
+        after.EvaluationFingerprint.Should().NotBe("stale-from-an-older-tzdata");
+        after
+            .ReconciledThroughUtc.Should()
+            .Be(
+                definition.ReconciledThroughUtc,
+                "nothing was reconciled, only re-interpreted — moving the watermark would declare the span since it "
+                    + "as accounted for"
+            );
+    }
+
+    [Fact]
+    public async Task should_rebase_even_when_the_new_instant_is_earlier_than_the_stale_projection()
+    {
+        var (manager, provider) = _Create();
+        // The pathological case: the stale projection sits 20 days out, so nothing due-based would ever surface it,
+        // yet current rules put the real next occurrence within the minute.
+        var definition = _Definition(nextDue: _Now.AddDays(20), fingerprint: "stale");
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        var after = (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!;
+        after
+            .NextDueUtc.Should()
+            .BeBefore(
+                _Now.AddDays(20),
+                "an occurrence the new rules moved earlier must not stay suppressed behind the stale later projection"
+            );
+    }
+
+    [Fact]
+    public async Task should_never_rebase_to_an_instant_in_the_past()
+    {
+        var (manager, provider) = _Create();
+        // Watermark far behind: derived purely from it, the next occurrence would land in the past and read as a
+        // misfire. Anchoring at or after the store instant is what stops a rule change becoming a fake backlog.
+        var definition = _Definition(nextDue: _Now.AddDays(20), fingerprint: "stale");
+        definition.ReconciledThroughUtc = _Now.AddDays(-30);
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        var after = (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!;
+        after
+            .NextDueUtc.Should()
+            .BeOnOrAfter(_Now, "a tick the changed rules moved into the past must not be replayed as missed");
+    }
+
+    [Fact]
+    public async Task should_not_touch_a_definition_whose_fingerprint_is_current()
+    {
+        var (manager, provider) = _Create();
+        var cache = new CronScheduleCache(TimeZoneInfo.Utc);
+        var definition = _Definition(
+            nextDue: _Now.AddDays(20),
+            fingerprint: cache.ComputeEvaluationFingerprint(timeZoneId: null)
+        );
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var rebased = await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        rebased.Should().Be(0);
+        var after = (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!;
+        after.NextDueUtc.Should().Be(definition.NextDueUtc, "matching rules means there is nothing to re-derive");
+    }
+
+    [Fact]
+    public async Task should_lose_the_fence_to_a_concurrent_definition_transition()
+    {
+        var (manager, provider) = _Create();
+        var definition = _Definition(nextDue: _Now.AddDays(20), fingerprint: "stale");
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        // A pause commits between the sweep's read and its write: the revision moves, so the rebase must lose.
+        await provider.PauseCronJobAsync(definition.Id, new DateTimeOffset(_Now, TimeSpan.Zero), AbortToken);
+
+        var rebased = await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        rebased.Should().Be(0, "a paused definition is not selectable, and a newer transition always wins the fence");
+        var after = (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!;
+        after.IsPaused.Should().BeTrue("the sweep must not resurrect or clobber a newer transition");
+    }
+
+    [Fact]
+    public async Task should_rebase_a_definition_that_was_positioned_before_fingerprinting_existed()
+    {
+        var (manager, provider) = _Create();
+        var definition = _Definition(nextDue: _Now.AddDays(20), fingerprint: null);
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        var rebased = await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        rebased.Should().Be(1, "a null fingerprint records nothing about how the position was derived");
+        (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!.EvaluationFingerprint.Should().NotBeNull();
+    }
+
+    private static (
+        InternalJobsManager<FakeTimeJob, FakeCronJob> Manager,
+        JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob> Provider
+    ) _Create()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(_Now, TimeSpan.Zero));
+        var services = new ServiceCollection();
+        services.AddSingleton<TimeProvider>(time);
+        services.AddHeadlessGuidGenerator();
+        services.AddSingleton(new SchedulerOptionsBuilder { NodeId = _NodeA });
+        services.AddSingleton(Substitute.For<IJobsHostScheduler>());
+        var sp = services.BuildServiceProvider();
+
+        var provider = new JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob>(sp);
+        var manager = new InternalJobsManager<FakeTimeJob, FakeCronJob>(
+            provider,
+            time,
+            Substitute.For<IJobsNotificationHubSender>(),
+            new CronScheduleCache(TimeZoneInfo.Utc),
+            NullLogger<InternalJobsManager<FakeTimeJob, FakeCronJob>>.Instance,
+            JobsRequestSerializationOptions.Default,
+            sp.GetRequiredService<IGuidGenerator>(),
+            sp,
+            sp.GetRequiredService<SchedulerOptionsBuilder>()
+        );
+
+        return (manager, provider);
+    }
+
+    private static FakeCronJob _Definition(DateTime nextDue, string? fingerprint) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Function = "cron-sweep",
+            Expression = "0 * * * * *",
+            ScheduleRevision = 2,
+            ReconciledThroughUtc = _Now.AddMinutes(-1),
+            NextDueUtc = nextDue,
+            EvaluationFingerprint = fingerprint,
+            CreatedAt = new DateTimeOffset(_Now.AddHours(-1), TimeSpan.Zero),
+            UpdatedAt = new DateTimeOffset(_Now.AddMinutes(-1), TimeSpan.Zero),
+        };
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronFingerprintSweepTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronFingerprintSweepTests.cs
@@ -143,6 +143,67 @@ public sealed class CronFingerprintSweepTests : TestBase
         (await provider.GetCronJobByIdAsync(definition.Id, AbortToken))!.EvaluationFingerprint.Should().NotBeNull();
     }
 
+    /// <summary>
+    /// The store applies the batch limit BEFORE the manager can confirm whether a candidate is really stale, so any
+    /// definition that is permanently a candidate consumes batch budget on every sweep, forever. A timezone missing
+    /// from the known-fingerprint set produces exactly that, and it starves the definitions the sweep exists to fix.
+    /// </summary>
+    [Fact]
+    public async Task should_not_let_definitions_in_other_time_zones_crowd_out_a_stale_one()
+    {
+        var (manager, provider) = _Create();
+        var cache = new CronScheduleCache(TimeZoneInfo.Utc);
+
+        // Two definitions in a zone that is NOT the scheduler fallback, each already carrying the correct fingerprint
+        // for its own zone, ordered ahead of the stale one by id.
+        var current = cache.ComputeEvaluationFingerprint("America/New_York");
+        var a = _Zoned(new Guid("00000001-0000-0000-0000-000000000000"), "America/New_York", current);
+        var b = _Zoned(new Guid("00000002-0000-0000-0000-000000000000"), "America/New_York", current);
+        var stale = _Zoned(new Guid("00000003-0000-0000-0000-000000000000"), timeZoneId: null, "stale-older-tzdata");
+
+        await provider.InsertCronJobsAsync([a, b, stale], AbortToken);
+
+        // A limit of 2 stands in for the default batch size with more zoned definitions than fit in one batch.
+        var rebased = await manager.RebaseStaleFingerprintsAsync(limit: 2, AbortToken);
+
+        rebased.Should().Be(1, "the genuinely stale definition must be reached, not crowded out by current ones");
+        (await provider.GetCronJobByIdAsync(stale.Id, AbortToken))!
+            .EvaluationFingerprint.Should()
+            .NotBe("stale-older-tzdata");
+    }
+
+    /// <summary>
+    /// A zone this host cannot resolve is exactly what the tzdata update this sweep exists for can produce. Such a
+    /// definition is permanently a candidate, so letting the resolve failure escape would abort every sweep at that
+    /// row for good.
+    /// </summary>
+    [Fact]
+    public async Task should_skip_an_unresolvable_time_zone_without_abandoning_the_sweep()
+    {
+        var (manager, provider) = _Create();
+        var unresolvable = _Zoned(new Guid("00000001-0000-0000-0000-000000000000"), "Mars/Olympus", "stale");
+        var healthy = _Zoned(new Guid("00000002-0000-0000-0000-000000000000"), timeZoneId: null, "stale");
+
+        await provider.InsertCronJobsAsync([unresolvable, healthy], AbortToken);
+
+        var rebased = await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        rebased.Should().Be(1, "the healthy definition is still rebased");
+        (await provider.GetCronJobByIdAsync(healthy.Id, AbortToken))!.EvaluationFingerprint.Should().NotBe("stale");
+        (await provider.GetCronJobByIdAsync(unresolvable.Id, AbortToken))!
+            .EvaluationFingerprint.Should()
+            .Be("stale", "a definition whose zone cannot be resolved here cannot be repositioned here either");
+    }
+
+    private static FakeCronJob _Zoned(Guid id, string? timeZoneId, string? fingerprint)
+    {
+        var definition = _Definition(nextDue: _Now.AddDays(20), fingerprint);
+        definition.Id = id;
+        definition.TimeZoneId = timeZoneId;
+
+        return definition;
+    }
+
     private static (
         InternalJobsManager<FakeTimeJob, FakeCronJob> Manager,
         JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob> Provider

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronRecoveryObservabilityTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Managers/CronRecoveryObservabilityTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Diagnostics;
+using Headless.Abstractions;
+using Headless.Jobs;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+using Headless.Jobs.Instrumentation;
+using Headless.Jobs.Interfaces;
+using Headless.Jobs.Managers;
+using Headless.Jobs.Models;
+using Headless.Jobs.Provider;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.Managers;
+
+/// <summary>
+/// What an operator can see when a schedule falls behind or its interpretation changes. Asserted through the
+/// instrumentation surface rather than a metrics backend, so the outcomes are observable in a plain unit test.
+/// </summary>
+public sealed class CronRecoveryObservabilityTests : TestBase
+{
+    public sealed class FakeTimeJob : TimeJobEntity<FakeTimeJob>;
+
+    public sealed class FakeCronJob : CronJobEntity;
+
+    private static readonly DateTime _Now = new(2026, 07, 26, 12, 00, 00, DateTimeKind.Utc);
+
+    private sealed record RecoveryOutcome(
+        MissedRunPolicy Policy,
+        int MissedCount,
+        bool CountIsLowerBound,
+        DateTime EarliestMissedUtc,
+        int SkippedOccurrenceCount
+    );
+
+    [Fact]
+    public async Task should_report_a_coalesced_recovery_with_its_missed_count()
+    {
+        var (manager, provider, outcomes, _) = _Create();
+        // Hourly, four hours behind: several occurrences missed, well past the grace threshold.
+        await provider.InsertCronJobsAsync([_Behind(MissedRunPolicy.Coalesce)], AbortToken);
+
+        await manager.GetNextJobs(AbortToken);
+
+        var outcome = outcomes.Should().ContainSingle().Subject;
+        outcome.Policy.Should().Be(MissedRunPolicy.Coalesce);
+        outcome.MissedCount.Should().BeGreaterThan(1);
+        outcome.CountIsLowerBound.Should().BeFalse("a four-hour hourly backlog is far inside the ceiling");
+        outcome.EarliestMissedUtc.Should().BeBefore(_Now);
+    }
+
+    [Fact]
+    public async Task should_report_a_skipped_recovery_distinctly_from_a_coalesced_one()
+    {
+        var (manager, provider, outcomes, _) = _Create();
+        await provider.InsertCronJobsAsync([_Behind(MissedRunPolicy.Skip)], AbortToken);
+
+        await manager.GetNextJobs(AbortToken);
+
+        outcomes
+            .Should()
+            .ContainSingle()
+            .Which.Policy.Should()
+            .Be(MissedRunPolicy.Skip, "the outcome must say what recovery DID, not merely that it triggered");
+    }
+
+    /// <summary>
+    /// A saturated count and an exact one call for different operator responses, and the distinction cannot be
+    /// recovered downstream — so it has to travel with the number.
+    /// </summary>
+    [Fact]
+    public async Task should_mark_a_saturated_count_as_a_lower_bound()
+    {
+        var (manager, provider, outcomes, _) = _Create();
+        // One-second schedule, four hours behind: ~14,400 instants, far past the evaluation ceiling.
+        var definition = _Behind(MissedRunPolicy.Coalesce);
+        definition.Expression = "* * * * * *";
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        await manager.GetNextJobs(AbortToken);
+
+        var outcome = outcomes.Should().ContainSingle().Subject;
+        outcome
+            .CountIsLowerBound.Should()
+            .BeTrue("the walk stopped at the ceiling, so the number is 'at least', not 'exactly'");
+        outcome.MissedCount.Should().Be(JobsRecoveryDefaults.EvaluationCeiling);
+        outcome
+            .EarliestMissedUtc.Should()
+            .Be(
+                _Now.AddHours(-4).AddSeconds(1),
+                "the earliest instant stays exact under saturation — it is what the coalesced run reports"
+            );
+    }
+
+    [Fact]
+    public async Task should_report_a_fingerprint_rebase()
+    {
+        var (manager, provider, _, rebases) = _Create();
+        var definition = _Behind(MissedRunPolicy.Coalesce);
+        definition.NextDueUtc = _Now.AddDays(20);
+        definition.EvaluationFingerprint = "stale";
+        await provider.InsertCronJobsAsync([definition], AbortToken);
+
+        await manager.RebaseStaleFingerprintsAsync(limit: 50, AbortToken);
+
+        rebases.Should().ContainSingle("the whole point of the fingerprint is that this is otherwise invisible");
+    }
+
+    [Fact]
+    public async Task should_report_no_recovery_outcome_for_ordinary_dispatch()
+    {
+        var (manager, provider, outcomes, _) = _Create();
+        var onTime = _Behind(MissedRunPolicy.Coalesce);
+        onTime.Expression = "0 * * * * *";
+        onTime.ReconciledThroughUtc = _Now.AddSeconds(-30);
+        onTime.NextDueUtc = _Now;
+        await provider.InsertCronJobsAsync([onTime], AbortToken);
+
+        await manager.GetNextJobs(AbortToken);
+
+        outcomes.Should().BeEmpty("a punctual dispatch is not a recovery and must not read like one");
+    }
+
+    private sealed class CapturingInstrumentation(List<RecoveryOutcome> outcomes, List<Guid> rebases)
+        : IJobsInstrumentation
+    {
+        public void LogCronRecoveryApplied(
+            Guid cronJobId,
+            string functionName,
+            MissedRunPolicy policy,
+            int missedCount,
+            bool countIsLowerBound,
+            DateTime earliestMissedUtc,
+            DateTime latestMissedUtc,
+            int skippedOccurrenceCount
+        ) =>
+            outcomes.Add(
+                new RecoveryOutcome(policy, missedCount, countIsLowerBound, earliestMissedUtc, skippedOccurrenceCount)
+            );
+
+        public void LogCronFingerprintRebased(
+            Guid cronJobId,
+            string functionName,
+            DateTime previousNextDueUtc,
+            DateTime rebasedNextDueUtc
+        ) => rebases.Add(cronJobId);
+
+        public Activity? StartJobActivity(string name, JobExecutionState state) => null;
+
+        public void LogJobEnqueued(string jobType, string functionName, Guid jobId, string? enqueuedFrom = null) { }
+
+        public void LogJobCompleted(Guid jobId, string functionName, long executionTimeMs, bool success) { }
+
+        public void LogJobFailed(Guid jobId, string functionName, Exception exception, int retryCount) { }
+
+        public void LogJobCancelled(Guid jobId, string functionName, string reason) { }
+
+        public void LogJobSkipped(Guid jobId, string functionName, string reason) { }
+
+        public void LogSeedingDataStarted(string seedingDataType) { }
+
+        public void LogSeedingDataCompleted(string seedingDataType) { }
+
+        public void LogRequestDeserializationFailure(
+            string requestType,
+            string functionName,
+            Guid jobId,
+            JobType type,
+            Exception exception
+        ) { }
+    }
+
+    private static (
+        InternalJobsManager<FakeTimeJob, FakeCronJob> Manager,
+        JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob> Provider,
+        List<RecoveryOutcome> Outcomes,
+        List<Guid> Rebases
+    ) _Create()
+    {
+        var outcomes = new List<RecoveryOutcome>();
+        var rebases = new List<Guid>();
+        var time = new FakeTimeProvider(new DateTimeOffset(_Now, TimeSpan.Zero));
+        var services = new ServiceCollection();
+        services.AddSingleton<TimeProvider>(time);
+        services.AddHeadlessGuidGenerator();
+        services.AddSingleton(new SchedulerOptionsBuilder { NodeId = "node-a" });
+        services.AddSingleton(Substitute.For<IJobsHostScheduler>());
+        services.AddSingleton<IJobsInstrumentation>(new CapturingInstrumentation(outcomes, rebases));
+        var sp = services.BuildServiceProvider();
+
+        var provider = new JobsInMemoryPersistenceProvider<FakeTimeJob, FakeCronJob>(sp);
+        var manager = new InternalJobsManager<FakeTimeJob, FakeCronJob>(
+            provider,
+            time,
+            Substitute.For<IJobsNotificationHubSender>(),
+            new CronScheduleCache(TimeZoneInfo.Utc),
+            NullLogger<InternalJobsManager<FakeTimeJob, FakeCronJob>>.Instance,
+            JobsRequestSerializationOptions.Default,
+            sp.GetRequiredService<IGuidGenerator>(),
+            sp,
+            sp.GetRequiredService<SchedulerOptionsBuilder>()
+        );
+
+        return (manager, provider, outcomes, rebases);
+    }
+
+    private static FakeCronJob _Behind(MissedRunPolicy policy) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Function = "cron-observability",
+            Expression = "0 0 * * * *",
+            ScheduleRevision = 0,
+            ReconciledThroughUtc = _Now.AddHours(-4),
+            NextDueUtc = _Now.AddHours(-3),
+            OnMissedRun = policy,
+            MissedRunGraceSeconds = 60,
+            CreatedAt = new DateTimeOffset(_Now.AddDays(-1), TimeSpan.Zero),
+            UpdatedAt = new DateTimeOffset(_Now.AddHours(-4), TimeSpan.Zero),
+        };
+}


### PR DESCRIPTION
> **Stacked PR — base is `xshaheen/jobs-cron-misfire-context` (#789), not `main`.**
> Chain is #785 → #787 → #789 → this. **This is the final slice**; merging it completes the plan.

## Summary

- **U11** — each cron definition now records an opaque **evaluation fingerprint** of the rules its projection was derived under.
- **U12** — a background sweep rebases definitions whose interpretation rules changed underneath them, selecting on staleness rather than due-ness.
- **U13** — recovery and rebase outcomes are observable through the existing instrumentation surface, with a saturated count always distinguishable from an exact one.
- **U14** — both documentation surfaces document the feature and the superseded "catch-up is outside this contract" claims are corrected.

The problem U11–U12 solve: a cron expression and a timezone identifier can stay **byte-identical** while the instant they resolve to moves — a tzdata update shifts a zone's transitions, or the cron library changes how it reads a field. Nothing in the persisted definition recorded that, so a position derived under the old rules kept a meaning nobody could see had changed.

## Related Work

Related: #676. Builds on #789 (slice 3). Plan: `docs/plans/2026-07-26-001-feat-jobs-cron-misfire-cursor-plan.md`

## Scope

Affected packages or domains:

- `Headless.Jobs.Abstractions` — fingerprint on the advance and candidate models, two instrumentation members, one provider member
- `Headless.Jobs.Core` — fingerprint computation, rebase, the sweep hosted service, sweep options
- `Headless.Jobs.EntityFramework` — stale-fingerprint read, fingerprint persistence on advance
- `docs/llms/jobs.md`, `src/Headless.Jobs.Core/README.md`, `CONCEPTS.md`

Out of scope: nothing — this completes U1–U14.

## Change Type

- [x] Feature
- [x] Documentation only (U14 portion)

## Compatibility and Breaking Changes

- [ ] No breaking changes
- [x] Breaking change (apply the `major` label and complete the details below)

- [x] Source/API compatibility
- [x] Binary compatibility
- [x] Behavioral compatibility (including changed defaults)

Breaking-change details:

```text
1. IJobPersistenceProvider gains GetStaleFingerprintDefinitionsAsync.
   Affected: custom IJobPersistenceProvider implementations.
   Why: the sweep selects on the OPPOSITE criterion from dispatch and cannot be composed from the
        existing members without losing that property.
   Migration: implement it — select non-paused definitions whose EvaluationFingerprint is null or
        absent from the supplied set, ordered stably, capped at the limit.

2. IJobsInstrumentation gains LogCronRecoveryApplied and LogCronFingerprintRebased.
   Affected: any custom IJobsInstrumentation implementation (internal surface).
   Migration: implement both; no-op bodies are valid.

3. Behavioral: a new hosted service (JobsFingerprintSweepBackgroundService) is registered alongside
   the existing scheduler services and sweeps once at startup, then hourly. On a host whose tzdata
   differs from the one that positioned the definitions, the first sweep WILL rebase projections —
   that is the intended behavior, and the rebase never replays an instant as missed.
```

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [x] `make test-unit`
- [x] `make test-integration`

Validation details:

```text
make build         -> Build succeeded. 0 Warning(s) 0 Error(s)
make format-check  -> Checked 4043 files, clean

Jobs unit              -> 717/717 passed
PostgreSQL integration -> 107/107 passed
SqlServer integration  -> 112/112 passed

CI runs unit tests only, so both relational suites were run locally and re-run after every change.
Both are fully green on this branch — the intermittent JobsClaimConformanceTests contention flake
noted on earlier slices did not reproduce here.
```

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [x] Added provider-conformance coverage where shared behavior changed
- [x] Updated XML docs for public API changes
- [x] Updated affected package `README.md` files
- [x] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files

```text
U14 closes the documentation debt carried since slice 1. Both surfaces were updated in lockstep, and
the documented API examples are COMPILED by DocumentedRecoveryApiTests rather than trusted to
review — doc drift is silent, and a renamed property or changed default leaves prose looking
authoritative while it quietly stops being true.
```

## Reviewer Guide

**Why the fingerprint hashes adjustment rules rather than a tzdata version.** .NET exposes no portable tzdata version, and the rules are what actually decides the instant. It also makes a rule change testable by constructing a zone with different rules, instead of asserting against whatever IANA data the CI image ships — a test that only fails on certain images teaches nothing.

**SHA-256, not a runtime string hash.** `string.GetHashCode` is randomized per process, so a fingerprint built from it would differ after every restart and make every definition look stale on every boot, rebasing the entire schedule set on startup. Worth confirming nothing in the digest path reintroduces a runtime hash.

**The fingerprint deliberately excludes the expression.** A changed expression already bumps `ScheduleRevision` and rebases through the edit path; this covers only what changes *underneath* an unchanged definition.

**Why the sweep is its own hosted service (KTD7).** It selects on the exact opposite criterion from dispatch. A rule change that moves an occurrence *earlier* hides behind the stale later projection, so a sweep keyed on due-ness would systematically skip the definitions that most need rebasing. Two opposed selection criteria in one loop is how one of them ends up quietly subordinated to the other.

**Two rebase properties are load-bearing.** The new projection is derived from the watermark but **anchored at or after the store instant**, so a tick the changed rules moved into the past is surfaced rather than replayed as a misfire — that is the difference between reporting a rule change and manufacturing a backlog out of one. And the **watermark itself does not move**: nothing was reconciled, only re-interpreted; moving it would silently declare the span since it as accounted for.

**Candidate selection is deliberately imprecise, in the safe direction.** The provider filters on "fingerprint not among the set this evaluator produces", which can surface a definition whose timezone the registry does not know. Each candidate is then confirmed by recomputing for its own zone. Erring this way costs a wasted read; erring the other way would miss a rebase.

**U13 consolidated two telemetry paths into one.** U7 logged recovery through the manager's own `LoggerMessage`; that is now removed in favour of the instrumentation surface, so there is a single path rather than two that can drift.

## Release Notes

Cron definitions now detect when their schedule *interpretation* has changed — a timezone-database update or a cron-library upgrade that makes an unchanged expression resolve to a different instant. A background sweep records the change and rebases the affected schedules under the current rules, without replaying anything as missed.

Recovery outcomes are also now observable: which policy resolved a backlog, how many occurrences were missed, and — importantly — whether that count is exact or a lower bound, since a long outage on a high-frequency schedule stops counting at a ceiling.

Documentation for the whole misfire-recovery feature has landed in the Jobs guide and package README, and the previous statements that catch-up was outside the Jobs contract have been corrected.
