### PR TITLE
test(couchbase): expand behavioral coverage

### DIFF
--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseAssemblyCollectionsReaderTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseAssemblyCollectionsReaderTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Couchbase;
+using Headless.Couchbase.Context;
+using Headless.Couchbase.Managers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Tests;
+
+public sealed class CouchbaseAssemblyCollectionsReaderTests
+{
+    private readonly CouchbaseAssemblyCollectionsReader _sut = new();
+
+    [Fact]
+    public void should_discover_annotated_document_sets_from_assemblies()
+    {
+        var collections = _sut.ReadCollections([typeof(TestBucketContext).Assembly]).ToList();
+
+        collections.Should().Contain(new ScopeCollection("sales", "orders"));
+        collections.Should().Contain(new ScopeCollection("inventory", "products"));
+        collections.Should().NotContain(x => x.Collection == nameof(TestBucketContext.IgnoredProperty));
+    }
+
+    [Fact]
+    public void should_discover_collections_from_live_context_types()
+    {
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var context = new TestBucketContext(
+            CouchbaseTestFactory.CreateBucket(cluster),
+            CouchbaseTestFactory.CreateTransactions(cluster),
+            NullLogger<CouchbaseBucketContext>.Instance
+        );
+
+        var collections = _sut.ReadCollections([context]).ToList();
+
+        collections
+            .Should()
+            .BeEquivalentTo([new ScopeCollection("sales", "orders"), new ScopeCollection("inventory", "products")]);
+    }
+
+    [Fact]
+    public void should_filter_loaded_assemblies_by_prefix()
+    {
+        var collections = _sut.ReadCollections("Headless.Couchbase.Tests.Unit").ToList();
+
+        collections.Should().Contain(new ScopeCollection("sales", "orders"));
+        _sut.ReadCollections("missing.assembly.prefix").Should().BeEmpty();
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseBucketContextTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseBucketContextTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Couchbase.KeyValue;
+using Headless.Couchbase.Context;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Tests;
+
+public sealed class CouchbaseBucketContextTests : TestBase
+{
+    [Fact]
+    public async Task should_honor_cancellation_before_starting_transaction()
+    {
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var context = new TestBucketContext(
+            CouchbaseTestFactory.CreateBucket(cluster),
+            CouchbaseTestFactory.CreateTransactions(cluster),
+            NullLogger<CouchbaseBucketContext>.Instance
+        );
+        var cancellationToken = new CancellationToken(canceled: true);
+        var operationCalled = false;
+
+        var act = () =>
+            context.ExecuteTransactionAsync(
+                _ =>
+                {
+                    operationCalled = true;
+                    return Task.FromResult(true);
+                },
+                cancellationToken: cancellationToken
+            );
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        operationCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void should_create_scope_and_collection_queryable()
+    {
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var bucket = CouchbaseTestFactory.CreateBucket(cluster);
+        var scope = Substitute.For<IScope>();
+        var collection = Substitute.For<ICouchbaseCollection>();
+        bucket.Name.Returns("app");
+#pragma warning disable VSTHRD103 // Linq2Couchbase's Query API intentionally uses the synchronous SDK lookup.
+        bucket.Scope("sales").Returns(scope);
+#pragma warning restore VSTHRD103
+        scope.Name.Returns("sales");
+        scope.Bucket.Returns(bucket);
+        scope.Collection("orders").Returns(collection);
+        collection.Name.Returns("orders");
+        collection.Scope.Returns(scope);
+        var context = new TestBucketContext(
+            bucket,
+            CouchbaseTestFactory.CreateTransactions(cluster),
+            NullLogger<CouchbaseBucketContext>.Instance
+        );
+
+        var query = context.Query<TestDocument>("sales", "orders");
+
+        query.ElementType.Should().Be(typeof(TestDocument));
+        _GetQueryKeyspace(query).Should().Be(("sales", "orders"));
+    }
+
+    private static (string Scope, string Collection) _GetQueryKeyspace<T>(IQueryable<T> query)
+    {
+        object instance = query;
+        var type = instance.GetType();
+        var scope = type.GetProperty("ScopeName")?.GetValue(instance);
+        var collection = type.GetProperty("CollectionName")?.GetValue(instance);
+
+        return (scope.Should().BeOfType<string>().Subject, collection.Should().BeOfType<string>().Subject);
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseClustersProviderTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseClustersProviderTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using Couchbase;
+using Headless.Couchbase.Clusters;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nito.AsyncEx;
+
+namespace Tests;
+
+public sealed class CouchbaseClustersProviderTests : TestBase
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task should_reject_missing_cluster_key(string? clusterKey)
+    {
+        await using var sut = _CreateProvider(
+            Substitute.For<ICouchbaseClusterOptionsProvider>(),
+            Substitute.For<ICouchbaseTransactionConfigProvider>()
+        );
+
+        var act = () => sut.GetClusterAsync(clusterKey!, AbortToken).AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task should_share_connection_attempt_when_one_caller_cancels_its_wait()
+    {
+        var releaseConnection = new TaskCompletionSource<CouchbaseClusterConnection>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var optionsProvider = Substitute.For<ICouchbaseClusterOptionsProvider>();
+        var sut = _CreateProvider(optionsProvider, Substitute.For<ICouchbaseTransactionConfigProvider>());
+        var lazy = new AsyncLazy<CouchbaseClusterConnection>(() => releaseConnection.Task);
+        _GetCache(sut).TryAdd("primary", lazy).Should().BeTrue();
+        var cancellation = new CancellationTokenSource();
+
+        try
+        {
+            var abandonedWait = sut.GetClusterAsync("primary", cancellation.Token).AsTask();
+            var sharedWait = sut.GetClusterAsync("primary", AbortToken).AsTask();
+            await cancellation.CancelAsync();
+            var cluster = CouchbaseTestFactory.CreateCluster();
+            var connection = new CouchbaseClusterConnection
+            {
+                Cluster = cluster,
+                Transactions = CouchbaseTestFactory.CreateTransactions(cluster),
+            };
+            releaseConnection.SetResult(connection);
+            Func<Task> abandonedAct = async () => _ = await abandonedWait;
+
+            await abandonedAct.Should().ThrowAsync<OperationCanceledException>();
+            var resolved = await sharedWait.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+
+            resolved.Should().BeSameAs(connection);
+            await optionsProvider.DidNotReceiveWithAnyArgs().GetAsync(default!, default);
+        }
+        finally
+        {
+            releaseConnection.TrySetCanceled();
+            cancellation.Dispose();
+            await sut.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task should_evict_failed_connection_so_next_call_retries()
+    {
+        var optionsProvider = Substitute.For<ICouchbaseClusterOptionsProvider>();
+        var failure = Task.FromException<ClusterOptions>(new InvalidOperationException("options unavailable"));
+        optionsProvider.GetAsync("primary", CancellationToken.None).Returns(new ValueTask<ClusterOptions>(failure));
+        await using var sut = _CreateProvider(optionsProvider, Substitute.For<ICouchbaseTransactionConfigProvider>());
+
+        var first = () => sut.GetClusterAsync("primary", AbortToken).AsTask();
+        var second = () => sut.GetClusterAsync("primary", AbortToken).AsTask();
+
+        await first.Should().ThrowAsync<InvalidOperationException>().WithMessage("options unavailable");
+        await second.Should().ThrowAsync<InvalidOperationException>().WithMessage("options unavailable");
+        await optionsProvider.Received(2).GetAsync("primary", CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task should_dispose_completed_cluster_connection()
+    {
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var transactions = CouchbaseTestFactory.CreateTransactions(cluster);
+        var connection = new CouchbaseClusterConnection { Cluster = cluster, Transactions = transactions };
+        var lazy = new AsyncLazy<CouchbaseClusterConnection>(() => Task.FromResult(connection));
+        _ = await lazy.Task;
+        var sut = _CreateProvider(
+            Substitute.For<ICouchbaseClusterOptionsProvider>(),
+            Substitute.For<ICouchbaseTransactionConfigProvider>()
+        );
+        _GetCache(sut).TryAdd("primary", lazy).Should().BeTrue();
+
+        await sut.DisposeAsync();
+
+        await cluster.Received(1).DisposeAsync();
+    }
+
+    private static CouchbaseClustersProvider _CreateProvider(
+        ICouchbaseClusterOptionsProvider optionsProvider,
+        ICouchbaseTransactionConfigProvider transactionProvider
+    )
+    {
+        return new(optionsProvider, transactionProvider, NullLogger<CouchbaseClustersProvider>.Instance);
+    }
+
+    private static ConcurrentDictionary<string, AsyncLazy<CouchbaseClusterConnection>> _GetCache(
+        CouchbaseClustersProvider provider
+    )
+    {
+        var cacheField = typeof(CouchbaseClustersProvider).GetField(
+            "_clusters",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly
+        );
+        var cache =
+            cacheField?.GetValue(provider) as ConcurrentDictionary<string, AsyncLazy<CouchbaseClusterConnection>>;
+        cache.Should().NotBeNull();
+
+        return cache!;
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseConfigurationProviderTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseConfigurationProviderTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Couchbase;
+using Couchbase.KeyValue;
+using Couchbase.Transactions.Config;
+using Headless.Couchbase.Clusters;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Hosting;
+
+namespace Tests;
+
+public sealed class CouchbaseConfigurationProviderTests : TestBase
+{
+    [Fact]
+    public async Task should_return_shared_cluster_options_for_every_key()
+    {
+        var options = new ClusterOptions();
+        var sut = new CouchbaseClusterOptionsProvider(options);
+
+        var first = await sut.GetAsync("primary", AbortToken);
+        var second = await sut.GetAsync("analytics", AbortToken);
+
+        first.Should().BeSameAs(options);
+        second.Should().BeSameAs(options);
+    }
+
+    [Fact]
+    public async Task should_apply_transaction_configuration_once_and_reuse_builder()
+    {
+        var configured = 0;
+        var sut = new CouchbaseTransactionConfigProvider(builder =>
+        {
+            configured++;
+            builder.ExpirationTime(TimeSpan.FromSeconds(30));
+        });
+
+        var first = await sut.GetAsync("primary", AbortToken);
+        var second = await sut.GetAsync("analytics", AbortToken);
+
+        configured.Should().Be(1);
+        first.Should().BeSameAs(second);
+        first.Build().ExpirationTime.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Theory]
+    [InlineData("Development", 500)]
+    [InlineData("Production", 100)]
+    public async Task should_build_environment_aware_transaction_defaults(string environmentName, int expirySeconds)
+    {
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+        var sut = new DefaultCouchbaseTransactionConfigProvider(environment);
+
+        var config = (await sut.GetAsync("primary", AbortToken)).Build();
+
+        config.KeyValueTimeout.Should().Be(TimeSpan.FromSeconds(10));
+        config.ExpirationTime.Should().Be(TimeSpan.FromSeconds(expirySeconds));
+        config.DurabilityLevel.Should().Be(DurabilityLevel.Majority);
+        config.CleanupLostAttempts.Should().BeTrue();
+        config.CleanupClientAttempts.Should().BeTrue();
+        config.CleanupWindow.Should().Be(TimeSpan.FromSeconds(120));
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseContextInitializationTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseContextInitializationTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Couchbase;
+using Couchbase.Linq;
+using Couchbase.Transactions;
+using Headless.Couchbase.Clusters;
+using Headless.Couchbase.Context;
+using Headless.Couchbase.ContextProvider;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Tests;
+
+public sealed class CouchbaseContextInitializationTests : TestBase
+{
+    [Fact]
+    public void should_initialize_declared_scope_and_collection_mappings()
+    {
+        var (provider, bucket, transactions) = _CreateDependencies();
+        using var providerLifetime = provider;
+
+        var context = CouchbaseBucketContextInitializer.Initialize<TestBucketContext>(
+            provider,
+            bucket,
+            transactions,
+            defaultScopeName: null
+        );
+
+        _GetMapping(context.Orders).Should().Be(("sales", "orders"));
+        _GetMapping(context.Products).Should().Be(("inventory", "products"));
+    }
+
+    [Fact]
+    public void should_flatten_declared_mappings_into_default_scope()
+    {
+        var (provider, bucket, transactions) = _CreateDependencies();
+        using var providerLifetime = provider;
+
+        var context = CouchbaseBucketContextInitializer.Initialize<TestBucketContext>(
+            provider,
+            bucket,
+            transactions,
+            defaultScopeName: "tenant-42"
+        );
+
+        _GetMapping(context.Orders).Should().Be(("tenant-42", "sales_orders"));
+        _GetMapping(context.Products).Should().Be(("tenant-42", "inventory_products"));
+    }
+
+    [Fact]
+    public void should_reject_document_set_without_collection_attribute()
+    {
+        var (provider, bucket, transactions) = _CreateDependencies();
+        using var providerLifetime = provider;
+        var act = () =>
+            CouchbaseBucketContextInitializer.Initialize<MissingAttributeBucketContext>(
+                provider,
+                bucket,
+                transactions,
+                defaultScopeName: null
+            );
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*Missing CouchbaseCollectionAttribute on Documents*");
+    }
+
+    [Fact]
+    public void should_reject_blank_collection_scope()
+    {
+        var (provider, bucket, transactions) = _CreateDependencies();
+        using var providerLifetime = provider;
+        var act = () =>
+            CouchbaseBucketContextInitializer.Initialize<InvalidAttributeBucketContext>(
+                provider,
+                bucket,
+                transactions,
+                defaultScopeName: null
+            );
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Invalid Scope on Documents*");
+    }
+
+    [Fact]
+    public async Task should_open_bucket_and_initialize_context_through_provider()
+    {
+        var clusterProvider = Substitute.For<ICouchbaseClustersProvider>();
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var bucket = CouchbaseTestFactory.CreateBucket(cluster);
+        var transactions = CouchbaseTestFactory.CreateTransactions(cluster);
+        var services = new ServiceCollection();
+        services.AddSingleton<ILogger<CouchbaseBucketContext>>(NullLogger<CouchbaseBucketContext>.Instance);
+        await using var serviceProvider = services.BuildServiceProvider();
+        clusterProvider
+            .GetClusterAsync("primary", AbortToken)
+            .Returns(new CouchbaseClusterConnection { Cluster = cluster, Transactions = transactions });
+        cluster.BucketAsync("app").Returns(bucket);
+        var sut = new BucketContextProvider(clusterProvider, serviceProvider);
+
+        var context = await sut.GetAsync<TestBucketContext>("primary", "app", "tenant", AbortToken);
+
+        _GetMapping(context.Orders).Should().Be(("tenant", "sales_orders"));
+        await cluster.Received(1).BucketAsync("app");
+    }
+
+    [Fact]
+    public async Task should_not_open_bucket_when_caller_is_cancelled()
+    {
+        var cancellationToken = new CancellationToken(canceled: true);
+        var clusterProvider = Substitute.For<ICouchbaseClustersProvider>();
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var transactions = CouchbaseTestFactory.CreateTransactions(cluster);
+        clusterProvider
+            .GetClusterAsync("primary", cancellationToken)
+            .Returns(new CouchbaseClusterConnection { Cluster = cluster, Transactions = transactions });
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var sut = new BucketContextProvider(clusterProvider, serviceProvider);
+
+        var act = () => sut.GetAsync<TestBucketContext>("primary", "app", null, cancellationToken).AsTask();
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await cluster.DidNotReceiveWithAnyArgs().BucketAsync(default!);
+    }
+
+    private static (ServiceProvider Provider, IBucket Bucket, Transactions Transactions) _CreateDependencies()
+    {
+        var cluster = CouchbaseTestFactory.CreateCluster();
+        var bucket = CouchbaseTestFactory.CreateBucket(cluster);
+        var transactions = CouchbaseTestFactory.CreateTransactions(cluster);
+        var services = new ServiceCollection();
+        services.AddSingleton<ILogger<CouchbaseBucketContext>>(NullLogger<CouchbaseBucketContext>.Instance);
+
+        return (services.BuildServiceProvider(), bucket, transactions);
+    }
+
+    private static (string Scope, string Collection) _GetMapping<T>(IDocumentSet<T> documentSet)
+    {
+        object instance = documentSet;
+        var type = instance.GetType();
+        var scope = type.GetProperty("ScopeName")?.GetValue(instance);
+        var collection = type.GetProperty("CollectionName")?.GetValue(instance);
+
+        return (scope.Should().BeOfType<string>().Subject, collection.Should().BeOfType<string>().Subject);
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseContextTestTypes.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseContextTestTypes.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Couchbase;
+using Couchbase.Linq;
+using Couchbase.Transactions;
+using Couchbase.Transactions.Config;
+using Headless.Couchbase.Context;
+using Headless.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Tests;
+
+internal sealed class TestBucketContext(
+    IBucket bucket,
+    Transactions transactions,
+    ILogger<CouchbaseBucketContext> logger
+) : CouchbaseBucketContext(bucket, transactions, logger)
+{
+    [CouchbaseCollection("sales", "orders")]
+    public IDocumentSet<TestDocument> Orders { get; set; } = null!;
+
+    [CouchbaseCollection("inventory", "products")]
+    public IDocumentSet<TestDocument> Products { get; set; } = null!;
+
+    public string? IgnoredProperty { get; set; }
+}
+
+internal sealed class MissingAttributeBucketContext(
+    IBucket bucket,
+    Transactions transactions,
+    ILogger<CouchbaseBucketContext> logger
+) : CouchbaseBucketContext(bucket, transactions, logger)
+{
+    public IDocumentSet<TestDocument> Documents { get; set; } = null!;
+}
+
+internal sealed class InvalidAttributeBucketContext(
+    IBucket bucket,
+    Transactions transactions,
+    ILogger<CouchbaseBucketContext> logger
+) : CouchbaseBucketContext(bucket, transactions, logger)
+{
+    [CouchbaseCollection(" ", "documents")]
+    public IDocumentSet<TestDocument> Documents { get; set; } = null!;
+}
+
+public sealed class TestDocument : Entity<string>
+{
+    public string? Value { get; init; }
+}
+
+internal static class CouchbaseTestFactory
+{
+    private static readonly Type _ClusterContextType =
+        typeof(ICluster).Assembly.GetType("Couchbase.Core.ClusterContext")
+        ?? throw new InvalidOperationException("Could not find ClusterContext type.");
+
+    private static readonly MethodInfo _AddClusterService = typeof(ClusterOptionsExtensions)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .Single(method =>
+            method.Name == nameof(ClusterOptionsExtensions.AddClusterService)
+            && method.IsGenericMethodDefinition
+            && method.GetGenericArguments().Length == 1
+            && method.GetParameters().Length == 2
+            && method.GetParameters()[1].ParameterType.IsGenericParameter
+        );
+
+    private static readonly MethodInfo _BuildServiceProvider =
+        typeof(ClusterOptions).GetMethod(
+            "BuildServiceProvider",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+        ) ?? throw new InvalidOperationException("Could not find ClusterOptions.BuildServiceProvider.");
+
+    public static ICluster CreateCluster()
+    {
+        var clusterContext = RuntimeHelpers.GetUninitializedObject(_ClusterContextType);
+        var options = new ClusterOptions();
+        _ = _AddClusterService.MakeGenericMethod(_ClusterContextType).Invoke(null, [options, clusterContext]);
+        options.AddLinq();
+        var serviceProvider = _BuildServiceProvider.Invoke(options, null) as IServiceProvider;
+        serviceProvider.Should().NotBeNull();
+        var cluster = Substitute.For<ICluster>();
+        cluster.ClusterServices.Returns(serviceProvider!);
+
+        return cluster;
+    }
+
+    public static IBucket CreateBucket(ICluster cluster)
+    {
+        var bucket = Substitute.For<IBucket>();
+        bucket.Cluster.Returns(cluster);
+
+        return bucket;
+    }
+
+    public static Transactions CreateTransactions(ICluster cluster)
+    {
+        var config = TransactionConfigBuilder
+            .Create()
+            .CleanupLostAttempts(cleanupLostAttempts: false)
+            .CleanupClientAttempts(cleanupClientAttempts: false);
+
+        return Transactions.Create(cluster, config);
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseEventingFunctionsSeederTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseEventingFunctionsSeederTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Couchbase;
+using Couchbase.Management.Eventing;
+using Headless.Couchbase.Clusters;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+public sealed class CouchbaseEventingFunctionsSeederTests : TestBase
+{
+    [Fact]
+    public async Task should_upsert_deployed_function_with_source_metadata_and_read_only_aliases()
+    {
+        var cluster = Substitute.For<ICluster>();
+        var manager = Substitute.For<IEventingFunctionManager>();
+        cluster.EventingFunctions.Returns(manager);
+        EventingFunction? capturedFunction = null;
+        UpsertFunctionOptions? capturedOptions = null;
+        manager
+            .UpsertFunctionAsync(Arg.Any<EventingFunction>(), Arg.Any<UpsertFunctionOptions>())
+            .Returns(call =>
+            {
+                capturedFunction = call.ArgAt<EventingFunction>(0);
+                capturedOptions = call.ArgAt<UpsertFunctionOptions>(1);
+                return Task.CompletedTask;
+            });
+        var source = new CouchbaseKeyspace("data", "sales", "orders");
+        var metadata = new CouchbaseKeyspace("system", "eventing", "metadata");
+        var aliases = new Dictionary<string, CouchbaseKeyspace>(StringComparer.Ordinal)
+        {
+            ["products"] = new("catalog", "inventory", "products"),
+        };
+
+        await cluster.UpsertFunctionAsync(
+            source,
+            metadata,
+            aliases,
+            "project-orders",
+            "function OnUpdate(doc, meta) {}",
+            workers: 3,
+            AbortToken
+        );
+
+        capturedFunction.Should().NotBeNull();
+        capturedFunction!.Name.Should().Be("project-orders");
+        capturedFunction.Code.Should().Be("function OnUpdate(doc, meta) {}");
+        capturedFunction.SourceKeySpace.Should().NotBeNull();
+        _ReadKeyspace(capturedFunction.SourceKeySpace!).Should().Be(source);
+        _ReadKeyspace(capturedFunction.MetaDataKeySpace!).Should().Be(metadata);
+        capturedFunction.Settings.DeploymentStatus.Should().Be(EventingFunctionDeploymentStatus.Deployed);
+        capturedFunction.Settings.ProcessingStatus.Should().Be(EventingFunctionProcessingStatus.Running);
+        capturedFunction.Settings.WorkerCount.Should().Be(3);
+        var deployment = _ReadProperty<DeploymentConfig>(capturedFunction, "DeploymentConfig");
+        var binding = deployment.BucketBindings.Should().ContainSingle().Which;
+        binding.Alias.Should().Be("products");
+        binding.Access.Should().Be(EventingFunctionBucketAccess.ReadOnly);
+        _ReadBinding(binding).Should().Be(aliases["products"]);
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.Token.Should().Be(AbortToken);
+        capturedOptions.Timeout.Should().Be(TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public async Task should_propagate_eventing_upsert_failure()
+    {
+        var cluster = Substitute.For<ICluster>();
+        var manager = Substitute.For<IEventingFunctionManager>();
+        cluster.EventingFunctions.Returns(manager);
+        manager
+            .UpsertFunctionAsync(Arg.Any<EventingFunction>(), Arg.Any<UpsertFunctionOptions>())
+            .Returns(Task.FromException(new InvalidOperationException("eventing unavailable")));
+
+        var act = () =>
+            cluster.UpsertFunctionAsync(
+                new CouchbaseKeyspace("data", "scope", "source"),
+                new CouchbaseKeyspace("system", "scope", "metadata"),
+                new Dictionary<string, CouchbaseKeyspace>(StringComparer.Ordinal),
+                "function",
+                "code",
+                cancellationToken: AbortToken
+            );
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("eventing unavailable");
+    }
+
+    private static CouchbaseKeyspace _ReadKeyspace(EventingFunctionKeyspace keyspace)
+    {
+        return new(
+            _ReadProperty<string>(keyspace, "Bucket"),
+            _ReadProperty<string>(keyspace, "Scope"),
+            _ReadProperty<string>(keyspace, "Collection")
+        );
+    }
+
+    private static CouchbaseKeyspace _ReadBinding(EventingFunctionBucketBinding binding)
+    {
+        return new(
+            _ReadProperty<string>(binding, "BucketName"),
+            _ReadProperty<string>(binding, "ScopeName"),
+            _ReadProperty<string>(binding, "CollectionName")
+        );
+    }
+
+    private static T _ReadProperty<T>(object instance, string propertyName)
+    {
+        var property = instance
+            .GetType()
+            .GetProperty(
+                propertyName,
+                System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.Public
+                    | System.Reflection.BindingFlags.NonPublic
+            );
+        property.Should().NotBeNull();
+
+        return property!.GetValue(instance).Should().BeOfType<T>().Subject;
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/CouchbaseManagerScopeCacheTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/CouchbaseManagerScopeCacheTests.cs
@@ -1,63 +1,233 @@
 // Copyright (c) Mahmoud Shaheen. All rights reserved.
 
-using System.Reflection;
 using Couchbase;
+using Couchbase.KeyValue;
 using Couchbase.Management.Collections;
+using Couchbase.Management.Query;
 using Headless.Couchbase.Clusters;
 using Headless.Couchbase.Managers;
+using Headless.Testing.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Tests;
 
-public sealed class CouchbaseManagerScopeCacheTests
+public sealed class CouchbaseManagerScopeCacheTests : TestBase
 {
     [Fact]
-    public async Task should_cache_scope_specs_as_frozen_read_only_metadata()
+    public async Task should_return_exist_without_mutating_when_scope_is_already_present()
     {
-        var manager = new CouchbaseManager(
-            Substitute.For<ICouchbaseClustersProvider>(),
-            Options.Create(new CouchbaseManagerOptions()),
-            NullLogger<CouchbaseManager>.Instance
-        );
-        var bucket = Substitute.For<IBucket>();
-        var collectionManager = Substitute.For<ICouchbaseCollectionManager>();
+        var fixture = _CreateFixture([_Scope("orders", "existing")]);
 
-        bucket.Name.Returns("bucket");
-        bucket.Collections.Returns(collectionManager);
-        collectionManager
-            .GetAllScopesAsync(Arg.Any<GetAllScopesOptions?>())
+        var result = await fixture.Manager.CreateScopeAsync("primary", "app", "orders", AbortToken);
+
+        result.Should().Be(CreateScopeStatus.Exist);
+        await fixture.Collections.DidNotReceiveWithAnyArgs().CreateScopeAsync((string)default!, default);
+    }
+
+    [Fact]
+    public async Task should_cache_scope_metadata_between_read_only_checks()
+    {
+        var fixture = _CreateFixture([_Scope("orders", "existing")]);
+
+        await fixture.Manager.CreateScopeAsync("primary", "app", "orders", AbortToken);
+        await fixture.Manager.CreateScopeAsync("primary", "app", "orders", AbortToken);
+
+        await fixture.Collections.Received(1).GetAllScopesAsync(Arg.Any<GetAllScopesOptions?>());
+    }
+
+    [Fact]
+    public async Task should_clear_scope_cache_after_successful_creation()
+    {
+        var fixture = _CreateFixture([]);
+        fixture
+            .Collections.GetAllScopesAsync(Arg.Any<GetAllScopesOptions?>())
             .Returns(
-                Task.FromResult<IEnumerable<ScopeSpec>>([new("scope") { Collections = [new("scope", "existing")] }])
+                Task.FromResult<IEnumerable<ScopeSpec>>([]),
+                Task.FromResult<IEnumerable<ScopeSpec>>([_Scope("orders")])
             );
 
-        var specs = await _GetBucketScopeSpecsAsync(manager, "cluster", bucket);
+        var created = await fixture.Manager.CreateScopeAsync("primary", "app", "orders", AbortToken);
+        var reread = await fixture.Manager.CreateScopeAsync("primary", "app", "orders", AbortToken);
 
-        specs.Should().BeAssignableTo<FrozenDictionary<string, FrozenSet<string>>>();
-        specs["scope"].Should().BeAssignableTo<FrozenSet<string>>();
-        specs["scope"].Should().Contain("existing");
+        created.Should().Be(CreateScopeStatus.Success);
+        reread.Should().Be(CreateScopeStatus.Exist);
+        await fixture.Collections.Received(1).CreateScopeAsync("orders", Arg.Any<CreateScopeOptions?>());
+        await fixture.Collections.Received(2).GetAllScopesAsync(Arg.Any<GetAllScopesOptions?>());
     }
 
-    private static async Task<FrozenDictionary<string, FrozenSet<string>>> _GetBucketScopeSpecsAsync(
-        CouchbaseManager manager,
-        string clusterKey,
-        IBucket bucket
-    )
+    [Fact]
+    public async Task should_return_failed_after_scope_creation_retries_are_exhausted()
     {
-        var method = typeof(CouchbaseManager).GetMethod(
-            "_GetBucketScopeSpecsAsync",
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly,
-            binder: null,
-            [typeof(string), typeof(IBucket)],
-            modifiers: null
+        var fixture = _CreateFixture([]);
+        fixture
+            .Collections.CreateScopeAsync("orders", Arg.Any<CreateScopeOptions?>())
+            .Returns(_ => throw new InvalidOperationException("cluster unavailable"));
+
+        var result = await fixture.Manager.CreateScopeAsync("primary", "app", "orders", AbortToken);
+
+        result.Should().Be(CreateScopeStatus.Failed);
+        await fixture.Collections.Received(2).CreateScopeAsync("orders", Arg.Any<CreateScopeOptions?>());
+    }
+
+    [Fact]
+    public async Task should_create_primary_index_for_existing_collection_when_missing()
+    {
+        var fixture = _CreateFixture([_Scope("orders", "receipts")]);
+        var scope = Substitute.For<IScope>();
+        var collection = Substitute.For<ICouchbaseCollection>();
+        var indexes = Substitute.For<ICollectionQueryIndexManager>();
+        fixture.Bucket.ScopeAsync("orders").Returns(scope);
+        scope.CollectionAsync("receipts").Returns(collection);
+        collection.QueryIndexes.Returns(indexes);
+        indexes
+            .GetAllIndexesAsync(Arg.Any<GetAllQueryIndexOptions>())
+            .Returns(Task.FromResult<IEnumerable<QueryIndex>>([]));
+
+        await fixture.Manager.CreateCollectionsAsync(
+            "primary",
+            "app",
+            "orders",
+            new HashSet<string>(StringComparer.Ordinal) { "receipts" },
+            AbortToken
         );
 
-        method.Should().NotBeNull();
-
-        var task = method!.Invoke(manager, [clusterKey, bucket]);
-
-        task.Should().BeOfType<Task<FrozenDictionary<string, FrozenSet<string>>>>();
-
-        return await ((Task<FrozenDictionary<string, FrozenSet<string>>>)task!).ConfigureAwait(false);
+        await fixture
+            .Collections.DidNotReceive()
+            .CreateCollectionAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CreateCollectionSettings>(),
+                Arg.Any<CreateCollectionOptions>()
+            );
+        await indexes.Received(1).CreatePrimaryIndexAsync(Arg.Any<CreatePrimaryQueryIndexOptions>());
     }
+
+    [Fact]
+    public async Task should_create_missing_collection_before_its_primary_index()
+    {
+        var fixture = _CreateFixture([_Scope("orders")]);
+        var scope = Substitute.For<IScope>();
+        var collection = Substitute.For<ICouchbaseCollection>();
+        var indexes = Substitute.For<ICollectionQueryIndexManager>();
+        scope.Name.Returns("orders");
+        fixture.Bucket.ScopeAsync("orders").Returns(scope);
+        scope.CollectionAsync("receipts").Returns(collection);
+        collection.QueryIndexes.Returns(indexes);
+
+        await fixture.Manager.CreateCollectionsAsync(
+            "primary",
+            "app",
+            "orders",
+            new HashSet<string>(StringComparer.Ordinal) { "receipts" },
+            AbortToken
+        );
+
+        Received.InOrder(() =>
+        {
+            _ = fixture.Collections.CreateCollectionAsync(
+                "orders",
+                "receipts",
+                Arg.Any<CreateCollectionSettings>(),
+                Arg.Any<CreateCollectionOptions>()
+            );
+            _ = indexes.CreatePrimaryIndexAsync(Arg.Any<CreatePrimaryQueryIndexOptions>());
+        });
+    }
+
+    [Fact]
+    public async Task should_create_secondary_index_with_requested_fields()
+    {
+        var fixture = _CreateFixture([]);
+        var scope = Substitute.For<IScope>();
+        var collection = Substitute.For<ICouchbaseCollection>();
+        var indexes = Substitute.For<ICollectionQueryIndexManager>();
+        fixture.Bucket.ScopeAsync("orders").Returns(scope);
+        scope.CollectionAsync("receipts").Returns(collection);
+        collection.QueryIndexes.Returns(indexes);
+        string[] fields = ["customerId", "createdAt"];
+
+        await fixture.Manager.CreateSecondaryIndexAsync(
+            "primary",
+            "app",
+            "orders",
+            "receipts",
+            "ix_customer_created",
+            fields,
+            AbortToken
+        );
+
+        await indexes
+            .Received(1)
+            .CreateIndexAsync(
+                "ix_customer_created",
+                Arg.Is<IEnumerable<string>>(actual => actual.SequenceEqual(fields)),
+                Arg.Any<CreateQueryIndexOptions>()
+            );
+    }
+
+    [Fact]
+    public async Task should_build_deferred_indexes_on_requested_bucket()
+    {
+        var fixture = _CreateFixture([]);
+        var indexes = Substitute.For<IQueryIndexManager>();
+        fixture.Cluster.QueryIndexes.Returns(indexes);
+
+        await fixture.Manager.BuildDeferredIndexesAsync("primary", "app", AbortToken);
+
+        await indexes.Received(1).BuildDeferredIndexesAsync("app", Arg.Any<BuildDeferredQueryIndexOptions>());
+    }
+
+    [Fact]
+    public async Task should_propagate_cancellation_before_manager_operation()
+    {
+        var cancellationToken = new CancellationToken(canceled: true);
+        var fixture = _CreateFixture([]);
+
+        var act = () => fixture.Manager.BuildDeferredIndexesAsync("primary", "app", cancellationToken);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private static ManagerFixture _CreateFixture(IEnumerable<ScopeSpec> scopes)
+    {
+        var clusters = Substitute.For<ICouchbaseClustersProvider>();
+        var cluster = Substitute.For<ICluster>();
+        var bucket = Substitute.For<IBucket>();
+        var collections = Substitute.For<ICouchbaseCollectionManager>();
+        bucket.Name.Returns("app");
+        bucket.Collections.Returns(collections);
+        cluster.BucketAsync("app").Returns(bucket);
+        clusters
+            .GetClusterAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new CouchbaseClusterConnection { Cluster = cluster, Transactions = null! });
+        collections.GetAllScopesAsync(Arg.Any<GetAllScopesOptions?>()).Returns(Task.FromResult(scopes));
+
+        var manager = new CouchbaseManager(
+            clusters,
+            Options.Create(
+                new CouchbaseManagerOptions
+                {
+                    MaxRetries = 1,
+                    RetryDelay = TimeSpan.Zero,
+                    Timeout = TimeSpan.FromSeconds(5),
+                }
+            ),
+            NullLogger<CouchbaseManager>.Instance
+        );
+
+        return new(manager, cluster, bucket, collections);
+    }
+
+    private static ScopeSpec _Scope(string scope, params string[] collections)
+    {
+        return new(scope) { Collections = [.. collections.Select(name => new CollectionSpec(scope, name))] };
+    }
+
+    private sealed record ManagerFixture(
+        CouchbaseManager Manager,
+        ICluster Cluster,
+        IBucket Bucket,
+        ICouchbaseCollectionManager Collections
+    );
 }

--- a/tests/Headless.Couchbase.Tests.Unit/DocumentSetExtensionsTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/DocumentSetExtensionsTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Couchbase.Core.Exceptions.KeyValue;
+using Couchbase.KeyValue;
+using Couchbase.KeyValue.RangeScan;
+using Couchbase.Linq;
+using Headless.Couchbase.Context;
+using Headless.Testing.Tests;
+
+namespace Tests;
+
+public sealed class DocumentSetExtensionsTests : TestBase
+{
+    [Fact]
+    public async Task should_get_document_by_stringified_id()
+    {
+        var (set, collection) = _CreateSet();
+        var result = Substitute.For<IGetResult>();
+        var document = new TestDocument { Id = "42", Value = "found" };
+        result.ContentAs<TestDocument>().Returns(document);
+        collection.GetAsync("42", Arg.Any<GetOptions>()).Returns(result);
+
+        var actual = await set.GetAsync<TestDocument, int>(42, AbortToken);
+
+        actual.Should().BeSameAs(document);
+        await collection.Received(1).GetAsync("42", Arg.Any<GetOptions>());
+    }
+
+    [Fact]
+    public async Task should_return_null_when_document_is_missing()
+    {
+        var (set, collection) = _CreateSet();
+        collection
+            .GetAsync("missing", Arg.Any<GetOptions?>())
+            .Returns(Task.FromException<IGetResult>(new DocumentNotFoundException()));
+
+        var actual = await set.GetAsync<TestDocument, string>("missing", new GetOptions());
+
+        actual.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task should_forward_exists_request_with_exact_options()
+    {
+        var (set, collection) = _CreateSet();
+        var options = new ExistsOptions();
+
+        await set.ExistsAsync<TestDocument, int>(42, options);
+
+        await collection.Received(1).ExistsAsync("42", options);
+    }
+
+    [Fact]
+    public async Task should_upsert_using_composite_entity_key()
+    {
+        var (set, collection) = _CreateSet<CompositeDocument>();
+        var document = new CompositeDocument("tenant", 42);
+        var options = new UpsertOptions();
+
+        await set.UpsertAsync(document, options);
+
+        await collection.Received(1).UpsertAsync("tenant:42", document, options);
+    }
+
+    [Fact]
+    public async Task should_insert_using_entity_key()
+    {
+        var (set, collection) = _CreateSet();
+        var document = new TestDocument { Id = "doc-1" };
+        var options = new InsertOptions();
+
+        await set.InsertAsync(document, options);
+
+        await collection.Received(1).InsertAsync("doc-1", document, options);
+    }
+
+    [Fact]
+    public async Task should_replace_using_entity_key()
+    {
+        var (set, collection) = _CreateSet();
+        var document = new TestDocument { Id = "doc-1" };
+        var options = new ReplaceOptions();
+
+        await set.ReplaceAsync(document, options);
+
+        await collection.Received(1).ReplaceAsync("doc-1", document, options);
+    }
+
+    [Fact]
+    public async Task should_remove_stringified_id()
+    {
+        var (set, collection) = _CreateSet();
+        var options = new RemoveOptions();
+
+        await set.RemoveAsync<TestDocument, int>(42, options);
+
+        await collection.Received(1).RemoveAsync("42", options);
+    }
+
+    [Fact]
+    public async Task should_unlock_stringified_id_with_cas()
+    {
+        var (set, collection) = _CreateSet();
+        var options = new UnlockOptions();
+
+        await set.UnlockAsync<TestDocument, int>(42, 123UL, options);
+
+        await collection.Received(1).UnlockAsync("42", 123UL, options);
+    }
+
+    [Fact]
+    public async Task should_forward_touch_and_read_expiry_operations()
+    {
+        var (set, collection) = _CreateSet();
+        var expiry = TimeSpan.FromMinutes(5);
+        var touchOptions = new TouchOptions();
+        var getAndTouchOptions = new GetAndTouchOptions();
+
+        await set.TouchAsync<TestDocument, int>(42, expiry, touchOptions);
+        await set.TouchWithCasAsync<TestDocument, int>(42, expiry, touchOptions);
+        await set.GetAndTouchAsync<TestDocument, int>(42, expiry, getAndTouchOptions);
+
+        await collection.Received(1).TouchAsync("42", expiry, touchOptions);
+        await collection.Received(1).TouchWithCasAsync("42", expiry, touchOptions);
+        await collection.Received(1).GetAndTouchAsync("42", expiry, getAndTouchOptions);
+    }
+
+    [Fact]
+    public async Task should_forward_lock_and_replica_reads()
+    {
+        var (set, collection) = _CreateSet();
+        var expiry = TimeSpan.FromSeconds(10);
+        var lockOptions = new GetAndLockOptions();
+        var anyReplicaOptions = new GetAnyReplicaOptions();
+        var allReplicaOptions = new GetAllReplicasOptions();
+
+        await set.GetAndLockAsync<TestDocument, int>(42, expiry, lockOptions);
+        await set.GetAnyReplicaAsync<TestDocument, int>(42, anyReplicaOptions);
+        _ = set.GetAllReplicas<TestDocument, int>(42, allReplicaOptions).ToList();
+
+        await collection.Received(1).GetAndLockAsync("42", expiry, lockOptions);
+        await collection.Received(1).GetAnyReplicaAsync("42", anyReplicaOptions);
+        collection.Received(1).GetAllReplicasAsync("42", allReplicaOptions);
+    }
+
+    [Fact]
+    public async Task should_forward_subdocument_reads_and_mutations()
+    {
+        var (set, collection) = _CreateSet();
+        LookupInSpec[] lookupSpecs = [LookupInSpec.Get("profile.name")];
+        MutateInSpec[] mutationSpecs = [MutateInSpec.Upsert("profile.active", true)];
+        var lookupOptions = new LookupInOptions();
+        var lookupAnyOptions = new LookupInAnyReplicaOptions();
+        var lookupAllOptions = new LookupInAllReplicasOptions();
+        var mutationOptions = new MutateInOptions();
+
+        await set.LookupInAsync<TestDocument, int>(42, lookupSpecs, lookupOptions);
+        await set.LookupInAnyReplicaAsync<TestDocument, int>(42, lookupSpecs, lookupAnyOptions);
+        _ = set.LookupInAllReplicasAsync<TestDocument, int>(42, lookupSpecs, lookupAllOptions);
+        await set.MutateInAsync<TestDocument, int>(42, mutationSpecs, mutationOptions);
+
+        await collection.Received(1).LookupInAsync("42", lookupSpecs, lookupOptions);
+        await collection.Received(1).LookupInAnyReplicaAsync("42", lookupSpecs, lookupAnyOptions);
+        collection.Received(1).LookupInAllReplicasAsync("42", lookupSpecs, lookupAllOptions);
+        await collection.Received(1).MutateInAsync("42", mutationSpecs, mutationOptions);
+    }
+
+    [Fact]
+    public void should_return_collection_scan_stream()
+    {
+        var (set, collection) = _CreateSet();
+        var scanType = Substitute.For<IScanType>();
+        var options = new ScanOptions();
+        var expected = Substitute.For<IAsyncEnumerable<IScanResult>>();
+        collection.ScanAsync(scanType, options).Returns(expected);
+
+        var actual = set.ScanAsync(scanType, options);
+
+        actual.Should().BeSameAs(expected);
+    }
+
+    private static (IDocumentSet<TestDocument> Set, ICouchbaseCollection Collection) _CreateSet()
+    {
+        return _CreateSet<TestDocument>();
+    }
+
+    private static (IDocumentSet<T> Set, ICouchbaseCollection Collection) _CreateSet<T>()
+    {
+        var set = Substitute.For<IDocumentSet<T>>();
+        var collection = Substitute.For<ICouchbaseCollection>();
+        set.Collection.Returns(collection);
+
+        return (set, collection);
+    }
+
+    public sealed record CompositeDocument(string Tenant, int Number) : Headless.Domain.IEntity
+    {
+        public IReadOnlyList<object> GetKeys() => [Tenant, Number];
+    }
+}

--- a/tests/Headless.Couchbase.Tests.Unit/SetupCouchbaseTests.cs
+++ b/tests/Headless.Couchbase.Tests.Unit/SetupCouchbaseTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Couchbase;
+using Headless.Couchbase.Clusters;
+using Headless.Couchbase.ContextProvider;
+using Headless.Couchbase.Managers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Tests;
+
+public sealed class SetupCouchbaseTests
+{
+    [Fact]
+    public void should_register_framework_services_as_singletons()
+    {
+        var services = new ServiceCollection();
+        Type[] serviceTypes =
+        [
+            typeof(ICouchbaseClustersProvider),
+            typeof(IBucketContextProvider),
+            typeof(ICouchbaseManager),
+            typeof(ICouchbaseAssemblyCollectionsReader),
+        ];
+
+        services.AddHeadlessCouchbase();
+
+        foreach (var serviceType in serviceTypes)
+        {
+            services
+                .Should()
+                .ContainSingle(x => x.ServiceType == serviceType)
+                .Which.Lifetime.Should()
+                .Be(ServiceLifetime.Singleton);
+        }
+    }
+
+    [Fact]
+    public void should_preserve_consumer_overrides()
+    {
+        var services = new ServiceCollection();
+        var manager = Substitute.For<ICouchbaseManager>();
+        services.AddSingleton(manager);
+
+        services.AddHeadlessCouchbase();
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ICouchbaseManager>().Should().BeSameAs(manager);
+    }
+
+    [Fact]
+    public void should_bind_manager_options_from_configuration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    [nameof(CouchbaseManagerOptions.MaxRetries)] = "5",
+                    [nameof(CouchbaseManagerOptions.RetryDelay)] = "00:00:00.250",
+                    [nameof(CouchbaseManagerOptions.Timeout)] = "00:00:20",
+                }
+            )
+            .Build();
+        var services = new ServiceCollection();
+        services.AddHeadlessCouchbase(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<CouchbaseManagerOptions>>().Value;
+
+        options.MaxRetries.Should().Be(5);
+        options.RetryDelay.Should().Be(TimeSpan.FromMilliseconds(250));
+        options.Timeout.Should().Be(TimeSpan.FromSeconds(20));
+    }
+
+    [Fact]
+    public void should_configure_manager_options_with_service_provider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new RetrySettings(7));
+        services.AddHeadlessCouchbase(
+            (options, provider) => options.MaxRetries = provider.GetRequiredService<RetrySettings>().MaxRetries
+        );
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<CouchbaseManagerOptions>>().Value.MaxRetries.Should().Be(7);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 1000)]
+    [InlineData(1, -1, 1000)]
+    [InlineData(1, 0, 10)]
+    [InlineData(1, 0, 86_400_000)]
+    public void should_reject_invalid_manager_options(int maxRetries, int retryDelayMs, int timeoutMs)
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessCouchbase(options =>
+        {
+            options.MaxRetries = maxRetries;
+            options.RetryDelay = TimeSpan.FromMilliseconds(retryDelayMs);
+            options.Timeout = TimeSpan.FromMilliseconds(timeoutMs);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var act = () => provider.GetRequiredService<IOptions<CouchbaseManagerOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>();
+    }
+
+    private sealed record RetrySettings(int MaxRetries);
+}


### PR DESCRIPTION
## Ticket / Work Item

Internal tracking intentionally omitted.

## Summary

- Headless.Couchbase now has deterministic regression coverage for manager lifecycle and cache invalidation, bucket/context initialization, cluster-provider cancellation and retry behavior, document operations, eventing payloads, DI configuration, disposal, and failure paths.
- The tests isolate caller cancellation from shared connection work and verify exact operation ordering and keyspace selection without relying on a live Couchbase endpoint.
- This is test-only: no production behavior, public API, dependencies, or generated code changed.

### Coverage

Fixed assembly universe: `Headless.Couchbase`, Release configuration.

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Line | 42/796 (5.2%) | 598/796 (75.1%) | +556 lines, +69.9 pp |
| Branch | 11/282 (3.9%) | 145/282 (51.4%) | +134 branches, +47.5 pp |
| Method | 4/124 (3.2%) | 106/124 (85.4%) | +102 methods, +82.2 pp |
| Fully covered method | 2/124 (1.6%) | 90/124 (72.5%) | +88 methods, +70.9 pp |

## Screenshots / Recording for any UI change

N/A - test-only library change with no UI surface.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated - N/A; deterministic unit paths require no external infrastructure
- [ ] Manual testing completed - N/A; no runtime behavior changed

Test evidence / result:

- Couchbase focused Release run with coverage: 51 passed, 0 skipped, 0 failed.
- Couchbase project build: 0 warnings, 0 errors.
- `make format-check`: 4,102 files checked successfully.
- Warning-level project analyzer gate: 0 warnings/errors.
- Full Release solution build: 378 projects, 0 warnings, 0 errors.
- Repository sequential unit run: 10,628 passed, 2 skipped, 1 failed in an unrelated messaging telemetry assertion. The failed test passed on focused retry, and its complete project then passed 1,065/1,065 with 0 skipped/failed.

## Reviewer Notes

The public successful `Cluster.ConnectAsync` / transaction readiness path still needs live Couchbase infrastructure; this PR covers deterministic provider contracts without weakening them into endpoint-dependent mocks. Transaction execution, concurrent scope creation, idempotent SDK already-exists exceptions, and generated logger branches remain the main weak areas.

## Risk / Impact

Low. Ownership is limited to Couchbase unit tests and fixtures. The SDK-backed fixture uses reflection only where Couchbase keeps required context service construction internal; no production seam was added.

## Post-Deploy

No additional operational monitoring is required because this change has no runtime impact.
