### PR TITLE
test: increase Entity Framework behavior coverage

### DIFF
--- a/tests/Headless.EntityFramework.Core.Tests.Unit/IndexPageExtensionsTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/IndexPageExtensionsTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
+using Headless.Primitives;
 using Headless.Testing.Tests;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,86 @@ namespace Tests;
 
 public sealed class IndexPageExtensionsTests : TestBase
 {
+    [Fact]
+    public async Task should_return_the_full_result_when_optional_paging_is_incomplete()
+    {
+        await using var fixture = await SqlitePageFixture.CreateAsync(AbortToken);
+
+        var page = await fixture.Context.Rows.ToIndexPageAsync(index: 1, size: null, cancellationToken: AbortToken);
+
+        page.Index.Should().Be(0);
+        page.TotalItems.Should().Be(9);
+        page.Items.Select(static row => row.Position).Should().BeEquivalentTo([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    [Fact]
+    public async Task should_return_the_full_ordered_projection_when_request_is_null()
+    {
+        await using var fixture = await SqlitePageFixture.CreateAsync(AbortToken);
+        IIndexPageRequest? request = null;
+
+        var page = await fixture.Context.Rows.ToIndexPageAsync(
+            static row => row.Position,
+            ascending: false,
+            static row => row.Name,
+            request,
+            AbortToken
+        );
+
+        page.TotalItems.Should().Be(9);
+        page.Items.Should().Equal("row-9", "row-8", "row-7", "row-6", "row-5", "row-4", "row-3", "row-2", "row-1");
+    }
+
+    [Theory]
+    [InlineData(-4, 4, -1)]
+    [InlineData(int.MaxValue, 2, int.MaxValue)]
+    public async Task should_return_an_empty_page_when_the_requested_offset_is_not_representable(
+        int index,
+        int size,
+        int expectedIndex
+    )
+    {
+        await using var fixture = await SqlitePageFixture.CreateAsync(AbortToken);
+
+        var page = await fixture.Context.Rows.ToIndexPageAsync(index, size, AbortToken);
+
+        page.Index.Should().Be(expectedIndex);
+        page.TotalItems.Should().Be(9);
+        page.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_return_requested_metadata_without_querying_a_page_when_source_is_empty()
+    {
+        await using var fixture = await SqlitePageFixture.CreateAsync(AbortToken);
+        await fixture.Context.Rows.ExecuteDeleteAsync(AbortToken);
+
+        var page = await fixture.Context.Rows.ToIndexPageAsync(
+            static row => row.Position,
+            ascending: true,
+            index: -2,
+            size: 4,
+            cancellationToken: AbortToken
+        );
+
+        page.Index.Should().Be(-2);
+        page.Size.Should().Be(4);
+        page.TotalItems.Should().Be(0);
+        page.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_propagate_cancellation_before_materializing_a_page()
+    {
+        await using var fixture = await SqlitePageFixture.CreateAsync(AbortToken);
+        var cancellationToken = new CancellationToken(canceled: true);
+
+        Func<Task> action = async () =>
+            await fixture.Context.Rows.ToIndexPageAsync(index: 0, size: 4, cancellationToken);
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     [Fact]
     public async Task should_return_partial_last_page_when_negative_index_targets_last_page()
     {

--- a/tests/Headless.EntityFramework.Core.Tests.Unit/ModelBuildingConventionsTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/ModelBuildingConventionsTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.EntityFramework;
+using Headless.EntityFramework.Configurations;
+using Headless.Primitives;
+using Headless.Testing.Tests;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+public sealed class ModelBuildingConventionsTests : TestBase
+{
+    [Fact]
+    public void should_apply_money_and_phone_complex_property_storage_contracts()
+    {
+        using var context = new ComplexValueDbContext(
+            new DbContextOptionsBuilder<ComplexValueDbContext>().UseSqlite("Data Source=:memory:").Options
+        );
+
+        var entityType = context.Model.FindEntityType(typeof(ComplexValueRow));
+        var price = entityType!.FindComplexProperty(nameof(ComplexValueRow.Price));
+        var alternatePrice = entityType.FindComplexProperty(nameof(ComplexValueRow.AlternatePrice));
+        var phone = entityType.FindComplexProperty(nameof(ComplexValueRow.Phone));
+        var alternatePhone = entityType.FindComplexProperty(nameof(ComplexValueRow.AlternatePhone));
+
+        price.Should().NotBeNull();
+        price!.ComplexType.FindProperty(nameof(Money.Amount))!.GetPrecision().Should().Be(32);
+        price.ComplexType.FindProperty(nameof(Money.Amount))!.GetScale().Should().Be(10);
+        price.ComplexType.FindProperty(nameof(Money.Amount))!.GetColumnName().Should().Be("PriceAmount");
+        price.ComplexType.FindProperty(nameof(Money.CurrencyCode))!.GetColumnName().Should().Be("PriceCurrency");
+        price.ComplexType.FindProperty(nameof(Money.CurrencyCode))!.GetMaxLength().Should().Be(4);
+        alternatePrice.Should().NotBeNull();
+        phone.Should().NotBeNull();
+        phone!.ComplexType.FindProperty(nameof(PhoneNumber.CountryCode))!.GetColumnName().Should().Be("DialCode");
+        phone.ComplexType.FindProperty(nameof(PhoneNumber.Number))!.GetColumnName().Should().Be("Subscriber");
+        phone
+            .ComplexType.FindProperty(nameof(PhoneNumber.Number))!
+            .GetMaxLength()
+            .Should()
+            .Be(PhoneNumberConstants.Numbers.MaxLength);
+        alternatePrice.Should().NotBeNull();
+        alternatePrice!.ComplexType.FindProperty(nameof(Money.Amount))!.GetPrecision().Should().Be(32);
+        alternatePrice.ComplexType.FindProperty(nameof(Money.Amount))!.GetScale().Should().Be(10);
+        alternatePrice.ComplexType.FindProperty(nameof(Money.Amount))!.GetColumnName().Should().Be("Amount");
+        alternatePrice.ComplexType.FindProperty(nameof(Money.CurrencyCode))!.GetColumnName().Should().Be("Currency");
+        alternatePrice.ComplexType.FindProperty(nameof(Money.CurrencyCode))!.GetMaxLength().Should().Be(3);
+        alternatePhone.Should().NotBeNull();
+        alternatePhone!
+            .ComplexType.FindProperty(nameof(PhoneNumber.CountryCode))!
+            .GetColumnName()
+            .Should()
+            .Be("PhoneCountryCode");
+        alternatePhone
+            .ComplexType.FindProperty(nameof(PhoneNumber.CountryCode))!
+            .GetMaxLength()
+            .Should()
+            .Be(PhoneNumberConstants.Codes.MaxLength);
+        alternatePhone.ComplexType.FindProperty(nameof(PhoneNumber.Number))!.GetColumnName().Should().Be("PhoneNumber");
+        alternatePhone
+            .ComplexType.FindProperty(nameof(PhoneNumber.Number))!
+            .GetMaxLength()
+            .Should()
+            .Be(PhoneNumberConstants.Numbers.MaxLength);
+    }
+
+    [Fact]
+    public async Task should_apply_query_filters_for_generic_and_untyped_builders()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(AbortToken);
+        await using var context = new FilterDbContext(
+            new DbContextOptionsBuilder<FilterDbContext>().UseSqlite(connection).Options
+        );
+        await context.Database.EnsureCreatedAsync(AbortToken);
+        object[] rows =
+        [
+            new GenericFilterRow { Id = 1, IsVisible = true },
+            new GenericFilterRow { Id = 2, IsVisible = false },
+            new GenericFilterRow { Id = 3, IsVisible = true },
+            new UntypedFilterRow { Id = 1, IsActive = true },
+            new UntypedFilterRow { Id = 2, IsActive = true },
+            new UntypedFilterRow { Id = 3, IsActive = false },
+        ];
+        await context.AddRangeAsync(rows, AbortToken);
+        await context.SaveChangesAsync(AbortToken);
+
+        var genericIds = await context.GenericRows.Select(static row => row.Id).ToListAsync(AbortToken);
+        var untypedIds = await context.UntypedRows.Select(static row => row.Id).ToListAsync(AbortToken);
+
+        genericIds.Should().BeEquivalentTo([1, 3]);
+        untypedIds.Should().BeEquivalentTo([1, 2]);
+    }
+
+    [Fact]
+    public void should_apply_only_matching_entity_configurations_from_an_assembly()
+    {
+        using var services = new ServiceCollection().BuildServiceProvider();
+        using var context = new AssemblyConfigurationDbContext(
+            services,
+            new DbContextOptionsBuilder<AssemblyConfigurationDbContext>().UseSqlite("Data Source=:memory:").Options
+        );
+
+        var property = context.Model.FindEntityType(typeof(AssemblyConfiguredRow))!.FindProperty("Name");
+
+        property!.GetMaxLength().Should().Be(37);
+        context.Model.FindEntityType(typeof(ExcludedAssemblyRow)).Should().BeNull();
+    }
+
+    [Fact]
+    public void should_apply_building_block_converters_and_relational_facets_by_convention()
+    {
+        using var context = new PrimitiveConventionDbContext(
+            new DbContextOptionsBuilder<PrimitiveConventionDbContext>().UseSqlite("Data Source=:memory:").Options
+        );
+        var entityType = context.Model.FindEntityType(typeof(PrimitiveConventionRow));
+
+        var amount = entityType!.FindProperty(nameof(PrimitiveConventionRow.Amount));
+        var accountId = entityType.FindProperty(nameof(PrimitiveConventionRow.AccountId));
+        var state = entityType.FindProperty(nameof(PrimitiveConventionRow.State));
+
+        amount!.GetPrecision().Should().Be(32);
+        amount.GetScale().Should().Be(10);
+        amount.GetTypeMapping().Converter.Should().BeOfType<MoneyAmountValueConverter>();
+        accountId!.GetTypeMapping().Converter.Should().BeOfType<AccountIdValueConverter>();
+        state!.GetMaxLength().Should().Be(Headless.Domain.DomainConstants.EnumMaxLength);
+        state.GetTypeMapping().Converter!.ProviderClrType.Should().Be<string>();
+    }
+
+    private sealed class ComplexValueDbContext(DbContextOptions<ComplexValueDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var entity = modelBuilder.Entity<ComplexValueRow>();
+            entity.HasKey(static row => row.Id);
+            entity.HasComplexMoney(
+                static row => row.Price,
+                amountColumnName: "PriceAmount",
+                codeColumnName: "PriceCurrency",
+                codeMaxLength: 4
+            );
+            entity.HasComplexMoney(nameof(ComplexValueRow.AlternatePrice));
+            entity.HasComplexPhoneNumber(
+                static row => row.Phone,
+                codeColumnName: "DialCode",
+                phoneColumnName: "Subscriber"
+            );
+            entity.HasComplexPhoneNumber(nameof(ComplexValueRow.AlternatePhone));
+        }
+    }
+
+    private sealed class ComplexValueRow
+    {
+        public int Id { get; init; }
+
+        public required Money Price { get; init; }
+
+        public required Money AlternatePrice { get; init; }
+
+        public required PhoneNumber Phone { get; init; }
+
+        public required PhoneNumber AlternatePhone { get; init; }
+    }
+
+    private sealed class FilterDbContext(DbContextOptions<FilterDbContext> options) : DbContext(options)
+    {
+        public DbSet<GenericFilterRow> GenericRows => Set<GenericFilterRow>();
+
+        public DbSet<UntypedFilterRow> UntypedRows => Set<UntypedFilterRow>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var generic = modelBuilder.Entity<GenericFilterRow>();
+            generic.AndHasQueryFilter(static row => row.IsVisible);
+
+            var untyped = modelBuilder.Entity<UntypedFilterRow>();
+            ((EntityTypeBuilder)untyped).AndHasQueryFilter<UntypedFilterRow>(static row => row.IsActive);
+        }
+    }
+
+    private sealed class GenericFilterRow
+    {
+        public int Id { get; init; }
+
+        public bool IsVisible { get; init; }
+    }
+
+    private sealed class UntypedFilterRow
+    {
+        public int Id { get; init; }
+
+        public bool IsActive { get; init; }
+    }
+
+    private sealed class AssemblyConfigurationDbContext(
+        IServiceProvider serviceProvider,
+        DbContextOptions<AssemblyConfigurationDbContext> options
+    ) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfigurationsFromAssembly(
+                typeof(ModelBuildingConventionsTests).Assembly,
+                serviceProvider,
+                static type => type == typeof(AssemblyConfiguredRowConfiguration)
+            );
+        }
+    }
+
+    public sealed class AssemblyConfiguredRowConfiguration : IEntityTypeConfiguration<AssemblyConfiguredRow>
+    {
+        public void Configure(EntityTypeBuilder<AssemblyConfiguredRow> builder)
+        {
+            builder.Property(static row => row.Name).HasMaxLength(37);
+        }
+    }
+
+    public sealed class AssemblyConfiguredRow
+    {
+        public int Id { get; init; }
+
+        public required string Name { get; init; }
+    }
+
+    public sealed class ExcludedAssemblyRowConfiguration : IEntityTypeConfiguration<ExcludedAssemblyRow>
+    {
+        public void Configure(EntityTypeBuilder<ExcludedAssemblyRow> builder)
+        {
+            builder.Property(static row => row.Name).HasMaxLength(99);
+        }
+    }
+
+    public sealed class ExcludedAssemblyRow
+    {
+        public int Id { get; init; }
+
+        public required string Name { get; init; }
+    }
+
+    private sealed class PrimitiveConventionDbContext(DbContextOptions<PrimitiveConventionDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<PrimitiveConventionRow> Rows => Set<PrimitiveConventionRow>();
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            configurationBuilder.AddBuildingBlocksPrimitivesConvertersMappings();
+        }
+    }
+
+    private sealed class PrimitiveConventionRow
+    {
+        public int Id { get; init; }
+
+        public MoneyAmount Amount { get; init; }
+
+        public required AccountId AccountId { get; init; }
+
+        public PrimitiveState State { get; init; }
+    }
+
+    private enum PrimitiveState
+    {
+        Unknown = 0,
+        Active = 1,
+    }
+}

--- a/tests/Headless.EntityFramework.Core.Tests.Unit/QueryableBehaviorTests.cs
+++ b/tests/Headless.EntityFramework.Core.Tests.Unit/QueryableBehaviorTests.cs
@@ -13,6 +13,26 @@ namespace Tests;
 public sealed class QueryableBehaviorTests : TestBase
 {
     [Fact]
+    public async Task should_find_entities_through_each_supported_identifier_contract()
+    {
+        await using var fixture = await QueryFixture.CreateAsync(AbortToken);
+
+        var generic = await Microsoft.EntityFrameworkCore.HeadlessQueryableExtensions.FirstByIdAsync<QueryRow, int>(
+            fixture.Context.Rows,
+            1,
+            AbortToken
+        );
+        var guid = await fixture.Context.GuidRows.FirstByIdAsync(QueryFixture.GuidId, AbortToken);
+        var longKey = await fixture.Context.LongRows.FirstByIdAsync(4_000_000_000L, AbortToken);
+        var stringKey = await fixture.Context.StringRows.FirstByIdAsync("row-key", AbortToken);
+
+        generic.Name.Should().Be("alpha");
+        guid.Name.Should().Be("guid");
+        longKey.Name.Should().Be("long");
+        stringKey.Name.Should().Be("string");
+    }
+
+    [Fact]
     public async Task should_return_an_entity_by_id_and_throw_a_typed_error_when_missing()
     {
         await using var fixture = await QueryFixture.CreateAsync(AbortToken);
@@ -59,8 +79,26 @@ public sealed class QueryableBehaviorTests : TestBase
         page.Items.Select(row => row.Name).Should().Equal("gamma", "beta");
     }
 
+    [Fact]
+    public async Task should_propagate_cancellation_from_async_query_materialization()
+    {
+        await using var fixture = await QueryFixture.CreateAsync(AbortToken);
+        var cancellationToken = new CancellationToken(canceled: true);
+
+        Func<Task> action = async () =>
+            await fixture.Context.Rows.ToLookupAsync(
+                static row => row.Category,
+                static row => row.Name,
+                cancellationToken: cancellationToken
+            );
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private sealed class QueryFixture : IAsyncDisposable
     {
+        public static readonly Guid GuidId = Guid.Parse("019c89b2-9647-7c18-80d5-681959b0845f");
+
         private readonly SqliteConnection _connection;
 
         private QueryFixture(SqliteConnection connection, QueryDbContext context)
@@ -105,6 +143,9 @@ public sealed class QueryableBehaviorTests : TestBase
                     ],
                     cancellationToken
                 );
+                context.GuidRows.Add(new GuidQueryRow { Id = GuidId, Name = "guid" });
+                context.LongRows.Add(new LongQueryRow { Id = 4_000_000_000L, Name = "long" });
+                context.StringRows.Add(new StringQueryRow { Id = "row-key", Name = "string" });
                 await context.SaveChangesAsync(cancellationToken);
                 return new QueryFixture(connection, context);
             }
@@ -126,6 +167,12 @@ public sealed class QueryableBehaviorTests : TestBase
     private sealed class QueryDbContext(DbContextOptions<QueryDbContext> options) : DbContext(options)
     {
         public DbSet<QueryRow> Rows => Set<QueryRow>();
+
+        public DbSet<GuidQueryRow> GuidRows => Set<GuidQueryRow>();
+
+        public DbSet<LongQueryRow> LongRows => Set<LongQueryRow>();
+
+        public DbSet<StringQueryRow> StringRows => Set<StringQueryRow>();
     }
 
     private sealed class QueryRow : Entity<int>
@@ -133,6 +180,21 @@ public sealed class QueryableBehaviorTests : TestBase
         public required string Name { get; init; }
 
         public required string Category { get; init; }
+    }
+
+    private sealed class GuidQueryRow : Entity<Guid>
+    {
+        public required string Name { get; init; }
+    }
+
+    private sealed class LongQueryRow : Entity<long>
+    {
+        public required string Name { get; init; }
+    }
+
+    private sealed class StringQueryRow : Entity<string>
+    {
+        public required string Name { get; init; }
     }
 
     private sealed class TestDataGridRequest : DataGridRequest;

--- a/tests/Headless.EntityFramework.Tests.Integration/EntityFrameworkInfrastructureBehaviorTests.cs
+++ b/tests/Headless.EntityFramework.Tests.Integration/EntityFrameworkInfrastructureBehaviorTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Linq.Expressions;
+using Headless.EntityFramework;
+using Headless.EntityFramework.Seeders;
+using Headless.Hosting.Seeders;
+using Headless.MultiTenancy;
+using Headless.Testing.Tests;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+public sealed class EntityFrameworkInfrastructureBehaviorTests : TestBase
+{
+    [Fact]
+    public void should_isolate_compiled_query_cache_keys_by_tenant_for_headless_contexts()
+    {
+        var expression = Expression.Constant(1);
+        var otherExpression = Expression.Constant(2);
+        var options = new DbContextOptionsBuilder<StubHeadlessDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .AddHeadlessExtension()
+            .Options;
+        using var context = new StubHeadlessDbContext(options, "tenant-a");
+        var generator = context.GetService<ICompiledQueryCacheKeyGenerator>();
+
+        var tenantA = generator.GenerateCacheKey(expression, async: true);
+        var tenantARepeat = generator.GenerateCacheKey(expression, async: true);
+        var tenantAOtherQuery = generator.GenerateCacheKey(otherExpression, async: true);
+        context.TenantId = "tenant-b";
+        var tenantB = generator.GenerateCacheKey(expression, async: true);
+
+        tenantA.Should().Be(tenantARepeat);
+        tenantA.Should().NotBe(tenantAOtherQuery);
+        tenantA.Should().NotBe(tenantB);
+        tenantA.GetHashCode().Should().Be(tenantARepeat.GetHashCode());
+    }
+
+    [Fact]
+    public async Task should_report_invalid_configuration_when_recorded_tenant_guard_resolves_disabled()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.AddHeadlessTenancy(tenancy => tenancy.EntityFramework(ef => ef.GuardTenantWrites()));
+        builder.Services.AddSingleton<IOptions<TenantWriteGuardOptions>>(
+            Options.Create(new TenantWriteGuardOptions { IsEnabled = false })
+        );
+        await using var provider = builder.Services.BuildServiceProvider();
+        var context = new HeadlessTenancyValidationContext(
+            provider,
+            provider.GetRequiredService<TenantPostureManifest>()
+        );
+
+        var diagnostics = provider
+            .GetServices<IHeadlessTenancyValidator>()
+            .SelectMany(validator => validator.Validate(context))
+            .ToArray();
+
+        diagnostics.Should().ContainSingle();
+        diagnostics[0].Severity.Should().Be(HeadlessTenancyDiagnosticSeverity.Error);
+        diagnostics[0].Code.Should().Be("HEADLESS_TENANCY_EF_WRITE_GUARD_DISABLED");
+        diagnostics[0].Seam.Should().Be(HeadlessEntityFrameworkTenancyBuilder.Seam);
+    }
+
+    [Fact]
+    public async Task should_emit_no_configuration_diagnostic_when_recorded_tenant_guard_is_enabled()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.AddHeadlessTenancy(tenancy => tenancy.EntityFramework(ef => ef.GuardTenantWrites()));
+        await using var provider = builder.Services.BuildServiceProvider();
+        var context = new HeadlessTenancyValidationContext(
+            provider,
+            provider.GetRequiredService<TenantPostureManifest>()
+        );
+
+        var diagnostics = provider
+            .GetServices<IHeadlessTenancyValidator>()
+            .SelectMany(validator => validator.Validate(context))
+            .ToArray();
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task should_fail_with_actionable_error_when_migration_seeder_has_no_context_registration()
+    {
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        var seeder = new DbMigrationSeeder<UnregisteredDbContext>(provider);
+
+        Func<Task> action = () => seeder.SeedAsync(AbortToken).AsTask();
+
+        var exception = await action.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().Contain(nameof(UnregisteredDbContext));
+        exception.Which.Message.Should().Contain(nameof(IDbContextFactory<UnregisteredDbContext>));
+    }
+
+    [Fact]
+    public void should_register_migration_seeder_once_when_registration_is_repeated()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDbMigrationSeeder<UnregisteredDbContext>();
+        services.AddDbMigrationSeeder<UnregisteredDbContext>();
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetServices<ISeeder>().Should().ContainSingle();
+        provider.GetServices<DbMigrationSeeder<UnregisteredDbContext>>().Should().ContainSingle();
+    }
+
+    private sealed class StubHeadlessDbContext(DbContextOptions options, string? tenantId)
+        : DbContext(options),
+            IHeadlessDbContext
+    {
+        public string? TenantId { get; set; } = tenantId;
+
+        public string? DefaultSchema => null;
+
+        public IServiceProvider ServiceProvider => EmptyServiceProvider.Instance;
+    }
+
+    private sealed class UnregisteredDbContext(DbContextOptions<UnregisteredDbContext> options) : DbContext(options);
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static EmptyServiceProvider Instance { get; } = new();
+
+        public object? GetService(Type serviceType)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Headless.EntityFramework.Tests.Integration/HeadlessDbContextFactoryTests.cs
+++ b/tests/Headless.EntityFramework.Tests.Integration/HeadlessDbContextFactoryTests.cs
@@ -96,6 +96,29 @@ public sealed class HeadlessDbContextFactoryTests(HeadlessDbContextTestFixture f
     }
 
     [Fact]
+    public void should_generate_compact_string_primary_keys_from_the_provider_keyed_guid_generator()
+    {
+        var providerGuid = Guid.Parse("019c89c2-d679-7721-804b-72de3c3ecabb");
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddKeyedSingleton<IGuidGenerator>(SequentialGuidType.Version7, new FixedGuidGenerator(providerGuid));
+        services.AddHeadlessDbContext<KeyedGuidDbContext>(options =>
+            options
+                .UseNpgsql("Host=localhost;Database=headless;Username=headless;Password=headless")
+                .GenerateCompactGuidForStringPrimaryKeys()
+        );
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        using var context = scope.ServiceProvider.GetRequiredService<KeyedGuidDbContext>();
+        var entity = new StringKeyedEntity { Name = "compact" };
+
+        context.StringEntities.Add(entity);
+
+        entity.Id.Should().Be(providerGuid.ToString("N"));
+    }
+
+    [Fact]
     public async Task should_dispose_owned_scope_when_dbcontext_constructor_throws()
     {
         // given — a scoped probe whose disposal we observe, and a context whose ctor throws.
@@ -172,7 +195,27 @@ file sealed class KeyedGuidDbContext(HeadlessDbContextServices services, DbConte
 {
     public DbSet<KeyedGuidEntity> Entities => Set<KeyedGuidEntity>();
 
+    public DbSet<StringKeyedEntity> StringEntities => Set<StringKeyedEntity>();
+
     public override string DefaultSchema => "";
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<StringKeyedEntity>().Property(static entity => entity.Id).ValueGeneratedOnAdd();
+    }
+}
+
+file sealed class StringKeyedEntity : IEntity<string>
+{
+    public string Id { get; private init; } = null!;
+
+    public required string Name { get; init; }
+
+    public IReadOnlyList<object> GetKeys()
+    {
+        return [Id];
+    }
 }
 
 file sealed class KeyedGuidEntity : IEntity<Guid>

--- a/tests/Headless.EntityFramework.Tests.Integration/HeadlessDbContextTests.cs
+++ b/tests/Headless.EntityFramework.Tests.Integration/HeadlessDbContextTests.cs
@@ -292,6 +292,88 @@ public sealed class HeadlessDbContextTests(HeadlessDbContextTestFixture fixture)
         (await db.Basics.CountAsync(AbortToken)).Should().Be(0);
     }
 
+    [Fact]
+    public async Task should_forward_argument_when_execute_transaction_async()
+    {
+        await using var scope = fixture.ServiceProvider.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<TestHeadlessDbContext>();
+
+        await db.ExecuteTransactionAsync(
+            static async (name, context, ct) =>
+            {
+                await context.Set<BasicEntity>().AddAsync(new BasicEntity { Name = name }, ct);
+                await context.SaveChangesAsync(ct);
+            },
+            "argument",
+            cancellationToken: AbortToken
+        );
+
+        (await db.Basics.SingleAsync(AbortToken)).Name.Should().Be("argument");
+    }
+
+    [Fact]
+    public async Task should_return_operation_result_when_execute_transaction_async()
+    {
+        await using var scope = fixture.ServiceProvider.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<TestHeadlessDbContext>();
+
+        var result = await db.ExecuteTransactionAsync(
+            static async (context, ct) =>
+            {
+                await context.Set<BasicEntity>().AddAsync(new BasicEntity { Name = "result" }, ct);
+                return await context.SaveChangesAsync(ct);
+            },
+            cancellationToken: AbortToken
+        );
+
+        result.Should().Be(1);
+        (await db.Basics.CountAsync(AbortToken)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_forward_argument_and_return_result_when_execute_transaction_async()
+    {
+        await using var scope = fixture.ServiceProvider.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<TestHeadlessDbContext>();
+
+        var result = await db.ExecuteTransactionAsync(
+            static async (name, context, ct) =>
+            {
+                await context.Set<BasicEntity>().AddAsync(new BasicEntity { Name = name }, ct);
+                await context.SaveChangesAsync(ct);
+
+                return name.Length;
+            },
+            "result-with-argument",
+            cancellationToken: AbortToken
+        );
+
+        result.Should().Be("result-with-argument".Length);
+        (await db.Basics.SingleAsync(AbortToken)).Name.Should().Be("result-with-argument");
+    }
+
+    [Fact]
+    public async Task should_not_invoke_transaction_operation_when_cancellation_is_already_requested()
+    {
+        await using var scope = fixture.ServiceProvider.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<TestHeadlessDbContext>();
+        var cancellationToken = new CancellationToken(canceled: true);
+        var invoked = false;
+
+        Func<Task> action = async () =>
+            await db.ExecuteTransactionAsync(
+                (_, _) =>
+                {
+                    invoked = true;
+                    return Task.CompletedTask;
+                },
+                cancellationToken: cancellationToken
+            );
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+        invoked.Should().BeFalse();
+    }
+
     // Global filters
 
     [Fact]


### PR DESCRIPTION
## Summary

- Strengthens regression confidence around EF query projections, paging boundaries, async cancellation, and typed identifier overloads.
- Exercises model-building conventions through finalized EF metadata, including complex value-object facets, configuration discovery predicates, primitive converters, and both query-filter overloads.
- Covers transaction overload forwarding, provider-keyed compact IDs, compiled-query cache isolation, invalid tenant-write-guard configuration, and seeder registration/error paths.
- Raises package coverage without production changes:

| Package | Metric | Before | After | Delta |
| --- | --- | ---: | ---: | ---: |
| `Headless.EntityFramework.Core` | Line | 558/1,432 (38.9%) | 857/1,432 (59.8%) | +299 / +20.9 pp |
|  | Branch | 134/416 (32.2%) | 217/416 (52.1%) | +83 / +19.9 pp |
|  | Method | 90/176 (51.1%) | 137/176 (77.8%) | +47 / +26.7 pp |
| `Headless.EntityFramework` | Line | 1,384/2,575 (53.7%) | 1,703/2,575 (66.1%) | +319 / +12.4 pp |
|  | Branch | 615/1,124 (54.7%) | 663/1,124 (58.9%) | +48 / +4.2 pp |
|  | Method | 243/388 (62.6%) | 290/388 (74.7%) | +47 / +12.1 pp |

Generated serializer-context code is excluded from both sides of the package comparison.

## Related Work

N/A

## Scope

Affected packages or domains:

- `Headless.EntityFramework.Core`
- `Headless.EntityFramework`

Out of scope:

- Production behavior changes
- The repository-wide analyzer Info/Suggestion sweep
- Fixing the existing `AndHasQueryFilter` composition defect described in Reviewer Guide

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A — tests only; no production files changed.
```

## Validation

- [x] Focused build or test for the affected projects
- [ ] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
Focused Core: 42 total, 42 passed, 0 skipped, 0 failed.
Focused EF integration: 84 total, 82 passed, 2 skipped, 0 failed. The two existing skips reference issue #249.
make ci-test TEST_MAX_PARALLEL=1: 10,593 total, 10,591 passed, 2 skipped, 0 failed.
make format-check: 4,095 files checked, passed.
dotnet restore headless-framework.slnx -p:Configuration=Release -m:1: passed (378 projects; 353 up-to-date).
make rebuild-no-restore MSBUILD_ARGS=-m:1: passed with 0 warnings and 0 errors.
make quality-analyzers MSBUILD_ARGS=-m:1: build had 0 warnings/errors; target exited 2 for five Info suggestions (three pre-existing, two in changed tests). The Info/Suggestion sweep is intentionally out of scope.

The initial parallel `make rebuild` hit MSB4166 after 13 child-node failures; the repository was restored and rebuilt successfully with single-node MSBuild. Reusable PostgreSQL containers were pre-started for the focused integration run to avoid a local OrbStack port-forward cold-start race.

Coverage reports: artifacts/ef-baseline/report/Summary.json and artifacts/ef-after/report/Summary.json.
```

The sequential `make ci-test` run is the repository-supported CI unit path over prebuilt modules, so `make test-unit` was not duplicated. The affected integration project was run directly; the full unrelated integration fleet was not run.

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
No public API, package behavior, or documentation changed. Provider behavior is exercised through the repository's established SQLite and PostgreSQL test patterns; no shared provider contract changed.
```

## Reviewer Guide

Review the behavior contracts rather than raw assertion count: query expressions are executed by EF providers, model conventions are asserted from finalized metadata, compiled-query keys come from a real EF service provider, and cancellation is verified before delegates or database work execute.

Known residual: an exploratory composition case showed that applying `AndHasQueryFilter` after an existing filter currently replaces rather than intersects that filter under EF Core 10 (`{1,3}` instead of `{1}`). This PR verifies the generic and untyped overloads independently but deliberately does not encode the broken composition as expected behavior or change production code. The next weakest areas are value-converter helpers and query-expression branches in Core, plus migrations, audit capture/persistence, convention extensions, and migration seeding in the main package.

Operational risk is low because the diff is test-only. No post-deploy monitoring is required; the PR author should confirm hosted CI uses the expected package coverage artifacts through the PR validation window. If hosted provider tests expose environment-specific behavior, mitigation is to isolate the provider fixture issue rather than weaken behavioral assertions.

## Release Notes

N/A — internal test coverage only.
