### PR TITLE
test(jobs): expand core and dashboard behavior coverage

### DIFF
--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardRegistrationTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/DashboardRegistrationTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Dashboard.Authentication;
+using Headless.Jobs;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Hubs;
+using Headless.Jobs.Infrastructure;
+using Headless.Jobs.Infrastructure.Dashboard;
+using Headless.Jobs.Interfaces;
+using Headless.Testing.Tests;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Tests.Dashboard;
+
+public sealed class DashboardRegistrationTests : TestBase
+{
+    [Fact]
+    public void should_fail_closed_when_authentication_was_not_explicitly_configured()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddHeadlessJobs(options => options.DisableBackgroundServices().AddDashboard());
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*authentication was not configured*")
+            .WithMessage("*WithNoAuth*");
+    }
+
+    [Fact]
+    public void should_wire_the_repository_pipeline_and_same_origin_cors_when_no_auth_is_selected()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHeadlessJobs(options =>
+            options
+                .DisableBackgroundServices()
+                .AddDashboard(dashboard =>
+                    dashboard
+                        .WithNoAuth()
+                        .ConfigureDashboardJsonOptions(json =>
+                            json.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+                        )
+                )
+        );
+
+        services
+            .Should()
+            .ContainSingle(descriptor =>
+                descriptor.ServiceType == typeof(IJobsDashboardRepository<TimeJobEntity, CronJobEntity>)
+                && descriptor.ImplementationType == typeof(JobsDashboardRepository<TimeJobEntity, CronJobEntity>)
+                && descriptor.Lifetime == ServiceLifetime.Scoped
+            );
+        services
+            .Should()
+            .ContainSingle(descriptor =>
+                descriptor.ServiceType == typeof(IJobsNotificationHubSender)
+                && descriptor.ImplementationType == typeof(JobsNotificationHubSender)
+                && descriptor.Lifetime == ServiceLifetime.Singleton
+            );
+        services.Should().Contain(descriptor => descriptor.ServiceType == typeof(IStartupFilter));
+
+        using var provider = services.BuildServiceProvider();
+        var dashboard = provider.GetRequiredService<DashboardOptionsBuilder>();
+        dashboard.Auth.Mode.Should().Be(AuthMode.None);
+        dashboard.DashboardJsonOptions.Should().NotBeNull();
+        dashboard.DashboardJsonOptions!.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.SnakeCaseLower);
+        dashboard
+            .DashboardJsonOptions.Converters.Should()
+            .ContainSingle(converter => converter is StringToByteArrayConverter);
+
+        var cors = provider.GetRequiredService<IOptions<CorsOptions>>().Value;
+        var policy = cors.GetPolicy("HeadlessJobsDashboardCORS");
+        policy.Should().NotBeNull();
+        policy!.Origins.Should().BeEmpty("the dashboard defaults to same-origin access");
+    }
+
+    [Fact]
+    public void should_add_auth_services_and_configured_cors_when_host_auth_is_selected()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddHeadlessJobs(options =>
+            options
+                .DisableBackgroundServices()
+                .AddDashboard(dashboard =>
+                    dashboard.WithHostAuthentication("Operators").SetCorsOrigins("https://ops.example.com")
+                )
+        );
+
+        services.Should().Contain(descriptor => descriptor.ServiceType == typeof(IAuthenticationService));
+        services.Should().Contain(descriptor => descriptor.ServiceType == typeof(IAuthenticationSchemeProvider));
+
+        using var provider = services.BuildServiceProvider();
+        var dashboard = provider.GetRequiredService<DashboardOptionsBuilder>();
+        dashboard.Auth.Mode.Should().Be(AuthMode.Host);
+        dashboard.Auth.HostAuthorizationPolicy.Should().Be("Operators");
+        provider.GetRequiredService<IAuthService>().Should().NotBeNull();
+        provider
+            .GetRequiredService<IOptions<CorsOptions>>()
+            .Value.GetPolicy("HeadlessJobsDashboardCORS")!
+            .Origins.Should()
+            .Equal("https://ops.example.com");
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsDashboardRepositoryBehaviorTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/JobsDashboardRepositoryBehaviorTests.cs
@@ -1,0 +1,282 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.Jobs;
+using Headless.Jobs.DashboardDtos;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+using Headless.Jobs.Infrastructure.Dashboard;
+using Headless.Jobs.Interfaces;
+using Headless.Jobs.Models;
+using Headless.Jobs.Provider;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.Dashboard;
+
+public sealed class JobsDashboardRepositoryBehaviorTests : TestBase
+{
+    private static readonly DateTimeOffset _Now = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task should_preserve_order_pagination_filters_and_combined_counts_when_querying_jobs()
+    {
+        using var fixture = new Fixture();
+        var recentSucceeded = fixture.TimeJob(
+            JobStatus.Succeeded,
+            _Now.AddDays(-1),
+            _Now.AddMinutes(-1),
+            ownerId: "Node-A"
+        );
+        var recentFailed = fixture.TimeJob(JobStatus.Failed, _Now.AddDays(-2), _Now.AddMinutes(-2), ownerId: "node-a");
+        var oldQueued = fixture.TimeJob(JobStatus.Queued, _Now.AddDays(-20), _Now.AddMinutes(-3));
+        await fixture.Provider.AddTimeJobsAsync([oldQueued, recentFailed, recentSucceeded], AbortToken);
+
+        var cronA = fixture.CronJob("cron-a", _Now.AddMinutes(-1));
+        var cronB = fixture.CronJob("cron-b", _Now.AddMinutes(-2));
+        await fixture.Provider.InsertCronJobsAsync([cronB, cronA], AbortToken);
+
+        var recentDueDone = fixture.Occurrence(
+            cronA,
+            JobStatus.DueDone,
+            _Now.AddDays(-1),
+            _Now.AddMinutes(-1),
+            ownerId: "NODE-A"
+        );
+        var recentCronFailed = fixture.Occurrence(cronA, JobStatus.Failed, _Now.AddDays(-3), _Now.AddMinutes(-2));
+        var oldCronSucceeded = fixture.Occurrence(cronB, JobStatus.Succeeded, _Now.AddDays(-20), _Now.AddMinutes(-3));
+        await fixture.Provider.InsertCronJobOccurrencesAsync(
+            [oldCronSucceeded, recentCronFailed, recentDueDone],
+            AbortToken
+        );
+
+        (await fixture.Repository.GetTimeJobsAsync(AbortToken))
+            .Select(x => x.Id)
+            .Should()
+            .Equal(recentSucceeded.Id, recentFailed.Id, oldQueued.Id);
+        var timePage = await fixture.Repository.GetTimeJobsPaginatedAsync(2, 1, AbortToken);
+        timePage.Items.Should().ContainSingle().Which.Id.Should().Be(recentFailed.Id);
+        timePage.TotalCount.Should().Be(3);
+        timePage.PageNumber.Should().Be(2);
+        timePage.PageSize.Should().Be(1);
+
+        (await fixture.Repository.GetCronJobsAsync(AbortToken)).Select(x => x.Id).Should().Equal(cronA.Id, cronB.Id);
+        var cronPage = await fixture.Repository.GetCronJobsPaginatedAsync(1, 1, AbortToken);
+        cronPage.Items.Should().ContainSingle().Which.Id.Should().Be(cronA.Id);
+        cronPage.TotalCount.Should().Be(2);
+
+        (await fixture.Repository.GetCronJobsOccurrencesAsync(cronA.Id, AbortToken))
+            .Select(x => x.Id)
+            .Should()
+            .Equal(recentDueDone.Id, recentCronFailed.Id);
+        var occurrencePage = await fixture.Repository.GetCronJobsOccurrencesPaginatedAsync(cronA.Id, 2, 1, AbortToken);
+        occurrencePage.Items.Should().ContainSingle().Which.Id.Should().Be(recentCronFailed.Id);
+        occurrencePage.TotalCount.Should().Be(2);
+
+        var allStatuses = Enum.GetValues<JobStatus>();
+        var timeStatuses = await fixture.Repository.GetTimeJobFullDataAsync(AbortToken);
+        timeStatuses.Select(result => result.Status).Should().BeEquivalentTo(allStatuses);
+        timeStatuses.Should().Contain((JobStatus.Succeeded, 1));
+        timeStatuses.Should().Contain((JobStatus.Failed, 1));
+        timeStatuses.Should().Contain((JobStatus.Queued, 1));
+        timeStatuses.Should().Contain((JobStatus.Cancelled, 0));
+
+        var cronStatuses = await fixture.Repository.GetCronJobFullDataAsync(AbortToken);
+        cronStatuses.Select(result => result.Status).Should().BeEquivalentTo(allStatuses);
+        cronStatuses.Should().Contain((JobStatus.DueDone, 1));
+        cronStatuses.Should().Contain((JobStatus.Failed, 1));
+        cronStatuses.Should().Contain((JobStatus.Succeeded, 1));
+
+        (await fixture.Repository.GetLastWeekJobStatusesAsync(AbortToken)).Should().Equal((0, 2), (1, 2), (2, 4));
+        (await fixture.Repository.GetOverallJobStatusesAsync(AbortToken))
+            .ToDictionary(x => x.Item1, x => x.Item2)
+            .Should()
+            .BeEquivalentTo(
+                new Dictionary<JobStatus, int>
+                {
+                    [JobStatus.Succeeded] = 2,
+                    [JobStatus.Failed] = 2,
+                    [JobStatus.Queued] = 1,
+                    [JobStatus.DueDone] = 1,
+                }
+            );
+
+        (await fixture.Repository.GetMachineJobsAsync(AbortToken))
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(("Node-A", 3));
+    }
+
+    [Fact]
+    public async Task should_filter_and_zero_fill_graph_data_when_range_and_cron_id_are_supplied()
+    {
+        using var fixture = new Fixture();
+        var cronA = fixture.CronJob("cron-a", _Now);
+        var cronB = fixture.CronJob("cron-b", _Now.AddMinutes(-1));
+        await fixture.Provider.InsertCronJobsAsync([cronA, cronB], AbortToken);
+
+        await fixture.Provider.AddTimeJobsAsync(
+            [
+                fixture.TimeJob(JobStatus.Succeeded, _Now.AddDays(-1), _Now),
+                fixture.TimeJob(JobStatus.Failed, _Now, _Now.AddMinutes(-1)),
+                fixture.TimeJob(JobStatus.Succeeded, _Now.AddDays(-2), _Now.AddMinutes(-2)),
+            ],
+            AbortToken
+        );
+
+        await fixture.Provider.InsertCronJobOccurrencesAsync(
+            [
+                fixture.Occurrence(cronA, JobStatus.Succeeded, _Now.AddDays(-1), _Now),
+                fixture.Occurrence(cronA, JobStatus.Failed, _Now.AddDays(1), _Now.AddMinutes(-1)),
+                fixture.Occurrence(cronB, JobStatus.Failed, _Now, _Now.AddMinutes(-2)),
+                fixture.Occurrence(cronA, JobStatus.Succeeded, _Now.AddDays(-2), _Now.AddMinutes(-3)),
+            ],
+            AbortToken
+        );
+
+        var timeGraph = await fixture.Repository.GetTimeJobsGraphSpecificDataAsync(-1, 1, AbortToken);
+        timeGraph.Select(x => x.Date).Should().Equal(_Now.AddDays(-1).Date, _Now.Date, _Now.AddDays(1).Date);
+        timeGraph[0].Results.Should().Contain(new JobStatusCount(JobStatus.Succeeded, 1));
+        timeGraph[1].Results.Should().Contain(new JobStatusCount(JobStatus.Failed, 1));
+        timeGraph[2].Results.Should().OnlyContain(x => x.Count == 0);
+
+        var cronGraph = await fixture.Repository.GetCronJobsGraphSpecificDataAsync(-1, 1, AbortToken);
+        cronGraph[0].Results.Should().Contain(new JobStatusCount(JobStatus.Succeeded, 1));
+        cronGraph[1].Results.Should().Contain(new JobStatusCount(JobStatus.Failed, 1));
+        cronGraph[2].Results.Should().Contain(new JobStatusCount(JobStatus.Failed, 1));
+
+        var cronById = await fixture.Repository.GetCronJobsGraphSpecificDataByIdAsync(cronA.Id, -1, 1, AbortToken);
+        cronById[1].Results.Should().OnlyContain(x => x.Count == 0);
+        cronById[2].Results.Should().Contain(new JobStatusCount(JobStatus.Failed, 1));
+
+        var allStatuses = Enum.GetValues<JobStatus>();
+        foreach (var day in timeGraph.Concat(cronGraph).Concat(cronById))
+        {
+            day.Results.Select(result => result.Status).Should().BeEquivalentTo(allStatuses);
+        }
+
+        (await fixture.Repository.GetTimeJobsGraphSpecificDataAsync(2, -2, AbortToken)).Should().BeEmpty();
+        (await fixture.Repository.GetCronJobsGraphSpecificDataAsync(2, -2, AbortToken)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_clamp_graph_range_when_day_offsets_exceed_the_supported_limit()
+    {
+        using var fixture = new Fixture();
+        var cron = fixture.CronJob("cron", _Now);
+        await fixture.Provider.InsertCronJobsAsync([cron], AbortToken);
+
+        var timeGraph = await fixture.Repository.GetTimeJobsGraphSpecificDataAsync(
+            int.MinValue,
+            int.MaxValue,
+            AbortToken
+        );
+        var cronGraph = await fixture.Repository.GetCronJobsGraphSpecificDataAsync(
+            int.MinValue,
+            int.MaxValue,
+            AbortToken
+        );
+        var cronById = await fixture.Repository.GetCronJobsGraphSpecificDataByIdAsync(
+            cron.Id,
+            int.MinValue,
+            int.MaxValue,
+            AbortToken
+        );
+
+        foreach (var graph in new[] { timeGraph, cronGraph, cronById })
+        {
+            graph.Should().HaveCount(733);
+            graph[0].Date.Should().Be(_Now.AddDays(-366).Date);
+            graph[^1].Date.Should().Be(_Now.AddDays(366).Date);
+        }
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly ServiceProvider _services;
+        private readonly FakeTimeProvider _timeProvider = new(_Now);
+
+        public Fixture()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<TimeProvider>(_timeProvider);
+            services.AddHeadlessGuidGenerator();
+            services.AddSingleton(new SchedulerOptionsBuilder { NodeId = "node-a" });
+            _services = services.BuildServiceProvider();
+
+            Provider = new JobsInMemoryPersistenceProvider<TimeJobEntity, CronJobEntity>(_services);
+            Repository = new JobsDashboardRepository<TimeJobEntity, CronJobEntity>(
+                new JobsExecutionContext(),
+                Provider,
+                Substitute.For<IJobsHostScheduler>(),
+                Substitute.For<IJobsNotificationHubSender>(),
+                new DashboardOptionsBuilder(),
+                Substitute.For<IJobsDispatcher>(),
+                JobFunctionRegistryBuilder.Build([], [], []),
+                _timeProvider,
+                _services.GetRequiredService<IGuidGenerator>(),
+                _services,
+                JobsRequestSerializationOptions.Default
+            );
+        }
+
+        public JobsInMemoryPersistenceProvider<TimeJobEntity, CronJobEntity> Provider { get; }
+
+        public JobsDashboardRepository<TimeJobEntity, CronJobEntity> Repository { get; }
+
+        public TimeJobEntity TimeJob(
+            JobStatus status,
+            DateTimeOffset executionTime,
+            DateTimeOffset createdAt,
+            string? ownerId = null
+        ) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Function = "time-job",
+                Status = status,
+                ExecutionTime = executionTime.UtcDateTime,
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+                OwnerId = ownerId,
+                LockedUntil = ownerId is null ? null : _Now.AddMinutes(5).UtcDateTime,
+            };
+
+        public CronJobEntity CronJob(string function, DateTimeOffset createdAt) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Function = function,
+                Expression = "0 * * * *",
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+            };
+
+        public CronJobOccurrenceEntity<CronJobEntity> Occurrence(
+            CronJobEntity cronJob,
+            JobStatus status,
+            DateTimeOffset executionTime,
+            DateTimeOffset createdAt,
+            string? ownerId = null
+        ) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CronJobId = cronJob.Id,
+                CronJob = cronJob,
+                Status = status,
+                ExecutionTime = executionTime.UtcDateTime,
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+                OwnerId = ownerId,
+                LockedUntil = ownerId is null ? null : _Now.AddMinutes(5).UtcDateTime,
+            };
+
+        public void Dispose()
+        {
+            _services.Dispose();
+        }
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/StringToByteArrayConverterTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Dashboard/StringToByteArrayConverterTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Jobs;
+using Headless.Jobs.Infrastructure;
+using Headless.Testing.Tests;
+
+namespace Tests.Dashboard;
+
+public sealed class StringToByteArrayConverterTests : TestBase
+{
+    private static readonly JobsRequestSerializationOptions _SerializationOptions =
+        JobsRequestSerializationOptions.Default;
+    private static readonly JsonSerializerOptions _JsonOptions = new()
+    {
+        Converters = { new StringToByteArrayConverter(_SerializationOptions) },
+    };
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("\"\"")]
+    public void should_deserialize_to_null_when_token_is_null_or_empty(string json)
+    {
+        JsonSerializer.Deserialize<byte[]?>(json, _JsonOptions).Should().BeNull();
+    }
+
+    [Fact]
+    public void should_reject_input_when_json_token_is_an_object()
+    {
+        var act = () => JsonSerializer.Deserialize<byte[]?>("{}", _JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void should_round_trip_the_request_when_json_token_is_a_string()
+    {
+        const string requestJson = "{\"name\":\"job\",\"count\":2}";
+        var encodedJson = JsonSerializer.Serialize(requestJson);
+
+        var bytes = JsonSerializer.Deserialize<byte[]>(encodedJson, _JsonOptions);
+        var serialized = JsonSerializer.Serialize(bytes, _JsonOptions);
+
+        bytes.Should().NotBeNull();
+        JobsHelper.ReadJobRequestAsString(bytes!, _SerializationOptions).Should().Be(requestJson);
+        JsonSerializer.Deserialize<string>(serialized).Should().Be(requestJson);
+    }
+}

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Managers/InternalJobsManagerTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Managers/InternalJobsManagerTests.cs
@@ -130,17 +130,7 @@ public sealed class InternalJobsManagerTests : TestBase
     {
         var provider = Substitute.For<IJobPersistenceProvider<FakeTimeJob, FakeCronJob>>();
         var sender = Substitute.For<IJobsNotificationHubSender>();
-        var manager = new InternalJobsManager<FakeTimeJob, FakeCronJob>(
-            provider,
-            TimeProvider.System,
-            sender,
-            new CronScheduleCache(TimeZoneInfo.Utc),
-            NullLogger<InternalJobsManager<FakeTimeJob, FakeCronJob>>.Instance,
-            JobsRequestSerializationOptions.Default,
-            Substitute.For<IGuidGenerator>(),
-            Substitute.For<IServiceProvider>(),
-            new SchedulerOptionsBuilder()
-        );
+        var manager = _CreateManager(provider, sender);
         var acceptedId = Guid.NewGuid();
         var rejectedId = Guid.NewGuid();
         provider.RequestTimeJobCancellationAsync(acceptedId, AbortToken).Returns(true);
@@ -272,6 +262,73 @@ public sealed class InternalJobsManagerTests : TestBase
         childContext.RunCondition.Should().Be(RunCondition.OnSuccess);
         var grandChildContext = childContext.TimeJobChildren.Should().ContainSingle().Which;
         grandChildContext.RunCondition.Should().Be(RunCondition.OnCancelled);
+    }
+
+    [Fact]
+    public async Task should_dispatch_cron_claims_when_timed_out_notification_fails()
+    {
+        var provider = Substitute.For<IJobPersistenceProvider<FakeTimeJob, FakeCronJob>>();
+        var sender = Substitute.For<IJobsNotificationHubSender>();
+        var manager = new InternalJobsManager<FakeTimeJob, FakeCronJob>(
+            provider,
+            TimeProvider.System,
+            sender,
+            new CronScheduleCache(TimeZoneInfo.Utc),
+            NullLogger<InternalJobsManager<FakeTimeJob, FakeCronJob>>.Instance,
+            JobsRequestSerializationOptions.Default,
+            Substitute.For<IGuidGenerator>(),
+            Substitute.For<IServiceProvider>(),
+            new SchedulerOptionsBuilder()
+        );
+        var cron = new FakeCronJob
+        {
+            Id = Guid.NewGuid(),
+            Function = "daily-report",
+            Expression = "0 0 5 * * *",
+            Retries = 3,
+            RetryIntervals = [10, 30, 60],
+        };
+        var occurrence = new CronJobOccurrenceEntity<FakeCronJob>
+        {
+            Id = Guid.NewGuid(),
+            CronJobId = cron.Id,
+            CronJob = cron,
+            ExecutionTime = new DateTime(2026, 8, 8, 5, 0, 0, DateTimeKind.Utc),
+            RetryCount = 1,
+        };
+        var laterOccurrence = new CronJobOccurrenceEntity<FakeCronJob>
+        {
+            Id = Guid.NewGuid(),
+            CronJobId = cron.Id,
+            CronJob = cron,
+            ExecutionTime = occurrence.ExecutionTime.AddMinutes(1),
+        };
+        provider
+            .QueueTimedOutTimeJobsAsync(Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<TimeJobEntity>());
+        provider
+            .QueueTimedOutCronJobOccurrencesAsync(AbortToken)
+            .Returns(new[] { occurrence, laterOccurrence }.ToAsyncEnumerable());
+        sender
+            .UpdateCronOccurrenceFromExecutionState<FakeCronJob>(
+                Arg.Is<JobExecutionState>(state => state.JobId == occurrence.Id)
+            )
+            .Returns(_ => throw new InvalidOperationException("hub offline"));
+
+        var contexts = await manager.RunTimedOutTickers(AbortToken);
+
+        contexts.Select(state => state.JobId).Should().Equal(occurrence.Id, laterOccurrence.Id);
+        var context = contexts[0];
+        context.JobId.Should().Be(occurrence.Id);
+        context.ParentId.Should().Be(cron.Id);
+        context.Type.Should().Be(JobType.CronJobOccurrence);
+        context.FunctionName.Should().Be("daily-report");
+        context.Retries.Should().Be(3);
+        context.RetryCount.Should().Be(1);
+        context.RetryIntervals.Should().Equal(10, 30, 60);
+        context.ExecutionTime.Should().Be(occurrence.ExecutionTime);
+        await sender.Received(2).UpdateCronOccurrenceFromExecutionState<FakeCronJob>(Arg.Any<JobExecutionState>());
+        await provider.DidNotReceiveWithAnyArgs().ReleaseAcquiredCronJobOccurrencesAsync(default!, AbortToken);
     }
 
     /// <summary>
@@ -444,7 +501,7 @@ public sealed class InternalJobsManagerTests : TestBase
         // empty-batch forms must reach the providers as the (owner-scoped) release-everything call. Previously []
         // short-circuited to a no-op and a faulted tick left its claims leased for a full LeaseDuration.
         var provider = Substitute.For<IJobPersistenceProvider<FakeTimeJob, FakeCronJob>>();
-        var manager = _ReleaseTestManager(provider);
+        var manager = _CreateManager(provider);
 
         await manager.ReleaseAcquiredResources(resources: null, AbortToken);
 
@@ -467,7 +524,7 @@ public sealed class InternalJobsManagerTests : TestBase
     public async Task release_acquired_resources_with_resources_releases_only_the_listed_ids()
     {
         var provider = Substitute.For<IJobPersistenceProvider<FakeTimeJob, FakeCronJob>>();
-        var manager = _ReleaseTestManager(provider);
+        var manager = _CreateManager(provider);
         var timeJobId = Guid.NewGuid();
         var occurrenceId = Guid.NewGuid();
 
@@ -509,7 +566,7 @@ public sealed class InternalJobsManagerTests : TestBase
         provider
             .ApplyParentTerminalRunConditionsAsync(parentId: null, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<DateTime?>(null));
-        var manager = _ReleaseTestManager(provider);
+        var manager = _CreateManager(provider);
 
         await manager.ReleaseDeadNodeResources(["node-a@1", "node-b@1", "node-c@1"], AbortToken);
 
@@ -522,8 +579,9 @@ public sealed class InternalJobsManagerTests : TestBase
         await provider.Received(1).ApplyParentTerminalRunConditionsAsync(parentId: null, AbortToken);
     }
 
-    private static InternalJobsManager<FakeTimeJob, FakeCronJob> _ReleaseTestManager(
-        IJobPersistenceProvider<FakeTimeJob, FakeCronJob> provider
+    private static InternalJobsManager<FakeTimeJob, FakeCronJob> _CreateManager(
+        IJobPersistenceProvider<FakeTimeJob, FakeCronJob> provider,
+        IJobsNotificationHubSender? sender = null
     )
     {
         return new InternalJobsManager<FakeTimeJob, FakeCronJob>(
@@ -531,7 +589,7 @@ public sealed class InternalJobsManagerTests : TestBase
             new Microsoft.Extensions.Time.Testing.FakeTimeProvider(
                 new DateTimeOffset(2026, 7, 17, 10, 0, 0, TimeSpan.Zero)
             ),
-            Substitute.For<IJobsNotificationHubSender>(),
+            sender ?? Substitute.For<IJobsNotificationHubSender>(),
             new CronScheduleCache(TimeZoneInfo.Utc),
             NullLogger<InternalJobsManager<FakeTimeJob, FakeCronJob>>.Instance,
             JobsRequestSerializationOptions.Default,

--- a/tests/Headless.Jobs.Composition.Tests.Unit/Provider/InMemoryCronOccurrenceLifecycleTests.cs
+++ b/tests/Headless.Jobs.Composition.Tests.Unit/Provider/InMemoryCronOccurrenceLifecycleTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.Jobs;
+using Headless.Jobs.Entities;
+using Headless.Jobs.Enums;
+using Headless.Jobs.Provider;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests.Provider;
+
+public sealed class InMemoryCronOccurrenceLifecycleTests : TestBase
+{
+    private const string _NodeA = "node-a";
+    private const string _NodeB = "node-b";
+    private static readonly DateTimeOffset _Now = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan _Lease = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public async Task should_claim_only_eligible_occurrences_and_honor_cancellation_when_acquiring_immediately()
+    {
+        using var fixture = new Fixture();
+        var active = fixture.CronJob(isPaused: false);
+        var paused = fixture.CronJob(isPaused: true);
+        await fixture.Provider.InsertCronJobsAsync([active, paused], AbortToken);
+
+        var eligible = fixture.Occurrence(active, JobStatus.Idle);
+        var pausedOccurrence = fixture.Occurrence(paused, JobStatus.Idle);
+        var liveForeignClaim = fixture.Occurrence(
+            active,
+            JobStatus.Queued,
+            ownerId: _NodeB,
+            lockedUntil: _Now.AddMinutes(1).UtcDateTime
+        );
+        var terminal = fixture.Occurrence(active, JobStatus.Succeeded);
+        await fixture.Provider.InsertCronJobOccurrencesAsync(
+            [eligible, pausedOccurrence, liveForeignClaim, terminal],
+            AbortToken
+        );
+
+        var acquired = await fixture.Provider.AcquireImmediateCronOccurrencesAsync(
+            [eligible.Id, pausedOccurrence.Id, liveForeignClaim.Id, terminal.Id, Guid.NewGuid()],
+            AbortToken
+        );
+
+        var claimed = acquired.Should().ContainSingle().Subject;
+        claimed.Id.Should().Be(eligible.Id);
+        claimed.Status.Should().Be(JobStatus.InProgress);
+        claimed.OwnerId.Should().Be(_NodeA);
+        claimed.LockedUntil.Should().Be(_Now.Add(_Lease).UtcDateTime);
+        claimed.CronJob.Should().NotBeNull().And.Match<CronJobEntity>(job => job.Id == active.Id);
+
+        (await fixture.Provider.AcquireImmediateCronOccurrencesAsync([eligible.Id], AbortToken)).Should().BeEmpty();
+
+        var cancelled = async () =>
+            await fixture.Provider.AcquireImmediateCronOccurrencesAsync(
+                [pausedOccurrence.Id],
+                new CancellationToken(canceled: true)
+            );
+        await cancelled.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task should_apply_each_death_policy_when_an_in_progress_lease_has_lapsed()
+    {
+        using var fixture = new Fixture();
+        var cron = fixture.CronJob(isPaused: false);
+        await fixture.Provider.InsertCronJobsAsync([cron], AbortToken);
+
+        var queued = fixture.Occurrence(cron, JobStatus.Queued, ownerId: _NodeA, retryCount: 2);
+        var retry = fixture.Occurrence(
+            cron,
+            JobStatus.InProgress,
+            policy: NodeDeathPolicy.Retry,
+            ownerId: _NodeA,
+            lockedUntil: _Now.AddSeconds(-1).UtcDateTime,
+            retryCount: 2
+        );
+        var markFailed = fixture.Occurrence(
+            cron,
+            JobStatus.InProgress,
+            policy: NodeDeathPolicy.MarkFailed,
+            ownerId: _NodeA,
+            lockedUntil: _Now.AddSeconds(-1).UtcDateTime
+        );
+        var skip = fixture.Occurrence(
+            cron,
+            JobStatus.InProgress,
+            policy: NodeDeathPolicy.Skip,
+            ownerId: _NodeA,
+            lockedUntil: _Now.AddSeconds(-1).UtcDateTime
+        );
+        var healthy = fixture.Occurrence(
+            cron,
+            JobStatus.InProgress,
+            policy: NodeDeathPolicy.Retry,
+            ownerId: _NodeA,
+            lockedUntil: _Now.AddMinutes(1).UtcDateTime
+        );
+        var otherOwner = fixture.Occurrence(cron, JobStatus.Idle, ownerId: _NodeB);
+        await fixture.Provider.InsertCronJobOccurrencesAsync(
+            [queued, retry, markFailed, skip, healthy, otherOwner],
+            AbortToken
+        );
+
+        var affected = await fixture.Provider.ReleaseDeadNodeOccurrenceResourcesAsync(_NodeA, AbortToken);
+
+        affected.Should().Be(4);
+        var stored = (await fixture.Provider.GetAllCronJobOccurrencesAsync(predicate: null, AbortToken)).ToDictionary(
+            occurrence => occurrence.Id
+        );
+
+        stored[queued.Id]
+            .Should()
+            .Match<CronJobOccurrenceEntity<CronJobEntity>>(occurrence =>
+                occurrence.Status == JobStatus.Idle
+                && occurrence.OwnerId == null
+                && occurrence.LockedUntil == null
+                && occurrence.RetryCount == 2
+            );
+        stored[retry.Id]
+            .Should()
+            .Match<CronJobOccurrenceEntity<CronJobEntity>>(occurrence =>
+                occurrence.Status == JobStatus.Idle
+                && occurrence.OwnerId == null
+                && occurrence.LockedUntil == null
+                && occurrence.RetryCount == 3
+            );
+        stored[markFailed.Id]
+            .Should()
+            .Match<CronJobOccurrenceEntity<CronJobEntity>>(occurrence =>
+                occurrence.Status == JobStatus.Failed
+                && occurrence.LockedUntil == null
+                && occurrence.ExceptionMessage == "Node is not alive!"
+                && occurrence.ExecutedAt == _Now
+            );
+        stored[skip.Id]
+            .Should()
+            .Match<CronJobOccurrenceEntity<CronJobEntity>>(occurrence =>
+                occurrence.Status == JobStatus.Skipped
+                && occurrence.LockedUntil == null
+                && occurrence.SkippedReason == "Node is not alive!"
+                && occurrence.ExecutedAt == _Now
+            );
+        stored[healthy.Id].Status.Should().Be(JobStatus.InProgress);
+        stored[healthy.Id].OwnerId.Should().Be(_NodeA);
+        stored[otherOwner.Id].OwnerId.Should().Be(_NodeB);
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly ServiceProvider _services;
+
+        public Fixture()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<TimeProvider>(new FakeTimeProvider(_Now));
+            services.AddHeadlessGuidGenerator();
+            services.AddSingleton(new SchedulerOptionsBuilder { NodeId = _NodeA, LeaseDuration = _Lease });
+            _services = services.BuildServiceProvider();
+            Provider = new JobsInMemoryPersistenceProvider<TimeJobEntity, CronJobEntity>(_services);
+        }
+
+        public JobsInMemoryPersistenceProvider<TimeJobEntity, CronJobEntity> Provider { get; }
+
+        public CronJobEntity CronJob(bool isPaused) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Function = "cron-job",
+                Expression = "* * * * *",
+                IsPaused = isPaused,
+            };
+
+        public CronJobOccurrenceEntity<CronJobEntity> Occurrence(
+            CronJobEntity cron,
+            JobStatus status,
+            NodeDeathPolicy policy = NodeDeathPolicy.Retry,
+            string? ownerId = null,
+            DateTime? lockedUntil = null,
+            int retryCount = 0
+        ) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CronJobId = cron.Id,
+                CronJob = cron,
+                ExecutionTime = _Now.UtcDateTime,
+                Status = status,
+                OnNodeDeath = policy,
+                OwnerId = ownerId,
+                LockedUntil = lockedUntil,
+                RetryCount = retryCount,
+            };
+
+        public void Dispose() => _services.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds deterministic coverage for Dashboard registration, query ordering/filtering/pagination, status aggregation, bounded graph ranges, and request serialization failures.
- Covers in-memory cron occurrence acquisition, cancellation, lease eligibility, and dead-node Retry/MarkFailed/Skip transitions.
- Pins timed-out cron dispatch so dashboard notification failure cannot discard the current or later claimed occurrences.
- Keeps the change test-only and builds on, rather than duplicates, the Dashboard metadata/options/registry/hub tests merged in #805.

## Related Work

Related: #805

## Scope

Affected packages or domains:

- `Headless.Jobs.Core`
- `Headless.Jobs.Dashboard`
- `Headless.Jobs.Composition.Tests.Unit`

Out of scope:

- Production-code changes
- Analyzer Info/Suggestion sweep
- Non-Jobs test projects

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A
```

## Validation

- [x] Focused build or test for the affected projects
- [ ] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
Baseline:
- Jobs composition tests: 725 passed, 0 skipped, 0 failed.
- Coverage report: artifacts/coverage/jobs-baseline/Summary.json

Final authoritative run:
- make test-project TEST_PROJECT=tests/Headless.Jobs.Composition.Tests.Unit/Headless.Jobs.Composition.Tests.Unit.csproj TEST_RESULTS_DIR=artifacts/test-results/jobs-authoritative TEST_ARGS='-p:EnableCodeCoverage=true --coverage-output-format cobertura'
- 738 passed, 0 skipped, 0 failed.
- Coverage report: artifacts/coverage/jobs-authoritative/Summary.json

Package coverage (line / branch / method):
- Headless.Jobs.Core: 76.309% / 68.1% / 82.0% -> 79.263% / 71.1% / 83.4%
  Delta: +2.954 pp / +3.0 pp / +1.4 pp; +198 lines, +87 branches, +9 methods.
- Headless.Jobs.Dashboard: 32.195% / 36.7% / 30.7% -> 52.536% / 60.7% / 43.7%
  Delta: +20.342 pp / +24.0 pp / +13.0 pp; +405 lines, +154 branches, +22 methods.

Additional gates:
- make build-project PROJECT=tests/Headless.Jobs.Composition.Tests.Unit/Headless.Jobs.Composition.Tests.Unit.csproj: succeeded, 0 warnings, 0 errors.
- make format-check: 4,097 files checked successfully.
- make quality-analyzers-project PROJECT=tests/Headless.Jobs.Composition.Tests.Unit/Headless.Jobs.Composition.Tests.Unit.csproj QUALITY_SEVERITY=warn: succeeded, 0 warnings, 0 errors.
- Pre-push hook: 5 changed files formatted; full incremental solution build succeeded with 0 warnings and 0 errors.

Intentionally skipped:
- Full make test-unit and integration suites: the change is isolated to one Jobs unit project; validation remained sequential and project-scoped.
- Analyzer Info/Suggestion sweep: explicitly out of scope; warning-level analyzer verification passed.
```

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
No production behavior, public API, package metadata, or documentation changed. The in-memory lifecycle tests target existing provider behavior; no shared provider contract changed.
```

## Reviewer Guide

- Review Dashboard query assertions for complete status sets, deterministic ordering, exact pagination metadata, and the +/-366-day allocation clamp.
- Review cron lifecycle assertions for paused/live/terminal filtering and lease-expiry policy transitions.
- Remaining weak areas: Dashboard endpoint handlers remain the largest uncovered package surface, and repository query behavior is exercised here only through the in-memory provider.
- Known pre-existing converter gaps remain intentionally unfixed: numeric-array reads and raw-byte write fallbacks recursively re-enter `StringToByteArrayConverter` and can stack-overflow; non-string scalar tokens can bind as null instead of producing a dashboard 400. Covering them safely requires production changes outside this test-only PR.
- A deterministic public-only seam for forcing competing in-memory claims into the same read/update window does not exist; atomic `TryUpdate` behavior is reviewed but not regression-guarded here.

## Release Notes

N/A - internal test coverage only.
