### PR TITLE
fix(ci): make messaging non-blocking tests deterministic

### DIFF
--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -996,11 +996,15 @@ public sealed class DispatcherTests : TestBase
         );
 
         await sender.Entered.Task.WaitAsync(AbortToken);
-        var returnedBeforeRelease = enqueueTask.IsCompleted;
-        sender.Release();
-        await enqueueTask;
+        try
+        {
+            await enqueueTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        }
+        finally
+        {
+            sender.Release();
+        }
 
-        returnedBeforeRelease.Should().BeTrue("committed enqueue must not run the sender continuation inline");
         await cts.CancelAsync();
     }
 
@@ -1022,11 +1026,15 @@ public sealed class DispatcherTests : TestBase
         );
 
         await sender.Entered.Task.WaitAsync(AbortToken);
-        var returnedBeforeRelease = commitTask.IsCompleted;
-        sender.Release();
-        await commitTask;
+        try
+        {
+            await commitTask.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        }
+        finally
+        {
+            sender.Release();
+        }
 
-        returnedBeforeRelease.Should().BeTrue("commit signaling must not run the sender continuation inline");
         await cts.CancelAsync();
     }
 


### PR DESCRIPTION
## Summary

- replace scheduler-sensitive `Task.IsCompleted` sampling with an awaited completion proof while the synchronous sender remains blocked
- cover both direct committed enqueue and commit-coordinator signaling
- preserve production semantics; this is a deterministic regression-test correction only

## Causal chain

The current `main` run passed Messaging provider conformance after #788, including Kafka, but failed the non-UTC unit-test job. The test observed the sender worker entering before the outer `Task.Run` completion became visible, then sampled `IsCompleted`; those schedulings have no ordering guarantee. Awaiting the operation with the sender still blocked proves the intended non-inline behavior directly.

## Verification

- `TZ=Africa/Cairo make ci-test`: 10,514 total; 10,512 passed; 2 skipped; 0 failed
- Messaging Core unit suite repeated 3x: 3,195/3,195 passed
- Kafka provider evidence repeated with fresh brokers 5x: 10/10 entry tests passed
- full local Messaging broker evidence: 7/7 entry tests passed
- Release build and push-hook build: 0 warnings, 0 errors
- `make format-check`: passed

Release/package publication is intentionally out of scope. No release, tag, package, or merge was published or performed.