### PR TITLE
build(deps): consolidate validated dependency updates

### DIFF
--- a/demo/Headless.Tus.Demo/frontend/package-lock.json
+++ b/demo/Headless.Tus.Demo/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "pretty-bytes": "^7.1.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-dropzone": "^20.0.0",
+        "react-dropzone": "^20.1.0",
         "tus-js-client": "^4.3.1",
         "use-tus": "^0.9.0"
       },
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-20.0.0.tgz",
-      "integrity": "sha512-Xw8tvvVPJQzj8ir5wivUMzA+G6R+aGhdU5KQzUMvVBlJNb26AW/0137VoYVmb5UgZcbhM9OCpjE4KOqqSL9QuQ==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-20.1.0.tgz",
+      "integrity": "sha512-id1t9JDYNQeFzzIfB5/C6TrpLchy29rTSDxsBH/pcxhILyv/6bSOTJwOlvUsTWXkC2GduuHIldDV6UQXNWfIuA==",
       "license": "MIT",
       "dependencies": {
         "attr-accept": "^2.2.5",

--- a/demo/Headless.Tus.Demo/frontend/package.json
+++ b/demo/Headless.Tus.Demo/frontend/package.json
@@ -17,7 +17,7 @@
     "pretty-bytes": "^7.1.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-dropzone": "^20.0.0",
+    "react-dropzone": "^20.1.0",
     "tus-js-client": "^4.3.1",
     "use-tus": "^0.9.0"
   },

--- a/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package-lock.json
@@ -13,18 +13,18 @@
         "cronstrue": "^3.24.0",
         "echarts": "^6.1.0",
         "maska": "^3.2.0",
-        "pinia": "^4.0.2",
+        "pinia": "^4.0.3",
         "timeago.js": "^4.0.2",
         "vite-plugin-dynamic-base": "^1.4.1",
         "vue": "^3.5.41",
         "vue-echarts": "^8.1.0",
         "vue-router": "^5.2.0",
-        "vuetify": "^4.1.8",
+        "vuetify": "^4.1.10",
         "yup": "^1.6.1"
       },
       "devDependencies": {
         "@mdi/font": "^7.4.47",
-        "@tsconfig/node22": "^22.0.0",
+        "@tsconfig/node22": "^22.0.6",
         "@types/node": "^26.2.0",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitejs/plugin-vue": "^6.0.8",
@@ -41,7 +41,7 @@
         "vite-plugin-dts": "^5.0.3",
         "vite-plugin-vue-devtools": "^8.2.1",
         "vitest": "^4.1.10",
-        "vue-tsc": "^3.3.9"
+        "vue-tsc": "^3.3.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1312,9 +1312,9 @@
       }
     },
     "node_modules/@tsconfig/node22": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
-      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.6.tgz",
+      "integrity": "sha512-/5thavHAnWDZwH2H6eEn/T8pBEBhtuKaWGMslsj82kJfvzQgOgEMK7X4goBbIUjgVtAzPTtM9Ml64LA0uxO6Iw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
-      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.10.tgz",
+      "integrity": "sha512-CR7ByBbgPHqhxrioKPOcZBqttaozzLNwtkCzXQ+uF8gLPHnUe03srPnGpdtHD3zp+bq5iyVkZ1WNx7W564RPwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4957,9 +4957,9 @@
       }
     },
     "node_modules/pinia": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.2.tgz",
-      "integrity": "sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.3.tgz",
+      "integrity": "sha512-XMQqpvjgG7LMqVhhFUzKLT4KEbsYbfZZ0CZU9PgdFm1O2VKBmIkykL8+SfNhOaT7sR0wT6BEgKT0YNDYWgmVRA==",
       "license": "MIT",
       "dependencies": {
         "nostics": "^1.1.4"
@@ -6405,14 +6405,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.9.tgz",
-      "integrity": "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.10.tgz",
+      "integrity": "sha512-YaDVxcW+CGtaOt3pZahMG5jYPx0hsUTxyEoPOTSMebcGUXP9lIBabQ14vfKMORb2CqqK5CxsNo/d1d+4IQwiKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.9"
+        "@vue/language-core": "3.3.10"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -6422,9 +6422,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.8.tgz",
-      "integrity": "sha512-003D/8b5462uZCD5CMRTZF3smADmOn47mzthNY0aP/xkslovR5yIc1qXjPdFN0LHcu+p3GEAVmMQabldaIQ5pg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.10.tgz",
+      "integrity": "sha512-7IDuicacXiE0yIZoFbYpIYLrQbOV45duwhsc/yqv2l2slatm4NHtuiB89/EpuxGEF8WHRVyLOEpOzP91RsxuxA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/src/Headless.Jobs.Dashboard/wwwroot/package.json
+++ b/src/Headless.Jobs.Dashboard/wwwroot/package.json
@@ -21,18 +21,18 @@
     "cronstrue": "^3.24.0",
     "echarts": "^6.1.0",
     "maska": "^3.2.0",
-    "pinia": "^4.0.2",
+    "pinia": "^4.0.3",
     "timeago.js": "^4.0.2",
     "vite-plugin-dynamic-base": "^1.4.1",
     "vue": "^3.5.41",
     "vue-echarts": "^8.1.0",
     "vue-router": "^5.2.0",
-    "vuetify": "^4.1.8",
+    "vuetify": "^4.1.10",
     "yup": "^1.6.1"
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",
-    "@tsconfig/node22": "^22.0.0",
+    "@tsconfig/node22": "^22.0.6",
     "@types/node": "^26.2.0",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitejs/plugin-vue": "^6.0.8",
@@ -49,7 +49,7 @@
     "vite-plugin-dts": "^5.0.3",
     "vite-plugin-vue-devtools": "^8.2.1",
     "vitest": "^4.1.10",
-    "vue-tsc": "^3.3.9"
+    "vue-tsc": "^3.3.10"
   },
   "overrides": {
     "brace-expansion": "5.0.9",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package-lock.json
@@ -11,17 +11,17 @@
         "axios": "^1.19.0",
         "echarts": "^6.1.0",
         "json-bigint": "^1.0.0",
-        "pinia": "^4.0.2",
+        "pinia": "^4.0.3",
         "timeago.js": "^4.0.2",
         "vite-plugin-dynamic-base": "^1.4.1",
         "vue": "^3.5.41",
         "vue-echarts": "^8.1.0",
         "vue-router": "^5.2.0",
-        "vuetify": "^4.1.8"
+        "vuetify": "^4.1.10"
       },
       "devDependencies": {
         "@mdi/font": "^7.4.47",
-        "@tsconfig/node22": "^22.0.0",
+        "@tsconfig/node22": "^22.0.6",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^26.2.0",
         "@typescript/native": "npm:typescript@7.0.2",
@@ -39,7 +39,7 @@
         "vite-plugin-dts": "^5.0.3",
         "vite-plugin-vue-devtools": "^8.2.1",
         "vitest": "^4.1.10",
-        "vue-tsc": "^3.3.9"
+        "vue-tsc": "^3.3.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1331,9 +1331,9 @@
       }
     },
     "node_modules/@tsconfig/node22": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
-      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.6.tgz",
+      "integrity": "sha512-/5thavHAnWDZwH2H6eEn/T8pBEBhtuKaWGMslsj82kJfvzQgOgEMK7X4goBbIUjgVtAzPTtM9Ml64LA0uxO6Iw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2491,9 +2491,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
-      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.10.tgz",
+      "integrity": "sha512-CR7ByBbgPHqhxrioKPOcZBqttaozzLNwtkCzXQ+uF8gLPHnUe03srPnGpdtHD3zp+bq5iyVkZ1WNx7W564RPwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4912,9 +4912,9 @@
       }
     },
     "node_modules/pinia": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.2.tgz",
-      "integrity": "sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.3.tgz",
+      "integrity": "sha512-XMQqpvjgG7LMqVhhFUzKLT4KEbsYbfZZ0CZU9PgdFm1O2VKBmIkykL8+SfNhOaT7sR0wT6BEgKT0YNDYWgmVRA==",
       "license": "MIT",
       "dependencies": {
         "nostics": "^1.1.4"
@@ -6275,14 +6275,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.9.tgz",
-      "integrity": "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.10.tgz",
+      "integrity": "sha512-YaDVxcW+CGtaOt3pZahMG5jYPx0hsUTxyEoPOTSMebcGUXP9lIBabQ14vfKMORb2CqqK5CxsNo/d1d+4IQwiKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.9"
+        "@vue/language-core": "3.3.10"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -6292,9 +6292,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.8.tgz",
-      "integrity": "sha512-003D/8b5462uZCD5CMRTZF3smADmOn47mzthNY0aP/xkslovR5yIc1qXjPdFN0LHcu+p3GEAVmMQabldaIQ5pg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.10.tgz",
+      "integrity": "sha512-7IDuicacXiE0yIZoFbYpIYLrQbOV45duwhsc/yqv2l2slatm4NHtuiB89/EpuxGEF8WHRVyLOEpOzP91RsxuxA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/src/Headless.Messaging.Dashboard/wwwroot/package.json
+++ b/src/Headless.Messaging.Dashboard/wwwroot/package.json
@@ -19,17 +19,17 @@
     "axios": "^1.19.0",
     "echarts": "^6.1.0",
     "json-bigint": "^1.0.0",
-    "pinia": "^4.0.2",
+    "pinia": "^4.0.3",
     "timeago.js": "^4.0.2",
     "vite-plugin-dynamic-base": "^1.4.1",
     "vue": "^3.5.41",
     "vue-echarts": "^8.1.0",
     "vue-router": "^5.2.0",
-    "vuetify": "^4.1.8"
+    "vuetify": "^4.1.10"
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",
-    "@tsconfig/node22": "^22.0.0",
+    "@tsconfig/node22": "^22.0.6",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^26.2.0",
     "@typescript/native": "npm:typescript@7.0.2",
@@ -47,7 +47,7 @@
     "vite-plugin-dts": "^5.0.3",
     "vite-plugin-vue-devtools": "^8.2.1",
     "vitest": "^4.1.10",
-    "vue-tsc": "^3.3.9"
+    "vue-tsc": "^3.3.10"
   },
   "overrides": {
     "brace-expansion": "5.0.9",


### PR DESCRIPTION
## Summary

Refreshes the Tus demo and both dashboard frontends with the quarantined, stable npm updates from Dependabot PR #846. The batch is rebuilt on current `main`; no application code, public contracts, generated assets, or documentation change.

## Dependencies

| Dependency | Ecosystem / exposure | Old | New | Risk | Source | Disposition |
| --- | --- | ---: | ---: | --- | --- | --- |
| `react-dropzone` | npm; Tus demo runtime | 20.0.0 | 20.1.0 | Low minor; exposes drag rejections | #846 | Include |
| `pinia` | npm; Jobs and Messaging dashboard runtime | 4.0.2 | 4.0.3 | Low patch; Vue peer contract remains satisfied | #846 | Include |
| `vuetify` | npm; Jobs and Messaging dashboard runtime | 4.1.8 | 4.1.10 | Low patch; UI bug fixes only | #846 | Include |
| `@tsconfig/node22` | npm; dashboard build/dev | 22.0.5 resolved (`^22.0.0` declared) | 22.0.6 | Low patch; Node 22 baseline retained | #846 | Include |
| `vue-tsc` | npm; dashboard build/dev | 3.3.9 | 3.3.10 | Low patch; TypeScript peer contract remains satisfied | #846 | Include |

All included releases were stable, non-deprecated in npm metadata, and older than the seven-day quarantine at the 2026-08-25T20:01:19Z inventory. Newer `react-dropzone` 20.1.1, Vuetify 4.1.11, and `vue-tsc` 3.3.11 remain quarantined until 2026-08-27T05:28:08Z, 2026-08-26T18:04:01Z, and 2026-08-28T10:11:21Z respectively, so this batch does not advance to them.

## Security

| Surface | Open findings | Disposition |
| --- | ---: | --- |
| Dependabot alerts | 0 | Queried successfully; no dependency vulnerability requires a fix |
| Code scanning | 0 | Queried successfully; no dependency-related or other open code alert |
| Secret scanning | 0 | Queried successfully; no protected human remediation required |

All three package trees resolve without npm advisories. No GitHub security alert is expected to change after merge.

## Compatibility and repairs

- Node 24.19.0 satisfies the packages' Node requirements; React, Vue, TypeScript, and Vite peer ranges remain compatible.
- The package-manager-generated lockfiles preserve the existing parent-scoped security overrides and lifecycle-script restrictions.
- No breaking or obsolete API repair was needed. No tests or documentation were changed because behavior and public contracts are unchanged.

## Validation

- `make bootstrap` — passed; tools and the full .NET solution restored.
- `npm ci` in all three frontend manifests — passed; 87 Tus, 412 Jobs, and 392 Messaging packages audited during clean install with 0 vulnerabilities.
- `npm audit --json` in all three manifests — passed; 0 info, low, moderate, high, or critical findings.
- `npm ls react-dropzone --all` — resolved only `react-dropzone@20.1.0` in Tus.
- `npm ls pinia vuetify @tsconfig/node22 vue-tsc @vue/language-core --all` in both dashboards — resolved `pinia@4.0.3`, `vuetify@4.1.10`, `@tsconfig/node22@22.0.6`, `vue-tsc@3.3.10`, and deduplicated `@vue/language-core@3.3.10`.
- `npm run build` in Tus, Jobs, and Messaging — passed, including TypeScript checks and production bundles.
- `npm run test:unit` — Jobs 48/48 passed; Messaging 47/47 passed; 0 failed and 0 skipped.
- `npm run lint:check` in both dashboards — passed.
- `make dashboards` — passed with clean installs, zero audit findings, and both production builds.
- `make build-project PROJECT=...` for Jobs Dashboard, Messaging Dashboard, and Tus Demo — all passed with 0 warnings and 0 errors.
- Pre-push full Release solution build — passed with 0 warnings and 0 errors.
- `git diff --check origin/main...HEAD` — passed.

The source PR's six file blobs exactly match this reconstructed branch. Source PR #846 was one commit behind `main`; its dashboard and Tus checks passed, while `Build and pack` was cancelled during its long-running unit-test step, so that result is treated as inconclusive rather than green.

## Excluded and remaining risk

- No Dependabot proposal or security finding was excluded. Only the newer releases listed above are deferred for release-age quarantine.
- At the 2026-08-25T20:09:43Z exact-head snapshot, Tus, Jobs SPA, and Messaging SPA passed; `Build and pack` was in progress. The PR was conflict-free and mergeable but blocked by that pending check and `REVIEW_REQUIRED`, with no reviews. All three GitHub security surfaces still reported zero open alerts.
- Manual review and approval remain required; this automation will not approve, enable auto-merge, merge, tag, release, or publish.

This PR was created by dependency automation. It has not been approved or merged.
