### PR TITLE
test: increase API Core and NSwag behavioral coverage

### DIFF
--- a/tests/Headless.Api.Composition.Tests.Unit/Diagnostics/DiagnosticListenerRegistrationTests.cs
+++ b/tests/Headless.Api.Composition.Tests.Unit/Diagnostics/DiagnosticListenerRegistrationTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Diagnostics;
+using Headless.Api;
+using Headless.Api.Diagnostics;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Tests.Diagnostics;
+
+public sealed class DiagnosticListenerRegistrationTests
+{
+    [Fact]
+    public async Task should_log_bad_request_until_composite_subscription_is_disposed()
+    {
+        // given
+        var listener = new DiagnosticListener("api-tests");
+        var loggerProvider = new CapturingLoggerProvider();
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(loggerProvider);
+        builder.Services.AddSingleton(listener);
+        await using var app = builder.Build();
+        var features = new FeatureCollection();
+        var exception = new BadHttpRequestException("invalid request line");
+        features.Set<IBadRequestExceptionFeature>(new BadRequestExceptionFeature(exception));
+
+        // when
+        var subscription = app.AddHeadlessApiDiagnosticListeners();
+        var payload = new
+        {
+            value = new KeyValuePair<string, object?>(DiagnosticSources.KestrelOnBadRequest, features),
+        };
+        listener.Write(DiagnosticSources.KestrelOnBadRequest, payload);
+        subscription.Dispose();
+        listener.Write(DiagnosticSources.KestrelOnBadRequest, payload);
+
+        // then
+        var entry = loggerProvider.Entries.Should().ContainSingle(item => item.EventId.Id == 5104).Which;
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Exception.Should().BeSameAs(exception);
+        entry.Message.Should().Be("Bad request received");
+    }
+
+    private sealed class BadRequestExceptionFeature(Exception error) : IBadRequestExceptionFeature
+    {
+        public Exception Error { get; } = error;
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new CapturingLogger(Entries);
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(List<LogEntry> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            entries.Add(new LogEntry(logLevel, eventId, exception, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, EventId EventId, Exception? Exception, string Message);
+}

--- a/tests/Headless.Api.Composition.Tests.Unit/Diagnostics/MiddlewareAnalysisDiagnosticAdapterTests.cs
+++ b/tests/Headless.Api.Composition.Tests.Unit/Diagnostics/MiddlewareAnalysisDiagnosticAdapterTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Api.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Tests.Diagnostics;
+
+public sealed class MiddlewareAnalysisDiagnosticAdapterTests
+{
+    [Fact]
+    public void should_log_structured_start_and_finish_events()
+    {
+        // given
+        var logger = new CapturingLogger();
+        var sut = new MiddlewareAnalysisDiagnosticAdapter(logger);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/orders/42";
+        context.Response.StatusCode = StatusCodes.Status202Accepted;
+
+        // when
+        sut.OnMiddlewareStarting(context, "OrdersMiddleware", Guid.Empty, 123);
+        sut.OnMiddlewareFinished(context, "OrdersMiddleware", Guid.Empty, 456, 17);
+
+        // then
+        logger.Entries.Should().HaveCount(2);
+        logger.Entries[0].EventId.Should().Be(new EventId(100, "MiddlewareStarting"));
+        logger.Entries[0].Message.Should().Contain("OrdersMiddleware").And.Contain("/orders/42").And.Contain("123");
+        logger.Entries[1].EventId.Should().Be(new EventId(101, "MiddlewareFinished"));
+        logger.Entries[1].Message.Should().Contain("OrdersMiddleware").And.Contain("17").And.Contain("202");
+    }
+
+    [Fact]
+    public void should_log_expanded_exception_details_when_information_enabled()
+    {
+        // given
+        var logger = new CapturingLogger();
+        var sut = new MiddlewareAnalysisDiagnosticAdapter(logger);
+        var exception = new InvalidOperationException("outer", new ArgumentException("inner"));
+
+        // when
+        sut.OnMiddlewareException(exception, new DefaultHttpContext(), "FailureMiddleware", Guid.Empty, 9, 3);
+
+        // then
+        var entry = logger.Entries.Should().ContainSingle().Which;
+        entry.EventId.Should().Be(new EventId(102, "MiddlewareException"));
+        entry.Exception.Should().BeSameAs(exception);
+        entry.Message.Should().Contain("FailureMiddleware").And.Contain("outer").And.Contain("inner");
+    }
+
+    [Fact]
+    public void should_not_expand_or_log_exception_when_information_disabled()
+    {
+        // given
+        var logger = new CapturingLogger { Enabled = false };
+        var sut = new MiddlewareAnalysisDiagnosticAdapter(logger);
+
+        // when
+        sut.OnMiddlewareException(
+            new InvalidOperationException("ignored"),
+            new DefaultHttpContext(),
+            "DisabledMiddleware",
+            Guid.Empty,
+            1,
+            2
+        );
+
+        // then
+        logger.Entries.Should().BeEmpty();
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public bool Enabled { get; init; } = true;
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return Enabled;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            Entries.Add(new LogEntry(logLevel, eventId, exception, formatter(state, exception)));
+        }
+
+        public sealed record LogEntry(LogLevel Level, EventId EventId, Exception? Exception, string Message);
+    }
+}

--- a/tests/Headless.Api.Composition.Tests.Unit/Extensions/Cookies/ConfigureApplicationCookiesExtensionsTests.cs
+++ b/tests/Headless.Api.Composition.Tests.Unit/Extensions/Cookies/ConfigureApplicationCookiesExtensionsTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Api.Extensions.Cookies;
+using Headless.Constants;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Tests.Extensions.Cookies;
+
+public sealed class ConfigureApplicationCookiesExtensionsTests
+{
+    [Theory]
+    [InlineData(true, StatusCodes.Status401Unauthorized, "/account/login")]
+    [InlineData(false, StatusCodes.Status403Forbidden, "/account/denied")]
+    public async Task should_return_api_status_and_preserve_redirect_location(
+        bool loginRedirect,
+        int expectedStatus,
+        string redirectUri
+    )
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthentication().AddCookie(IdentityConstants.ApplicationScheme);
+        services.ConfigureApiApplicationCookie();
+        using var provider = services.BuildServiceProvider();
+        var options = provider
+            .GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+            .Get(IdentityConstants.ApplicationScheme);
+        var context = new DefaultHttpContext { RequestServices = provider };
+        var redirectContext = new RedirectContext<CookieAuthenticationOptions>(
+            context,
+            new AuthenticationScheme(IdentityConstants.ApplicationScheme, null, typeof(CookieAuthenticationHandler)),
+            options,
+            new AuthenticationProperties(),
+            redirectUri
+        );
+
+        // when
+        if (loginRedirect)
+        {
+            await options.Events.OnRedirectToLogin(redirectContext);
+        }
+        else
+        {
+            await options.Events.OnRedirectToAccessDenied(redirectContext);
+        }
+
+        // then
+        context.Response.StatusCode.Should().Be(expectedStatus);
+        context.Response.Headers[HttpHeaderNames.Location].Should().ContainSingle().Which.Should().Be(redirectUri);
+    }
+}

--- a/tests/Headless.Api.Composition.Tests.Unit/Identity/Authentication/AuthenticationRegistrationTests.cs
+++ b/tests/Headless.Api.Composition.Tests.Unit/Identity/Authentication/AuthenticationRegistrationTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Api.Identity.Authentication.ApiKey;
+using Headless.Api.Identity.Authentication.Basic;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Tests.Identity.Authentication;
+
+public sealed class AuthenticationRegistrationTests
+{
+    [Fact]
+    public async Task should_register_custom_api_key_scheme_options_and_transient_store()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+
+        // when
+        services
+            .AddAuthentication()
+            .AddApiKey<RegistrationUser, string, RegistrationApiKeyStore>(
+                "PartnerKey",
+                "Partner API key",
+                options =>
+                {
+                    options.ApiKeyHeaderName = "X-Partner-Key";
+                    options.AllowApiKeyInQueryString = true;
+                    options.ApiKeyParamName = "partner_key";
+                }
+            );
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        var scheme = await provider.GetRequiredService<IAuthenticationSchemeProvider>().GetSchemeAsync("PartnerKey");
+        var options = provider
+            .GetRequiredService<IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>>()
+            .Get("PartnerKey");
+        scheme.Should().NotBeNull();
+        scheme!.DisplayName.Should().Be("Partner API key");
+        scheme.HandlerType.Should().Be<ApiKeyAuthenticationHandler<RegistrationUser, string>>();
+        options.ApiKeyHeaderName.Should().Be("X-Partner-Key");
+        options.AllowApiKeyInQueryString.Should().BeTrue();
+        options.ApiKeyParamName.Should().Be("partner_key");
+        provider
+            .GetRequiredService<IApiKeyStore<RegistrationUser, string>>()
+            .Should()
+            .BeOfType<RegistrationApiKeyStore>();
+        provider
+            .GetRequiredService<IApiKeyStore<RegistrationUser, string>>()
+            .Should()
+            .NotBeSameAs(provider.GetRequiredService<IApiKeyStore<RegistrationUser, string>>());
+    }
+
+    [Fact]
+    public async Task should_register_basic_scheme_with_defaults_and_custom_options()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+
+        // when
+        services
+            .AddAuthentication()
+            .AddBasicSchema<RegistrationUser, string>(configureOptions: options => options.Scheme = "InternalBasic");
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        var scheme = await provider
+            .GetRequiredService<IAuthenticationSchemeProvider>()
+            .GetSchemeAsync(BasicAuthenticationOptions.DefaultScheme);
+        var options = provider
+            .GetRequiredService<IOptionsMonitor<BasicAuthenticationOptions>>()
+            .Get(BasicAuthenticationOptions.DefaultScheme);
+        scheme.Should().NotBeNull();
+        scheme!.DisplayName.Should().Be(BasicAuthenticationOptions.DefaultScheme);
+        scheme.HandlerType.Should().Be<BasicAuthenticationHandler<RegistrationUser, string>>();
+        options.Scheme.Should().Be("InternalBasic");
+    }
+
+    private sealed class RegistrationUser : IdentityUser<string>;
+
+    private sealed class RegistrationApiKeyStore : IApiKeyStore<RegistrationUser, string>
+    {
+        public ValueTask<RegistrationUser?> GetActiveApiKeyUserAsync(
+            string apiKey,
+            CancellationToken cancellationToken = default
+        )
+        {
+            return ValueTask.FromResult<RegistrationUser?>(null);
+        }
+    }
+}

--- a/tests/Headless.Api.Composition.Tests.Unit/Identity/TokenProviders/IdentityBuilderExtensionsRegistrationTests.cs
+++ b/tests/Headless.Api.Composition.Tests.Unit/Identity/TokenProviders/IdentityBuilderExtensionsRegistrationTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Api.Identity.TokenProviders;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Tests.Identity.TokenProviders;
+
+public sealed class IdentityBuilderExtensionsRegistrationTests
+{
+    [Fact]
+    public void should_register_configured_password_reset_code_as_identity_default()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        var identity = services.AddIdentityCore<RegistrationTokenUser>();
+
+        // when
+        identity.AddPasswordResetCodeProvider<RegistrationTokenUser>(options =>
+        {
+            options.Name = "ShortResetCode";
+            options.Timestep = TimeSpan.FromSeconds(45);
+            options.Variance = 1;
+            options.HashMode = TotpHashMode.Sha256;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        var identityOptions = provider.GetRequiredService<IOptions<IdentityOptions>>().Value;
+        var providerOptions = provider.GetRequiredService<IOptions<PasswordResetCodeProviderOptions>>().Value;
+        identityOptions.Tokens.PasswordResetTokenProvider.Should().Be("ShortResetCode");
+        identityOptions
+            .Tokens.ProviderMap["ShortResetCode"]
+            .ProviderType.Should()
+            .Be<PasswordResetCodeProvider<RegistrationTokenUser>>();
+        providerOptions.Timestep.Should().Be(TimeSpan.FromSeconds(45));
+        providerOptions.Variance.Should().Be(1);
+        providerOptions.HashMode.Should().Be(TotpHashMode.Sha256);
+        services.Should().ContainSingle(descriptor => descriptor.ServiceType == typeof(TotpRfc6238Generator));
+    }
+
+    [Fact]
+    public void should_register_configured_email_confirmation_token_as_identity_default()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        var identity = services.AddIdentityCore<RegistrationTokenUser>();
+
+        // when
+        identity.AddEmailConfirmationTokenProvider<RegistrationTokenUser>(options =>
+        {
+            options.Name = "EmailLink";
+            options.TokenLifespan = TimeSpan.FromMinutes(20);
+        });
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        var identityOptions = provider.GetRequiredService<IOptions<IdentityOptions>>().Value;
+        var providerOptions = provider.GetRequiredService<IOptions<EmailConfirmationTokenProviderOptions>>().Value;
+        identityOptions.Tokens.EmailConfirmationTokenProvider.Should().Be("EmailLink");
+        identityOptions
+            .Tokens.ProviderMap["EmailLink"]
+            .ProviderType.Should()
+            .Be<EmailConfirmationTokenProvider<RegistrationTokenUser>>();
+        providerOptions.TokenLifespan.Should().Be(TimeSpan.FromMinutes(20));
+    }
+
+    [Fact]
+    public void should_keep_totp_generator_singleton_when_both_code_providers_are_registered()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        var identity = services.AddIdentityCore<RegistrationTokenUser>();
+
+        // when
+        identity.AddPasswordResetCodeProvider<RegistrationTokenUser>(null);
+        identity.AddEmailConfirmationCodeProvider<RegistrationTokenUser>(null);
+
+        // then
+        services.Should().ContainSingle(descriptor => descriptor.ServiceType == typeof(TotpRfc6238Generator));
+    }
+
+    private sealed class RegistrationTokenUser;
+}

--- a/tests/Headless.Api.Composition.Tests.Unit/Setup/CoreServiceRegistrationTests.cs
+++ b/tests/Headless.Api.Composition.Tests.Unit/Setup/CoreServiceRegistrationTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.Abstractions;
+using Headless.Api;
+using Headless.Api.Diagnostics;
+using Headless.Api.Middlewares;
+using Headless.Serializer;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.MiddlewareAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests.Setup;
+
+public sealed class CoreServiceRegistrationTests
+{
+    [Fact]
+    public void should_insert_middleware_analysis_filter_before_existing_startup_filters()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        services.AddTransient<IStartupFilter, ExistingStartupFilter>();
+
+        // when
+        services.AddMiddlewareAnalyzerFilter();
+
+        // then
+        services[0].ServiceType.Should().Be<IStartupFilter>();
+        services[0].ImplementationType.Should().Be<AnalysisStartupFilter>();
+        services[1].ImplementationType.Should().Be<ExistingStartupFilter>();
+    }
+
+    [Fact]
+    public void should_register_one_shared_json_stack_when_called_repeatedly()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+
+        // when
+        services.AddHeadlessJsonService().AddHeadlessJsonService();
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        var jsonSerializer = provider.GetRequiredService<IJsonSerializer>();
+        provider.GetServices<IJsonSerializer>().Should().ContainSingle();
+        provider.GetRequiredService<ITextSerializer>().Should().BeSameAs(jsonSerializer);
+        provider.GetRequiredService<ISerializer>().Should().BeSameAs(jsonSerializer);
+    }
+
+    [Fact]
+    public void should_preserve_custom_json_options_provider()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        var custom = Substitute.For<IJsonOptionsProvider>();
+        services.AddSingleton(custom);
+
+        // when
+        services.AddHeadlessJsonService();
+        using var provider = services.BuildServiceProvider();
+
+        // then
+        provider.GetRequiredService<IJsonOptionsProvider>().Should().BeSameAs(custom);
+    }
+
+    [Fact]
+    public void should_register_problem_details_and_exception_handler_idempotently()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+
+        // when
+        services.AddHeadlessProblemDetails().AddHeadlessProblemDetails();
+        // then
+        services.Should().ContainSingle(descriptor => descriptor.ServiceType == typeof(IProblemDetailsCreator));
+        services
+            .Should()
+            .ContainSingle(descriptor =>
+                descriptor.ServiceType == typeof(IExceptionHandler)
+                && descriptor.ImplementationType == typeof(HeadlessApiExceptionHandler)
+            );
+    }
+
+    private sealed class ExistingStartupFilter : IStartupFilter
+    {
+        public Action<Microsoft.AspNetCore.Builder.IApplicationBuilder> Configure(
+            Action<Microsoft.AspNetCore.Builder.IApplicationBuilder> next
+        )
+        {
+            return next;
+        }
+    }
+}

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/OperationProcessors/ApiExtraInformationOperationProcessorTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/OperationProcessors/ApiExtraInformationOperationProcessorTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Headless.OpenApi.Nswag.OperationProcessors;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using NSwag;
+using NSwag.Generation.AspNetCore;
+
+namespace Tests.OperationProcessors;
+
+public sealed class ApiExtraInformationOperationProcessorTests
+{
+    private readonly ApiExtraInformationOperationProcessor _sut = new();
+
+    [Fact]
+    public void should_preserve_deprecation_and_enrich_response_and_parameter_metadata()
+    {
+        // given
+        var operation = new OpenApiOperation { IsDeprecated = true };
+        var response = new OpenApiResponse();
+        response.Content["application/json"] = new OpenApiMediaType();
+        response.Content["text/plain"] = new OpenApiMediaType();
+        operation.Responses["200"] = response;
+        operation.Parameters.Add(new OpenApiParameter { Name = "limit", Schema = new NJsonSchema.JsonSchema() });
+
+        var apiDescription = new ApiDescription { ActionDescriptor = new ActionDescriptor() };
+        var responseType = new ApiResponseType { StatusCode = 200 };
+        responseType.ApiResponseFormats.Add(new ApiResponseFormat { MediaType = "application/json" });
+        apiDescription.SupportedResponseTypes.Add(responseType);
+        apiDescription.ParameterDescriptions.Add(
+            new ApiParameterDescription
+            {
+                Name = "LIMIT",
+                DefaultValue = 25,
+                IsRequired = true,
+                ModelMetadata = _GetLimitMetadata(),
+            }
+        );
+        var context = _CreateContext(operation, apiDescription);
+
+        // when
+        var result = _sut.Process(context);
+
+        // then
+        result.Should().BeTrue();
+        operation.IsDeprecated.Should().BeTrue();
+        response.Content.Keys.Should().Equal("application/json");
+        var parameter = operation.Parameters.Should().ContainSingle().Which;
+        parameter.Description.Should().Be("Maximum number of orders");
+        parameter.Schema.Default.Should().Be("25");
+        parameter.IsRequired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void should_preserve_existing_parameter_metadata_and_ignore_unknown_parameters()
+    {
+        // given
+        var operation = new OpenApiOperation();
+        operation.Parameters.Add(
+            new OpenApiParameter
+            {
+                Name = "limit",
+                Description = "consumer description",
+                Schema = new NJsonSchema.JsonSchema { Default = "10" },
+            }
+        );
+        operation.Parameters.Add(new OpenApiParameter { Name = "unknown", Schema = new NJsonSchema.JsonSchema() });
+        var apiDescription = new ApiDescription { ActionDescriptor = new ActionDescriptor() };
+        apiDescription.ParameterDescriptions.Add(
+            new ApiParameterDescription
+            {
+                Name = "limit",
+                DefaultValue = 25,
+                ModelMetadata = _GetLimitMetadata(),
+            }
+        );
+        var context = _CreateContext(operation, apiDescription);
+
+        // when
+        _sut.Process(context);
+
+        // then
+        operation.Parameters[0].Description.Should().Be("consumer description");
+        operation.Parameters[0].Schema.Default.Should().Be("10");
+        operation.Parameters[1].Description.Should().BeNull();
+        operation.Parameters[1].Schema.Default.Should().BeNull();
+    }
+
+    [Fact]
+    public void should_filter_default_response_content_types()
+    {
+        // given
+        var operation = new OpenApiOperation();
+        var response = new OpenApiResponse();
+        response.Content["application/problem+json"] = new OpenApiMediaType();
+        response.Content["text/html"] = new OpenApiMediaType();
+        operation.Responses["default"] = response;
+        var apiDescription = new ApiDescription { ActionDescriptor = new ActionDescriptor() };
+        var responseType = new ApiResponseType { IsDefaultResponse = true };
+        responseType.ApiResponseFormats.Add(new ApiResponseFormat { MediaType = "application/problem+json" });
+        apiDescription.SupportedResponseTypes.Add(responseType);
+
+        // when
+        _sut.Process(_CreateContext(operation, apiDescription));
+
+        // then
+        response.Content.Keys.Should().Equal("application/problem+json");
+    }
+
+    private static readonly MethodInfo _Method = typeof(object).GetMethod(
+        nameof(ToString),
+        BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+        Type.EmptyTypes
+    )!;
+
+    private static ModelMetadata _GetLimitMetadata()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddControllers();
+        using var provider = services.BuildServiceProvider();
+        return provider
+            .GetRequiredService<IModelMetadataProvider>()
+            .GetMetadataForProperty(typeof(QueryRequest), nameof(QueryRequest.Limit));
+    }
+
+    private static AspNetCoreOperationProcessorContext _CreateContext(
+        OpenApiOperation operation,
+        ApiDescription apiDescription
+    )
+    {
+        var description = new OpenApiOperationDescription
+        {
+            Operation = operation,
+            Path = "/orders",
+            Method = "GET",
+        };
+
+        return new AspNetCoreOperationProcessorContext(
+            new OpenApiDocument(),
+            description,
+            typeof(object),
+            _Method,
+            null!,
+            null!,
+            null!,
+            [description]
+        )
+        {
+            ApiDescription = apiDescription,
+        };
+    }
+
+    private sealed class QueryRequest
+    {
+        [Display(Description = "Maximum number of orders")]
+        public int Limit { get; init; }
+    }
+}

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/OperationProcessors/AuthorizationResponseOperationProcessorTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/OperationProcessors/AuthorizationResponseOperationProcessorTests.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using System.Reflection;
+using Headless.OpenApi.Nswag.OperationProcessors;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using NSwag;
+using NSwag.Generation.AspNetCore;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Tests.OperationProcessors;
+
+public sealed class AuthorizationResponseOperationProcessorTests
+{
+    private readonly UnauthorizedResponseOperationProcessor _unauthorized = new();
+    private readonly ForbiddenResponseOperationProcessor _forbidden = new();
+
+    [Fact]
+    public void should_add_unauthorized_only_for_plain_authorize_metadata()
+    {
+        // given
+        var context = _CreateContext(endpointMetadata: [new AuthorizeAttribute()]);
+
+        // when
+        _unauthorized.Process(context);
+        _forbidden.Process(context);
+
+        // then
+        context.OperationDescription.Operation.Responses.Should().ContainKey("401");
+        context.OperationDescription.Operation.Responses.Should().NotContainKey("403");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void should_add_forbidden_for_authorize_policy_or_roles(bool usePolicy)
+    {
+        // given
+        var authorize = new AuthorizeAttribute();
+        if (usePolicy)
+        {
+            authorize.Policy = "orders.write";
+        }
+        else
+        {
+            authorize.Roles = "admin";
+        }
+
+        var context = _CreateContext(endpointMetadata: [authorize]);
+
+        // when
+        _forbidden.Process(context);
+
+        // then
+        var response = context.OperationDescription.Operation.Responses["403"];
+        response.Description.Should().Contain("necessary permissions");
+    }
+
+    [Fact]
+    public void should_add_authentication_and_forbidden_responses_from_effective_policy_requirements()
+    {
+        // given
+        var policy = new AuthorizationPolicy(
+            [new DenyAnonymousAuthorizationRequirement(), new ClaimsAuthorizationRequirement("scope", ["orders"])],
+            []
+        );
+        var filter = new FilterDescriptor(new AuthorizeFilter(policy), FilterScope.Action);
+        var context = _CreateContext(filterDescriptors: [filter]);
+
+        // when
+        _unauthorized.Process(context);
+        _forbidden.Process(context);
+
+        // then
+        context.OperationDescription.Operation.Responses.Keys.Should().Contain(["401", "403"]);
+    }
+
+    [Fact]
+    public void should_skip_auth_responses_when_endpoint_allows_anonymous()
+    {
+        // given
+        var policy = new AuthorizationPolicy([new DenyAnonymousAuthorizationRequirement()], []);
+        var context = _CreateContext(
+            endpointMetadata: [new AllowAnonymousAttribute(), new AuthorizeAttribute { Roles = "admin" }],
+            filterDescriptors: [new FilterDescriptor(new AuthorizeFilter(policy), FilterScope.Action)]
+        );
+
+        // when
+        _unauthorized.Process(context);
+        _forbidden.Process(context);
+
+        // then
+        context.OperationDescription.Operation.Responses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void should_preserve_existing_auth_responses()
+    {
+        // given
+        var unauthorized = new OpenApiResponse { Description = "custom unauthorized" };
+        var forbidden = new OpenApiResponse { Description = "custom forbidden" };
+        var context = _CreateContext(endpointMetadata: [new AuthorizeAttribute { Roles = "admin" }]);
+        context.OperationDescription.Operation.Responses["401"] = unauthorized;
+        context.OperationDescription.Operation.Responses["403"] = forbidden;
+
+        // when
+        _unauthorized.Process(context);
+        _forbidden.Process(context);
+
+        // then
+        context.OperationDescription.Operation.Responses["401"].Should().BeSameAs(unauthorized);
+        context.OperationDescription.Operation.Responses["403"].Should().BeSameAs(forbidden);
+    }
+
+    [Fact]
+    public void should_ignore_non_aspnet_operation_contexts()
+    {
+        // given
+        var description = _CreateDescription();
+        var context = new OperationProcessorContext(
+            new OpenApiDocument(),
+            description,
+            typeof(object),
+            _Method,
+            null!,
+            null!,
+            null!,
+            [description]
+        );
+
+        // when
+        var unauthorizedResult = _unauthorized.Process(context);
+        var forbiddenResult = _forbidden.Process(context);
+
+        // then
+        unauthorizedResult.Should().BeTrue();
+        forbiddenResult.Should().BeTrue();
+        description.Operation.Responses.Should().BeEmpty();
+    }
+
+    private static readonly MethodInfo _Method = typeof(object).GetMethod(
+        nameof(ToString),
+        BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+        Type.EmptyTypes
+    )!;
+
+    private static AspNetCoreOperationProcessorContext _CreateContext(
+        IList<object>? endpointMetadata = null,
+        IList<FilterDescriptor>? filterDescriptors = null
+    )
+    {
+        var description = _CreateDescription();
+        var context = new AspNetCoreOperationProcessorContext(
+            new OpenApiDocument(),
+            description,
+            typeof(object),
+            _Method,
+            null!,
+            null!,
+            null!,
+            [description]
+        )
+        {
+            ApiDescription = new ApiDescription
+            {
+                ActionDescriptor = new ActionDescriptor
+                {
+                    EndpointMetadata = endpointMetadata ?? [],
+                    FilterDescriptors = filterDescriptors ?? [],
+                },
+            },
+        };
+
+        return context;
+    }
+
+    private static OpenApiOperationDescription _CreateDescription()
+    {
+        return new()
+        {
+            Operation = new OpenApiOperation(),
+            Path = "/orders",
+            Method = "GET",
+        };
+    }
+}

--- a/tests/Headless.OpenApi.Nswag.Tests.Unit/SetupNswagTests.cs
+++ b/tests/Headless.OpenApi.Nswag.Tests.Unit/SetupNswagTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Mahmoud Shaheen. All rights reserved.
+
+using Headless.OpenApi.Nswag;
+using Headless.OpenApi.Nswag.OperationProcessors;
+using Headless.OpenApi.Nswag.SchemaProcessors;
+using Headless.Primitives;
+using Microsoft.Extensions.DependencyInjection;
+using NJsonSchema;
+using NJsonSchema.Generation.TypeMappers;
+using NSwag.AspNetCore;
+using NSwag.Generation.AspNetCore;
+using NSwag.Generation.Processors.Security;
+
+namespace Tests;
+
+public sealed class SetupNswagTests
+{
+    [Fact]
+    public void should_register_default_processors_security_and_primitive_mappings()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+
+        // when
+        services.AddNswagOpenApi(options => options.AddApiKeySecurity = true);
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<OpenApiDocumentRegistration>().Settings;
+
+        // then
+        settings
+            .OperationProcessors.Should()
+            .ContainSingle(processor => processor is ApiExtraInformationOperationProcessor);
+        settings
+            .OperationProcessors.Should()
+            .ContainSingle(processor => processor is UnauthorizedResponseOperationProcessor);
+        settings
+            .OperationProcessors.Should()
+            .ContainSingle(processor => processor is ForbiddenResponseOperationProcessor);
+        settings.OperationProcessors.Should().ContainSingle(processor => processor is ProblemDetailsOperationProcessor);
+        settings
+            .SchemaSettings.SchemaProcessors.Should()
+            .ContainSingle(processor => processor is FluentValidationSchemaProcessor);
+        settings
+            .SchemaSettings.SchemaProcessors.Should()
+            .ContainSingle(processor => processor is GenericNullabilitySchemaProcessor);
+        settings.DocumentProcessors.OfType<SecurityDefinitionAppender>().Should().HaveCount(2);
+        settings.OperationProcessors.OfType<AspNetCoreOperationSecurityScopeProcessor>().Should().HaveCount(2);
+        settings.SchemaSettings.TypeMappers.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public void should_honor_service_provider_callback_and_disabled_optional_features()
+    {
+        // given
+        IServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+        var marker = new Marker();
+        services.AddSingleton(marker);
+
+        // when
+        services.AddNswagOpenApi(
+            options =>
+            {
+                options.AddBearerSecurity = false;
+                options.AddApiKeySecurity = false;
+                options.AddPrimitiveMappings = false;
+            },
+            (settings, provider) =>
+            {
+                settings.Title = provider.GetRequiredService<Marker>().Title;
+                settings.GenerateOriginalParameterNames = false;
+            }
+        );
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<OpenApiDocumentRegistration>().Settings;
+
+        // then
+        settings.Title.Should().Be(marker.Title);
+        settings.GenerateOriginalParameterNames.Should().BeFalse();
+        settings.DocumentProcessors.OfType<SecurityDefinitionAppender>().Should().BeEmpty();
+        settings.OperationProcessors.OfType<AspNetCoreOperationSecurityScopeProcessor>().Should().BeEmpty();
+        settings.SchemaSettings.TypeMappers.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(typeof(MoneyAmount), JsonObjectType.Number, "decimal", false)]
+    [InlineData(typeof(MoneyAmount?), JsonObjectType.Number, "decimal", true)]
+    [InlineData(typeof(Month), JsonObjectType.Integer, "int32", false)]
+    [InlineData(typeof(Month?), JsonObjectType.Integer, "int32", true)]
+    [InlineData(typeof(AccountId), JsonObjectType.String, "string", false)]
+    [InlineData(typeof(UserId), JsonObjectType.String, "string", false)]
+    public void should_map_building_block_primitives(Type type, JsonObjectType schemaType, string format, bool nullable)
+    {
+        // given
+        var settings = new AspNetCoreOpenApiDocumentGeneratorSettings();
+        settings.SchemaSettings.AddBuildingBlocksPrimitiveMappings();
+        var mapper = settings
+            .SchemaSettings.TypeMappers.OfType<PrimitiveTypeMapper>()
+            .Single(x => x.MappedType == type);
+        var schema = new JsonSchema();
+
+        // when
+        mapper.GenerateSchema(schema, null!);
+
+        // then
+        schema.Type.Should().Be(schemaType);
+        schema.Format.Should().Be(format);
+        schema.IsNullableRaw.Should().Be(nullable ? true : null);
+    }
+
+    private sealed class Marker
+    {
+        public string Title { get; } = "Consumer API";
+    }
+}


### PR DESCRIPTION
## Summary

- Locks down public API Core behavior around diagnostic adapters, cookie redirects, authentication/token-provider registration, JSON/problem-details setup, ordering, and idempotency.
- Covers the remaining high-value NSwag authorization, operation metadata, setup-option, security, and primitive-mapping branches without asserting generated OpenAPI or validation-source output.
- Changes tests only; no production seam or runtime behavior changed.

## Related Work

Related: #805

## Scope

Affected packages or domains:

- `Headless.Api.Core`
- `Headless.OpenApi.Nswag`

Out of scope:

- Analyzer Info/Suggestion sweep
- Generated OpenAPI documents or validation source output
- Getter/setter-only and production-code changes

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [ ] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A
```

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [ ] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
make test-project TEST_PROJECT=tests/Headless.Api.Composition.Tests.Unit/Headless.Api.Composition.Tests.Unit.csproj
  337 passed, 0 skipped, 0 failed

make test-project TEST_PROJECT=tests/Headless.OpenApi.Nswag.Tests.Unit/Headless.OpenApi.Nswag.Tests.Unit.csproj
  56 passed, 0 skipped, 0 failed

dotnet build <each affected test project> --configuration Release --no-restore --no-incremental -m:1
  Both succeeded with 0 warnings and 0 errors

make format-check
  4,117 files checked

make build MSBUILD_ARGS=-m:1
  378-project Release build succeeded with 0 warnings and 0 errors

make ci-test TEST_MAX_PARALLEL=1
  Final retry: 10,689 total; 10,687 passed; 2 existing skips; 0 failed
  A preceding run had one intermittent unrelated MessagingTelemetryTests failure.
  The class then passed 25/25 across five isolated repetitions and passed in the full retry.

make pack-built MSBUILD_ARGS=-m:1
  169 canonical packages produced with SBOMs at 0.11.1-preview.0.138

Integration and manual runtime validation were not run because this is a unit-test-only change with no production code.
```

Coverage uses the same fixed package universe before and after:

| Package | Metric | Before | After | Delta |
| --- | --- | ---: | ---: | ---: |
| Headless.Api.Core | Line | 54.1% (997/1,841) | 61.4% (1,132/1,841) | +7.3 pp |
| Headless.Api.Core | Branch | 59.6% (379/635) | 66.1% (420/635) | +6.5 pp |
| Headless.Api.Core | Method | 40.8% (157/384) | 46.6% (179/384) | +5.8 pp |
| Headless.OpenApi.Nswag | Line | 59.2% (467/788) | 88.3% (696/788) | +29.1 pp |
| Headless.OpenApi.Nswag | Branch | 49.4% (144/291) | 78.6% (229/291) | +29.2 pp |
| Headless.OpenApi.Nswag | Method | 53.8% (28/52) | 88.4% (46/52) | +34.6 pp |

## Tests and Documentation

- [x] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
No public API, shared provider contract, package behavior, or documentation changed.
```

## Reviewer Guide

Review the test fidelity around diagnostic disposal, API cookie redirects, transient authentication stores, repeated service registration, 401/403 selection, consumer metadata preservation, and optional NSwag features.

Remaining meaningful weak areas are API middleware/tenancy/application-builder branches and complex FluentValidation schema branches. Reflection-driven mapper discovery remains intentionally untested because it would primarily assert generated-output plumbing.

## Release Notes

N/A — internal test coverage only.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this PR changes tests only and produces no runtime artifact or behavior. Validation window and owner are not applicable; revert the two test commits if CI exposes an environment-specific test regression.
