### PR TITLE
build(deps): consolidate validated dependency updates

### DIFF
--- a/demo/Headless.Tus.Demo/frontend/package-lock.json
+++ b/demo/Headless.Tus.Demo/frontend/package-lock.json
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1678,7 +1678,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/demo/Headless.Tus.Demo/frontend/package.json
+++ b/demo/Headless.Tus.Demo/frontend/package.json
@@ -29,6 +29,6 @@
     "vite": "^8.1.5"
   },
   "overrides": {
-    "postcss": "8.5.18"
+    "postcss": "8.5.23"
   }
 }

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -2789,9 +2789,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@mdi/font": "^7.4.47",
         "@tsconfig/node22": "^22.0.0",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/eslint-config-prettier": "^10.1.0",
@@ -1469,9 +1469,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -4659,9 +4659,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
-      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5049,7 +5049,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -52,7 +52,7 @@
     "vue-tsc": "^3.3.8"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "fast-uri": "3.1.2",
     "postcss": "8.5.23",
     "shell-quote": "1.9.0",

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@mdi/font": "^7.4.47",
     "@tsconfig/node22": "^22.0.0",
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/eslint-config-prettier": "^10.1.0",

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -54,7 +54,7 @@
   "overrides": {
     "brace-expansion": "5.0.8",
     "fast-uri": "3.1.2",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "shell-quote": "1.9.0",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -4634,9 +4634,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
-      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4985,9 +4985,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5004,7 +5004,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -2812,9 +2812,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -23,7 +23,7 @@
         "@mdi/font": "^7.4.47",
         "@tsconfig/node22": "^22.0.0",
         "@types/json-bigint": "^1.0.4",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/eslint-config-prettier": "^10.1.0",
@@ -1495,9 +1495,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -50,7 +50,7 @@
     "vue-tsc": "^3.3.8"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "fast-uri": "3.1.2",
     "postcss": "8.5.23",
     "shell-quote": "1.9.0",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -52,7 +52,7 @@
   "overrides": {
     "brace-expansion": "5.0.8",
     "fast-uri": "3.1.2",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "shell-quote": "1.9.0",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -31,7 +31,7 @@
     "@mdi/font": "^7.4.47",
     "@tsconfig/node22": "^22.0.0",
     "@types/json-bigint": "^1.0.4",
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/eslint-config-prettier": "^10.1.0",


### PR DESCRIPTION
## Summary

Consolidates the validated frontend dependency batch on one branch. The batch removes the known PostCSS path-traversal advisory from all three frontend graphs, updates the dashboard Node type definitions, and removes the high-severity `brace-expansion` denial-of-service advisory from both dashboard graphs. No application code or public API changed.

The 2026-08-07 daily audit found no new open Dependabot PRs and no new eligible dependency changes. The published branch remains unchanged at `c25dca9643b90c520fcedb49d1eaf934b47ead34`.

## Dependency dispositions

| Dependency | Previous version | New version | Ecosystem | Risk level | Source Dependabot PR / advisory | Disposition |
| --- | --- | --- | --- | --- | --- | --- |
| `postcss` (Tus, Jobs, Messaging) | 8.5.18 | 8.5.23 | npm transitive override | Medium security | Alerts 199, 201, 203 / GHSA-fxqj-rqcc-2cmp | Included; first patched stable release, published 2026-07-24 |
| `@types/node` (Jobs and Messaging) | 26.1.1 | 26.1.2 | npm direct development | Low | #796 | Included; prior release-age deferral expired 2026-08-04 17:32 UTC |
| `brace-expansion` (Jobs and Messaging) | 5.0.8 | 5.0.9 | npm transitive override | High security | npm audit / GHSA-rgw5-rvv9-x895 | Included; first patched stable release, quarantine expired 2026-08-06 10:00:32 UTC |

No open Dependabot PRs existed at the 2026-08-07 audit. The `brace-expansion` proposal was carried forward from the prior run's recorded quarantine disposition and reconstructed from npm metadata after the release became eligible. No source Dependabot branch was modified.

## Compatibility, maintenance, and security evidence

- `postcss` 8.5.23, `@types/node` 26.1.2, and `brace-expansion` 5.0.9 are stable, non-deprecated releases whose publication dates exceed the seven-day quarantine.
- `brace-expansion` 5.0.9 is maintained by the established upstream maintainers, supports Node `20 || >=22`, and is the first patched 5.x release for GHSA-rgw5-rvv9-x895.
- PostCSS 8.5.23 is the first patched release for GHSA-fxqj-rqcc-2cmp. The three open repository alerts target `main`; the consolidated branch resolves all three affected graphs.
- Normal npm lockfile regeneration changed only the authoritative overrides, resolved versions, tarball URLs, and registry integrity values.
- Fresh clean installs and npm audits on the exact PR head report zero vulnerabilities in all three frontend dependency graphs.

## Breaking changes and obsolete APIs repaired

None. The three upgrades are dependency-graph-only patch changes. Clean type checks, builds, tests, and hosted CI required no source, configuration, compatibility shim, warning suppression, or obsolete API repair.

## Tests and documentation

No tests or documentation changed because there is no application behavior or public contract change. Existing dashboard and framework tests exercise the affected build and packaging boundaries.

## Validation

Current 2026-08-07 exact-head validation:

```text
make bootstrap
  Passed in a fresh detached worktree; full solution restore completed.

make dashboards
  Passed clean npm installs, Vue type checks, and production Vite builds for both dashboards on Node 24.18.0.
  Both clean installs reported 0 vulnerabilities.

demo/Headless.Tus.Demo/frontend: npm ci && npm run build && npm audit --json
  Passed TypeScript/Vite build; audit reported 0 vulnerabilities.

Jobs dashboard: npm run lint:check && npm run test:unit && npm audit --json
  Passed lint, 48/48 Vitest tests, and audit with 0 vulnerabilities.

Messaging dashboard: npm run lint:check && npm run test:unit && npm audit --json
  Passed lint, 47/47 Vitest tests, and audit with 0 vulnerabilities.

git diff --check
  Passed.
```

The exact unchanged head also has successful current hosted checks: `Build and pack`, both required dashboard SPA builds, and the Tus demo build. The prior full local validation on this same SHA passed `make ci-build` with 0 warnings/errors and 10,514 unit tests (10,512 passed, 2 skipped), generated and verified 169 NuGet packages, and passed `make quality-analyzers`.

Integration tests were not run because the changed surface is limited to frontend dependency graphs. Clean frontend builds and audits, both frontend unit suites, the exact-head hosted full build/package check, and the prior exact-head full .NET validation cover the affected delivery boundary.

## Excluded proposals

None. `brace-expansion` 5.0.9 was previously excluded only by release-age quarantine; that disposition was superseded by inclusion after the quarantine expired.

## Remaining risks and manual review

- GitHub will continue showing the three default-branch PostCSS alerts until this PR is merged; this automation does not merge.
- All required hosted checks are successful. One approving review is still required; there are currently no reviews, comments, or unresolved review threads.
- The repository's npm configuration currently prints an informational warning that `min-release-age-exclude` is unknown to npm 11; the automation independently enforced the seven-day publication-age policy and did not bypass package-manager protections.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this changes build-time frontend dependency graphs only and has no runtime configuration, public API, or deployment behavior impact. The existing dashboard smoke/build checks remain the owner-independent validation signal after merge.

## Reviewer guide

Review the security provenance and the six dependency manifest/lockfile changes. The branch contains only the PostCSS, Node type, and `brace-expansion` version/resolution changes. No migration, runtime rollout, or public API review is required.

This PR was created by dependency automation. It has not been approved or merged.
