### PR TITLE
build(deps): consolidate validated dependency updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
         run: make restore
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: manual
@@ -75,4 +75,4 @@ jobs:
         run: make rebuild-no-restore
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4

--- a/.github/workflows/messaging-azure-service-bus-conformance.yml
+++ b/.github/workflows/messaging-azure-service-bus-conformance.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/demo/Headless.Tus.Demo/frontend/package-lock.json
+++ b/demo/Headless.Tus.Demo/frontend/package-lock.json
@@ -14,8 +14,8 @@
         "@uppy/react": "^5.2.0",
         "@uppy/tus": "^5.1.1",
         "pretty-bytes": "^7.1.1",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-dropzone": "^19.1.1",
         "tus-js-client": "^4.3.1",
         "use-tus": "^0.9.0"
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
-        "@vitejs/plugin-react": "^6.0.3",
+        "@vitejs/plugin-react": "^6.0.4",
         "typescript": "~7.0.2",
         "vite": "^8.1.5"
       }
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1726,24 +1726,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-dropzone": {

--- a/demo/Headless.Tus.Demo/frontend/package.json
+++ b/demo/Headless.Tus.Demo/frontend/package.json
@@ -15,8 +15,8 @@
     "@uppy/react": "^5.2.0",
     "@uppy/tus": "^5.1.1",
     "pretty-bytes": "^7.1.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-dropzone": "^19.1.1",
     "tus-js-client": "^4.3.1",
     "use-tus": "^0.9.0"
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "~7.0.2",
     "vite": "^8.1.5"
   },

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -13,13 +13,13 @@
         "cronstrue": "^3.24.0",
         "echarts": "^6.1.0",
         "maska": "^3.2.0",
-        "pinia": "^3.0.4",
+        "pinia": "^4.0.2",
         "timeago.js": "^4.0.2",
         "vite-plugin-dynamic-base": "^1.4.1",
         "vue": "^3.5.40",
         "vue-echarts": "^8.0.1",
         "vue-router": "^5.2.0",
-        "vuetify": "^4.1.5",
+        "vuetify": "^4.1.6",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -31,7 +31,7 @@
         "@vue/eslint-config-prettier": "^10.1.0",
         "@vue/eslint-config-typescript": "^14.9.0",
         "@vue/tsconfig": "^0.9.1",
-        "eslint": "^10.7.0",
+        "eslint": "^10.8.0",
         "eslint-plugin-vue": "^10.10.0",
         "happy-dom": "^20.11.1",
         "npm-run-all2": "^9.0.2",
@@ -39,7 +39,7 @@
         "typescript": "npm:@typescript/typescript6@6.0.2",
         "vite": "^8.1.5",
         "vite-plugin-dts": "^5.0.3",
-        "vite-plugin-vue-devtools": "^8.1.5",
+        "vite-plugin-vue-devtools": "^8.2.1",
         "vitest": "^4.1.10",
         "vue-tsc": "^3.3.8"
       }
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2437,94 +2437,37 @@
         "@vue/devtools-kit": "^8.1.5"
       }
     },
-    "node_modules/@vue/devtools-api/node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
-        "birpc": "^2.6.1",
-        "hookable": "^5.5.3",
-        "perfect-debounce": "^2.0.0"
-      }
-    },
-    "node_modules/@vue/devtools-api/node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/devtools-api/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "license": "MIT"
-    },
     "node_modules/@vue/devtools-core": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.5.tgz",
-      "integrity": "sha512-5e5jQOEssCdZA1wlFEUkIDtb+cAOWuLNWJ52fm4PBWbF7e3oTnM2fneaL42E5lJoolAaUQ678tv/XEb3h4e86Q==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.2.1.tgz",
+      "integrity": "sha512-s/VfAY9oDTb/kFEWmy461jaFde2MIV1RO/gi1vwM+PAZBZ/Pc2Ndu3BNBdZUze8QDUuyYvElbEEGA83syjJfzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.5",
-        "@vue/devtools-shared": "^8.1.5"
+        "@vue/devtools-kit": "^8.2.1",
+        "@vue/devtools-shared": "^8.2.1"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
       }
     },
-    "node_modules/@vue/devtools-core/node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
-      "dev": true,
+    "node_modules/@vue/devtools-kit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+      "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
+        "@vue/devtools-shared": "^8.2.1",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
         "perfect-debounce": "^2.0.0"
       }
     },
-    "node_modules/@vue/devtools-core/node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/devtools-core/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/devtools-kit": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
-      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^7.7.10",
-        "birpc": "^2.3.0",
-        "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^1.0.0",
-        "speakingurl": "^14.0.1",
-        "superjson": "^2.2.2"
-      }
-    },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
-      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rfdc": "^1.4.1"
-      }
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+      "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
+      "license": "MIT"
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "10.2.0",
@@ -3025,21 +2968,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-anything": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
-      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-what": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/cronstrue": {
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.24.0.tgz",
@@ -3389,9 +3317,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3401,7 +3329,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -3425,7 +3353,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4162,18 +4090,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-what": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
-      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4691,12 +4607,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
-    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -5046,9 +4956,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5084,33 +4994,28 @@
       }
     },
     "node_modules/pinia": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
-      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.2.tgz",
+      "integrity": "sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^7.7.7"
+        "nostics": "^1.1.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "typescript": ">=4.5.0",
+        "@vue/devtools-api": "^8.1.5",
+        "typescript": ">=5.6.0",
         "vue": "^3.5.11"
       },
       "peerDependenciesMeta": {
+        "@vue/devtools-api": {
+          "optional": false
+        },
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/pinia/node_modules/@vue/devtools-api": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
-      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-kit": "^7.7.10"
       }
     },
     "node_modules/pkg-types": {
@@ -5327,12 +5232,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
-    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -5495,15 +5394,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/speakingurl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5517,18 +5407,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/superjson": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
-      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-      "license": "MIT",
-      "dependencies": {
-        "copy-anything": "^4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/synckit": {
       "version": "0.11.12",
@@ -6207,23 +6085,16 @@
         }
       }
     },
-    "node_modules/vite-plugin-inspect/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/vite-plugin-vue-devtools": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-8.1.5.tgz",
-      "integrity": "sha512-QSVntSN0sbVV08CZntMWOfF8McyPyYyYd19sChLjxYyFCC7Fcpey74ztw1uCCU23wTmR2yWPb92uaxVD4Lw0Fg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-8.2.1.tgz",
+      "integrity": "sha512-5JLxXWWCo5lJMw16/xVeNvJ8k2zLwZPf1vITLzya/2IePrCBeGe/p/iAokgXHZpEi39fcYtPXmO8SaKeXmqCAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-core": "^8.1.5",
-        "@vue/devtools-kit": "^8.1.5",
-        "@vue/devtools-shared": "^8.1.5",
+        "@vue/devtools-core": "^8.2.1",
+        "@vue/devtools-kit": "^8.2.1",
+        "@vue/devtools-shared": "^8.2.1",
         "sirv": "^3.0.2",
         "vite-plugin-inspect": "^11.3.3",
         "vite-plugin-vue-inspector": "^6.0.0"
@@ -6234,33 +6105,6 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
-    },
-    "node_modules/vite-plugin-vue-devtools/node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
-        "birpc": "^2.6.1",
-        "hookable": "^5.5.3",
-        "perfect-debounce": "^2.0.0"
-      }
-    },
-    "node_modules/vite-plugin-vue-devtools/node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vite-plugin-vue-devtools/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite-plugin-vue-inspector": {
       "version": "6.0.0",
@@ -6616,9 +6460,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.5.tgz",
-      "integrity": "sha512-cR3XMzWbVll9wSdarhH7asT27zm23rMNM5dQ9pMGwTPGwEm0km8mY6ERJAGHIa/nMw0pYXWHjf1O9qJ/0PtZCQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.6.tgz",
+      "integrity": "sha512-VOsRTsNfs+FE4JXMONZkqX2yznSqC/FXG9/pgVVjsoqIjUvJg+CfFTuOlgyWVFrZYY+crk7LV9uaiN8bZREV/g==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -21,13 +21,13 @@
     "cronstrue": "^3.24.0",
     "echarts": "^6.1.0",
     "maska": "^3.2.0",
-    "pinia": "^3.0.4",
+    "pinia": "^4.0.2",
     "timeago.js": "^4.0.2",
     "vite-plugin-dynamic-base": "^1.4.1",
     "vue": "^3.5.40",
     "vue-echarts": "^8.0.1",
     "vue-router": "^5.2.0",
-    "vuetify": "^4.1.5",
+    "vuetify": "^4.1.6",
     "yup": "^1.6.1"
   },
   "devDependencies": {
@@ -39,7 +39,7 @@
     "@vue/eslint-config-prettier": "^10.1.0",
     "@vue/eslint-config-typescript": "^14.9.0",
     "@vue/tsconfig": "^0.9.1",
-    "eslint": "^10.7.0",
+    "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
     "happy-dom": "^20.11.1",
     "npm-run-all2": "^9.0.2",
@@ -47,7 +47,7 @@
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
-    "vite-plugin-vue-devtools": "^8.1.5",
+    "vite-plugin-vue-devtools": "^8.2.1",
     "vitest": "^4.1.10",
     "vue-tsc": "^3.3.8"
   },

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -11,13 +11,13 @@
         "axios": "^1.18.1",
         "echarts": "^6.1.0",
         "json-bigint": "^1.0.0",
-        "pinia": "^3.0.4",
+        "pinia": "^4.0.2",
         "timeago.js": "^4.0.2",
         "vite-plugin-dynamic-base": "^1.4.1",
         "vue": "^3.5.40",
         "vue-echarts": "^8.0.1",
         "vue-router": "^5.2.0",
-        "vuetify": "^4.1.5"
+        "vuetify": "^4.1.6"
       },
       "devDependencies": {
         "@mdi/font": "^7.4.47",
@@ -29,7 +29,7 @@
         "@vue/eslint-config-prettier": "^10.1.0",
         "@vue/eslint-config-typescript": "^14.9.0",
         "@vue/tsconfig": "^0.9.1",
-        "eslint": "^10.7.0",
+        "eslint": "^10.8.0",
         "eslint-plugin-vue": "^10.10.0",
         "happy-dom": "^20.11.1",
         "npm-run-all2": "^9.0.2",
@@ -37,7 +37,7 @@
         "typescript": "npm:@typescript/typescript6@6.0.2",
         "vite": "^8.1.5",
         "vite-plugin-dts": "^5.0.3",
-        "vite-plugin-vue-devtools": "^8.1.5",
+        "vite-plugin-vue-devtools": "^8.2.1",
         "vitest": "^4.1.10",
         "vue-tsc": "^3.3.8"
       }
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2463,94 +2463,37 @@
         "@vue/devtools-kit": "^8.1.5"
       }
     },
-    "node_modules/@vue/devtools-api/node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
-        "birpc": "^2.6.1",
-        "hookable": "^5.5.3",
-        "perfect-debounce": "^2.0.0"
-      }
-    },
-    "node_modules/@vue/devtools-api/node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/devtools-api/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "license": "MIT"
-    },
     "node_modules/@vue/devtools-core": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.5.tgz",
-      "integrity": "sha512-5e5jQOEssCdZA1wlFEUkIDtb+cAOWuLNWJ52fm4PBWbF7e3oTnM2fneaL42E5lJoolAaUQ678tv/XEb3h4e86Q==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.2.1.tgz",
+      "integrity": "sha512-s/VfAY9oDTb/kFEWmy461jaFde2MIV1RO/gi1vwM+PAZBZ/Pc2Ndu3BNBdZUze8QDUuyYvElbEEGA83syjJfzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.5",
-        "@vue/devtools-shared": "^8.1.5"
+        "@vue/devtools-kit": "^8.2.1",
+        "@vue/devtools-shared": "^8.2.1"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
       }
     },
-    "node_modules/@vue/devtools-core/node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
-      "dev": true,
+    "node_modules/@vue/devtools-kit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+      "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
+        "@vue/devtools-shared": "^8.2.1",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
         "perfect-debounce": "^2.0.0"
       }
     },
-    "node_modules/@vue/devtools-core/node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/devtools-core/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vue/devtools-kit": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
-      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^7.7.10",
-        "birpc": "^2.3.0",
-        "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^1.0.0",
-        "speakingurl": "^14.0.1",
-        "superjson": "^2.2.2"
-      }
-    },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
-      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rfdc": "^1.4.1"
-      }
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+      "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
+      "license": "MIT"
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "10.2.0",
@@ -3048,21 +2991,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-anything": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
-      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-what": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3403,9 +3331,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3415,7 +3343,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -3439,7 +3367,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4134,18 +4062,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-what": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
-      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4666,12 +4582,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
-    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -5001,9 +4911,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5039,33 +4949,28 @@
       }
     },
     "node_modules/pinia": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
-      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.2.tgz",
+      "integrity": "sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^7.7.7"
+        "nostics": "^1.1.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "typescript": ">=4.5.0",
+        "@vue/devtools-api": "^8.1.5",
+        "typescript": ">=5.6.0",
         "vue": "^3.5.11"
       },
       "peerDependenciesMeta": {
+        "@vue/devtools-api": {
+          "optional": false
+        },
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/pinia/node_modules/@vue/devtools-api": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
-      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-kit": "^7.7.10"
       }
     },
     "node_modules/pkg-types": {
@@ -5267,12 +5172,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
-    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -5429,15 +5328,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/speakingurl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5451,18 +5341,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/superjson": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
-      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-      "license": "MIT",
-      "dependencies": {
-        "copy-anything": "^4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/synckit": {
       "version": "0.11.12",
@@ -6077,23 +5955,16 @@
         }
       }
     },
-    "node_modules/vite-plugin-inspect/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/vite-plugin-vue-devtools": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-8.1.5.tgz",
-      "integrity": "sha512-QSVntSN0sbVV08CZntMWOfF8McyPyYyYd19sChLjxYyFCC7Fcpey74ztw1uCCU23wTmR2yWPb92uaxVD4Lw0Fg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-8.2.1.tgz",
+      "integrity": "sha512-5JLxXWWCo5lJMw16/xVeNvJ8k2zLwZPf1vITLzya/2IePrCBeGe/p/iAokgXHZpEi39fcYtPXmO8SaKeXmqCAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-core": "^8.1.5",
-        "@vue/devtools-kit": "^8.1.5",
-        "@vue/devtools-shared": "^8.1.5",
+        "@vue/devtools-core": "^8.2.1",
+        "@vue/devtools-kit": "^8.2.1",
+        "@vue/devtools-shared": "^8.2.1",
         "sirv": "^3.0.2",
         "vite-plugin-inspect": "^11.3.3",
         "vite-plugin-vue-inspector": "^6.0.0"
@@ -6104,33 +5975,6 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
-    },
-    "node_modules/vite-plugin-vue-devtools/node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
-        "birpc": "^2.6.1",
-        "hookable": "^5.5.3",
-        "perfect-debounce": "^2.0.0"
-      }
-    },
-    "node_modules/vite-plugin-vue-devtools/node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vite-plugin-vue-devtools/node_modules/perfect-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite-plugin-vue-inspector": {
       "version": "6.0.0",
@@ -6486,9 +6330,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.5.tgz",
-      "integrity": "sha512-cR3XMzWbVll9wSdarhH7asT27zm23rMNM5dQ9pMGwTPGwEm0km8mY6ERJAGHIa/nMw0pYXWHjf1O9qJ/0PtZCQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.6.tgz",
+      "integrity": "sha512-VOsRTsNfs+FE4JXMONZkqX2yznSqC/FXG9/pgVVjsoqIjUvJg+CfFTuOlgyWVFrZYY+crk7LV9uaiN8bZREV/g==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -19,13 +19,13 @@
     "axios": "^1.18.1",
     "echarts": "^6.1.0",
     "json-bigint": "^1.0.0",
-    "pinia": "^3.0.4",
+    "pinia": "^4.0.2",
     "timeago.js": "^4.0.2",
     "vite-plugin-dynamic-base": "^1.4.1",
     "vue": "^3.5.40",
     "vue-echarts": "^8.0.1",
     "vue-router": "^5.2.0",
-    "vuetify": "^4.1.5"
+    "vuetify": "^4.1.6"
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",
@@ -37,7 +37,7 @@
     "@vue/eslint-config-prettier": "^10.1.0",
     "@vue/eslint-config-typescript": "^14.9.0",
     "@vue/tsconfig": "^0.9.1",
-    "eslint": "^10.7.0",
+    "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
     "happy-dom": "^20.11.1",
     "npm-run-all2": "^9.0.2",
@@ -45,7 +45,7 @@
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
-    "vite-plugin-vue-devtools": "^8.1.5",
+    "vite-plugin-vue-devtools": "^8.2.1",
     "vitest": "^4.1.10",
     "vue-tsc": "^3.3.8"
   },


### PR DESCRIPTION
## Summary

Consolidates the eligible Dependabot updates from #796, #797, #798, and #799 onto the current `main` base (`959e646e5be420e464828677db9f1afd053d7190`). The batch contains only package manifest/lockfile changes and pinned GitHub Action revisions.

| Dependency | Previous version | New version | Ecosystem | Risk | Source Dependabot PR | Disposition |
| --- | --- | --- | --- | --- | --- | --- |
| React / React DOM | 19.1.0 | 19.2.8 | npm runtime | Low | #796 | Included |
| @vitejs/plugin-react | 6.0.3 | 6.0.4 | npm development | Low | #796 | Included |
| Vuetify (Jobs + Messaging) | 4.1.5 | 4.1.6 | npm runtime | Low | #796 | Included |
| ESLint (Jobs + Messaging) | 10.7.0 | 10.8.0 | npm development | Low | #796 | Included |
| vite-plugin-vue-devtools (Jobs + Messaging) | 8.1.5 | 8.2.1 | npm development | Low | #796 | Included |
| @types/node (Jobs + Messaging) | 26.1.1 | 26.1.2 | npm development | Low | #796 | Excluded pending seven-day release-age quarantine; eligible after 2026-08-04 17:32 UTC |
| Pinia (Jobs dashboard) | 3.0.4 | 4.0.2 | npm runtime | Medium | #797 | Included |
| Pinia (Messaging dashboard) | 3.0.4 | 4.0.2 | npm runtime | Medium | #798 | Included |
| github/codeql-action/init + analyze | v4.37.2 | v4.37.3 | GitHub Actions | Low | #799 | Included |
| actions/checkout | v7.0.0 | v7.0.1 | GitHub Actions | Low | #799 | Included |

## Compatibility and repairs

Pinia 4 is ESM-only and updates its devtools API dependency. Both dashboards already use module-based Vite builds, and clean installs, type checks, builds, lint checks, and unit tests passed without application-code changes. All included versions are stable, maintained, and older than the seven-day policy threshold.

No public API, configuration, or documentation change was required. Existing Dependabot alerts for transitive PostCSS in the three frontend lockfiles remain; this batch neither adds nor resolves them.

## Validation

| Command | Outcome |
| --- | --- |
| `make bootstrap` | Passed in the fresh candidate worktree |
| `make dashboards` | Passed: clean installs, type checks, and Vite builds for both dashboards |
| Tus frontend: `npm ci && npm run build` | Passed |
| Dashboard `npm run lint:check` and `npm run test:unit` | Passed: 95 Vitest tests total (48 Jobs, 47 Messaging) |
| `make ci-build` | Formatting and full build passed with 0 warnings / 0 errors; broad test portion had 3 unrelated `Headless.Jobs.Composition.Tests.Unit` failures |
| Baseline `Headless.Jobs.Composition.Tests.Unit` on exact `origin/main` | Passed: 645/645 |
| Candidate focused Jobs composition test (twice) | Same 3 failures; no C#, project, or test files changed in this batch |
| `make quality-analyzers` | Failed on pre-existing analyzer backlog outside the eight-file diff; no new attributable diagnostics |
| `make pack-built` and `make verify-packages` | Passed: 169 immutable package archives verified |
| `git diff --check` | Passed |

## Remaining risks and manual review

- Hosted CI is still required; validate the Jobs-composition test-isolation failure independently if it recurs.
- Review the Pinia 4 major-upgrade behavior in dashboard development tooling.
- Revisit `@types/node` 26.1.2 after its release-age quarantine expires.

This PR was created by dependency automation. It has not been approved or merged.
