### PR TITLE
perf(messaging): avoid redundant retry lease release

### DIFF
--- a/src/Headless.Messaging.Core/Internal/IMessageSender.cs
+++ b/src/Headless.Messaging.Core/Internal/IMessageSender.cs
@@ -32,6 +32,12 @@ internal interface IMessageSender
     /// lifetime.
     /// </summary>
     Task<OperateResult> SendAsync(MediumMessage message, IServiceProvider dispatchServices);
+
+    Task<OperateResult> SendRetryAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState executionState
+    );
 }
 
 internal sealed class MessageSender : IMessageSender
@@ -78,6 +84,24 @@ internal sealed class MessageSender : IMessageSender
 
     public Task<OperateResult> SendAsync(MediumMessage message, IServiceProvider dispatchServices)
     {
+        return _SendAsync(message, dispatchServices, executionState: null);
+    }
+
+    public Task<OperateResult> SendRetryAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState executionState
+    )
+    {
+        return _SendAsync(message, dispatchServices, executionState);
+    }
+
+    private Task<OperateResult> _SendAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState? executionState
+    )
+    {
         Argument.IsNotNull(dispatchServices);
 
         // Outbox sender doesn't propagate user cancellation; messages should be delivered.
@@ -87,11 +111,20 @@ internal sealed class MessageSender : IMessageSender
         // state. The row keeps its prior NextRetryAt/Status and the persisted retry processor picks
         // it up on restart.
         return _retryPipeline.ExecuteAsync(
-            (_, ct) => _SendWithoutRetryAsync(message, ct),
+            (_, ct) => _SendWithoutRetryAsync(message, executionState, ct),
             (inlineRetries, exception, delay, strategyFailed, ct) =>
-                _HandleRetryAsync(message, exception, dispatchServices, inlineRetries, delay, strategyFailed, ct),
+                _HandleRetryAsync(
+                    message,
+                    exception,
+                    dispatchServices,
+                    inlineRetries,
+                    delay,
+                    strategyFailed,
+                    executionState,
+                    ct
+                ),
             (inlineRetries, exception, ct) =>
-                _HandleNonRetryableAsync(message, exception, dispatchServices, inlineRetries, ct),
+                _HandleNonRetryableAsync(message, exception, dispatchServices, inlineRetries, executionState, ct),
             message.StorageId,
             _shutdownToken
         );
@@ -99,6 +132,7 @@ internal sealed class MessageSender : IMessageSender
 
     private async Task<MessagingRetryAttempt> _SendWithoutRetryAsync(
         MediumMessage message,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -137,7 +171,7 @@ internal sealed class MessageSender : IMessageSender
         var transportMsg = await _serializer
             .SerializeToTransportMessageAsync(message.Origin, cancellationToken)
             .ConfigureAwait(false);
-        var selected = await _ResolveTransportAsync(message).ConfigureAwait(false);
+        var selected = await _ResolveTransportAsync(message, executionState).ConfigureAwait(false);
         if (selected.Result is { } failure)
         {
             return MessagingRetryAttempt.Completed(failure);
@@ -178,7 +212,7 @@ internal sealed class MessageSender : IMessageSender
         {
             try
             {
-                await _SetSuccessfulState(message, CancellationToken.None).ConfigureAwait(false);
+                await _SetSuccessfulState(message, executionState, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -204,7 +238,10 @@ internal sealed class MessageSender : IMessageSender
         return MessagingRetryAttempt.Retryable(OperateResult.Failed(result.Exception!));
     }
 
-    private async Task<(ITransport? Transport, OperateResult? Result)> _ResolveTransportAsync(MediumMessage message)
+    private async Task<(ITransport? Transport, OperateResult? Result)> _ResolveTransportAsync(
+        MediumMessage message,
+        RetryExecutionState? executionState
+    )
     {
         if (!Enum.IsDefined(message.Lane))
         {
@@ -214,7 +251,7 @@ internal sealed class MessageSender : IMessageSender
                     $"Stored message {message.StorageId} has unsupported MessageLane value '{(short)message.Lane}'."
                 )
             );
-            await _MarkMissingLaneTransportFailedAsync(message, ex).ConfigureAwait(false);
+            await _MarkMissingLaneTransportFailedAsync(message, ex, executionState).ConfigureAwait(false);
             return (null, OperateResult.Failed(ex));
         }
 
@@ -222,31 +259,39 @@ internal sealed class MessageSender : IMessageSender
         {
             MessageLane.Bus when _busTransport is not null => (_busTransport, null),
             MessageLane.Queue when _queueTransport is not null => (_queueTransport, null),
-            MessageLane.Bus => await _MissingTransportAsync(message, nameof(IBusTransport)).ConfigureAwait(false),
-            MessageLane.Queue => await _MissingTransportAsync(message, nameof(IQueueTransport)).ConfigureAwait(false),
+            MessageLane.Bus => await _MissingTransportAsync(message, nameof(IBusTransport), executionState)
+                .ConfigureAwait(false),
+            MessageLane.Queue => await _MissingTransportAsync(message, nameof(IQueueTransport), executionState)
+                .ConfigureAwait(false),
             _ => throw new UnreachableException(),
         };
     }
 
     private async Task<(ITransport? Transport, OperateResult? Result)> _MissingTransportAsync(
         MediumMessage message,
-        string transportType
+        string transportType,
+        RetryExecutionState? executionState
     )
     {
         var ex = new InvalidOperationException(
             $"Stored message {message.StorageId} requires {transportType}, but no matching transport is registered."
         );
-        await _MarkMissingLaneTransportFailedAsync(message, ex).ConfigureAwait(false);
+        await _MarkMissingLaneTransportFailedAsync(message, ex, executionState).ConfigureAwait(false);
         return (null, OperateResult.Failed(ex));
     }
 
-    private async Task _MarkMissingLaneTransportFailedAsync(MediumMessage message, Exception ex)
+    private async Task _MarkMissingLaneTransportFailedAsync(
+        MediumMessage message,
+        Exception ex,
+        RetryExecutionState? executionState
+    )
     {
         var originalInlineAttempts = message.InlineAttempts;
         message.ExpiresAt = _timeProvider.GetUtcNow().AddSeconds(_options.FailedMessageExpiredAfter);
         message.NextRetryAt = null;
+        DateTimeOffset? lockedUntil = null;
 
-        await _dataStorage
+        var affected = await _dataStorage
             .ChangePublishRetryStateAsync(
                 message,
                 StatusName.Failed,
@@ -254,19 +299,25 @@ internal sealed class MessageSender : IMessageSender
                 // before any transport attempt, so no exception is stamped onto Origin.
                 MessageContentWrite.Preserve,
                 nextRetryAt: null,
-                lockedUntil: null,
+                lockedUntil,
                 originalRetries: message.Retries,
                 originalInlineAttempts,
                 cancellationToken: CancellationToken.None
             )
             .ConfigureAwait(false);
+        executionState?.RecordLeaseTransition(affected, lockedUntil);
 
         _logger.StoredMessageMissingLaneTransport(ex, message.StorageId, message.Lane.ToString("D"));
     }
 
-    private async Task _SetSuccessfulState(MediumMessage message, CancellationToken cancellationToken)
+    private async Task _SetSuccessfulState(
+        MediumMessage message,
+        RetryExecutionState? executionState,
+        CancellationToken cancellationToken
+    )
     {
         message.ExpiresAt = _timeProvider.GetUtcNow().AddSeconds(_options.SucceedMessageExpiredAfter);
+        DateTimeOffset? lockedUntil = null;
         var updated = await _dataStorage
             .ChangePublishRetryStateAsync(
                 message,
@@ -275,12 +326,13 @@ internal sealed class MessageSender : IMessageSender
                 // byte-identical — re-serializing it would be a wasted write on the hottest path.
                 MessageContentWrite.Preserve,
                 nextRetryAt: null,
-                lockedUntil: null,
+                lockedUntil,
                 originalRetries: message.Retries,
                 originalInlineAttempts: message.InlineAttempts,
                 cancellationToken
             )
             .ConfigureAwait(false);
+        executionState?.RecordLeaseTransition(updated, lockedUntil);
 
         if (!updated)
         {
@@ -299,6 +351,7 @@ internal sealed class MessageSender : IMessageSender
         int _,
         TimeSpan delay,
         bool strategyFailed,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -314,6 +367,7 @@ internal sealed class MessageSender : IMessageSender
                 dispatchServices,
                 inlineRetries,
                 decision,
+                executionState,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -325,6 +379,7 @@ internal sealed class MessageSender : IMessageSender
         Exception exception,
         IServiceProvider dispatchServices,
         int _,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -335,6 +390,7 @@ internal sealed class MessageSender : IMessageSender
                 dispatchServices,
                 inlineRetries,
                 MessagingRetryDecision.Stop,
+                executionState,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -346,6 +402,7 @@ internal sealed class MessageSender : IMessageSender
         IServiceProvider dispatchServices,
         int inlineRetries,
         MessagingRetryDecision decision,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -395,7 +452,8 @@ internal sealed class MessageSender : IMessageSender
                     decision,
                     state,
                     originalRetries,
-                    originalInlineAttempts
+                    originalInlineAttempts,
+                    executionState
                 )
                 .ConfigureAwait(false);
             return MessagingRetryDecision.Stop;
@@ -412,7 +470,8 @@ internal sealed class MessageSender : IMessageSender
                 decision,
                 state,
                 originalRetries: message.Retries,
-                originalInlineAttempts
+                originalInlineAttempts,
+                executionState
             )
             .ConfigureAwait(false);
     }
@@ -424,7 +483,8 @@ internal sealed class MessageSender : IMessageSender
         MessagingRetryDecision decision,
         RetryNextState state,
         int originalRetries,
-        int originalInlineAttempts
+        int originalInlineAttempts,
+        RetryExecutionState? executionState
     )
     {
         // #14 — Preserve the active pickup lease on inline-in-flight transitions; clear it on
@@ -445,6 +505,7 @@ internal sealed class MessageSender : IMessageSender
                 CancellationToken.None
             )
             .ConfigureAwait(false);
+        executionState?.RecordLeaseTransition(affected, lockedUntil);
 
         if (affected && decision.Outcome == MessagingRetryDecision.Kind.Exhausted)
         {

--- a/src/Headless.Messaging.Core/Internal/ISubscribeExecutor.cs
+++ b/src/Headless.Messaging.Core/Internal/ISubscribeExecutor.cs
@@ -41,6 +41,14 @@ internal interface ISubscribeExecutor
         ConsumerExecutorDescriptor? descriptor = null,
         CancellationToken cancellationToken = default
     );
+
+    Task<OperateResult> ExecuteRetryAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState executionState,
+        ConsumerExecutorDescriptor? descriptor = null,
+        CancellationToken cancellationToken = default
+    );
 }
 
 internal sealed class SubscribeExecutor(
@@ -60,11 +68,33 @@ internal sealed class SubscribeExecutor(
     private readonly RetryPolicyOptions _retryPolicy = options.Value.RetryPolicy;
     private readonly MessagingRetryPipeline _retryPipeline = new(options.Value.RetryPolicy, timeProvider, logger);
 
-    public async Task<OperateResult> ExecuteAsync(
+    public Task<OperateResult> ExecuteAsync(
         MediumMessage message,
         IServiceProvider dispatchServices,
         ConsumerExecutorDescriptor? descriptor = null,
         CancellationToken cancellationToken = default
+    )
+    {
+        return _ExecuteAsync(message, dispatchServices, executionState: null, descriptor, cancellationToken);
+    }
+
+    public Task<OperateResult> ExecuteRetryAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState executionState,
+        ConsumerExecutorDescriptor? descriptor = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _ExecuteAsync(message, dispatchServices, executionState, descriptor, cancellationToken);
+    }
+
+    private async Task<OperateResult> _ExecuteAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState? executionState,
+        ConsumerExecutorDescriptor? descriptor,
+        CancellationToken cancellationToken
     )
     {
         Argument.IsNotNull(dispatchServices);
@@ -98,6 +128,7 @@ internal sealed class SubscribeExecutor(
                         exception,
                         dispatchServices,
                         decision: MessagingRetryDecision.Stop,
+                        executionState: executionState,
                         cancellationToken: cancellationToken
                     )
                     .ConfigureAwait(false);
@@ -110,11 +141,20 @@ internal sealed class SubscribeExecutor(
 
         return await _retryPipeline
             .ExecuteAsync(
-                (_, ct) => _ExecuteWithoutRetryAsync(message, descriptor, ct),
+                (_, ct) => _ExecuteWithoutRetryAsync(message, descriptor, executionState, ct),
                 (inlineRetries, exception, delay, strategyFailed, ct) =>
-                    _HandleRetryAsync(message, exception, dispatchServices, inlineRetries, delay, strategyFailed, ct),
+                    _HandleRetryAsync(
+                        message,
+                        exception,
+                        dispatchServices,
+                        inlineRetries,
+                        delay,
+                        strategyFailed,
+                        executionState,
+                        ct
+                    ),
                 (inlineRetries, exception, ct) =>
-                    _HandleNonRetryableAsync(message, exception, dispatchServices, inlineRetries, ct),
+                    _HandleNonRetryableAsync(message, exception, dispatchServices, inlineRetries, executionState, ct),
                 message.StorageId,
                 cancellationToken
             )
@@ -124,6 +164,7 @@ internal sealed class SubscribeExecutor(
     private async Task<MessagingRetryAttempt> _ExecuteWithoutRetryAsync(
         MediumMessage message,
         ConsumerExecutorDescriptor descriptor,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -176,7 +217,7 @@ internal sealed class SubscribeExecutor(
 
             sp.Stop();
 
-            await _SetSuccessfulState(message).ConfigureAwait(false);
+            await _SetSuccessfulState(message, executionState).ConfigureAwait(false);
 
             MessageEventCounterSource.Log.WriteInvokeTimeMetrics(sp.Elapsed.TotalMilliseconds);
             if (logger.IsEnabled(LogLevel.Information))
@@ -206,7 +247,7 @@ internal sealed class SubscribeExecutor(
         }
     }
 
-    private async ValueTask _SetSuccessfulState(MediumMessage message)
+    private async ValueTask _SetSuccessfulState(MediumMessage message, RetryExecutionState? executionState)
     {
         // R8 — the cancellation token parameter is unused since F30 switched the storage write
         // to CancellationToken.None below. The method is private; the parameter is removed
@@ -217,6 +258,7 @@ internal sealed class SubscribeExecutor(
         // the row is already terminal (typically Failed/NULL after a prior exhausted attempt),
         // surface the asymmetry for operators. Use CancellationToken.None so the must-complete
         // success-write semantics align with the publish-path's MessageSender._SetSuccessfulState.
+        DateTimeOffset? lockedUntil = null;
         var updated = await dataStorage
             .ChangeReceiveRetryStateAsync(
                 message,
@@ -226,12 +268,13 @@ internal sealed class SubscribeExecutor(
                 // row was stored. Preserving here would drop that stamp from the persisted envelope.
                 MessageContentWrite.Refresh,
                 nextRetryAt: null,
-                lockedUntil: null,
+                lockedUntil,
                 originalRetries: message.Retries,
                 originalInlineAttempts: message.InlineAttempts,
                 cancellationToken: CancellationToken.None
             )
             .ConfigureAwait(false);
+        executionState?.RecordLeaseTransition(updated, lockedUntil);
 
         if (!updated)
         {
@@ -252,6 +295,7 @@ internal sealed class SubscribeExecutor(
         int _,
         TimeSpan delay,
         bool strategyFailed,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -267,6 +311,7 @@ internal sealed class SubscribeExecutor(
                 dispatchServices,
                 inlineRetries,
                 decision,
+                executionState,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -278,6 +323,7 @@ internal sealed class SubscribeExecutor(
         Exception exception,
         IServiceProvider dispatchServices,
         int _,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -288,6 +334,7 @@ internal sealed class SubscribeExecutor(
                 dispatchServices,
                 inlineRetries,
                 MessagingRetryDecision.Stop,
+                executionState,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -299,6 +346,7 @@ internal sealed class SubscribeExecutor(
         IServiceProvider dispatchServices,
         int inlineRetries = 0,
         MessagingRetryDecision decision = default,
+        RetryExecutionState? executionState = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -352,6 +400,7 @@ internal sealed class SubscribeExecutor(
                     state,
                     originalRetries,
                     originalInlineAttempts,
+                    executionState,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -370,6 +419,7 @@ internal sealed class SubscribeExecutor(
                 state,
                 originalRetries: message.Retries,
                 originalInlineAttempts,
+                executionState,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -383,6 +433,7 @@ internal sealed class SubscribeExecutor(
         RetryNextState state,
         int originalRetries,
         int originalInlineAttempts,
+        RetryExecutionState? executionState,
         CancellationToken cancellationToken
     )
     {
@@ -421,6 +472,7 @@ internal sealed class SubscribeExecutor(
                 CancellationToken.None
             )
             .ConfigureAwait(false);
+        executionState?.RecordLeaseTransition(affected, lockedUntil);
 
         if (affected && decision.Outcome == MessagingRetryDecision.Kind.Exhausted)
         {

--- a/src/Headless.Messaging.Core/Processor/Dispatcher.cs
+++ b/src/Headless.Messaging.Core/Processor/Dispatcher.cs
@@ -7,6 +7,7 @@ using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
 using Headless.Messaging.Monitoring;
 using Headless.Messaging.Persistence;
+using Headless.Messaging.Retry;
 using Headless.Messaging.Transport;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -343,13 +344,14 @@ internal sealed class Dispatcher
                 return;
             }
 
+            var executionState = new RetryExecutionState();
             try
             {
-                await _SendMessageDirectlyAsync(message).ConfigureAwait(false);
+                await _SendMessageDirectlyAsync(message, executionState).ConfigureAwait(false);
             }
             finally
             {
-                await attempt.CompleteAsync().ConfigureAwait(false);
+                await attempt.CompleteAsync(executionState.LeaseClearedByTransition).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -387,16 +389,23 @@ internal sealed class Dispatcher
                 return;
             }
 
+            var executionState = new RetryExecutionState();
             try
             {
                 await using var dispatchScope = _scopeFactory.CreateAsyncScope();
                 await _executor
-                    .ExecuteAsync(message, dispatchScope.ServiceProvider, descriptor: null, TasksCts.Token)
+                    .ExecuteRetryAsync(
+                        message,
+                        dispatchScope.ServiceProvider,
+                        executionState,
+                        descriptor: null,
+                        TasksCts.Token
+                    )
                     .ConfigureAwait(false);
             }
             finally
             {
-                await attempt.CompleteAsync().ConfigureAwait(false);
+                await attempt.CompleteAsync(executionState.LeaseClearedByTransition).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -876,10 +885,15 @@ internal sealed class Dispatcher
             return;
         }
 
+        RetryExecutionState? executionState = retryAttempt is null ? null : new RetryExecutionState();
         try
         {
             await using var dispatchScope = _scopeFactory.CreateAsyncScope();
-            var result = await _sender.SendAsync(message, dispatchScope.ServiceProvider).ConfigureAwait(false);
+            var result = executionState is null
+                ? await _sender.SendAsync(message, dispatchScope.ServiceProvider).ConfigureAwait(false)
+                : await _sender
+                    .SendRetryAsync(message, dispatchScope.ServiceProvider, executionState)
+                    .ConfigureAwait(false);
             if (!result.Succeeded)
             {
                 _logger.MessagePublishException(result.Exception, message.Origin.Id, result.ToString());
@@ -893,17 +907,21 @@ internal sealed class Dispatcher
         {
             if (retryAttempt is not null)
             {
-                await retryAttempt.CompleteAsync().ConfigureAwait(false);
+                await retryAttempt.CompleteAsync(executionState!.LeaseClearedByTransition).ConfigureAwait(false);
             }
         }
     }
 
-    private async Task _SendMessageDirectlyAsync(MediumMessage message)
+    private async Task _SendMessageDirectlyAsync(MediumMessage message, RetryExecutionState? executionState = null)
     {
         try
         {
             await using var dispatchScope = _scopeFactory.CreateAsyncScope();
-            var result = await _sender.SendAsync(message, dispatchScope.ServiceProvider).ConfigureAwait(false);
+            var result = executionState is null
+                ? await _sender.SendAsync(message, dispatchScope.ServiceProvider).ConfigureAwait(false)
+                : await _sender
+                    .SendRetryAsync(message, dispatchScope.ServiceProvider, executionState)
+                    .ConfigureAwait(false);
             if (!result.Succeeded)
             {
                 _logger.MessagePublishException(result.Exception, message.Origin.Id, result.ToString());
@@ -949,12 +967,28 @@ internal sealed class Dispatcher
             return;
         }
 
+        RetryExecutionState? executionState = retryAttempt is null ? null : new RetryExecutionState();
         try
         {
             await using var dispatchScope = _scopeFactory.CreateAsyncScope();
-            await _executor
-                .ExecuteAsync(message, dispatchScope.ServiceProvider, descriptor, TasksCts.Token)
-                .ConfigureAwait(false);
+            if (executionState is null)
+            {
+                await _executor
+                    .ExecuteAsync(message, dispatchScope.ServiceProvider, descriptor, TasksCts.Token)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await _executor
+                    .ExecuteRetryAsync(
+                        message,
+                        dispatchScope.ServiceProvider,
+                        executionState,
+                        descriptor,
+                        TasksCts.Token
+                    )
+                    .ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -968,7 +1002,7 @@ internal sealed class Dispatcher
         {
             if (retryAttempt is not null)
             {
-                await retryAttempt.CompleteAsync().ConfigureAwait(false);
+                await retryAttempt.CompleteAsync(executionState!.LeaseClearedByTransition).ConfigureAwait(false);
             }
         }
     }

--- a/src/Headless.Messaging.Core/Processor/RetryDispatchAttempt.cs
+++ b/src/Headless.Messaging.Core/Processor/RetryDispatchAttempt.cs
@@ -164,8 +164,14 @@ internal sealed class RetryDispatchAttempt
         await AbandonQueuedAsync().ConfigureAwait(false);
     }
 
-    public ValueTask CompleteAsync()
+    public ValueTask CompleteAsync(bool leaseClearedByTransition = false)
     {
+        if (leaseClearedByTransition)
+        {
+            _ = Interlocked.CompareExchange(ref _state, (int)AttemptState.Completed, (int)AttemptState.Running);
+            return ValueTask.CompletedTask;
+        }
+
         return _TransitionAndReleaseAsync(AttemptState.Running, AttemptState.Completed);
     }
 

--- a/src/Headless.Messaging.Core/Retry/RetryExecutionState.cs
+++ b/src/Headless.Messaging.Core/Retry/RetryExecutionState.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+namespace Headless.Messaging.Retry;
+
+internal sealed class RetryExecutionState
+{
+    public bool LeaseClearedByTransition { get; private set; }
+
+    public void RecordLeaseTransition(bool affected, DateTimeOffset? lockedUntil)
+    {
+        if (affected)
+        {
+            LeaseClearedByTransition = lockedUntil is null;
+        }
+    }
+}

--- a/tests/Headless.Messaging.Core.Tests.Harness/DataStorageTestsBase.cs
+++ b/tests/Headless.Messaging.Core.Tests.Harness/DataStorageTestsBase.cs
@@ -1882,32 +1882,113 @@ public abstract class DataStorageTestsBase : TestBase
         var storage = GetStorage();
         var releaseStorage = storage.Should().BeAssignableTo<IGracefulLeaseReleaseStorage>().Subject;
         NodeMembership.SetIdentity("graceful-terminal-owner");
-        var stored = await _StoreFailedPublishedMessageAsync("graceful-terminal-published");
-        var claimed = (await storage.GetPublishedMessagesOfNeedRetryAsync(MessageLane.Bus, AbortToken))
+        var storedPublished = await _StoreFailedPublishedMessageAsync("graceful-terminal-published");
+        var claimedPublished = (await storage.GetPublishedMessagesOfNeedRetryAsync(MessageLane.Bus, AbortToken))
             .Should()
-            .ContainSingle(message => message.StorageId == stored.StorageId)
+            .ContainSingle(message => message.StorageId == storedPublished.StorageId)
             .Subject;
-        var identity = new MessageLeaseIdentity(
-            claimed.StorageId,
-            claimed.Owner,
-            claimed.LockedUntil!.Value,
-            claimed.Lane
+        var publishedIdentity = new MessageLeaseIdentity(
+            claimedPublished.StorageId,
+            claimedPublished.Owner,
+            claimedPublished.LockedUntil!.Value,
+            claimedPublished.Lane
         );
         (
-            await storage.ChangePublishStateAsync(
-                claimed,
+            await storage.ChangePublishRetryStateAsync(
+                claimedPublished,
                 StatusName.Succeeded,
+                MessageContentWrite.Preserve,
                 nextRetryAt: null,
-                lockedUntil: claimed.LockedUntil,
+                lockedUntil: null,
+                originalRetries: claimedPublished.Retries,
+                originalInlineAttempts: claimedPublished.InlineAttempts,
                 cancellationToken: AbortToken
             )
         )
             .Should()
             .BeTrue();
 
-        (await releaseStorage.ReleasePublishedLeaseAsync(identity, AbortToken))
+        if (Capabilities.SupportsMonitoringApi)
+        {
+            var roundTripped = await storage
+                .GetMonitoringApi()
+                .GetPublishedMessageAsync(claimedPublished.StorageId, AbortToken);
+            roundTripped.Should().NotBeNull();
+            roundTripped!.LockedUntil.Should().BeNull("the successful retry transition must clear its lease");
+        }
+
+        (await releaseStorage.ReleasePublishedLeaseAsync(publishedIdentity, AbortToken))
             .Should()
             .BeFalse("graceful release must never rewrite a terminal row");
+
+        var storedReceived = await _StoreFailedReceivedMessageAsync(
+            "graceful-terminal-received",
+            "graceful-terminal-group"
+        );
+        var claimedReceived = (await storage.GetReceivedMessagesOfNeedRetryAsync(MessageLane.Bus, AbortToken))
+            .Should()
+            .ContainSingle(message => message.StorageId == storedReceived.StorageId)
+            .Subject;
+        var receivedIdentity = new MessageLeaseIdentity(
+            claimedReceived.StorageId,
+            claimedReceived.Owner,
+            claimedReceived.LockedUntil!.Value,
+            claimedReceived.Lane
+        );
+        (
+            await storage.ChangeReceiveRetryStateAsync(
+                claimedReceived,
+                StatusName.Succeeded,
+                MessageContentWrite.Preserve,
+                nextRetryAt: null,
+                lockedUntil: null,
+                originalRetries: claimedReceived.Retries,
+                originalInlineAttempts: claimedReceived.InlineAttempts,
+                cancellationToken: AbortToken
+            )
+        )
+            .Should()
+            .BeTrue();
+
+        if (Capabilities.SupportsMonitoringApi)
+        {
+            var roundTripped = await storage
+                .GetMonitoringApi()
+                .GetReceivedMessageAsync(claimedReceived.StorageId, AbortToken);
+            roundTripped.Should().NotBeNull();
+            roundTripped!.LockedUntil.Should().BeNull("the successful retry transition must clear its lease");
+        }
+
+        (await releaseStorage.ReleaseReceivedLeaseAsync(receivedIdentity, AbortToken))
+            .Should()
+            .BeFalse("graceful release must never rewrite a terminal row");
+
+        var storedTerminal = await _StoreFailedPublishedMessageAsync("graceful-terminal-preserved-lease");
+        var claimedTerminal = (await storage.GetPublishedMessagesOfNeedRetryAsync(MessageLane.Bus, AbortToken))
+            .Should()
+            .ContainSingle(message => message.StorageId == storedTerminal.StorageId)
+            .Subject;
+        var terminalIdentity = new MessageLeaseIdentity(
+            claimedTerminal.StorageId,
+            claimedTerminal.Owner,
+            claimedTerminal.LockedUntil!.Value,
+            claimedTerminal.Lane
+        );
+        (
+            await storage.ChangePublishStateAsync(
+                claimedTerminal,
+                StatusName.Succeeded,
+                nextRetryAt: null,
+                lockedUntil: claimedTerminal.LockedUntil,
+                cancellationToken: AbortToken
+            )
+        )
+            .Should()
+            .BeTrue();
+
+        (await releaseStorage.ReleasePublishedLeaseAsync(terminalIdentity, AbortToken))
+            .Should()
+            .BeFalse("graceful release must remain fenced by terminal status");
     }
 
     public virtual async Task should_batch_release_only_exact_published_retry_lease_generations()

--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -534,13 +534,19 @@ public sealed class DispatcherTests : TestBase
         var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
         var releaser = (IGracefulLeaseReleaseStorage)storage;
         _executor
-            .ExecuteAsync(
+            .ExecuteRetryAsync(
                 Arg.Any<MediumMessage>(),
                 Arg.Any<IServiceProvider>(),
+                Arg.Any<RetryExecutionState>(),
                 Arg.Any<ConsumerExecutorDescriptor?>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(OperateResult.Success);
+            .Returns(call =>
+            {
+                var message = call.Arg<MediumMessage>();
+                call.Arg<RetryExecutionState>().RecordLeaseTransition(affected: true, message.LockedUntil);
+                return OperateResult.Success;
+            });
         var options = Options.Create(new MessagingOptions());
         await using var dispatcher = new Dispatcher(
             _logger,
@@ -560,9 +566,10 @@ public sealed class DispatcherTests : TestBase
 
         await _executor
             .Received(1)
-            .ExecuteAsync(
+            .ExecuteRetryAsync(
                 message,
                 Arg.Any<IServiceProvider>(),
+                Arg.Any<RetryExecutionState>(),
                 Arg.Any<ConsumerExecutorDescriptor?>(),
                 Arg.Any<CancellationToken>()
             );

--- a/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/DispatcherTests.cs
@@ -8,6 +8,7 @@ using Headless.Messaging.Messages;
 using Headless.Messaging.Monitoring;
 using Headless.Messaging.Persistence;
 using Headless.Messaging.Processor;
+using Headless.Messaging.Retry;
 using Headless.Messaging.Transactions;
 using Headless.Messaging.Transport;
 using Headless.Testing.Tests;
@@ -29,6 +30,257 @@ public sealed class DispatcherTests : TestBase
         .GetRequiredService<IServiceScopeFactory>();
 
     [Fact]
+    public async Task completed_published_retry_does_not_release_a_cleared_lease_again()
+    {
+        var sender = Substitute.For<IMessageSender>();
+        sender
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>())
+            .Returns(call =>
+            {
+                call.Arg<RetryExecutionState>().RecordLeaseTransition(affected: true, lockedUntil: null);
+                return OperateResult.Success;
+            });
+        var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            sender,
+            Options.Create(new MessagingOptions { EnablePublishParallelSend = false }),
+            _executor,
+            storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        await dispatcher.StartAsync(AbortToken);
+        var message = _CreateRetryMessage(owner: "node-a", lockedUntil: DateTimeOffset.UtcNow.AddMinutes(5));
+
+        await ((IRetryDispatcher)dispatcher).DispatchPublishedAsync(message, AbortToken);
+
+        await sender
+            .Received(1)
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>());
+        await ((IGracefulLeaseReleaseStorage)storage)
+            .DidNotReceive()
+            .ReleasePublishedLeaseAsync(Arg.Any<MessageLeaseIdentity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task completed_received_retry_does_not_release_a_cleared_lease_again()
+    {
+        _executor
+            .ExecuteRetryAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<IServiceProvider>(),
+                Arg.Any<RetryExecutionState>(),
+                Arg.Any<ConsumerExecutorDescriptor?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(call =>
+            {
+                call.Arg<RetryExecutionState>().RecordLeaseTransition(affected: true, lockedUntil: null);
+                return OperateResult.Success;
+            });
+        var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            Substitute.For<IMessageSender>(),
+            Options.Create(new MessagingOptions { EnableSubscriberParallelExecute = false }),
+            _executor,
+            storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        await dispatcher.StartAsync(AbortToken);
+        var message = _CreateRetryMessage(owner: "node-a", lockedUntil: DateTimeOffset.UtcNow.AddMinutes(5));
+
+        await ((IRetryDispatcher)dispatcher).DispatchReceivedAsync(message, AbortToken);
+
+        await _executor
+            .Received(1)
+            .ExecuteRetryAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<IServiceProvider>(),
+                Arg.Any<RetryExecutionState>(),
+                Arg.Any<ConsumerExecutorDescriptor?>(),
+                Arg.Any<CancellationToken>()
+            );
+        await ((IGracefulLeaseReleaseStorage)storage)
+            .DidNotReceive()
+            .ReleaseReceivedLeaseAsync(Arg.Any<MessageLeaseIdentity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task later_lease_preserving_transition_keeps_completion_release_required()
+    {
+        var sender = Substitute.For<IMessageSender>();
+        sender
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>())
+            .Returns(call =>
+            {
+                var executionState = call.Arg<RetryExecutionState>();
+                var message = call.Arg<MediumMessage>();
+                executionState.RecordLeaseTransition(affected: true, lockedUntil: null);
+                executionState.RecordLeaseTransition(affected: true, message.LockedUntil);
+                return OperateResult.Success;
+            });
+        var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            sender,
+            Options.Create(new MessagingOptions { EnablePublishParallelSend = false }),
+            _executor,
+            storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        await dispatcher.StartAsync(AbortToken);
+        var message = _CreateRetryMessage(owner: "node-a", lockedUntil: DateTimeOffset.UtcNow.AddMinutes(5));
+
+        await ((IRetryDispatcher)dispatcher).DispatchPublishedAsync(message, AbortToken);
+
+        await ((IGracefulLeaseReleaseStorage)storage)
+            .Received(1)
+            .ReleasePublishedLeaseAsync(
+                Arg.Is<MessageLeaseIdentity>(identity =>
+                    identity.StorageId == message.StorageId
+                    && identity.Owner == message.Owner
+                    && identity.LockedUntil == message.LockedUntil
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task failed_lease_clearing_transition_keeps_completion_release_required()
+    {
+        var sender = Substitute.For<IMessageSender>();
+        sender
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>())
+            .Returns(call =>
+            {
+                call.Arg<RetryExecutionState>().RecordLeaseTransition(affected: false, lockedUntil: null);
+                return OperateResult.Success;
+            });
+        var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            sender,
+            Options.Create(new MessagingOptions { EnablePublishParallelSend = false }),
+            _executor,
+            storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        await dispatcher.StartAsync(AbortToken);
+        var message = _CreateRetryMessage(owner: "node-a", lockedUntil: DateTimeOffset.UtcNow.AddMinutes(5));
+
+        await ((IRetryDispatcher)dispatcher).DispatchPublishedAsync(message, AbortToken);
+
+        await ((IGracefulLeaseReleaseStorage)storage)
+            .Received(1)
+            .ReleasePublishedLeaseAsync(
+                Arg.Is<MessageLeaseIdentity>(identity =>
+                    identity.StorageId == message.StorageId
+                    && identity.Owner == message.Owner
+                    && identity.LockedUntil == message.LockedUntil
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task queued_published_retry_does_not_release_a_cleared_lease_again()
+    {
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = Substitute.For<IMessageSender>();
+        sender
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>())
+            .Returns(call =>
+            {
+                call.Arg<RetryExecutionState>().RecordLeaseTransition(affected: true, lockedUntil: null);
+                completed.TrySetResult();
+                return OperateResult.Success;
+            });
+        var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            sender,
+            Options.Create(new MessagingOptions { EnablePublishParallelSend = true, PublishBatchSize = 1 }),
+            _executor,
+            storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        await dispatcher.StartAsync(AbortToken);
+        var message = _CreateRetryMessage(owner: "node-a", lockedUntil: DateTimeOffset.UtcNow.AddMinutes(5));
+
+        await ((IRetryDispatcher)dispatcher).DispatchPublishedAsync(message, AbortToken);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+        await dispatcher.DisposeAsync(TimeSpan.FromSeconds(2), AbortToken);
+
+        await sender
+            .Received(1)
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>());
+        await ((IGracefulLeaseReleaseStorage)storage)
+            .DidNotReceive()
+            .ReleasePublishedLeaseAsync(Arg.Any<MessageLeaseIdentity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task queued_received_retry_does_not_release_a_cleared_lease_again()
+    {
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _executor
+            .ExecuteRetryAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<IServiceProvider>(),
+                Arg.Any<RetryExecutionState>(),
+                Arg.Any<ConsumerExecutorDescriptor?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(call =>
+            {
+                call.Arg<RetryExecutionState>().RecordLeaseTransition(affected: true, lockedUntil: null);
+                completed.TrySetResult();
+                return OperateResult.Success;
+            });
+        var storage = Substitute.For<IDataStorage, IGracefulLeaseReleaseStorage>();
+        await using var dispatcher = new Dispatcher(
+            _logger,
+            Substitute.For<IMessageSender>(),
+            Options.Create(
+                new MessagingOptions
+                {
+                    EnableSubscriberParallelExecute = true,
+                    SubscriberParallelExecuteThreadCount = 1,
+                }
+            ),
+            _executor,
+            storage,
+            TimeProvider.System,
+            _scopeFactory
+        );
+        await dispatcher.StartAsync(AbortToken);
+        var message = _CreateRetryMessage(owner: "node-a", lockedUntil: DateTimeOffset.UtcNow.AddMinutes(5));
+
+        await ((IRetryDispatcher)dispatcher).DispatchReceivedAsync(message, AbortToken);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(2), AbortToken);
+        await dispatcher.DisposeAsync(TimeSpan.FromSeconds(2), AbortToken);
+
+        await _executor
+            .Received(1)
+            .ExecuteRetryAsync(
+                Arg.Any<MediumMessage>(),
+                Arg.Any<IServiceProvider>(),
+                Arg.Any<RetryExecutionState>(),
+                Arg.Any<ConsumerExecutorDescriptor?>(),
+                Arg.Any<CancellationToken>()
+            );
+        await ((IGracefulLeaseReleaseStorage)storage)
+            .DidNotReceive()
+            .ReleaseReceivedLeaseAsync(Arg.Any<MessageLeaseIdentity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task shutdown_releases_queued_retry_but_not_running_retry()
     {
         var timeProvider = new FakeTimeProvider();
@@ -39,9 +291,12 @@ public sealed class DispatcherTests : TestBase
         );
         var sender = Substitute.For<IMessageSender>();
         sender
-            .SendAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>())
-            .Returns(async _ =>
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>())
+            .Returns(async call =>
             {
+                var executionState = call.Arg<RetryExecutionState>();
+                var message = call.Arg<MediumMessage>();
+                executionState.RecordLeaseTransition(affected: true, message.LockedUntil);
                 runningEntered.TrySetResult();
                 await releaseRunning.Task.ConfigureAwait(false);
                 return OperateResult.Success;
@@ -144,7 +399,7 @@ public sealed class DispatcherTests : TestBase
             .Returns(_ => BlockReleaseAsync());
         var sender = Substitute.For<IMessageSender>();
         sender
-            .SendAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>())
+            .SendRetryAsync(Arg.Any<MediumMessage>(), Arg.Any<IServiceProvider>(), Arg.Any<RetryExecutionState>())
             .Returns(async _ =>
             {
                 runningEntered.TrySetResult();
@@ -1778,6 +2033,15 @@ public sealed class DispatcherTests : TestBase
         }
 
         public Task<OperateResult> SendAsync(MediumMessage message, IServiceProvider dispatchServices)
+        {
+            return SendAsync(message);
+        }
+
+        public Task<OperateResult> SendRetryAsync(
+            MediumMessage message,
+            IServiceProvider dispatchServices,
+            RetryExecutionState executionState
+        )
         {
             return SendAsync(message);
         }

--- a/tests/Headless.Messaging.Core.Tests.Unit/Helpers/TestThreadSafeMessageSender.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/Helpers/TestThreadSafeMessageSender.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Headless.Messaging;
 using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
+using Headless.Messaging.Retry;
 
 namespace Tests.Helpers;
 
@@ -23,6 +24,15 @@ public sealed class TestThreadSafeMessageSender : IMessageSender
     }
 
     public Task<OperateResult> SendAsync(MediumMessage message, IServiceProvider dispatchServices)
+    {
+        return SendAsync(message);
+    }
+
+    Task<OperateResult> IMessageSender.SendRetryAsync(
+        MediumMessage message,
+        IServiceProvider dispatchServices,
+        RetryExecutionState executionState
+    )
     {
         return SendAsync(message);
     }

--- a/tests/Headless.Messaging.Core.Tests.Unit/MessageSenderTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/MessageSenderTests.cs
@@ -7,6 +7,7 @@ using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
 using Headless.Messaging.Monitoring;
 using Headless.Messaging.Persistence;
+using Headless.Messaging.Retry;
 using Headless.Messaging.Serialization;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,8 @@ namespace Tests;
 
 public sealed class MessageSenderTests : TestBase
 {
+    private static readonly IServiceProvider _EmptyScope = new ServiceCollection().BuildServiceProvider();
+
     private static MediumMessage _CreateMediumMessage(MessageLane lane = MessageLane.Bus)
     {
         var headers = new Dictionary<string, string?>(StringComparer.Ordinal)
@@ -221,10 +224,12 @@ public sealed class MessageSenderTests : TestBase
         );
 
         // when
-        var result = await sender.SendAsync(_CreateMediumMessage());
+        var executionState = new RetryExecutionState();
+        var result = await sender.SendRetryAsync(_CreateMediumMessage(), _EmptyScope, executionState);
 
         // then
         result.Succeeded.Should().BeTrue();
+        executionState.LeaseClearedByTransition.Should().BeTrue();
         attempts.Should().Be(5);
     }
 
@@ -339,10 +344,12 @@ public sealed class MessageSenderTests : TestBase
         );
 
         // when
-        var result = await sender.SendAsync(_CreateMediumMessage());
+        var executionState = new RetryExecutionState();
+        var result = await sender.SendRetryAsync(_CreateMediumMessage(), _EmptyScope, executionState);
 
         // then
         result.Succeeded.Should().BeFalse();
+        executionState.LeaseClearedByTransition.Should().BeTrue();
         await storage
             .Received(1)
             .ChangePublishRetryStateAsync(

--- a/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorCancellationTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorCancellationTests.cs
@@ -8,6 +8,7 @@ using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
 using Headless.Messaging.Monitoring;
 using Headless.Messaging.Persistence;
+using Headless.Messaging.Retry;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -237,10 +238,12 @@ public sealed class SubscribeExecutorCancellationTests : TestBase
         var descriptor = _CreateDescriptor();
 
         // when
-        var result = await executor.ExecuteAsync(message, _EmptyScope, descriptor, cts.Token);
+        var executionState = new RetryExecutionState();
+        var result = await executor.ExecuteRetryAsync(message, _EmptyScope, executionState, descriptor, cts.Token);
 
         // then — Shutdown OCE: no state write, no OnExhausted. Row keeps prior NextRetryAt/Status.
         result.Succeeded.Should().BeFalse();
+        executionState.LeaseClearedByTransition.Should().BeFalse();
         message.Retries.Should().Be(0);
         callbackInvoked.Should().BeFalse();
         await storage

--- a/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorRetryTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorRetryTests.cs
@@ -172,7 +172,7 @@ public sealed class SubscribeExecutorRetryTests : TestBase
             _EmptyScope,
             executionState,
             _CreateDescriptor(),
-            CancellationToken.None
+            AbortToken
         );
 
         // then
@@ -286,7 +286,7 @@ public sealed class SubscribeExecutorRetryTests : TestBase
             _EmptyScope,
             executionState,
             _CreateDescriptor(),
-            CancellationToken.None
+            AbortToken
         );
 
         // then

--- a/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorRetryTests.cs
+++ b/tests/Headless.Messaging.Core.Tests.Unit/SubscribeExecutorRetryTests.cs
@@ -8,6 +8,7 @@ using Headless.Messaging.Internal;
 using Headless.Messaging.Messages;
 using Headless.Messaging.Monitoring;
 using Headless.Messaging.Persistence;
+using Headless.Messaging.Retry;
 using Headless.Testing.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -165,10 +166,18 @@ public sealed class SubscribeExecutorRetryTests : TestBase
         var message = _CreateMediumMessage();
 
         // when
-        var result = await executor.ExecuteAsync(message, _EmptyScope, _CreateDescriptor(), CancellationToken.None);
+        var executionState = new RetryExecutionState();
+        var result = await executor.ExecuteRetryAsync(
+            message,
+            _EmptyScope,
+            executionState,
+            _CreateDescriptor(),
+            CancellationToken.None
+        );
 
         // then
         result.Succeeded.Should().BeTrue();
+        executionState.LeaseClearedByTransition.Should().BeTrue();
         attempts.Should().Be(5);
         // Inline retries do not increment MediumMessage.Retries (which now counts persisted pickups
         // only). The 5th attempt succeeded inline, so no persist-transition ever happened.
@@ -271,10 +280,18 @@ public sealed class SubscribeExecutorRetryTests : TestBase
         var message = _CreateMediumMessage();
 
         // when
-        var result = await executor.ExecuteAsync(message, _EmptyScope, _CreateDescriptor(), CancellationToken.None);
+        var executionState = new RetryExecutionState();
+        var result = await executor.ExecuteRetryAsync(
+            message,
+            _EmptyScope,
+            executionState,
+            _CreateDescriptor(),
+            CancellationToken.None
+        );
 
         // then
         result.Succeeded.Should().BeFalse();
+        executionState.LeaseClearedByTransition.Should().BeTrue();
         await storage
             .Received(1)
             .ChangeReceiveRetryStateAsync(


### PR DESCRIPTION
## Summary

- Persisted retry completion skips the redundant exact lease-release command only when a successful durable transition already cleared the lease.
- Failed, canceled, uncertain, and lease-preserving transitions still release the exact owner/deadline lease. Ordinary non-retry dispatch is unchanged.
- This follow-up to merged PR #802 is rebuilt on current `main`.

## Related Work

Closes #803

Related: #802

## Scope

Affected packages or domains:

- `Headless.Messaging.Core` retry dispatch, completion, and storage conformance

Out of scope:

- Lease duration, retry scheduling, at-least-once semantics, public APIs, and configuration

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Performance
- [ ] Documentation only
- [ ] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A
```

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

- Messaging Core unit tests: 1,099/1,099 passed locally.
- Pre-push Release solution build: 0 warnings, 0 errors.
- [Exact-head CI](https://github.com/xshaheen/headless-framework/actions/runs/32792111861): format, build, unit coverage, and messaging conformance passed. The non-UTC rerun failed 1 of 10,757 tests in `RetryProcessorDistributedLockTests.should_call_storage_when_lock_always_granted`; packaging was skipped.

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [x] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
No public API, configuration, or documentation contract changed.
```

## Reviewer Guide

Only an affected durable transition whose final `LockedUntil` is null may suppress completion release. Failed writes, cancellation, uncertainty, or a later lease-preserving transition must keep exact release enabled.

| Scenario | Before | After |
|---|---:|---:|
| Transition cleared the lease | 1 no-op release command | 0 release commands |
| Transition did not prove the lease was cleared | 1 exact release command | 1 exact release command |
| Ordinary non-retry dispatch | 0 retry trackers | 0 retry trackers |

## Release Notes

Messaging retry completion avoids a redundant lease-release command when the durable transition already cleared the lease.
