### PR TITLE
build(deps): consolidate validated dependency updates

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   },


### PR DESCRIPTION
## Summary

- Updates the repository-pinned .NET SDK from `10.0.302` to the stable `10.0.400` feature band.
- Includes the .NET 10.0.11 security servicing release carried by SDK 10.0.400.
- Reconstructs the eligible update from authoritative metadata after the seven-day release quarantine elapsed; no Dependabot branch commit was reused.

## Dependency disposition

| Dependency | Ecosystem | Old | New | Risk | Source | Disposition |
| --- | --- | --- | --- | --- | --- | --- |
| .NET SDK | `dotnet-sdk` | 10.0.302 | 10.0.400 | Medium: toolchain feature-band update, no target-framework change | Dependabot PR #839; [official .NET 10 metadata](https://builds.dotnet.microsoft.com/dotnet/release-metadata/10.0/releases.json); [SDK release](https://github.com/dotnet/sdk/releases/tag/v10.0.400) | Include. Stable and published 2026-08-11T21:42:06Z; quarantine satisfied before evaluation at 2026-08-19T11:34:21Z. |

No other open Dependabot PRs existed at the 2026-08-21T20:01:34Z inventory.

## Security disposition

| Alert/advisory | Severity | Affected path/exposure | Patched version | Related PR | Expected resolution |
| --- | --- | --- | --- | --- | --- |
| .NET 10.0.11 security servicing release (CVE-2026-62898, CVE-2026-62899, CVE-2026-62900, CVE-2026-62901, CVE-2026-62886, CVE-2026-62871, CVE-2026-70354, CVE-2026-62902, CVE-2026-62897, CVE-2026-62909) | Per Microsoft advisories | `global.json`; SDK/build toolchain and bundled runtime exposure | SDK 10.0.400 / runtime 10.0.11 | #839 | Toolchain is updated when this PR merges. GitHub reported no repository Dependabot alert for these CVEs. |

GitHub security surfaces were independently re-queried at 2026-08-21T20:01:34Z and returned zero open Dependabot alerts, zero code-scanning alerts, and zero secret-scanning alerts. No security surface was unavailable or permission-blocked. No installs or broad local validation were rerun for this evidence-backed no-op because no eligible inventory change existed. The prior NuGet transitive advisory audit reported all 169 source projects clean.

## Compatibility and repairs

- The repository remains on .NET 10 and C# 14; only the SDK feature band changes.
- No removed or obsolete API, configuration, serialization, provider, browser, or public-contract repair was required.
- No lockfile or dependency graph changed.
- The official macOS arm64 SDK archive was verified against Microsoft's published SHA-512 before validation.

## Files, tests, and documentation

- Changed: `global.json` only.
- Tests: no version-assertion test added; the full repository unit suite and packaging pipeline exercise the toolchain boundary.
- Documentation: unchanged because public APIs, packages, configuration, defaults, and runtime behavior did not change.

## Validation

| Command | Outcome |
| --- | --- |
| `shasum -a 512 -c` against the official SDK 10.0.400 archive hash | Pass |
| `make bootstrap` | Pass |
| `make ci-build` | Pass: clean restore/build, formatting, 10,751 tests (10,749 passed, 0 failed, 2 skipped), 169 package/SBOM builds |
| `make verify-packages` | Pass: 169 immutable package archives verified |
| `make nuget-advisory-audit` | Pass: 169/169 source projects clean, including transitive packages |
| `make quality-analyzers` | Completed with exit 2 from existing informational analyzer findings; no changed C# files and no SDK-upgrade warning/error was introduced |
| Repository pre-push hook | Pass: incremental Release build, 0 warnings, 0 errors |
| Exact-head `Dashboards` workflow dispatch | Pass: both required SPA build/test/lint jobs and Tus demo build |
| Exact-head `Build and pack` | Pass: completed successfully in 36m31s |
| `git diff --check` | Pass |

Provider integration suites were not rerun because this change does not alter runtime packages or provider code; the broad clean build, complete unit suite, package validation, and hosted required checks are the proportional gates.

## Excluded and deferred findings

- None. The only previously deferred candidate, SDK 10.0.400, became eligible when its seven-day quarantine elapsed.
- No dependency-maintenance code-scanning findings and no report-only secret-scanning findings were present.

## Remaining risks and manual actions

- The required dashboard workflow does not trigger for `global.json` under its PR path filter, so automation dispatched the unchanged workflow against exact head `7e40f5e8318314abecf5198b85f22a5870b1862b`; all three jobs passed.
- All required exact-head checks are successful. Required human review remains the only merge gate.
- Review the feature-band/toolchain change and approve it if satisfactory; merge remains a manual action.
- There are no GitHub dependency alerts expected to close after merge because all queried alert surfaces currently report zero open findings.

## Post-merge monitoring

- Confirm the default-branch build uses SDK 10.0.400 and all required checks remain green.
- Re-query GitHub security surfaces after merge; they currently contain no open findings.

This PR was created by dependency automation. It has not been approved or merged.

