### PR TITLE
test: cover jobs dashboard, NSwag, and EF Core behavior

### DIFF
--- a/tests/Headless.EntityFramework.Core.Tests.Unit/CountPerMonthExtensionsTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/CountPerMonthExtensionsTests.cs
@@ -39,6 +39,23 @@ public sealed class CountPerMonthExtensionsTests : TestBase
         fixture.CommandLog.Commands.Any(_IsGroupedCountSql).Should().BeTrue();
     }
 
+    [Fact]
+    public async Task should_reject_an_inverted_date_time_offset_range_before_query_execution()
+    {
+        var offset = TimeSpan.FromHours(2);
+        var query = Array.Empty<MonthCountRow>().AsQueryable();
+
+        Func<Task> action = async () =>
+            await query.CountPerMonthAsync(
+                static row => row.DateTimeOffsetValue,
+                new DateTimeOffset(2026, 4, 20, 0, 0, 0, offset),
+                new DateTimeOffset(2026, 1, 15, 0, 0, 0, offset),
+                AbortToken
+            );
+
+        await action.Should().ThrowAsync<ArgumentException>().WithParameterName("start");
+    }
+
     private static bool _IsGroupedCountSql(string sql)
     {
         return sql.Contains("GROUP BY", StringComparison.OrdinalIgnoreCase)

--- a/tests/Headless.EntityFramework.Core.Tests.Unit/CountPerMonthExtensionsTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/CountPerMonthExtensionsTests.cs
@@ -42,11 +42,12 @@ public sealed class CountPerMonthExtensionsTests : TestBase
     [Fact]
     public async Task should_reject_an_inverted_date_time_offset_range_before_query_execution()
     {
+        await using var fixture = await MonthCountFixture.CreateAsync(AbortToken);
+        fixture.CommandLog.Clear();
         var offset = TimeSpan.FromHours(2);
-        var query = Array.Empty<MonthCountRow>().AsQueryable();
 
         Func<Task> action = async () =>
-            await query.CountPerMonthAsync(
+            await fixture.Context.Rows.CountPerMonthAsync(
                 static row => row.DateTimeOffsetValue,
                 new DateTimeOffset(2026, 4, 20, 0, 0, 0, offset),
                 new DateTimeOffset(2026, 1, 15, 0, 0, 0, offset),
@@ -54,6 +55,7 @@ public sealed class CountPerMonthExtensionsTests : TestBase
             );
 
         await action.Should().ThrowAsync<ArgumentException>().WithParameterName("start");
+        fixture.CommandLog.Commands.Should().BeEmpty();
     }
 
     private static bool _IsGroupedCountSql(string sql)

--- a/tests/Headless.EntityFramework.Core.Tests.Unit/QueryableBehaviorTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/QueryableBehaviorTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Domain;
+using Headless.EntityFramework;
+using Headless.Exceptions;
+using Headless.Primitives;
+using Headless.Testing.Tests;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Tests;
+
+public sealed class QueryableBehaviorTests : TestBase
+{
+    [Fact]
+    public async Task should_return_an_entity_by_id_and_throw_a_typed_error_when_missing()
+    {
+        await using var fixture = await QueryFixture.CreateAsync(AbortToken);
+
+        var found = await fixture.Context.Rows.FirstByIdAsync(2, AbortToken);
+        Func<Task> missing = async () => await fixture.Context.Rows.FirstByIdAsync(99, AbortToken);
+
+        found.Name.Should().Be("beta");
+        var exception = await missing.Should().ThrowAsync<EntityNotFoundException>();
+        exception.Which.Entity.Should().Be(nameof(QueryRow));
+        exception.Which.Key.Should().Be("99");
+    }
+
+    [Fact]
+    public async Task should_materialize_a_lookup_with_the_requested_projection_and_comparer()
+    {
+        await using var fixture = await QueryFixture.CreateAsync(AbortToken);
+
+        var lookup = await fixture.Context.Rows.ToLookupAsync(
+            row => row.Category,
+            row => row.Name,
+            StringComparer.OrdinalIgnoreCase,
+            AbortToken
+        );
+
+        lookup.Should().HaveCount(2);
+        lookup["group-a"].Should().Equal("alpha", "beta");
+        lookup["GROUP-B"].Should().Equal("gamma");
+    }
+
+    [Fact]
+    public async Task should_apply_data_grid_ordering_before_paging()
+    {
+        await using var fixture = await QueryFixture.CreateAsync(AbortToken);
+        var request = new TestDataGridRequest
+        {
+            Orders = [new OrderBy(nameof(QueryRow.Name), Ascending: false)],
+            Page = new TestIndexPageRequest { Index = 0, Size = 2 },
+        };
+
+        var page = await fixture.Context.Rows.ToDataGridAsync(request, AbortToken);
+
+        page.TotalItems.Should().Be(3);
+        page.Items.Select(row => row.Name).Should().Equal("gamma", "beta");
+    }
+
+    private sealed class QueryFixture : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        private QueryFixture(SqliteConnection connection, QueryDbContext context)
+        {
+            _connection = connection;
+            Context = context;
+        }
+
+        public QueryDbContext Context { get; }
+
+        public static async Task<QueryFixture> CreateAsync(CancellationToken cancellationToken)
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync(cancellationToken);
+            var context = new QueryDbContext(
+                new DbContextOptionsBuilder<QueryDbContext>().UseSqlite(connection).Options
+            );
+
+            try
+            {
+                await context.Database.EnsureCreatedAsync(cancellationToken);
+                await context.Rows.AddRangeAsync(
+                    [
+                        new QueryRow
+                        {
+                            Id = 1,
+                            Name = "alpha",
+                            Category = "group-a",
+                        },
+                        new QueryRow
+                        {
+                            Id = 2,
+                            Name = "beta",
+                            Category = "GROUP-A",
+                        },
+                        new QueryRow
+                        {
+                            Id = 3,
+                            Name = "gamma",
+                            Category = "group-b",
+                        },
+                    ],
+                    cancellationToken
+                );
+                await context.SaveChangesAsync(cancellationToken);
+                return new QueryFixture(connection, context);
+            }
+            catch
+            {
+                await context.DisposeAsync();
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+
+    private sealed class QueryDbContext(DbContextOptions<QueryDbContext> options) : DbContext(options)
+    {
+        public DbSet<QueryRow> Rows => Set<QueryRow>();
+    }
+
+    private sealed class QueryRow : Entity<int>
+    {
+        public required string Name { get; init; }
+
+        public required string Category { get; init; }
+    }
+
+    private sealed class TestDataGridRequest : DataGridRequest;
+
+    private sealed class TestIndexPageRequest : IndexPageRequest;
+}

--- a/tests/Headless.EntityFramework.Core.Tests.Unit/ValueConverterTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/ValueConverterTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Text.Json.Serialization;
+using Headless.EntityFramework.Configurations;
+using Headless.Primitives;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+public sealed class ValueConverterTests : TestBase
+{
+    [Fact]
+    public void should_round_trip_string_backed_identifiers()
+    {
+        var accountConverter = new AccountIdValueConverter();
+        var userConverter = new UserIdValueConverter();
+
+        var account = _RoundTrip(accountConverter, new AccountId("account-1"));
+        var user = _RoundTrip(userConverter, new UserId("user-1"));
+
+        account.Should().Be(new AccountId("account-1"));
+        user.Should().Be(new UserId("user-1"));
+    }
+
+    [Fact]
+    public void should_round_trip_numeric_primitives_without_losing_precision()
+    {
+        var amount = _RoundTrip(new MoneyAmountValueConverter(), new MoneyAmount(123.4567890123m));
+        var month = _RoundTrip(new MonthValueConverter(), new Month(8));
+
+        amount.Should().Be(new MoneyAmount(123.4567890123m));
+        month.Should().Be(new Month(8));
+    }
+
+    [Fact]
+    public void should_round_trip_reflection_based_json_values()
+    {
+        var converter = new JsonValueConverter<Payload>();
+        var payload = new Payload("alpha", [1, 2, 3]);
+
+        var result = _RoundTrip(converter, payload);
+
+        result.Should().BeEquivalentTo(payload);
+    }
+
+    [Fact]
+    public void should_round_trip_source_generated_json_values()
+    {
+        var converter = new JsonValueConverter<Payload, PayloadJsonContext>(PayloadJsonContext.Default.Payload);
+        var payload = new Payload("alpha", [1, 2, 3]);
+
+        var result = _RoundTrip(converter, payload);
+
+        result.Should().BeEquivalentTo(payload);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("{}")]
+    public void should_read_empty_locale_storage_as_null(string? storedValue)
+    {
+        var fromProvider = new LocalesValueConverter().ConvertFromProviderExpression.Compile();
+
+        fromProvider(storedValue).Should().BeNull();
+    }
+
+    [Fact]
+    public void should_round_trip_nested_locales()
+    {
+        Locales locales = new()
+        {
+            ["en"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["name"] = "Book" },
+            ["ar"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["name"] = "كتاب" },
+        };
+
+        var result = _RoundTrip(new LocalesValueConverter(), locales);
+
+        result.Should().BeEquivalentTo(locales);
+    }
+
+    [Fact]
+    public void locale_comparer_should_use_deep_order_independent_equality_and_snapshot_the_outer_dictionary()
+    {
+        var comparer = new LocalesValueComparer();
+        Locales first = new()
+        {
+            ["en"] = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "Book",
+                ["description"] = "Description",
+            },
+        };
+        Locales same = new()
+        {
+            ["en"] = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] = "Description",
+                ["name"] = "Book",
+            },
+        };
+        var equals = comparer.EqualsExpression.Compile();
+        var snapshot = comparer.SnapshotExpression.Compile()(first);
+
+        equals(first, same).Should().BeTrue();
+        equals(first, null).Should().BeFalse();
+        snapshot.Should().NotBeSameAs(first);
+        snapshot!["fr"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["name"] = "Livre" };
+        first.Should().NotContainKey("fr");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("{}")]
+    public void should_read_empty_extra_properties_storage_as_an_empty_bag(string? storedValue)
+    {
+        var fromProvider = new ExtraPropertiesValueConverter().ConvertFromProviderExpression.Compile();
+
+        fromProvider(storedValue!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void should_round_trip_extra_properties_with_inferred_value_types()
+    {
+        ExtraProperties properties = new() { ["enabled"] = true, ["name"] = "alpha" };
+
+        var result = _RoundTrip(new ExtraPropertiesValueConverter(), properties);
+
+        result.Should().BeEquivalentTo(properties);
+        result["enabled"].Should().BeOfType<bool>();
+    }
+
+    [Fact]
+    public void extra_properties_comparer_should_detect_value_changes_and_create_an_independent_snapshot()
+    {
+        var comparer = new ExtraPropertiesValueComparer();
+        ExtraProperties first = new() { ["name"] = "alpha" };
+        ExtraProperties same = new() { ["name"] = "alpha" };
+        ExtraProperties changed = new() { ["name"] = "beta" };
+        var equals = comparer.EqualsExpression.Compile();
+        var snapshot = comparer.SnapshotExpression.Compile()(first);
+
+        equals(first, same).Should().BeTrue();
+        equals(first, changed).Should().BeFalse();
+        snapshot.Should().NotBeSameAs(first);
+        snapshot["name"] = "changed";
+        first["name"].Should().Be("alpha");
+    }
+
+    private static TModel _RoundTrip<TModel, TProvider>(
+        Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<TModel, TProvider> converter,
+        TModel value
+    )
+    {
+        var stored = converter.ConvertToProviderExpression.Compile()(value);
+        return converter.ConvertFromProviderExpression.Compile()(stored);
+    }
+
+    public sealed record Payload(string Name, int[] Values);
+}
+
+[JsonSerializable(typeof(ValueConverterTests.Payload))]
+internal sealed partial class PayloadJsonContext : JsonSerializerContext;

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardEndpointMetadataTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardEndpointMetadataTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Dashboard.Authentication;
+using Headless.Jobs;
+using Headless.Jobs.Endpoints;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Interfaces;
+using Headless.Jobs.Interfaces.Managers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests.Dashboard;
+
+public sealed class DashboardEndpointMetadataTests
+{
+    [Fact]
+    public async Task should_apply_the_configured_host_policy_only_to_dashboard_api_endpoints()
+    {
+        await using var app = _CreateApp(new DashboardOptionsBuilder().WithHostAuthentication("DashboardAdmin"));
+
+        _GetEndpoint(app, "GetAuthInfo").Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
+        _GetEndpoint(app, "ValidateAuth").Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
+        _GetEndpoint(app, "GetTimeJobsPaginated")
+            .Metadata.GetOrderedMetadata<IAuthorizeData>()
+            .Should()
+            .ContainSingle(data => data.Policy == "DashboardAdmin");
+        _GetHubEndpoint(app).Metadata.GetMetadata<IAllowAnonymous>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task should_use_default_authorization_when_host_auth_has_no_named_policy()
+    {
+        await using var app = _CreateApp(new DashboardOptionsBuilder().WithHostAuthentication());
+
+        var authorization = _GetEndpoint(app, "GetOptions").Metadata.GetOrderedMetadata<IAuthorizeData>();
+
+        authorization.Should().ContainSingle();
+        authorization[0].Policy.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_not_attach_host_authorization_metadata_when_auth_is_handled_by_dashboard_middleware()
+    {
+        await using var app = _CreateApp(new DashboardOptionsBuilder().WithApiKey("secret"));
+
+        _GetEndpoint(app, "GetOptions").Metadata.GetOrderedMetadata<IAuthorizeData>().Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("CreateChainJobs")]
+    [InlineData("UpdateTimeJob")]
+    [InlineData("DeleteTimeJobsBatch")]
+    [InlineData("AddCronJob")]
+    [InlineData("UpdateCronJob")]
+    public async Task should_cap_request_bodies_on_mutating_payload_endpoints(string endpointName)
+    {
+        await using var app = _CreateApp(new DashboardOptionsBuilder().WithNoAuth());
+
+        var requestSizeLimit = _GetEndpoint(app, endpointName).Metadata.GetMetadata<RequestSizeLimitAttribute>();
+
+        requestSizeLimit.Should().NotBeNull();
+        ((IRequestSizeLimitMetadata)requestSizeLimit!)
+            .MaxRequestBodySize.Should()
+            .Be(DashboardOptionsBuilder.MaxRequestBodyBytes);
+    }
+
+    [Fact]
+    public async Task should_expose_unique_endpoint_names_for_every_dashboard_route()
+    {
+        await using var app = _CreateApp(new DashboardOptionsBuilder().WithNoAuth());
+        var names = _Endpoints(app)
+            .Select(endpoint => endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName)
+            .Where(name => name is not null)
+            .ToArray();
+
+        names.Should().OnlyHaveUniqueItems();
+        names.Should().Contain("CancelJob");
+        names.Should().Contain("GetLiveNodes");
+        names.Should().Contain("GetJobRequest");
+    }
+
+    private static WebApplication _CreateApp(DashboardOptionsBuilder config)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Services.AddRouting();
+        builder.Services.AddSignalR();
+        builder.Services.AddCors();
+        builder.Services.AddSingleton(config);
+        builder.Services.AddSingleton(Substitute.For<IAuthService>());
+        builder.Services.AddSingleton(new JobsExecutionContext());
+        builder.Services.AddSingleton(new SchedulerOptionsBuilder());
+        builder.Services.AddSingleton(Substitute.For<IJobsDashboardRepository<TimeJobEntity, CronJobEntity>>());
+        builder.Services.AddSingleton(Substitute.For<ITimeJobManager<TimeJobEntity>>());
+        builder.Services.AddSingleton(Substitute.For<ICronJobManager<CronJobEntity>>());
+        builder.Services.AddSingleton(Substitute.For<IJobScheduler>());
+        builder.Services.AddSingleton(Substitute.For<IJobsHostScheduler>());
+        builder.Services.AddAuthorization(options =>
+            options.AddPolicy("DashboardAdmin", policy => policy.RequireAssertion(_ => true))
+        );
+
+        var app = builder.Build();
+        app.MapDashboardEndpoints<TimeJobEntity, CronJobEntity>(config);
+        return app;
+    }
+
+    private static Endpoint _GetEndpoint(WebApplication app, string endpointName)
+    {
+        return _Endpoints(app)
+            .Single(endpoint =>
+                string.Equals(
+                    endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName,
+                    endpointName,
+                    StringComparison.Ordinal
+                )
+            );
+    }
+
+    private static Endpoint _GetHubEndpoint(WebApplication app)
+    {
+        return _Endpoints(app)
+            .Single(endpoint =>
+                endpoint is RouteEndpoint routeEndpoint
+                && string.Equals(routeEndpoint.RoutePattern.RawText, "/job-notification-hub", StringComparison.Ordinal)
+            );
+    }
+
+    private static IReadOnlyList<Endpoint> _Endpoints(WebApplication app)
+    {
+        return ((IEndpointRouteBuilder)app).DataSources.SelectMany(source => source.Endpoints).ToArray();
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardEndpointMetadataTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardEndpointMetadataTests.cs
@@ -6,6 +6,7 @@ using Headless.Jobs.Endpoints;
 using Headless.Jobs.Entities;
 using Headless.Jobs.Interfaces;
 using Headless.Jobs.Interfaces.Managers;
+using Headless.Testing.Tests;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -16,7 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Tests.Dashboard;
 
-public sealed class DashboardEndpointMetadataTests
+public sealed class DashboardEndpointMetadataTests : TestBase
 {
     [Fact]
     public async Task should_apply_the_configured_host_policy_only_to_dashboard_api_endpoints()
@@ -74,11 +75,13 @@ public sealed class DashboardEndpointMetadataTests
     {
         await using var app = _CreateApp(new DashboardOptionsBuilder().WithNoAuth());
         var names = _Endpoints(app)
+            .OfType<RouteEndpoint>()
+            .Where(endpoint => endpoint.RoutePattern.RawText?.StartsWith("/api", StringComparison.Ordinal) is true)
             .Select(endpoint => endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName)
-            .Where(name => name is not null)
             .ToArray();
 
-        names.Should().OnlyHaveUniqueItems();
+        names.Should().NotContainNulls();
+        names.OfType<string>().Should().OnlyHaveUniqueItems();
         names.Should().Contain("CancelJob");
         names.Should().Contain("GetLiveNodes");
         names.Should().Contain("GetJobRequest");

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardOptionsTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardOptionsTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Dashboard.Authentication;
+using Headless.Jobs;
+using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+
+namespace Tests.Dashboard;
+
+public sealed class DashboardOptionsTests : TestBase
+{
+    [Fact]
+    public void should_default_to_same_origin_and_require_an_explicit_auth_choice()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        builder.BasePath.Should().Be("/jobs/dashboard");
+        builder.BackendDomain.Should().BeNull();
+        builder.CorsPolicyBuilder.Should().BeNull();
+        builder.Auth.Mode.Should().Be(AuthMode.None);
+        builder.AuthConfigured.Should().BeFalse();
+        ((Action)builder.Validate).Should().Throw<InvalidOperationException>().WithMessage("*authentication*");
+    }
+
+    [Fact]
+    public void should_build_a_credentialed_cors_policy_for_explicit_origins()
+    {
+        var builder = new DashboardOptionsBuilder().SetCorsOrigins(
+            "https://admin.example.com",
+            "https://ops.example.com"
+        );
+        var policyBuilder = new CorsPolicyBuilder();
+
+        builder.CorsPolicyBuilder!(policyBuilder);
+        var policy = policyBuilder.Build();
+
+        policy.Origins.Should().Equal("https://admin.example.com", "https://ops.example.com");
+        policy.AllowAnyHeader.Should().BeTrue();
+        policy.AllowAnyMethod.Should().BeTrue();
+        policy.SupportsCredentials.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_reject_an_empty_cors_origin_list()
+    {
+        var act = () => new DashboardOptionsBuilder().SetCorsOrigins();
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void should_configure_paths_and_custom_cors_policy_fluently()
+    {
+        Action<CorsPolicyBuilder> cors = static policy => policy.WithMethods("GET");
+
+        var builder = new DashboardOptionsBuilder()
+            .SetBasePath("/admin/jobs")
+            .SetBackendDomain("https://api.example.com")
+            .SetCorsPolicy(cors);
+
+        builder.BasePath.Should().Be("/admin/jobs");
+        builder.BackendDomain.Should().Be("https://api.example.com");
+        builder.CorsPolicyBuilder.Should().BeSameAs(cors);
+    }
+
+    [Fact]
+    public void should_explicitly_allow_an_unauthenticated_dashboard()
+    {
+        var builder = new DashboardOptionsBuilder().WithNoAuth();
+
+        builder.AuthConfigured.Should().BeTrue();
+        builder.Auth.Mode.Should().Be(AuthMode.None);
+        builder.Auth.IsEnabled.Should().BeFalse();
+        ((Action)builder.Validate).Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_configure_basic_auth_credentials()
+    {
+        var builder = new DashboardOptionsBuilder().WithBasicAuth("admin", "password");
+
+        builder.AuthConfigured.Should().BeTrue();
+        builder.Auth.Mode.Should().Be(AuthMode.Basic);
+        builder.Auth.BasicCredentials.Should().Be("admin:password".ToBase64());
+        ((Action)builder.Validate).Should().NotThrow();
+    }
+
+    [Fact]
+    public void should_configure_api_key_authentication()
+    {
+        var builder = new DashboardOptionsBuilder().WithApiKey("secret-key");
+
+        builder.AuthConfigured.Should().BeTrue();
+        builder.Auth.Mode.Should().Be(AuthMode.ApiKey);
+        builder.Auth.ApiKey.Should().Be("secret-key");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("DashboardAdmin")]
+    public void should_configure_host_authentication(string? policy)
+    {
+        var builder = new DashboardOptionsBuilder().WithHostAuthentication(policy);
+
+        builder.AuthConfigured.Should().BeTrue();
+        builder.Auth.Mode.Should().Be(AuthMode.Host);
+        builder.Auth.HostAuthorizationPolicy.Should().Be(policy);
+    }
+
+    [Fact]
+    public void should_configure_custom_authentication_and_session_timeout()
+    {
+        static bool validator(string token, IServiceProvider _) => token == "valid";
+
+        var builder = new DashboardOptionsBuilder().WithCustomAuth(validator).WithSessionTimeout(30);
+
+        builder.AuthConfigured.Should().BeTrue();
+        builder.Auth.Mode.Should().Be(AuthMode.Custom);
+        builder.Auth.CustomValidator.Should().BeSameAs((Func<string, IServiceProvider, bool>)validator);
+        builder.Auth.SessionTimeoutMinutes.Should().Be(30);
+    }
+
+    [Fact]
+    public void should_preserve_dashboard_json_customizations_across_multiple_callbacks()
+    {
+        var builder = new DashboardOptionsBuilder()
+            .ConfigureDashboardJsonOptions(options => options.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower)
+            .ConfigureDashboardJsonOptions(options => options.WriteIndented = true)
+            .ConfigureDashboardJsonOptions(null);
+
+        builder.DashboardJsonOptions.Should().NotBeNull();
+        builder.DashboardJsonOptions!.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.SnakeCaseLower);
+        builder.DashboardJsonOptions.WriteIndented.Should().BeTrue();
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsDashboardRegistryTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsDashboardRegistryTests.cs
@@ -28,6 +28,55 @@ public sealed class JobsDashboardRegistryTests : TestBase
     }
 
     [Fact]
+    public void should_generate_a_representative_request_example_from_the_host_registry_type()
+    {
+        var registry = JobFunctionRegistryBuilder.Build(
+            [new KeyValuePair<string, JobFunctionRegistration>(_FunctionName, _Registration())],
+            [
+                new KeyValuePair<string, (string, Type)>(
+                    _FunctionName,
+                    (typeof(ExampleRequest).FullName!, typeof(ExampleRequest))
+                ),
+            ],
+            []
+        );
+        var (repository, _, _, serviceProvider) = _CreateRepository(registry);
+        using (serviceProvider)
+        {
+            var function = repository.GetJobFunctions().Should().ContainSingle().Which;
+
+            function.Item2.Item1.Should().Be(typeof(ExampleRequest).FullName);
+            function.Item2.Item2.Should().Contain("\"Name\": \"string\"");
+            function.Item2.Item2.Should().Contain("\"Retries\": 123");
+            function.Item2.Item2.Should().Contain("\"Tags\": [");
+            function.Item2.Item3.Should().Be(JobPriority.High);
+        }
+    }
+
+    [Fact]
+    public void should_return_an_empty_request_example_when_the_registered_type_cannot_be_constructed()
+    {
+        var registry = JobFunctionRegistryBuilder.Build(
+            [new KeyValuePair<string, JobFunctionRegistration>(_FunctionName, _Registration())],
+            [
+                new KeyValuePair<string, (string, Type)>(
+                    _FunctionName,
+                    (typeof(AbstractRequest).FullName!, typeof(AbstractRequest))
+                ),
+            ],
+            []
+        );
+        var (repository, _, _, serviceProvider) = _CreateRepository(registry);
+        using (serviceProvider)
+        {
+            var function = repository.GetJobFunctions().Should().ContainSingle().Which;
+
+            function.Item2.Item1.Should().Be(typeof(AbstractRequest).FullName);
+            function.Item2.Item2.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
     public async Task should_dispatch_on_demand_occurrences_with_the_host_registry_delegate_and_priority()
     {
         var registration = _Registration();
@@ -153,4 +202,15 @@ public sealed class JobsDashboardRegistryTests : TestBase
     }
 
     private sealed record DashboardRequest(string Value);
+
+    private sealed class ExampleRequest
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int? Retries { get; set; }
+
+        public List<string> Tags { get; set; } = [];
+    }
+
+    private abstract class AbstractRequest;
 }

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsNotificationHubTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsNotificationHubTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using Headless.Dashboard.Authentication;
+using Headless.Jobs.Hubs;
+using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.Dashboard;
+
+public sealed class JobsNotificationHubTests : TestBase
+{
+    [Fact]
+    public async Task should_abort_an_unauthenticated_connection_without_marking_the_context_authenticated()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService
+            .AuthenticateAsync(Arg.Any<HttpContext>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Failure("invalid token"));
+        var (hub, context, _, _) = _Create(authService);
+
+        await hub.OnConnectedAsync();
+
+        context.Received(1).Abort();
+        context.Items.Should().NotContainKey("authenticated");
+    }
+
+    [Fact]
+    public async Task should_record_the_authenticated_user_on_connection()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService
+            .AuthenticateAsync(Arg.Any<HttpContext>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Success("operator"));
+        var (hub, context, _, _) = _Create(authService);
+
+        await hub.OnConnectedAsync();
+
+        context.DidNotReceive().Abort();
+        context.Items["username"].Should().Be("operator");
+        context.Items["authenticated"].Should().Be(true);
+    }
+
+    [Theory]
+    [InlineData(true, "GroupJoined")]
+    [InlineData(false, "Error")]
+    public async Task should_only_join_groups_for_authenticated_connections(bool authenticated, string responseMethod)
+    {
+        var (hub, context, caller, groups) = _Create(Substitute.For<IAuthService>());
+        if (authenticated)
+        {
+            context.Items["authenticated"] = true;
+            context.Items["username"] = "operator";
+        }
+
+        await hub.JoinGroup("cron-job-1");
+
+        if (authenticated)
+        {
+            await groups.Received(1).AddToGroupAsync("connection-1", "cron-job-1", Arg.Any<CancellationToken>());
+        }
+        else
+        {
+            await groups
+                .DidNotReceive()
+                .AddToGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        await caller.Received(1).SendCoreAsync(responseMethod, Arg.Any<object?[]>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(true, "GroupLeft")]
+    [InlineData(false, "Error")]
+    public async Task should_only_leave_groups_for_authenticated_connections(bool authenticated, string responseMethod)
+    {
+        var (hub, context, caller, groups) = _Create(Substitute.For<IAuthService>());
+        if (authenticated)
+        {
+            context.Items["authenticated"] = true;
+            context.Items["username"] = "operator";
+        }
+
+        await hub.LeaveGroup("cron-job-1");
+
+        if (authenticated)
+        {
+            await groups.Received(1).RemoveFromGroupAsync("connection-1", "cron-job-1", Arg.Any<CancellationToken>());
+        }
+        else
+        {
+            await groups
+                .DidNotReceive()
+                .RemoveFromGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        await caller.Received(1).SendCoreAsync(responseMethod, Arg.Any<object?[]>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_report_connection_authentication_and_injected_utc_time()
+    {
+        var now = new DateTimeOffset(2026, 8, 5, 9, 30, 0, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider(now);
+        var (hub, context, caller, _) = _Create(Substitute.For<IAuthService>(), timeProvider);
+        context.Items["authenticated"] = true;
+        context.Items["username"] = "operator";
+        object? payload = null;
+        caller
+            .SendCoreAsync("Status", Arg.Any<object?[]>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                payload = callInfo.ArgAt<object?[]>(1)[0];
+                return Task.CompletedTask;
+            });
+
+        await hub.GetStatus();
+
+        payload.Should().NotBeNull();
+        _Read(payload!, "connectionId").Should().Be("connection-1");
+        _Read(payload!, "authenticated").Should().Be(true);
+        _Read(payload!, "username").Should().Be("operator");
+        _Read(payload!, "timestamp").Should().Be(now.UtcDateTime);
+    }
+
+    private static (
+        JobsNotificationHub Hub,
+        HubCallerContext Context,
+        IClientProxy Caller,
+        IGroupManager Groups
+    ) _Create(IAuthService authService, TimeProvider? timeProvider = null)
+    {
+        var context = Substitute.For<HubCallerContext>();
+        var items = new Dictionary<object, object?>();
+        var features = new FeatureCollection();
+        features.Set<IHttpContextFeature>(new TestHttpContextFeature { HttpContext = new DefaultHttpContext() });
+        context.ConnectionId.Returns("connection-1");
+        context.Items.Returns(items);
+        context.Features.Returns(features);
+
+        var caller = Substitute.For<ISingleClientProxy>();
+        caller
+            .SendCoreAsync(Arg.Any<string>(), Arg.Any<object?[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var clients = Substitute.For<IHubCallerClients>();
+        clients.Caller.Returns(caller);
+        var groups = Substitute.For<IGroupManager>();
+
+        var hub = new JobsNotificationHub(
+            NullLogger<JobsNotificationHub>.Instance,
+            authService,
+            timeProvider ?? TimeProvider.System
+        )
+        {
+            Context = context,
+            Clients = clients,
+            Groups = groups,
+        };
+
+        return (hub, context, caller, groups);
+    }
+
+    private static object? _Read(object value, string propertyName)
+    {
+        return value.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)?.GetValue(value);
+    }
+
+    private sealed class TestHttpContextFeature : IHttpContextFeature
+    {
+        public HttpContext? HttpContext { get; set; }
+    }
+}

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/OperationProcessors/ProblemDetailsOperationProcessorTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/OperationProcessors/ProblemDetailsOperationProcessorTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using Headless.OpenApi.Nswag.Models;
+using Headless.OpenApi.Nswag.OperationProcessors;
+using Headless.Testing.Tests;
+using NJsonSchema.Generation;
+using NSwag;
+using NSwag.Generation;
+using NSwag.Generation.AspNetCore;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Tests.OperationProcessors;
+
+public sealed class ProblemDetailsOperationProcessorTests : TestBase
+{
+    public static TheoryData<string, Type> ProblemResponseCases =>
+        new()
+        {
+            { "400", typeof(BadRequestProblemDetails) },
+            { "401", typeof(UnauthorizedProblemDetails) },
+            { "403", typeof(ForbiddenProblemDetails) },
+            { "404", typeof(EntityNotFoundProblemDetails) },
+            { "409", typeof(ConflictProblemDetails) },
+            { "422", typeof(UnprocessableEntityProblemDetails) },
+            { "429", typeof(TooManyRequestsProblemDetails) },
+        };
+
+    [Theory]
+    [MemberData(nameof(ProblemResponseCases))]
+    public void should_attach_the_typed_problem_schema_and_example_to_known_error_responses(
+        string statusCode,
+        Type problemType
+    )
+    {
+        var context = _CreateContext((statusCode, new OpenApiResponse()));
+
+        var processed = new ProblemDetailsOperationProcessor().Process(context);
+
+        processed.Should().BeTrue();
+        var mediaType = context.OperationDescription.Operation.Responses[statusCode].Content[
+            "application/problem+json"
+        ];
+        mediaType.Schema.Reference.Should().BeSameAs(context.Document.Definitions[problemType.Name]);
+        mediaType.Example.Should().BeOfType(problemType);
+    }
+
+    [Fact]
+    public void should_replace_an_existing_problem_media_schema_without_removing_other_content_types()
+    {
+        var response = new OpenApiResponse();
+        response.Content["application/problem+json"] = new OpenApiMediaType
+        {
+            Schema = new NJsonSchema.JsonSchema { Type = NJsonSchema.JsonObjectType.String },
+        };
+        response.Content["application/json"] = new OpenApiMediaType();
+        var context = _CreateContext(("400", response));
+
+        new ProblemDetailsOperationProcessor().Process(context);
+
+        response.Content.Keys.Should().BeEquivalentTo("application/problem+json", "application/json");
+        response
+            .Content["application/problem+json"]
+            .Schema.Reference.Should()
+            .BeSameAs(context.Document.Definitions[nameof(BadRequestProblemDetails)]);
+    }
+
+    [Fact]
+    public void should_leave_unrecognized_responses_unchanged_while_registering_shared_definitions_once()
+    {
+        var response = new OpenApiResponse { Description = "Server error" };
+        var context = _CreateContext(("500", response));
+        var processor = new ProblemDetailsOperationProcessor();
+
+        processor.Process(context);
+        var definitions = context.Document.Definitions.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value,
+            StringComparer.Ordinal
+        );
+        processor.Process(context);
+
+        response.Content.Should().BeEmpty();
+        context.Document.Definitions.Should().HaveCount(definitions.Count);
+        context.Document.Definitions.Should().ContainKeys(definitions.Keys.ToArray());
+        context.Document.Definitions.Should().ContainKey(nameof(HeadlessProblemDetails));
+    }
+
+    private static OperationProcessorContext _CreateContext(
+        params (string StatusCode, OpenApiResponse Response)[] responses
+    )
+    {
+        var document = new OpenApiDocument();
+        var operation = new OpenApiOperation();
+        foreach (var (statusCode, response) in responses)
+        {
+            operation.Responses[statusCode] = response;
+        }
+
+        var description = new OpenApiOperationDescription
+        {
+            Operation = operation,
+            Path = "/test",
+            Method = "GET",
+        };
+        var settings = new AspNetCoreOpenApiDocumentGeneratorSettings();
+        var resolver = new JsonSchemaResolver(new NJsonSchema.JsonSchema(), settings.SchemaSettings);
+        var generator = new OpenApiDocumentGenerator(settings, resolver);
+
+        return new OperationProcessorContext(
+            document,
+            description,
+            typeof(ProblemDetailsOperationProcessorTests),
+            typeof(ProblemDetailsOperationProcessorTests).GetMethod(
+                nameof(_Endpoint),
+                BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly,
+                binder: null,
+                Type.EmptyTypes,
+                modifiers: null
+            ),
+            generator,
+            resolver,
+            settings,
+            [description]
+        );
+    }
+
+    private static void _Endpoint() { }
+}

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/SchemaProcessors/FluentValidationSchemaProcessorTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/SchemaProcessors/FluentValidationSchemaProcessorTests.cs
@@ -22,6 +22,7 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
         using var services = _CreateServices(new RequestValidator());
         var schema = _CreateObjectSchema(
             ("Name", JsonObjectType.String | JsonObjectType.Null),
+            ("Code", JsonObjectType.String | JsonObjectType.Null),
             ("Age", JsonObjectType.Integer),
             ("Score", JsonObjectType.Number),
             ("Email", JsonObjectType.String)
@@ -34,9 +35,11 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
         schema.RequiredProperties.Should().Contain("Name");
         schema.Properties["Name"].IsNullableRaw.Should().BeFalse();
         schema.Properties["Name"].Type.Should().NotHaveFlag(JsonObjectType.Null);
-        schema.Properties["Name"].MinLength.Should().Be(1);
+        schema.Properties["Name"].MinLength.Should().Be(2);
         schema.Properties["Name"].MaxLength.Should().Be(10);
         schema.Properties["Name"].Pattern.Should().Be("^[a-z]+$");
+        schema.RequiredProperties.Should().Contain("Code");
+        schema.Properties["Code"].MinLength.Should().Be(1);
         schema.Properties["Age"].Minimum.Should().Be(18);
         schema.Properties["Age"].Maximum.Should().Be(100);
         schema.Properties["Age"].IsExclusiveMaximum.Should().BeTrue();
@@ -58,7 +61,7 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
         new FluentValidationSchemaProcessor(services).Process(_CreateContext(propertyType, schema));
 
         schema.IsNullableRaw.Should().BeFalse();
-        schema.MinLength.Should().Be(1);
+        schema.MinLength.Should().Be(2);
         schema.MaxLength.Should().Be(10);
         schema.Pattern.Should().Be("^[a-z]+$");
     }
@@ -80,7 +83,7 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
         );
 
         schema.Properties["Name"].MaxLength.Should().Be(77);
-        schema.Properties["Name"].MinLength.Should().Be(1);
+        schema.Properties["Name"].MinLength.Should().BeNull();
     }
 
     [Theory]
@@ -89,7 +92,7 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
     public void should_honor_the_error_policy_when_a_custom_rule_throws(bool throwOnError)
     {
         using var services = _CreateServices(new RequestValidator());
-        var schema = _CreateObjectSchema(("Name", JsonObjectType.String));
+        var schema = _CreateObjectSchema(("Name", JsonObjectType.String), ("Code", JsonObjectType.String));
         FluentValidationRule failingRule = new()
         {
             RuleName = "FailingRule",
@@ -163,6 +166,8 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
     {
         public string? Name { get; set; }
 
+        public string? Code { get; set; }
+
         public int Age { get; set; }
 
         public decimal Score { get; set; }
@@ -174,7 +179,8 @@ public sealed class FluentValidationSchemaProcessorTests : TestBase
     {
         public RequestValidator()
         {
-            RuleFor(request => request.Name).NotEmpty().Length(2, 10).Matches("^[a-z]+$");
+            RuleFor(request => request.Name).NotNull().Length(2, 10).Matches("^[a-z]+$");
+            RuleFor(request => request.Code).NotEmpty();
             RuleFor(request => request.Age).GreaterThanOrEqualTo(18).LessThan(100);
             RuleFor(request => request.Score).ExclusiveBetween(1, 10);
             RuleFor(request => request.Email).EmailAddress(EmailValidationMode.AspNetCoreCompatible);

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/SchemaProcessors/FluentValidationSchemaProcessorTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/SchemaProcessors/FluentValidationSchemaProcessorTests.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using FluentValidation;
+using FluentValidation.Validators;
+using Headless.OpenApi.Nswag;
+using Headless.OpenApi.Nswag.SchemaProcessors;
+using Headless.OpenApi.Nswag.SchemaProcessors.FluentValidation.Models;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Namotion.Reflection;
+using NJsonSchema;
+using NJsonSchema.Generation;
+
+namespace Tests.SchemaProcessors;
+
+public sealed class FluentValidationSchemaProcessorTests : TestBase
+{
+    [Fact]
+    public void should_project_common_validator_constraints_to_an_object_schema()
+    {
+        using var services = _CreateServices(new RequestValidator());
+        var schema = _CreateObjectSchema(
+            ("Name", JsonObjectType.String | JsonObjectType.Null),
+            ("Age", JsonObjectType.Integer),
+            ("Score", JsonObjectType.Number),
+            ("Email", JsonObjectType.String)
+        );
+
+        new FluentValidationSchemaProcessor(services).Process(
+            _CreateContext(typeof(Request).ToContextualType(), schema)
+        );
+
+        schema.RequiredProperties.Should().Contain("Name");
+        schema.Properties["Name"].IsNullableRaw.Should().BeFalse();
+        schema.Properties["Name"].Type.Should().NotHaveFlag(JsonObjectType.Null);
+        schema.Properties["Name"].MinLength.Should().Be(1);
+        schema.Properties["Name"].MaxLength.Should().Be(10);
+        schema.Properties["Name"].Pattern.Should().Be("^[a-z]+$");
+        schema.Properties["Age"].Minimum.Should().Be(18);
+        schema.Properties["Age"].Maximum.Should().Be(100);
+        schema.Properties["Age"].IsExclusiveMaximum.Should().BeTrue();
+        schema.Properties["Score"].ExclusiveMinimum.Should().Be(1);
+        schema.Properties["Score"].ExclusiveMaximum.Should().Be(10);
+        schema.Properties["Email"].Pattern.Should().Be("^[^@]+@[^@]+$");
+    }
+
+    [Fact]
+    public void should_apply_declaring_type_rules_when_a_property_schema_is_processed_directly()
+    {
+        using var services = _CreateServices(new RequestValidator());
+        var propertyType = typeof(Request)
+            .GetProperty(nameof(Request.Name), BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)!
+            .ToContextualProperty()
+            .PropertyType;
+        var schema = new JsonSchema { Type = JsonObjectType.String | JsonObjectType.Null };
+
+        new FluentValidationSchemaProcessor(services).Process(_CreateContext(propertyType, schema));
+
+        schema.IsNullableRaw.Should().BeFalse();
+        schema.MinLength.Should().Be(1);
+        schema.MaxLength.Should().Be(10);
+        schema.Pattern.Should().Be("^[a-z]+$");
+    }
+
+    [Fact]
+    public void should_replace_a_default_rule_when_a_custom_rule_uses_the_same_name()
+    {
+        using var services = _CreateServices(new RequestValidator());
+        var schema = _CreateObjectSchema(("Name", JsonObjectType.String));
+        FluentValidationRule replacement = new()
+        {
+            RuleName = FluentValidationRule.LengthRule.RuleName,
+            Matches = validator => validator is ILengthValidator,
+            Apply = context => context.PropertySchema.MaxLength = 77,
+        };
+
+        new FluentValidationSchemaProcessor(services, rules: [replacement]).Process(
+            _CreateContext(typeof(Request).ToContextualType(), schema)
+        );
+
+        schema.Properties["Name"].MaxLength.Should().Be(77);
+        schema.Properties["Name"].MinLength.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void should_honor_the_error_policy_when_a_custom_rule_throws(bool throwOnError)
+    {
+        using var services = _CreateServices(new RequestValidator());
+        var schema = _CreateObjectSchema(("Name", JsonObjectType.String));
+        FluentValidationRule failingRule = new()
+        {
+            RuleName = "FailingRule",
+            Matches = validator => validator is INotEmptyValidator,
+            Apply = _ => throw new InvalidOperationException("rule failed"),
+        };
+        var processor = new FluentValidationSchemaProcessor(
+            services,
+            new HeadlessNswagOptions { ThrowOnSchemaProcessingError = throwOnError },
+            [failingRule]
+        );
+
+        var act = () => processor.Process(_CreateContext(typeof(Request).ToContextualType(), schema));
+
+        if (throwOnError)
+        {
+            act.Should().Throw<InvalidOperationException>().WithMessage("rule failed");
+        }
+        else
+        {
+            act.Should().NotThrow();
+        }
+    }
+
+    [Fact]
+    public void should_leave_the_schema_unchanged_when_no_validator_is_registered()
+    {
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var schema = _CreateObjectSchema(("Name", JsonObjectType.String));
+
+        new FluentValidationSchemaProcessor(services).Process(
+            _CreateContext(typeof(Request).ToContextualType(), schema)
+        );
+
+        schema.RequiredProperties.Should().BeEmpty();
+        schema.Properties["Name"].MaxLength.Should().BeNull();
+    }
+
+    private static ServiceProvider _CreateServices(IValidator<Request> validator)
+    {
+        return new ServiceCollection()
+            .AddSingleton(validator)
+            .AddSingleton<IValidator<Request>>(validator)
+            .BuildServiceProvider();
+    }
+
+    private static JsonSchema _CreateObjectSchema(params (string Name, JsonObjectType Type)[] properties)
+    {
+        var schema = new JsonSchema { Type = JsonObjectType.Object };
+        foreach (var (name, type) in properties)
+        {
+            schema.Properties[name] = new JsonSchemaProperty { Type = type };
+        }
+
+        return schema;
+    }
+
+    private static SchemaProcessorContext _CreateContext(ContextualType contextualType, JsonSchema schema)
+    {
+        var settings = new SystemTextJsonSchemaGeneratorSettings();
+        return new SchemaProcessorContext(
+            contextualType,
+            schema,
+            new JsonSchemaResolver(schema, settings),
+            new JsonSchemaGenerator(settings),
+            settings
+        );
+    }
+
+    private sealed class Request
+    {
+        public string? Name { get; set; }
+
+        public int Age { get; set; }
+
+        public decimal Score { get; set; }
+
+        public string? Email { get; set; }
+    }
+
+    private sealed class RequestValidator : AbstractValidator<Request>
+    {
+        public RequestValidator()
+        {
+            RuleFor(request => request.Name).NotEmpty().Length(2, 10).Matches("^[a-z]+$");
+            RuleFor(request => request.Age).GreaterThanOrEqualTo(18).LessThan(100);
+            RuleFor(request => request.Score).ExclusiveBetween(1, 10);
+            RuleFor(request => request.Email).EmailAddress(EmailValidationMode.AspNetCoreCompatible);
+        }
+    }
+}

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/SchemaProcessors/SchemaProcessorContextExtensionsTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/SchemaProcessors/SchemaProcessorContextExtensionsTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.OpenApi.Nswag.SchemaProcessors;
+using Headless.Testing.Tests;
+using Namotion.Reflection;
+using NJsonSchema;
+using NJsonSchema.Generation;
+
+namespace Tests.SchemaProcessors;
+
+public sealed class SchemaProcessorContextExtensionsTests : TestBase
+{
+    [Fact]
+    public void should_add_only_non_nullable_object_properties_to_required()
+    {
+        var schema = _CreateObjectSchema();
+        schema.Properties["required"] = new JsonSchemaProperty { Type = JsonObjectType.String };
+        schema.Properties["nullable"] = new JsonSchemaProperty { Type = JsonObjectType.String | JsonObjectType.Null };
+
+        var result = schema.NormalizeNullableAsRequired();
+
+        result.Should().BeSameAs(schema);
+        schema.RequiredProperties.Should().Equal("required");
+    }
+
+    [Fact]
+    public void should_not_duplicate_an_existing_required_property()
+    {
+        var schema = _CreateObjectSchema();
+        schema.Properties["name"] = new JsonSchemaProperty { Type = JsonObjectType.String };
+        schema.RequiredProperties.Add("name");
+
+        schema.NormalizeNullableAsRequired().NormalizeNullableAsRequired();
+
+        schema.RequiredProperties.Should().Equal("name");
+    }
+
+    [Theory]
+    [InlineData(JsonObjectType.String)]
+    [InlineData(JsonObjectType.Array)]
+    public void should_leave_non_object_schemas_unchanged(JsonObjectType schemaType)
+    {
+        var schema = new JsonSchema { Type = schemaType };
+
+        schema.NormalizeNullableAsRequired();
+
+        schema.RequiredProperties.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void processor_should_delegate_to_required_normalization()
+    {
+        var schema = _CreateObjectSchema();
+        schema.Properties["name"] = new JsonSchemaProperty { Type = JsonObjectType.String };
+
+        new NullabilityAsRequiredSchemaProcessor().Process(_CreateContext(schema));
+
+        schema.RequiredProperties.Should().Equal("name");
+    }
+
+    private static JsonSchema _CreateObjectSchema()
+    {
+        return new JsonSchema { Type = JsonObjectType.Object };
+    }
+
+    private static SchemaProcessorContext _CreateContext(JsonSchema schema)
+    {
+        var settings = new SystemTextJsonSchemaGeneratorSettings();
+        return new SchemaProcessorContext(
+            typeof(object).ToContextualType(),
+            schema,
+            new JsonSchemaResolver(schema, settings),
+            new JsonSchemaGenerator(settings),
+            settings
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Locks down previously untested public behavior, error paths, and branching logic in the Jobs dashboard, NSwag integration, and EF Core helpers.
- Adds 67 deterministic tests without production seams or generated-code assertions.
- Raises package coverage substantially: Jobs Dashboard to 32.1% line / 36.6% branch, NSwag to 66.5% / 52.9%, and EF Core to 40.2% / 33.5%.

## Related Work

N/A

## Scope

Affected packages or domains:

- `Headless.Jobs.Dashboard`
- `Headless.OpenApi.Nswag`
- `Headless.EntityFramework.Core`

Out of scope:

- Production behavior or public API changes
- Generated-code testing
- Repository-wide analyzer Info/Suggestion triage

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A
```

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [x] `make test-unit`
- [x] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
Focused tests:
- Headless.Jobs.Composition.Tests.Unit: 725 passed, 0 failed, 0 skipped
- Headless.OpenApi.Nswag.Tests.Unit: 38 passed, 0 failed, 0 skipped
- Headless.EntityFramework.Core.Tests.Unit: 30 passed, 0 failed, 0 skipped

make format-check: 4,093 files checked successfully
make test-unit: 10,581 total; 10,579 passed; 2 expected skips; 0 failed
make test-integration TEST_MAX_PARALLEL=1: 2,412 total; 2,349 passed; 63 expected/credential-gated skips; 0 failed

The pre-push make build gate passed with 0 errors and reported 338 warnings. Analyzer diagnostic remediation is intentionally handled separately.

The first coverage-instrumented integration attempt encountered Redis timing and SQL Server deadlock noise. After building the documented compatibility probes, the authoritative serialized integration run passed.
```

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
Provider-conformance coverage and documentation updates are not applicable: this PR changes tests only and does not change shared behavior, public APIs, package guidance, or configuration.
```

## Reviewer Guide

The highest-value assertions cover dashboard authentication and route metadata, notification delivery, registry error paths, NSwag problem-details and FluentValidation schema projection, EF query execution, value converters, and invalid-range rejection before database execution.

Coverage comparisons use the preserved full-suite baseline artifact. The EF Core artifact baseline was 29.4% line / 18.2% branch, differing from the earlier reported 30.7% / 19.9% because the runs used different instrumentation universes.

## Release Notes

N/A — internal test coverage only.
