### PR TITLE
test(caching): expand hybrid cache behavior coverage

### DIFF
--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheInvalidationConsumerTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheInvalidationConsumerTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Messaging;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests;
+
+public sealed class HybridCacheInvalidationConsumerTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    [Fact]
+    public async Task should_route_unnamed_message_to_default_hybrid()
+    {
+        using var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        using var l2 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        var cache = new HybridCache(
+            l1,
+            new InMemoryRemoteCacheAdapter(l2),
+            Substitute.For<IBus>(),
+            new HybridCacheOptions { InstanceId = "node-b" },
+            timeProvider: _timeProvider
+        );
+        await using var _ = cache;
+        const string key = "key";
+        const string otherKey = "other-key";
+        await l1.UpsertAsync(key, "value", TimeSpan.FromMinutes(5), AbortToken);
+        await l1.UpsertAsync(otherKey, "other-value", TimeSpan.FromMinutes(5), AbortToken);
+        await l2.UpsertAsync(key, "value", TimeSpan.FromMinutes(5), AbortToken);
+        var provider = Substitute.For<ICacheProvider>();
+        provider.GetCacheOrNull(CacheConstants.HybridCacheProvider).Returns(cache);
+        var consumer = _CreateConsumer(provider);
+
+        await consumer.ConsumeAsync(
+            _CreateContext(new CacheInvalidationMessage { InstanceId = "node-a", Key = key }),
+            AbortToken
+        );
+
+        (await l1.ExistsAsync(key, AbortToken)).Should().BeFalse();
+        (await l1.ExistsAsync(otherKey, AbortToken)).Should().BeTrue();
+        (await l2.ExistsAsync(key, AbortToken)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task should_ignore_message_when_target_cache_is_not_registered()
+    {
+        var provider = Substitute.For<ICacheProvider>();
+        provider.GetCacheOrNull("missing").Returns((ICache?)null);
+        var consumer = _CreateConsumer(provider);
+
+        var act = async () =>
+            await consumer.ConsumeAsync(
+                _CreateContext(
+                    new CacheInvalidationMessage
+                    {
+                        InstanceId = "node-a",
+                        CacheName = "missing",
+                        Key = "key",
+                    }
+                ),
+                AbortToken
+            );
+
+        await act.Should().NotThrowAsync();
+        provider.Received(1).GetCacheOrNull("missing");
+    }
+
+    [Fact]
+    public async Task should_swallow_non_cancellation_failure_at_consumer_boundary()
+    {
+        var provider = Substitute.For<ICacheProvider>();
+        provider
+            .GetCacheOrNull(CacheConstants.HybridCacheProvider)
+            .Returns(_ => throw new InvalidOperationException("provider failed"));
+        var consumer = _CreateConsumer(provider);
+
+        var act = async () =>
+            await consumer.ConsumeAsync(
+                _CreateContext(new CacheInvalidationMessage { InstanceId = "node-a", Key = "key" }),
+                AbortToken
+            );
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task should_propagate_caller_cancellation_from_consumer_boundary()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        var provider = Substitute.For<ICacheProvider>();
+        provider
+            .GetCacheOrNull(CacheConstants.HybridCacheProvider)
+            .Returns(_ => throw new OperationCanceledException(cancellation.Token));
+        var consumer = _CreateConsumer(provider);
+
+        var act = async () =>
+            await consumer.ConsumeAsync(
+                _CreateContext(new CacheInvalidationMessage { InstanceId = "node-a", Key = "key" }),
+                cancellation.Token
+            );
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private static HybridCacheInvalidationConsumer _CreateConsumer(ICacheProvider provider)
+    {
+        return new(provider, NullLogger<HybridCacheInvalidationConsumer>.Instance);
+    }
+
+    private ConsumeContext<CacheInvalidationMessage> _CreateContext(CacheInvalidationMessage message)
+    {
+        return new()
+        {
+            Lane = MessageLane.Bus,
+            Message = message,
+            MessageId = Faker.Random.Guid().ToString(),
+            CorrelationId = null,
+            Headers = new MessageHeader(new Dictionary<string, string?>(StringComparer.Ordinal)),
+            Timestamp = _timeProvider.GetUtcNow(),
+            MessageName = nameof(CacheInvalidationMessage),
+        };
+    }
+}

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheNumericOperationsTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheNumericOperationsTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Messaging;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests;
+
+public sealed class HybridCacheNumericOperationsTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly List<IDisposable> _disposables = [];
+
+    private (HybridCache cache, InMemoryCache l1, InMemoryCache l2, IBus bus) _CreateCache()
+    {
+        var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });
+        var l2 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });
+        var bus = Substitute.For<IBus>();
+        bus.PublishAsync(Arg.Any<CacheInvalidationMessage>(), Arg.Any<PublishOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var cache = new HybridCache(
+            l1,
+            new InMemoryRemoteCacheAdapter(l2),
+            bus,
+            new HybridCacheOptions(),
+            timeProvider: _timeProvider
+        );
+
+        _disposables.Add(l1);
+        _disposables.Add(l2);
+        return (cache, l1, l2, bus);
+    }
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+
+        _disposables.Clear();
+        await base.DisposeAsyncCore().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task should_sync_double_increment_result_from_l2_to_l1()
+    {
+        var (cache, l1, l2, bus) = _CreateCache();
+        await using var _ = cache;
+        const string key = "counter";
+        var expiration = TimeSpan.FromMinutes(5);
+        await l1.UpsertAsync(key, 99d, expiration, AbortToken);
+        await l2.UpsertAsync(key, 1.5d, expiration, AbortToken);
+
+        var result = await cache.IncrementAsync(key, 0.5d, expiration, AbortToken);
+
+        result.Should().Be(2d);
+        (await l1.GetAsync<double>(key, AbortToken)).Value.Should().Be(2d);
+        (await l2.GetAsync<double>(key, AbortToken)).Value.Should().Be(2d);
+        await bus.Received(1)
+            .PublishAsync(
+                Arg.Is<CacheInvalidationMessage>(message => message.Key == key),
+                Arg.Any<PublishOptions?>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task should_sync_higher_value_to_l1_when_l2_changes()
+    {
+        var (cache, l1, l2, _) = _CreateCache();
+        await using var _ = cache;
+        const string key = "high-watermark";
+        var expiration = TimeSpan.FromMinutes(5);
+        await l2.UpsertAsync(key, 5L, expiration, AbortToken);
+
+        var difference = await cache.SetIfHigherAsync(key, 10L, expiration, AbortToken);
+
+        difference.Should().Be(5L);
+        (await l1.GetAsync<long>(key, AbortToken)).Value.Should().Be(10L);
+        (await l2.GetAsync<long>(key, AbortToken)).Value.Should().Be(10L);
+    }
+
+    [Fact]
+    public async Task should_evict_unknown_l1_value_when_set_if_higher_does_not_change_l2()
+    {
+        var (cache, l1, l2, _) = _CreateCache();
+        await using var _ = cache;
+        const string key = "high-watermark";
+        var expiration = TimeSpan.FromMinutes(5);
+        await l1.UpsertAsync(key, 1d, expiration, AbortToken);
+        await l2.UpsertAsync(key, 10d, expiration, AbortToken);
+
+        var difference = await cache.SetIfHigherAsync(key, 9d, expiration, AbortToken);
+
+        difference.Should().Be(0d);
+        (await l1.GetAsync<double>(key, AbortToken)).HasValue.Should().BeFalse();
+        (await l2.GetAsync<double>(key, AbortToken)).Value.Should().Be(10d);
+    }
+
+    [Fact]
+    public async Task should_sync_lower_value_to_l1_when_l2_changes()
+    {
+        var (cache, l1, l2, _) = _CreateCache();
+        await using var _ = cache;
+        const string key = "low-watermark";
+        var expiration = TimeSpan.FromMinutes(5);
+        await l2.UpsertAsync(key, 10d, expiration, AbortToken);
+
+        var difference = await cache.SetIfLowerAsync(key, 4d, expiration, AbortToken);
+
+        difference.Should().Be(6d);
+        (await l1.GetAsync<double>(key, AbortToken)).Value.Should().Be(4d);
+        (await l2.GetAsync<double>(key, AbortToken)).Value.Should().Be(4d);
+    }
+
+    [Fact]
+    public async Task should_evict_unknown_l1_value_when_set_if_lower_does_not_change_l2()
+    {
+        var (cache, l1, l2, _) = _CreateCache();
+        await using var _ = cache;
+        const string key = "low-watermark";
+        var expiration = TimeSpan.FromMinutes(5);
+        await l1.UpsertAsync(key, 99L, expiration, AbortToken);
+        await l2.UpsertAsync(key, 4L, expiration, AbortToken);
+
+        var difference = await cache.SetIfLowerAsync(key, 5L, expiration, AbortToken);
+
+        difference.Should().Be(0L);
+        (await l1.GetAsync<long>(key, AbortToken)).HasValue.Should().BeFalse();
+        (await l2.GetAsync<long>(key, AbortToken)).Value.Should().Be(4L);
+    }
+
+    [Theory]
+    [InlineData(NumericOperation.IncrementDouble)]
+    [InlineData(NumericOperation.IncrementLong)]
+    [InlineData(NumericOperation.HigherDouble)]
+    [InlineData(NumericOperation.HigherLong)]
+    [InlineData(NumericOperation.LowerDouble)]
+    [InlineData(NumericOperation.LowerLong)]
+    public async Task should_remove_existing_value_when_numeric_expiration_is_zero(NumericOperation operation)
+    {
+        var (cache, l1, l2, _) = _CreateCache();
+        await using var _ = cache;
+        var key = $"expired-{operation}";
+        var expiration = TimeSpan.FromMinutes(5);
+        await l1.UpsertAsync(key, 10d, expiration, AbortToken);
+        await l2.UpsertAsync(key, 10d, expiration, AbortToken);
+
+        var result = operation switch
+        {
+            NumericOperation.IncrementDouble => await cache.IncrementAsync(key, 1d, TimeSpan.Zero, AbortToken),
+            NumericOperation.IncrementLong => await cache.IncrementAsync(key, 1L, TimeSpan.Zero, AbortToken),
+            NumericOperation.HigherDouble => await cache.SetIfHigherAsync(key, 11d, TimeSpan.Zero, AbortToken),
+            NumericOperation.HigherLong => await cache.SetIfHigherAsync(key, 11L, TimeSpan.Zero, AbortToken),
+            NumericOperation.LowerDouble => await cache.SetIfLowerAsync(key, 9d, TimeSpan.Zero, AbortToken),
+            NumericOperation.LowerLong => await cache.SetIfLowerAsync(key, 9L, TimeSpan.Zero, AbortToken),
+            _ => throw new InvalidOperationException($"Unknown operation: {operation}"),
+        };
+
+        result.Should().Be(0d);
+        (await l1.ExistsAsync(key, AbortToken)).Should().BeFalse();
+        (await l2.ExistsAsync(key, AbortToken)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_wipe_l1_and_not_queue_non_replay_safe_numeric_failure()
+    {
+        var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });
+        var remote = new TogglableRemoteCache(_timeProvider);
+        var bus = Substitute.For<IBus>();
+        bus.PublishAsync(Arg.Any<CacheInvalidationMessage>(), Arg.Any<PublishOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var cache = new HybridCache(
+            l1,
+            remote,
+            bus,
+            new HybridCacheOptions { EnableAutoRecovery = true },
+            timeProvider: _timeProvider
+        );
+        await using var _ = cache;
+        _disposables.Add(l1);
+        _disposables.Add(remote);
+        const string key = "counter";
+        await l1.UpsertAsync(key, 10d, TimeSpan.FromMinutes(5), AbortToken);
+        remote.FailWrites = true;
+
+        var act = async () => await cache.SetIfHigherAsync(key, 11d, TimeSpan.FromMinutes(5), AbortToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await l1.ExistsAsync(key, AbortToken)).Should().BeFalse();
+        cache.RecoveryQueue!.Count.Should().Be(0, "numeric deltas cannot be replayed safely");
+    }
+
+    public enum NumericOperation
+    {
+        IncrementDouble = 0,
+        IncrementLong = 1,
+        HigherDouble = 2,
+        HigherLong = 3,
+        LowerDouble = 4,
+        LowerLong = 5,
+    }
+}

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheReadMatrixTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheReadMatrixTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Messaging;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests;
+
+public sealed class HybridCacheReadMatrixTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    private (HybridCache cache, InMemoryCache l1, IRemoteCache l2) _CreateCache(HybridCacheOptions? options = null)
+    {
+        var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });
+        var l2 = Substitute.For<IRemoteCache>();
+
+        return (
+            new HybridCache(
+                l1,
+                l2,
+                Substitute.For<IBus>(),
+                options ?? new HybridCacheOptions(),
+                timeProvider: _timeProvider
+            ),
+            l1,
+            l2
+        );
+    }
+
+    [Fact]
+    public async Task should_return_l1_hit_without_reading_non_framed_l2()
+    {
+        var (cache, l1, l2) = _CreateCache();
+        await using var _ = cache;
+        using var __ = l1;
+        const string key = "l1-hit";
+        await l1.UpsertAsync(key, 7, TimeSpan.FromMinutes(5), AbortToken);
+
+        var result = await cache.GetAsync<int>(key, AbortToken);
+
+        result.Value.Should().Be(7);
+        await l2.DidNotReceive().GetWithExpirationAsync<int>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task should_preserve_shorter_l2_expiration_when_promoting_non_framed_hit()
+    {
+        var (cache, l1, l2) = _CreateCache();
+        await using var _ = cache;
+        using var __ = l1;
+        const string key = "l2-hit";
+        var l2Expiration = TimeSpan.FromMinutes(2);
+        l2.GetWithExpirationAsync<int>(key, Arg.Any<CancellationToken>())
+            .Returns(new CacheValueWithExpiration<int>(new CacheValue<int>(42, hasValue: true), l2Expiration));
+
+        var result = await cache.GetAsync<int>(key, AbortToken);
+
+        result.Value.Should().Be(42);
+        (await l1.GetAsync<int>(key, AbortToken)).Value.Should().Be(42);
+        (await l1.GetExpirationAsync(key, AbortToken)).Should().Be(l2Expiration);
+    }
+
+    [Fact]
+    public async Task should_cap_non_framed_l2_expiration_when_promoting_to_l1()
+    {
+        var localExpiration = TimeSpan.FromMinutes(1);
+        var (cache, l1, l2) = _CreateCache(new HybridCacheOptions { DefaultLocalExpiration = localExpiration });
+        await using var _ = cache;
+        using var __ = l1;
+        const string key = "long-lived-l2-hit";
+        l2.GetWithExpirationAsync<int>(key, Arg.Any<CancellationToken>())
+            .Returns(
+                new CacheValueWithExpiration<int>(new CacheValue<int>(42, hasValue: true), TimeSpan.FromMinutes(30))
+            );
+
+        var result = await cache.GetAsync<int>(key, AbortToken);
+
+        result.Value.Should().Be(42);
+        (await l1.GetExpirationAsync(key, AbortToken)).Should().Be(localExpiration);
+    }
+
+    [Fact]
+    public async Task should_preserve_miss_when_non_framed_l2_has_no_value()
+    {
+        var (cache, l1, l2) = _CreateCache();
+        await using var _ = cache;
+        using var __ = l1;
+        const string key = "missing";
+        l2.GetWithExpirationAsync<int>(key, Arg.Any<CancellationToken>())
+            .Returns(new CacheValueWithExpiration<int>(CacheValue<int>.NoValue, null));
+
+        var result = await cache.GetAsync<int>(key, AbortToken);
+
+        result.HasValue.Should().BeFalse();
+        (await l1.ExistsAsync(key, AbortToken)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task should_merge_l1_hits_and_non_framed_l2_results_and_seed_only_hits()
+    {
+        var (cache, l1, l2) = _CreateCache();
+        await using var _ = cache;
+        using var __ = l1;
+        var expiration = TimeSpan.FromMinutes(3);
+        await l1.UpsertAsync("local", 1, expiration, AbortToken);
+        l2.GetAllWithExpirationAsync<int>(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(
+                new Dictionary<string, CacheValueWithExpiration<int>>(StringComparer.Ordinal)
+                {
+                    ["remote"] = new(new CacheValue<int>(2, hasValue: true), expiration),
+                    ["missing"] = new(CacheValue<int>.NoValue, null),
+                }
+            );
+
+        var result = await cache.GetAllAsync<int>(["local", "remote", "missing"], AbortToken);
+
+        result["local"].Value.Should().Be(1);
+        result["remote"].Value.Should().Be(2);
+        result["missing"].HasValue.Should().BeFalse();
+        (await l1.GetAsync<int>("remote", AbortToken)).Value.Should().Be(2);
+        (await l1.ExistsAsync("missing", AbortToken)).Should().BeFalse();
+        await l2.Received(1)
+            .GetAllWithExpirationAsync<int>(
+                Arg.Is<IEnumerable<string>>(keys => keys.Order().SequenceEqual(new[] { "missing", "remote" })),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task should_short_circuit_exists_on_l1_hit()
+    {
+        var (cache, l1, l2) = _CreateCache();
+        await using var _ = cache;
+        using var __ = l1;
+        const string key = "exists";
+        await l1.UpsertAsync(key, 1, TimeSpan.FromMinutes(5), AbortToken);
+
+        (await cache.ExistsAsync(key, AbortToken)).Should().BeTrue();
+
+        await l2.DidNotReceive().ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        cache.LocalCacheHits.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task should_fall_back_to_l2_for_exists_and_expiration_misses()
+    {
+        var (cache, l1, l2) = _CreateCache();
+        await using var _ = cache;
+        using var __ = l1;
+        const string key = "remote";
+        var expiration = TimeSpan.FromMinutes(4);
+        l2.ExistsAsync(key, Arg.Any<CancellationToken>()).Returns(true);
+        l2.GetExpirationAsync(key, Arg.Any<CancellationToken>()).Returns(expiration);
+
+        (await cache.ExistsAsync(key, AbortToken)).Should().BeTrue();
+        (await cache.GetExpirationAsync(key, AbortToken)).Should().Be(expiration);
+    }
+
+    [Fact]
+    public async Task should_propagate_cancellation_during_l2_exists_read()
+    {
+        using var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions { CloneValues = true });
+        using var l2 = new GatedRemoteCache(_timeProvider)
+        {
+            ReadGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+        var cache = new HybridCache(
+            l1,
+            l2,
+            Substitute.For<IBus>(),
+            new HybridCacheOptions(),
+            timeProvider: _timeProvider
+        );
+        await using var _ = cache;
+        using var cancellation = new CancellationTokenSource();
+
+        Func<Task<bool>> act = () => cache.ExistsAsync("slow", cancellation.Token).AsTask();
+        var assertion = act.Should().ThrowAsync<OperationCanceledException>();
+
+        await l2.ReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        await cancellation.CancelAsync();
+        await assertion;
+    }
+}

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheRecoveryQueueConcurrencyTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheRecoveryQueueConcurrencyTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Caching;
+using Headless.Testing.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Tests;
+
+public sealed class HybridCacheRecoveryQueueConcurrencyTests : TestBase
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    [Fact]
+    public async Task should_run_only_one_recovery_pass_when_process_calls_overlap()
+    {
+        using var queue = _CreateQueue();
+        var replayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReplay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        queue.Enqueue(
+            "key",
+            HybridCacheRecoveryKind.SetEntry,
+            _timeProvider.GetUtcNow() + TimeSpan.FromMinutes(5),
+            async cancellationToken =>
+            {
+                Interlocked.Increment(ref attempts);
+                replayStarted.TrySetResult();
+                await releaseReplay.Task.WaitAsync(cancellationToken);
+                return HybridCacheRecoveryReplayOutcome.Replayed;
+            }
+        );
+
+        var firstPass = queue.ProcessAsync(AbortToken);
+        try
+        {
+            await replayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+
+            await queue.ProcessAsync(AbortToken).WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+            attempts.Should().Be(1);
+            queue.Count.Should().Be(1, "the in-flight replay still owns the queued item");
+        }
+        finally
+        {
+            releaseReplay.TrySetResult();
+            await firstPass.WaitAsync(TimeSpan.FromSeconds(5), AbortToken);
+        }
+
+        attempts.Should().Be(1);
+        queue.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task should_leave_items_queued_when_recovery_pass_is_cancelled_before_replay()
+    {
+        using var queue = _CreateQueue();
+        var attempts = 0;
+        queue.Enqueue(
+            "key",
+            HybridCacheRecoveryKind.Remove,
+            _timeProvider.GetUtcNow() + TimeSpan.FromMinutes(5),
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                return new ValueTask<HybridCacheRecoveryReplayOutcome>(HybridCacheRecoveryReplayOutcome.Replayed);
+            }
+        );
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await queue.ProcessAsync(cancellation.Token);
+
+        attempts.Should().Be(0);
+        queue.Count.Should().Be(1, "cancellation must not lose pending recovery work");
+
+        await queue.ProcessAsync(AbortToken);
+
+        attempts.Should().Be(1, "a cancelled pass must release the process gate");
+        queue.Count.Should().Be(0);
+    }
+
+    private HybridCacheRecoveryQueue _CreateQueue()
+    {
+        return new(
+            new HybridCacheOptions { EnableAutoRecovery = true, AutoRecoveryMaxRetries = 2 },
+            _timeProvider,
+            NullLogger.Instance
+        );
+    }
+}

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSetupTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/HybridCacheSetupTests.cs
@@ -3,6 +3,7 @@
 using Headless.Caching;
 using Headless.Messaging;
 using Headless.Testing.Tests;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 
@@ -18,26 +19,9 @@ public sealed class HybridCacheSetupTests : TestBase
     {
         // given - a memory tier plus a fake remote tier (the Redis-backed equivalent of AddRedisTier is
         // exercised in the Redis integration suite), composed under a default hybrid
-        var services = new ServiceCollection();
-        services.AddSingleton<TimeProvider>(_timeProvider);
-        services.AddSingleton(Substitute.For<IBus>());
-
         using var l2Inner = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
         var remote = new InMemoryRemoteCacheAdapter(l2Inner);
-
-        services.AddHeadlessCaching(setup =>
-        {
-            setup.AddMemoryTier();
-            setup.RegisterTierProvider(
-                CacheConstants.RemoteCacheProvider,
-                svc =>
-                {
-                    svc.AddSingleton<IRemoteCache>(remote);
-                    svc.AddKeyedSingleton<ICache>(CacheConstants.RemoteCacheProvider, remote);
-                }
-            );
-            setup.UseHybrid();
-        });
+        var services = _CreateServices(remote, setup => setup.UseHybrid());
 
         await using var provider = services.BuildServiceProvider();
 
@@ -61,4 +45,73 @@ public sealed class HybridCacheSetupTests : TestBase
         (await memoryTier.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
         (await l2Inner.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
     }
+
+    [Fact]
+    public async Task should_configure_default_hybrid_with_service_provider_aware_action()
+    {
+        using var l2Inner = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        var remote = new InMemoryRemoteCacheAdapter(l2Inner);
+        var services = _CreateServices(
+            remote,
+            setup =>
+                setup.UseHybrid(
+                    (options, provider) => options.InstanceId = provider.GetRequiredService<SetupIdentity>().Value
+                )
+        );
+        services.AddSingleton(new SetupIdentity("configured-node"));
+
+        await using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredService<HybridCache>();
+
+        provider.GetRequiredService<HybridCacheOptions>().InstanceId.Should().Be("configured-node");
+        await cache.UpsertAsync("key", "value", TimeSpan.FromMinutes(5), AbortToken);
+        (await l2Inner.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
+    }
+
+    [Fact]
+    public async Task should_bind_default_hybrid_options_from_configuration()
+    {
+        using var l2Inner = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        var remote = new InMemoryRemoteCacheAdapter(l2Inner);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    [nameof(HybridCacheOptions.InstanceId)] = "configuration-node",
+                    [nameof(HybridCacheOptions.DefaultLocalExpiration)] = "00:03:00",
+                }
+            )
+            .Build();
+        var services = _CreateServices(remote, setup => setup.UseHybrid(configuration));
+
+        await using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ICache>().Should().BeOfType<HybridCache>();
+        var options = provider.GetRequiredService<HybridCacheOptions>();
+
+        options.InstanceId.Should().Be("configuration-node");
+        options.DefaultLocalExpiration.Should().Be(TimeSpan.FromMinutes(3));
+    }
+
+    private ServiceCollection _CreateServices(IRemoteCache remote, Action<HeadlessCachingSetupBuilder> configureHybrid)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TimeProvider>(_timeProvider);
+        services.AddSingleton(Substitute.For<IBus>());
+        services.AddHeadlessCaching(setup =>
+        {
+            setup.AddMemoryTier();
+            setup.RegisterTierProvider(
+                CacheConstants.RemoteCacheProvider,
+                svc =>
+                {
+                    svc.AddSingleton<IRemoteCache>(remote);
+                    svc.AddKeyedSingleton<ICache>(CacheConstants.RemoteCacheProvider, remote);
+                }
+            );
+            configureHybrid(setup);
+        });
+        return services;
+    }
+
+    private sealed record SetupIdentity(string Value);
 }

--- a/tests/Headless.Caching.Hybrid.Tests.Unit/NamedHybridCacheTests.cs
+++ b/tests/Headless.Caching.Hybrid.Tests.Unit/NamedHybridCacheTests.cs
@@ -3,8 +3,10 @@
 using Headless.Caching;
 using Headless.Messaging;
 using Headless.Testing.Tests;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Tests;
@@ -419,6 +421,82 @@ public sealed class NamedHybridCacheTests : TestBase
         factoryCalls.Should().Be(2, "per-call options must beat the hybrid's default and both tier defaults");
     }
 
+    [Fact]
+    public async Task should_configure_named_hybrid_with_service_provider_aware_action()
+    {
+        var services = _CreateBaseServices();
+        var tierNames = new TierNames("tenant-l1", "tenant-l2");
+        services.AddSingleton(tierNames);
+        using var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        using var l2Inner = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        services.AddKeyedSingleton<ICache>(tierNames.Local, l1);
+        services.AddKeyedSingleton<ICache>(tierNames.Remote, new InMemoryRemoteCacheAdapter(l2Inner));
+        services.AddHeadlessCaching(setup =>
+        {
+            setup.RegisterDefaultProvider(CacheConstants.MemoryCacheProvider, static _ => { });
+            setup.AddNamed(
+                "tenant",
+                instance =>
+                    instance.UseHybrid(
+                        (options, provider) =>
+                        {
+                            var names = provider.GetRequiredService<TierNames>();
+                            options.LocalCacheName = names.Local;
+                            options.RemoteCacheName = names.Remote;
+                            options.CacheName = "caller-override";
+                        }
+                    )
+            );
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredKeyedService<ICache>("tenant");
+        await cache.UpsertAsync("key", "value", TimeSpan.FromMinutes(5), AbortToken);
+
+        (await l1.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
+        (await l2Inner.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
+        var options = provider.GetRequiredService<IOptionsMonitor<HybridCacheOptions>>().Get("tenant");
+        options.CacheName.Should().Be("tenant");
+        options.InvalidationRoutingName.Should().Be("tenant");
+    }
+
+    [Fact]
+    public async Task should_bind_named_hybrid_from_configuration_and_preserve_registration_identity()
+    {
+        var services = _CreateBaseServices();
+        using var l1 = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        using var l2Inner = new InMemoryCache(_timeProvider, new InMemoryCacheOptions());
+        services.AddKeyedSingleton<ICache>("configured-l1", l1);
+        services.AddKeyedSingleton<ICache>("configured-l2", new InMemoryRemoteCacheAdapter(l2Inner));
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    [nameof(HybridCacheOptions.LocalCacheName)] = "configured-l1",
+                    [nameof(HybridCacheOptions.RemoteCacheName)] = "configured-l2",
+                    [nameof(HybridCacheOptions.CacheName)] = "caller-override",
+                }
+            )
+            .Build();
+        services.AddHeadlessCaching(setup =>
+        {
+            setup.RegisterDefaultProvider(CacheConstants.MemoryCacheProvider, static _ => { });
+            setup.AddNamed("tenant", instance => instance.UseHybrid(configuration));
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredKeyedService<ICache>("tenant");
+        await cache.UpsertAsync("key", "value", TimeSpan.FromMinutes(5), AbortToken);
+
+        (await l1.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
+        (await l2Inner.GetAsync<string>("key", AbortToken)).Value.Should().Be("value");
+        var options = provider.GetRequiredService<IOptionsMonitor<HybridCacheOptions>>().Get("tenant");
+        options.CacheName.Should().Be("tenant");
+        options.InvalidationRoutingName.Should().Be("tenant");
+    }
+
     // Reserved-name rejection is owned by AddHeadlessCaching's AddNamed gate and is covered by
     // Headless.Caching.Core.Tests.Unit/CachingSetupBuilderTests.
+
+    private sealed record TierNames(string Local, string Remote);
 }


### PR DESCRIPTION
## Summary

- Adds regression coverage for Hybrid Cache L1/L2 hit and miss paths, promotion, fallback, expiration, invalidation, recovery, cancellation, concurrency, numeric operations, and named setup.
- Makes cancellation and invalidation assertions resistant to false positives by proving recovery-gate reuse and key-scoped L1-only invalidation behavior.
- Raises package coverage from 80.7% to 87.8% line, 68.3% to 75.6% branch, and 91.9% to 97.4% method coverage without production changes.

## Related Work

N/A

## Scope

Affected packages or domains:

- `Headless.Caching.Hybrid` tests and narrowly scoped test fixtures

Out of scope:

- Production behavior and public API changes
- Generated logger implementations
- Analyzer Info/Suggestion sweep
- Unrelated packages and provider behavior

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A — test-only change; production sources are unchanged.
```

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [x] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
Focused Hybrid coverage:
make test-project-fast TEST_PROJECT=tests/Headless.Caching.Hybrid.Tests.Unit/Headless.Caching.Hybrid.Tests.Unit.csproj TEST_RESULTS_DIR=artifacts/test-results/hybrid-after-rebase TEST_ARGS='-p:EnableCodeCoverage=true --coverage-output-format cobertura'
Result: 299 total, 299 passed, 0 skipped, 0 failed.

Fixed-universe coverage (Headless.Caching.Hybrid assembly):
Line:   80.7% (6312/7818) -> 87.8% (6870/7818), +7.1 pp / +558 covered lines
Branch: 68.3% (1919/2808) -> 75.6% (2124/2808), +7.3 pp / +205 covered branches
Method: 91.9% (469/510)  -> 97.4% (497/510),  +5.5 pp / +28 covered methods

make quality-analyzers-project PROJECT=tests/Headless.Caching.Hybrid.Tests.Unit/Headless.Caching.Hybrid.Tests.Unit.csproj
Result: passed with no analyzer findings.

make format-check
Result: 4,112 files checked; clean.

make build
Result: succeeded with 0 warnings and 0 errors.

make test-project TEST_PROJECT=tests/Headless.Caching.Redis.Tests.Integration/Headless.Caching.Redis.Tests.Integration.csproj
Result: 242 total, 242 passed, 0 skipped, 0 failed.

make ci-test TEST_MAX_PARALLEL=1
Result: 10,686 total, 10,684 passed, 2 skipped, 0 failed; sequential execution.
The two skips are existing PrimitiveGenerator unsupported primitive-of-primitive cases.

The repository-wide integration target was not run; the relevant Redis integration project passed sequentially.
Manual/end-to-end verification is not applicable to this test-only change.
```

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
No shared behavior, public API, package guidance, or provider contract changed; documentation and provider-conformance updates are not applicable.
```

## Reviewer Guide

- Start with `HybridCacheReadMatrixTests` for L1/L2 hits, misses, promotion, bulk reads, expiration caps, fallback, and cancellation.
- Review `HybridCacheInvalidationConsumerTests` and `HybridCacheRecoveryQueueConcurrencyTests` for error propagation, key-scoped invalidation, single-replay concurrency, cancellation retention, and gate recovery.
- Review `HybridCacheNumericOperationsTests`, `HybridCacheSetupTests`, and `NamedHybridCacheTests` for numeric mutation failures and default/named registration contracts.
- Production files are intentionally untouched. Remaining weak areas are high-combinatorial generic/bulk degradation paths, recovery queue retry/expiry/admission/timer edges, and registration/validator edge branches.

## Release Notes

N/A — internal test-only change.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this is a test-only change with no runtime package behavior changes. CI through merge is the validation window; failure signals are Hybrid/Redis suite regressions or package coverage regressions. The PR author owns follow-up, and mitigation is reverting the test-only commit.
