### PR TITLE
test: enforce generated coverage denominator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ TEST_RESULTS_DIR ?= $(ARTIFACTS_DIR)/test-results
 COVERAGE_DIR ?= $(ARTIFACTS_DIR)/coverage
 COVERAGE_REPORT_DIR ?= $(COVERAGE_DIR)/report
 COVERAGE_REPORT_TYPES ?= Html;JsonSummary
+COVERAGE_SETTINGS ?= eng/coverage.runsettings
 DEPENDENCY_AUDIT_DIR ?= $(ARTIFACTS_DIR)/dependency-audit
 PROJECT ?=
 TEST_PROJECT ?=
@@ -53,8 +54,8 @@ DOTNET_OUTDATED_AUDIT_ARGS ?= --no-restore --idle-timeout $(DEPENDENCY_AUDIT_IDL
 DEPENDENCY_SECURITY_AUDIT_ARGS ?= --timeout-seconds "$(DEPENDENCY_SECURITY_AUDIT_TIMEOUT)" --output-dir "$(DEPENDENCY_AUDIT_DIR)/security" --project "$(PROJECT)" --scan vulnerable --include-transitive --scan deprecated
 NUGET_ADVISORY_AUDIT_ARGS ?= --timeout-seconds "$(NUGET_ADVISORY_AUDIT_TIMEOUT)" --output-dir "$(DEPENDENCY_AUDIT_DIR)/nuget-advisories" --scan vulnerable --include-transitive
 
-COVERAGE_ARGS ?= -p:EnableCodeCoverage=true --coverage-output-format cobertura
-CI_TEST_ARGS ?= --report-trx --coverage --coverage-output-format cobertura
+COVERAGE_ARGS ?= -p:EnableCodeCoverage=true --coverage-output-format cobertura --coverage-settings "$(COVERAGE_SETTINGS)"
+CI_TEST_ARGS ?= --report-trx --coverage --coverage-output-format cobertura --coverage-settings "$(COVERAGE_SETTINGS)"
 
 .PHONY: help
 help: ## Show available commands.
@@ -219,6 +220,28 @@ test-fast: ## Run all tests without restore/build. Requires existing $(CONFIGURA
 ci-test: ## Run prebuilt unit tests with CI coverage output. Requires existing $(CONFIGURATION) build outputs.
 	@mkdir -p "$(TEST_RESULTS_DIR)"
 	$(DOTNET) test --test-modules "$(UNIT_TEST_MODULES)" --root-directory "$(CURDIR)" --results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) $(TEST_ARGS) $(TEST_FILTER) $(CI_TEST_ARGS)
+	$(MAKE) coverage-verify-generated-sources
+
+.PHONY: coverage-verify-generated-sources
+coverage-verify-generated-sources: ## Verify generated implementations exist in build output but not Cobertura reports.
+	@set -eu; \
+		generated_file="$$(find src -type f -path '*/obj/*/generated/*' -name '*.cs' -print -quit)"; \
+		if [ -z "$$generated_file" ]; then \
+			echo "No compiler/source-generated implementation was found under src/**/obj/**/generated/**."; \
+			exit 1; \
+		fi; \
+		report_file="$$(find "$(TEST_RESULTS_DIR)" -type f -name '*.cobertura.xml' -print -quit)"; \
+		if [ -z "$$report_file" ]; then \
+			echo "No Cobertura report was found under $(TEST_RESULTS_DIR)."; \
+			exit 1; \
+		fi; \
+		scan_result="$$(find "$(TEST_RESULTS_DIR)" -type f -name '*.cobertura.xml' \
+			-exec sh -c 'report=$$1; pattern=$$2; grep -Eq "$$pattern" "$$report"; status=$$?; if [ "$$status" -eq 0 ]; then printf "MATCH:%s\n" "$$report"; exit 0; fi; if [ "$$status" -gt 1 ]; then printf "ERROR:%s:%s\n" "$$status" "$$report"; exit 0; fi; exit 1' sh {} 'filename="[^"]*[/\\]obj[/\\].*[/\\]generated[/\\]' \; -quit)"; \
+		case "$$scan_result" in \
+			MATCH:*) echo "Generated implementations remain in Cobertura coverage. First: $${scan_result#MATCH:}"; exit 1 ;; \
+			ERROR:*) echo "Failed to inspect a Cobertura report: $$scan_result"; exit 1 ;; \
+		esac; \
+		echo "Verified generated implementations are absent from Cobertura coverage."
 
 .PHONY: ci-messaging-conformance-evidence
 ci-messaging-conformance-evidence: ## Execute every supported local-broker messaging conformance scenario (Azure uses its protected workflow).
@@ -298,6 +321,7 @@ coverage: tools build ## Collect Cobertura coverage via MTP's in-process coverag
 	$(DOTNET) test --solution "$(SOLUTION)" --configuration "$(CONFIGURATION)" --no-build \
 		--results-directory "$(TEST_RESULTS_DIR)" --max-parallel-test-modules $(TEST_MAX_PARALLEL) \
 		$(TEST_ARGS) $(TEST_FILTER) $(COVERAGE_ARGS)
+	$(MAKE) coverage-verify-generated-sources
 
 .PHONY: coverage-html
 coverage-html: coverage ## Generate HTML coverage report plus Summary.json.

--- a/eng/coverage.runsettings
+++ b/eng/coverage.runsettings
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0">
+        <Configuration>
+          <CodeCoverage>
+            <Sources>
+              <Exclude>
+                <!--
+                  Directory.Build.props enables EmitCompilerGeneratedFiles, which writes
+                  source-generator implementations here.
+                  Filtering the generated output path keeps hand-written partial declarations
+                  and compiler-generated behavior attributed to production source in scope.
+                -->
+                <Source>.*[/\\]obj[/\\].*[/\\]generated[/\\].*</Source>
+              </Exclude>
+            </Sources>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

- Apply one Microsoft Testing Platform coverage settings file to both repository coverage entry points.
- Exclude only compiler/source-generator implementations emitted under `obj/**/generated/**`; hand-written partial classes and production-source compiler state machines remain measured.
- Fail coverage validation when generated implementations leak back into Cobertura output, or when build/report evidence is missing.

## Related Work

N/A. The branch starts from the current default branch, which includes merged PR #805.

## Scope

Affected packages or domains:

- Repository-wide coverage collection and reporting for all 144 measured `Headless.*` assemblies.

Out of scope:

- Production behavior and public APIs.
- Coverage-only tests, generated-code tests, and the prior analyzer Info/Suggestion sweep.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation only
- [x] Test only
- [x] Build or CI

## Compatibility and Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (apply the `major` label and complete the details below)
- [ ] Compatibility impact is uncertain and needs reviewer input

- [ ] Source/API compatibility
- [ ] Binary compatibility
- [ ] Behavioral compatibility (including changed defaults)
- [ ] Configuration or deployment compatibility
- [ ] Data, storage, or serialization compatibility

Breaking-change details:

```text
N/A
```

## Coverage Evidence

Measurement snapshot: `493251f4117d75b62fe49476a32381b57446f21a`. The branch was subsequently fast-forwarded through test-only PRs #812 and #813; they do not change the instrumented production denominator, but can increase the covered numerator.

The controlled raw/filtered comparison used the same 114 test modules and 144 assembly universe. Percentages are calculated from exact counts rather than ReportGenerator's one-decimal display.

| Metric | Raw | Filtered | Delta |
| --- | ---: | ---: | ---: |
| Line | 98,620 / 161,074 (61.2265%) | 76,185 / 112,216 (67.8914%) | +6.6649 pp |
| Branch | 33,135 / 54,843 (60.4179%) | 26,612 / 40,667 (65.4388%) | +5.0209 pp |
| Method | 10,982 / 16,589 (66.2005%) | 9,758 / 13,866 (70.3736%) | +4.1731 pp |

Raw output contained 8,433 generated class records across confirmed generator families: regex (6,171), logging (1,118 across two generators), primitives (624), JSON serialization (442), resources (29), metrics (21), OpenAPI (12), validation (10), and Jobs discovery (6). Filtered output contained zero `obj/**/generated/**` paths. The assembly count remains 144; class/file counts move from 2,382/1,868 to 2,155/1,585.

This is denominator hygiene, not newly tested behavior. The path-specific filter removes generated implementations only; it does not exclude hand-written partial declarations or entire assemblies.

## Validation

- [x] Focused build or test for the affected projects
- [x] `make build`
- [x] `make format-check`
- [ ] `make test-unit`
- [ ] `make test-integration`
- [x] Manual or end-to-end verification
- [ ] No runtime validation required (documentation or workflow text only)

Validation details:

```text
make bootstrap
  passed

make rebuild-no-restore MSBUILD_ARGS=-m:1
  passed: 0 warnings, 0 errors

make format-check
  passed: 4,121 files

Raw sequential MTP coverage run
  10,656 total; 10,654 passed; 2 skipped; 0 failed
  The new verifier then rejected the intentionally unfiltered raw reports, as expected.

Filtered sequential MTP coverage attempts
  10,656 total; 10,653 passed; 2 skipped; 1 failed
  Two separate attempts hit different pre-existing Messaging timing tests. Each exact failure passed immediately in isolation (1/1). No production or test source is changed here.

make coverage-verify-generated-sources TEST_RESULTS_DIR=<filtered-results>
  passed: generated implementations absent from all 114 Cobertura reports

make quality-analyzers QUALITY_SEVERITY=warn
  passed; analyzer Info/Suggestion work intentionally remains out of scope
```

## Tests and Documentation

- [ ] Added or updated tests for behavior changes
- [ ] Added provider-conformance coverage where shared behavior changed
- [ ] Updated XML docs for public API changes
- [ ] Updated affected package `README.md` files
- [ ] Updated matching `docs/llms/` guidance
- [x] No package versions were added directly to `.csproj` files
- [ ] Tests and documentation are not affected

```text
The Makefile verifier is the regression test for coverage-report behavior. No runtime behavior, package documentation, or public API changed.
```

## Reviewer Guide

Review `eng/coverage.runsettings` first: the exclusion is deliberately source-path-specific. Then review `coverage-verify-generated-sources`, which proves generated implementations exist in build output while rejecting any Cobertura report that still contains them.

### Post-Deploy Monitoring & Validation

No runtime monitoring is required. Confirm the next CI coverage summary preserves all 144 assemblies and that the generated-source verifier passes. Roll back by reverting this commit if the filter misclassifies production source.

## Release Notes

N/A — internal coverage reporting only.
